### PR TITLE
Added Bitstamp API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
 		<module>xchange-cavirtex</module>
 		<module>xchange-btce</module>
 		<module>xchange-openexchangerates</module>
+    <module>xchange-bitstamp</module>
 	</modules>
 
 	<build>

--- a/xchange-bitstamp/api-specification.txt
+++ b/xchange-bitstamp/api-specification.txt
@@ -1,0 +1,21 @@
+Bitstamp Exchange API specification
+================================
+
+Public API
+
+Documentation
+-------------
+https://www.bitstamp.net/api/
+
+Ticker
+------
+ https://www.bitstamp.net/api/ticker/
+
+Orders
+------
+https://www.bitstamp.net/api/order_book/
+
+Trades
+------
+https://www.bitstamp.net/api/transactions/
+

--- a/xchange-bitstamp/pom.xml
+++ b/xchange-bitstamp/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.xeiam.xchange</groupId>
+    <artifactId>xchange-parent</artifactId>
+    <version>${currentVersion}</version>
+  </parent>
+
+  <artifactId>xchange-bitstamp</artifactId>
+  <!-- This version is tied to the version of the parent -->
+  <version>${currentVersion}</version>
+
+  <name>Bitstamp Exchange</name>
+  <description>XChange implementations for the Bitstamp Exchange.</description>
+
+  <url>http://xeiam.com</url>
+  <inceptionYear>2012</inceptionYear>
+
+  <organization>
+    <name>Xeiam, LLC</name>
+    <url>http://xeiam.com</url>
+  </organization>
+
+  <!-- Parent provides default configuration for dependencies -->
+  <dependencies>
+
+    <!-- Project dependencies (version automatically set through parent) -->
+    <dependency>
+      <groupId>com.xeiam.xchange</groupId>
+      <artifactId>xchange-core</artifactId>
+      <version>${currentVersion}</version>
+    </dependency>
+
+    <!-- Third party dependencies -->
+
+    <!-- Get this dependency from git://github.com/mmazi/bitstamp-api.git :
+      git clone git://github.com/mmazi/bitstamp-api.git
+      cd bitstamp-api
+      mvn clean install
+    -->
+    <dependency>
+      <groupId>si.mazi.bitcoin</groupId>
+      <artifactId>bitstamp-api</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/BitstampExchange.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/BitstampExchange.java
@@ -1,0 +1,31 @@
+package com.xeiam.xchange.bitstamp;
+
+import com.xeiam.xchange.BaseExchange;
+import com.xeiam.xchange.Exchange;
+import com.xeiam.xchange.ExchangeSpecification;
+import com.xeiam.xchange.bitstamp.polling.BitstampPollingMarketDataService;
+
+/**
+ * @author Matija Mazi <br/>
+ * @created 12/30/12 9:36 PM
+ */
+public class BitstampExchange extends BaseExchange implements Exchange {
+  @Override
+  public ExchangeSpecification getDefaultExchangeSpecification() {
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass().getCanonicalName());
+    exchangeSpecification.setUri("https://www.bitstamp.net");
+    exchangeSpecification.setVersion("");
+    exchangeSpecification.setHost("www.bitstamp.net");
+    exchangeSpecification.setPort(80);
+    return exchangeSpecification;
+  }
+
+  @Override
+  public void applySpecification(ExchangeSpecification exchangeSpecification) {
+    if (exchangeSpecification == null) {
+      exchangeSpecification = getDefaultExchangeSpecification();
+    }
+    this.pollingMarketDataService = new BitstampPollingMarketDataService(exchangeSpecification);
+  }
+
+}

