### PR TITLE
BTCE getTrades returns only orders with typ "ASK"

### DIFF
--- a/xchange-btce/src/main/java/com/xeiam/xchange/btce/BTCEAdapters.java
+++ b/xchange-btce/src/main/java/com/xeiam/xchange/btce/BTCEAdapters.java
@@ -118,7 +118,7 @@ public final class BTCEAdapters {
    */
   public static Trade adaptTrade(BTCETrade BTCETrade) {
 
-    OrderType orderType = BTCETrade.equals("bid") ? OrderType.BID : OrderType.ASK;
+    OrderType orderType = BTCETrade.getTradeType().equalsIgnoreCase("bid") ? OrderType.BID : OrderType.ASK;
     BigDecimal amount = BTCETrade.getAmount();
     String currency = BTCETrade.getPriceCurrency();
     BigMoney price = MoneyUtils.parse(currency + " " + BTCETrade.getPrice());


### PR DESCRIPTION
I fixed the check for the order type in the BTCEAdapters class.

BTCETrade.equals("bid") ? OrderType.BID : OrderType.ASK;
to
BTCETrade.getTradeType().equalsIgnoreCase("bid") ? OrderType.BID : OrderType.ASK;
