### PR TITLE
Fixed the streaming API

### DIFF
--- a/xchange-core/src/main/java/com/xeiam/xchange/service/streaming/BaseWebSocketExchangeService.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/service/streaming/BaseWebSocketExchangeService.java
@@ -23,6 +23,7 @@ package com.xeiam.xchange.service.streaming;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -68,7 +69,8 @@ public abstract class BaseWebSocketExchangeService extends BaseExchangeService i
     reconnectService = new ReconnectService(this, exchangeStreamingConfiguration);
   }
 
-  protected synchronized void internalConnect(URI uri, ExchangeEventListener exchangeEventListener) {
+  protected synchronized void internalConnect(URI uri, ExchangeEventListener exchangeEventListener,
+                                              Map<String, String> headers) {
 
     log.info("internalConnect");
 
@@ -77,7 +79,7 @@ public abstract class BaseWebSocketExchangeService extends BaseExchangeService i
 
     try {
       log.debug("Attempting to open a websocket against {}", uri);
-      this.exchangeEventProducer = new WebSocketEventProducer(uri.toString(), exchangeEventListener);
+      this.exchangeEventProducer = new WebSocketEventProducer(uri.toString(), exchangeEventListener, headers);
       exchangeEventProducer.connect();
     } catch (URISyntaxException e) {
       throw new ExchangeException("Failed to open websocket!", e);
@@ -106,4 +108,5 @@ public abstract class BaseWebSocketExchangeService extends BaseExchangeService i
     return event;
 
   }
+
 }

--- a/xchange-core/src/main/java/com/xeiam/xchange/service/streaming/WebSocketEventProducer.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/service/streaming/WebSocketEventProducer.java
@@ -21,14 +21,15 @@
  */
 package com.xeiam.xchange.service.streaming;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
 import org.java_websocket.client.WebSocketClient;
-import org.java_websocket.drafts.Draft_10;
+import org.java_websocket.drafts.Draft_17;
 import org.java_websocket.handshake.ServerHandshake;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
 
 /**
  * @author timmolter
@@ -46,9 +47,10 @@ public class WebSocketEventProducer extends WebSocketClient {
    * @param exchangeEventProducer
    * @throws URISyntaxException
    */
-  public WebSocketEventProducer(String url, ExchangeEventListener exchangeEventListener) throws URISyntaxException {
+  public WebSocketEventProducer(String url, ExchangeEventListener exchangeEventListener, Map<String, String> headers)
+          throws URISyntaxException {
 
-    super(new URI(url), new Draft_10());
+    super(new URI(url), new Draft_17(), headers, 0);
     this.exchangeEventListener = exchangeEventListener;
 
   }

--- a/xchange-mtgox/src/main/java/com/xeiam/xchange/mtgox/v1/service/marketdata/streaming/MtGoxWebsocketMarketDataService.java
+++ b/xchange-mtgox/src/main/java/com/xeiam/xchange/mtgox/v1/service/marketdata/streaming/MtGoxWebsocketMarketDataService.java
@@ -22,6 +22,8 @@
 package com.xeiam.xchange.mtgox.v1.service.marketdata.streaming;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,8 +51,8 @@ public class MtGoxWebsocketMarketDataService extends BaseWebSocketExchangeServic
   /**
    * Configured from the super class reading of the exchange specification
    */
-  private final String apiBase = String.format("ws://websocket.%s:%s/mtgox", exchangeSpecification.getHost(), exchangeSpecification.getPort());
 
+  private final String apiBase = String.format("ws://websocket.%s:%s/mtgox", exchangeSpecification.getHost(), exchangeSpecification.getPort());
   private final ExchangeEventListener exchangeEventListener;
 
   /**
@@ -84,11 +86,13 @@ public class MtGoxWebsocketMarketDataService extends BaseWebSocketExchangeServic
   public void connect() {
 
     URI uri = URI.create(apiBase + "?Currency=" + configuration.getCurrencyCode());
+    Map<String, String> headers = new HashMap<String, String>(1);
+    headers.put("Origin", String.format("%s:%s", exchangeSpecification.getHost(), exchangeSpecification.getPort()));
 
     logger.debug("Streaming URI='{}'", uri);
 
     // Use the default internal connect
-    internalConnect(uri, exchangeEventListener);
+    internalConnect(uri, exchangeEventListener, headers);
   }
 
 }


### PR DESCRIPTION
Yesterday the streaming API was working great but suddenly it stop working.

I joined #mtgox @ freenode and a developer told me that there was a bug and I would need to set the `Origin` header by hand.

After changing that it continue failing so I compared the request generated by XChange and goxtool. There was an issue with the protocol to be used. To solve that, I changed from `draft_10` to `draft_17`.
