### PR TITLE
Convert microseconds to milliseconds; mtgox sends microseconds in order book updates.

### DIFF
--- a/xchange-mtgox/src/main/java/com/xeiam/xchange/mtgox/v1/MtGoxAdapters.java
+++ b/xchange-mtgox/src/main/java/com/xeiam/xchange/mtgox/v1/MtGoxAdapters.java
@@ -208,7 +208,7 @@ public final class MtGoxAdapters {
     String transactionCurrency = mtGoxDepthStream.getPriceCurrency();
     BigMoney price = MtGoxUtils.getPrice(transactionCurrency, mtGoxDepthStream.getPriceInt());
     BigDecimal deltaVolume = new BigDecimal(mtGoxDepthStream.getVolume());
-    long date = mtGoxDepthStream.getDate();
+    long date = mtGoxDepthStream.getDate() / 1000;
 
     OrderBookUpdate depthStream = new OrderBookUpdate(orderType, newVolume, tradableIdentifier, transactionCurrency, date, price, deltaVolume);
     return depthStream;


### PR DESCRIPTION
You might consider changing the interface of an OrderBookUpdate to take a Date rather than a long, pushing the task of creating a Date object down to each exchange adapter. A long in the interface can be misinterpreted to mean seconds, milliseconds, microseconds, etc.
