### PR TITLE
Bug fix: Tests were locale-dependent and would fail on non US locales

### DIFF
--- a/xchange-btce/src/test/java/com/xeiam/xchange/btce/service/marketdata/BTCETickerJSONTest.java
+++ b/xchange-btce/src/test/java/com/xeiam/xchange/btce/service/marketdata/BTCETickerJSONTest.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
 import java.util.TimeZone;
+import java.util.Locale;
 
 import org.junit.Test;
 
@@ -58,7 +59,7 @@ public class BTCETickerJSONTest {
     assertThat("Unexpected Return Low value", BTCETicker.getTicker().getLow(), equalTo(new BigDecimal("13")));
     assertThat("Unexpected Return Volume value", BTCETicker.getTicker().getVol(), equalTo(new BigDecimal("40418.44988")));
 
-    SimpleDateFormat f = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss");
+    SimpleDateFormat f = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss", Locale.US );
     f.setTimeZone(TimeZone.getTimeZone("UTC"));
     String dateString = f.format(DateUtils.fromMillisUtc(BTCETicker.getTicker().getServerTime() * 1000L));
     assertTrue("timestamp should convert to a UTC String", dateString.equals("2012-Dec-22 19:12:09"));

--- a/xchange-mtgox/src/test/java/com/xeiam/xchange/mtgox/v1/service/MtGoxAdapterTest.java
+++ b/xchange-mtgox/src/test/java/com/xeiam/xchange/mtgox/v1/service/MtGoxAdapterTest.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -82,6 +83,7 @@ public class MtGoxAdapterTest {
 
   @Test
   public void testOrderAdapterWithOpenOrders() throws IOException {
+    final String correctTimestampString = "2012-Apr-08 14:59:11";
 
     // Read in the JSON from the example resources
     InputStream is = MtGoxAdapterTest.class.getResourceAsStream("/v1/trade/example-openorders-data.json");
@@ -103,11 +105,12 @@ public class MtGoxAdapterTest {
     assertTrue("tradableIdentifier should be BTC", openorders.get(0).getTradableIdentifier().equals("BTC"));
     assertTrue("transactionCurrency should be USD", openorders.get(0).getTransactionCurrency().equals("USD"));
 
-    SimpleDateFormat f = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss");
+    SimpleDateFormat f = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss", Locale.US );
     f.setTimeZone(TimeZone.getTimeZone("UTC"));
     String dateString = f.format(openorders.get(0).getTimestamp());
-    // System.out.println(dateString);
-    assertTrue("transactionCurrency should be USD", dateString.equals("2012-Apr-08 14:59:11"));
+    System.out.println(dateString);
+    assertTrue( "dateString should be '" + correctTimestampString + "', but was '" + dateString + "'",
+                dateString.equals( correctTimestampString ) );
   }
 
   @Test


### PR DESCRIPTION
BTC-e and MtGox Tests were locale-dependent and would fail on non-US locales.
One of the test error messages was wrong.