--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/polling/BitstampPollingMarketDataService.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/polling/BitstampPollingMarketDataService.java
@@ -1,0 +1,103 @@
+package com.xeiam.xchange.bitstamp.polling;
+
+import com.xeiam.xchange.CurrencyPair;
+import com.xeiam.xchange.ExchangeSpecification;
+import com.xeiam.xchange.dto.Order;
+import com.xeiam.xchange.dto.marketdata.*;
+import com.xeiam.xchange.dto.trade.LimitOrder;
+import com.xeiam.xchange.service.BasePollingExchangeService;
+import com.xeiam.xchange.service.marketdata.polling.PollingMarketDataService;
+import org.joda.money.BigMoney;
+import org.joda.money.CurrencyUnit;
+import org.joda.time.DateTime;
+import si.mazi.bitstampapi.BitStamp;
+import si.mazi.bitstampapi.BitstampFactory;
+import si.mazi.bitstampapi.model.Transaction;
+
+import java.math.BigDecimal;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Matija Mazi <br/>
+ */
+public class BitstampPollingMarketDataService extends BasePollingExchangeService implements PollingMarketDataService {
+  public static final List<CurrencyPair> CURRENCY_PAIRS = Arrays.asList(CurrencyPair.BTC_USD);
+
+  private final BitStamp bitStamp;
+  private static final CurrencyUnit BTC = CurrencyUnit.of("BTC");
+  private static final CurrencyUnit USD = CurrencyUnit.of("USD");
+
+  public BitstampPollingMarketDataService(ExchangeSpecification exchangeSpecification) {
+    super(exchangeSpecification);
+    bitStamp = BitstampFactory.createResteasyEndpoint();
+  }
+
+  @Override
+  public List<CurrencyPair> getExchangeSymbols() {
+    return CURRENCY_PAIRS;
+  }
+
+  @Override
+  public Ticker getTicker(String tradableIdentifier, String currency) {
+    checkArgument(tradableIdentifier.equals(BTC.getCode()));
+    checkArgument(currency.equals(USD.getCode()));
+    si.mazi.bitstampapi.model.Ticker tck = bitStamp.getTicker();
+    return new TickerBuilder()
+        .withAsk(BigMoney.of(USD, tck.getAsk()))
+        .withBid(BigMoney.of(USD, tck.getBid()))
+        .withHigh(BigMoney.of(USD, tck.getHigh()))
+        .withLow(BigMoney.of(USD, tck.getLow()))
+        .withLast(BigMoney.of(USD, tck.getLast()))
+        .withVolume(new BigDecimal(tck.getVolume()))
+        .build();
+  }
+
+  @Override
+  public OrderBook getPartialOrderBook(String tradableIdentifier, String currency) {
+    return getFullOrderBook(tradableIdentifier, currency);
+  }
+
+  @Override
+  public OrderBook getFullOrderBook(String tradableIdentifier, String currency) {
+    si.mazi.bitstampapi.model.OrderBook orderBook = bitStamp.getOrderBook();
+    List<LimitOrder> asks = createOrders(tradableIdentifier, currency, Order.OrderType.ASK, orderBook.getAsks());
+    List<LimitOrder> bids = createOrders(tradableIdentifier, currency, Order.OrderType.BID, orderBook.getBids());
+    return new OrderBook(asks, bids);
+  }
+
+  private List<LimitOrder> createOrders(String tradableIdentifier, String currency, Order.OrderType orderType, List<List<Double>> orders) {
+    List<LimitOrder> limitOrders = new ArrayList<LimitOrder>();
+    for (List<Double> ask : orders) {
+      checkArgument(ask.size() == 2, "Expected a pair (price, amount) but got {0} elements.", ask.size());
+      limitOrders.add(createOrder(tradableIdentifier, currency, ask, orderType));
+    }
+    return limitOrders;
+  }
+
+  private LimitOrder createOrder(String tradableIdentifier, String currency, List<Double> priceAndAmount, Order.OrderType orderType) {
+    return new LimitOrder(orderType, new BigDecimal(priceAndAmount.get(1)), tradableIdentifier, currency, BigMoney.of(CurrencyUnit.USD, priceAndAmount.get(0)));
+  }
+
+  @Override
+  public Trades getTrades(String tradableIdentifier, String currency) {
+    List<Transaction> transactions = bitStamp.getTransactions(24 * 3600); // 24 hours
+    List<Trade> trades = new ArrayList<Trade>();
+    for (Transaction tx : transactions) {
+      trades.add(new Trade(null, new BigDecimal(tx.getAmount()), "BTC", "USD", BigMoney.of(CurrencyUnit.of(currency), tx.getPrice()), new DateTime(tx.getTransactionDate())));
+    }
+    return new Trades(trades);
+  }
+
+  private static void checkArgument(boolean argument) {
+    checkArgument(argument, "Illegal argument.");
+  }
+
+  private static void checkArgument(boolean argument, String msgPattern, Object... msgArgs) {
+    if (!argument) {
+      throw new IllegalArgumentException(MessageFormat.format(msgPattern, msgArgs));
+    }
+  }
+}

--- a/xchange-examples/pom.xml
+++ b/xchange-examples/pom.xml
@@ -57,6 +57,12 @@
 			<artifactId>xchange-btce</artifactId>
 			<version>${currentVersion}</version>
 		</dependency>
