### PR TITLE
bitfloor module missing in parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
 		<module>xchange-bitcoincharts</module>
 		<module>xchange-bitcoincentral</module>
 		<module>xchange-bitcoin24</module>
+		<module>xchange-bitfloor</module>
 	</modules>
 
 	<dependencyManagement>


### PR DESCRIPTION
mvn clean package doesn't work since the bitfloor module is not added to the parent pom.

Error was:

> [ERROR] Failed to execute goal on project xchange-examples: Could not resolve  dependencies for project com.xeiam.xchange:xchange-examples:jar:develop-SNAPSHOT: Could not find artifact com.xeiam.xchange:xchange-bitfloor:jar:develop-SNAPSHOT -> [Help 1]
