### PR TITLE
Upgrade to rescu 1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
 			<dependency>
 				<groupId>com.github.mmazi</groupId>
 				<artifactId>rescu</artifactId>
-				<version>1.1.0</version>
+				<version>1.2.0-SNAPSHOT</version>
 			</dependency>
 
 		</dependencies>

--- a/xchange-btce/src/main/java/com/xeiam/xchange/btce/service/BTCEHmacPostBodyDigest.java
+++ b/xchange-btce/src/main/java/com/xeiam/xchange/btce/service/BTCEHmacPostBodyDigest.java
@@ -32,7 +32,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestInvocationParams;
+import si.mazi.rescu.RestInvocation;
 
 /**
  * This may be used as the value of a @HeaderParam, @QueryParam or @PathParam to create a digest of the post body (composed of @FormParam's). Don't use as the value of a @FormParam, it will probably
@@ -73,10 +73,10 @@ public class BTCEHmacPostBodyDigest implements ParamsDigest {
   }
 
   @Override
-  public String digestParams(RestInvocationParams restInvocationParams) {
+  public String digestParams(RestInvocation RestInvocation) {
 
     try {
-      String postBody = restInvocationParams.getRequestBody();
+      String postBody = RestInvocation.getRequestBody();
       mac.update(postBody.getBytes("UTF-8"));
       return String.format("%0128x", new BigInteger(1, mac.doFinal()));
     } catch (UnsupportedEncodingException e) {

--- a/xchange-mtgox/src/main/java/com/xeiam/xchange/mtgox/v2/service/MtGoxV2Digest.java
+++ b/xchange-mtgox/src/main/java/com/xeiam/xchange/mtgox/v2/service/MtGoxV2Digest.java
@@ -30,7 +30,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestInvocationParams;
+import si.mazi.rescu.RestInvocation;
 import si.mazi.rescu.utils.Base64;
 
 /**
@@ -68,11 +68,11 @@ public class MtGoxV2Digest implements ParamsDigest {
   }
 
   @Override
-  public String digestParams(RestInvocationParams restInvocationParams) {
+  public String digestParams(RestInvocation RestInvocation) {
 
-    mac.update(restInvocationParams.getMethodPath().getBytes());
+    mac.update(RestInvocation.getMethodPath().getBytes());
     mac.update(new byte[] { 0 });
-    mac.update(restInvocationParams.getRequestBody().getBytes());
+    mac.update(RestInvocation.getRequestBody().getBytes());
 
     return Base64.encodeBytes(mac.doFinal()).trim();
   }


### PR DESCRIPTION
A public API class was renamed in rescu today. Because of this, rescu was promoted to 1.2. Use this patch to upgrade, when desired. (1.2 is still SNAPSHOT.)