+		<!-- XChange Bitstamp exchange support -->
+		<dependency>
+			<groupId>com.xeiam.xchange</groupId>
+			<artifactId>xchange-bitstamp</artifactId>
+			<version>${currentVersion}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>ch.qos.logback</groupId>

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitstamp/marketdata/DepthDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitstamp/marketdata/DepthDemo.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2012 Xeiam LLC http://xeiam.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.xeiam.xchange.examples.bitstamp.marketdata;
+
+import com.xeiam.xchange.Currencies;
+import com.xeiam.xchange.Exchange;
+import com.xeiam.xchange.ExchangeFactory;
+import com.xeiam.xchange.bitstamp.BitstampExchange;
+import com.xeiam.xchange.dto.marketdata.OrderBook;
+import com.xeiam.xchange.service.marketdata.polling.PollingMarketDataService;
+
+/**
+ * Demonstrate requesting Order Book at Bitstamp
+ */
+public class DepthDemo {
+
+  public static void main(String[] args) {
+
+    // Use the factory to get Bitstamp exchange API using default settings
+    Exchange btce = ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class.getName());
+
+    // Interested in the public polling market data feed (no authentication)
+    PollingMarketDataService marketDataService = btce.getPollingMarketDataService();
+
+    // Get the latest order book data for BTC/CAD
+    OrderBook orderBook = marketDataService.getFullOrderBook(Currencies.BTC, Currencies.USD);
+
+    System.out.println(orderBook.toString());
+
+  }
+
+}

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitstamp/marketdata/TickerDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitstamp/marketdata/TickerDemo.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2012 Xeiam LLC http://xeiam.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.xeiam.xchange.examples.bitstamp.marketdata;
+
+import com.xeiam.xchange.Currencies;
+import com.xeiam.xchange.Exchange;
+import com.xeiam.xchange.ExchangeFactory;
+import com.xeiam.xchange.bitstamp.BitstampExchange;
+import com.xeiam.xchange.dto.marketdata.Ticker;
+import com.xeiam.xchange.service.marketdata.polling.PollingMarketDataService;
+
+/**
+ * Demonstrate requesting Order Book at Bitstamp
+ */
+public class TickerDemo {
+
+  public static void main(String[] args) {
+
+    // Use the factory to get Bitstamp exchange API using default settings
+    Exchange btce = ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class.getName());
+//    Exchange btce = ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class.getName());
+
+    // Interested in the public polling market data feed (no authentication)
+    PollingMarketDataService marketDataService = btce.getPollingMarketDataService();
+
+    // Get the latest ticker data showing BTC to CAD
+    Ticker ticker = marketDataService.getTicker(Currencies.BTC, Currencies.USD);
+    double value = ticker.getLast().getAmount().doubleValue();
+    String currency = ticker.getLast().getCurrencyUnit().toString();
+
+    System.out.println("Last: " + currency + "-" + value);
+    System.out.println("Last: " + ticker.getLast().toString());
+    System.out.println("Volume: " + ticker.getVolume().toString());
+    System.out.println("High: " + ticker.getHigh().toString());
+    System.out.println("Low: " + ticker.getLow().toString());
+
+  }
+
+}

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitstamp/marketdata/TradesDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitstamp/marketdata/TradesDemo.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2012 Xeiam LLC http://xeiam.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.xeiam.xchange.examples.bitstamp.marketdata;
+
+import com.xeiam.xchange.Currencies;
+import com.xeiam.xchange.Exchange;
+import com.xeiam.xchange.ExchangeFactory;
+import com.xeiam.xchange.bitstamp.BitstampExchange;
+import com.xeiam.xchange.dto.marketdata.Trades;
+import com.xeiam.xchange.service.marketdata.polling.PollingMarketDataService;
+
+/**
+ * Demonstrate requesting Order Book at Bitstamp
+ */
+public class TradesDemo {
+
+  public static void main(String[] args) {
+
+    // Use the factory to get Bitstamp exchange API using default settings
+    Exchange btce = ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class.getName());
+
+
+    // Interested in the public polling market data feed (no authentication)
+    PollingMarketDataService marketDataService = btce.getPollingMarketDataService();
+
+    // Get the latest trade data for BTC/CAD
+    Trades trades = marketDataService.getTrades(Currencies.BTC, Currencies.USD);
+
+    System.out.println(trades.toString());
+
+  }
+
+}


### PR DESCRIPTION
Hi,

(I requested a pull into master before, sorry; fixing this now with a pull request into the develop branch.)

I've added Bitstamp API to XChange, together with examples. Code organization is the same as with BTC-E API. Currently includes public market data only (ticker, order book, trades).

Currently it's using a dependency on [si.mazi.bitcoin:bitstamp-api](https://github.com/mmazi/bitstamp-api) (instructions included in pom). 

bitstamp-api is a very small library (just the model, the intefrace, a dependency on RestEasy and a few lines of actual code) and I can merge it into XChange if that makes sense. Then it could probably use XChange's model directly which would reduce the code even more.

If this is useful, I might add user trading api etc. in the future.

Matija
