### PR TITLE
Use Apache's cxf-rt-frontend-jaxrs instead of JBoss' resteasy

### DIFF
--- a/xchange-bitstamp-standalone/pom.xml
+++ b/xchange-bitstamp-standalone/pom.xml
@@ -33,26 +33,11 @@
 			<artifactId>jackson-jaxrs</artifactId>
 			<version>1.9.9</version>
 		</dependency>
-		<dependency>
-			<groupId>org.jboss.resteasy</groupId>
-			<artifactId>resteasy-jaxrs</artifactId>
-			<version>${version.resteasy-jaxrs}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.scannotation</groupId>
-					<artifactId>scannotation</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-simple</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.jboss.resteasy</groupId>
-			<artifactId>resteasy-client</artifactId>
-			<version>${version.resteasy-jaxrs}</version>
-		</dependency>
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+      <version>2.6.4</version>
+    </dependency>
 
 	</dependencies>
 

--- a/xchange-bitstamp-standalone/src/main/java/com/xeiam/xchange/bitstamp/api/BitstampFactory.java
+++ b/xchange-bitstamp-standalone/src/main/java/com/xeiam/xchange/bitstamp/api/BitstampFactory.java
@@ -22,11 +22,9 @@
  */
 package com.xeiam.xchange.bitstamp.api;
 
+import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
+import org.apache.cxf.jaxrs.provider.ProviderFactory;
 import org.codehaus.jackson.jaxrs.JacksonJsonProvider;
-import org.jboss.resteasy.client.jaxrs.ResteasyClient;
-import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
-import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
 /**
  * @author Matija Mazi <br/>
@@ -35,15 +33,11 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 public class BitstampFactory {
 
   static {
-    ResteasyProviderFactory factory = ResteasyProviderFactory.getInstance();
-    factory.registerProviderInstance(new JacksonJsonProvider());
-    RegisterBuiltin.register(factory);
+    ProviderFactory factory = ProviderFactory.getSharedInstance();
+    factory.registerUserProvider(new JacksonJsonProvider());
   }
 
   public static BitStamp createResteasyEndpoint() {
-
-    ResteasyClient client = new ResteasyClient();
-    ResteasyWebTarget target = client.target("https://www.bitstamp.net/");
-    return target.proxy(BitStamp.class);
+    return JAXRSClientFactory.create("https://www.bitstamp.net/", BitStamp.class);
   }
 }


### PR DESCRIPTION
Here's an alternative that uses Apache cxf instead of JBoss RestEasy to create the Rest client. This removes some dependencies, but introduces new ones (some of them strange, like geronimo javamail). You can use it in case it makes your CI config easier or something, otherwise just ignore it. It's not a big improvement, if at all, I think.

Here's the new set of dependencies:

[INFO] --- maven-dependency-plugin:2.1:tree (default-cli) @ xchange-bitstamp-standalone ---
[INFO] com.xeiam.xchange:xchange-bitstamp-standalone:jar:1.3.0-SNAPSHOT
[INFO] +- org.codehaus.jackson:jackson-jaxrs:jar:1.9.9:compile
[INFO] |  +- org.codehaus.jackson:jackson-core-asl:jar:1.9.7:compile (version managed from 1.9.9)
[INFO] |  - org.codehaus.jackson:jackson-mapper-asl:jar:1.9.7:compile (version managed from 1.9.9)
[INFO] +- org.apache.cxf:cxf-rt-frontend-jaxrs:jar:2.6.4:compile
[INFO] |  +- org.apache.cxf:cxf-api:jar:2.6.4:compile
[INFO] |  |  +- org.codehaus.woodstox:woodstox-core-asl:jar:4.1.4:runtime
[INFO] |  |  |  - org.codehaus.woodstox:stax2-api:jar:3.1.1:runtime
[INFO] |  |  +- org.apache.ws.xmlschema:xmlschema-core:jar:2.0.3:compile
[INFO] |  |  +- org.apache.geronimo.specs:geronimo-javamail_1.4_spec:jar:1.7.1:compile
[INFO] |  |  - wsdl4j:wsdl4j:jar:1.6.2:compile
[INFO] |  +- org.apache.cxf:cxf-rt-core:jar:2.6.4:compile
[INFO] |  |  - com.sun.xml.bind:jaxb-impl:jar:2.2.5.1:compile
[INFO] |  +- javax.ws.rs:jsr311-api:jar:1.1.1:compile
[INFO] |  +- org.apache.cxf:cxf-rt-bindings-xml:jar:2.6.4:compile
[INFO] |  - org.apache.cxf:cxf-rt-transports-http:jar:2.6.4:compile
[INFO] +- org.hamcrest:hamcrest-library:jar:1.3:test
[INFO] |  - org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] - junit:junit-dep:jar:4.10:test
