### PR TITLE
Make BTCE adaptTradeHistory convert timestamps to milliseconds

### DIFF
--- a/xchange-btce/src/main/java/com/xeiam/xchange/btce/BTCEAdapters.java
+++ b/xchange-btce/src/main/java/com/xeiam/xchange/btce/BTCEAdapters.java
@@ -195,7 +195,7 @@ public final class BTCEAdapters {
       String[] pair = bTCEOrder.getPair().split("_");
       String currency = pair[1].toUpperCase();
       BigMoney price = BigMoney.of(CurrencyUnit.of(currency), bTCEOrder.getRate());
-      Date timestamp = new Date(bTCEOrder.getTimestampCreated() * 1000);
+      Date timestamp = DateUtils.fromMillisUtc(bTCEOrder.getTimestampCreated() * 1000L);
       limitOrders.add(new LimitOrder(orderType, bTCEOrder.getAmount(), pair[0].toUpperCase(), currency, Long.toString(id), timestamp, price));
     }
     return new OpenOrders(limitOrders);
@@ -212,7 +212,7 @@ public final class BTCEAdapters {
       String transactionCurrency = pair[1].toUpperCase();
       BigMoney price = BigMoney.of(CurrencyUnit.of(transactionCurrency), result.getRate());
       BigDecimal tradableAmount = result.getAmount();
-      Date timeStamp = new Date(result.getTimestamp());
+      Date timeStamp = DateUtils.fromMillisUtc(result.getTimestamp() * 1000L);
       trades.add(new Trade(type, tradableAmount, tradableIdentifier, transactionCurrency, price, timeStamp, entry.getKey()));
     }
     return new Trades(trades);

--- a/xchange-btce/src/test/java/com/xeiam/xchange/btce/service/BTCEAdapterTest.java
+++ b/xchange-btce/src/test/java/com/xeiam/xchange/btce/service/BTCEAdapterTest.java
@@ -132,6 +132,6 @@ public class BTCEAdapterTest {
     assertThat(lastTrade.getId()).isEqualTo(7258275L);
     assertThat(lastTrade.getType()).isEqualTo(OrderType.ASK);
     assertThat(lastTrade.getPrice()).isEqualTo(MoneyUtils.parse("USD 125.75"));
-    assertThat(lastTrade.getTimestamp().getTime()).isEqualTo(1378194574L);
+    assertThat(lastTrade.getTimestamp().getTime()).isEqualTo(1378194574000L);
   }
 }


### PR DESCRIPTION
This was missing in the BTCEAdapters which resulted in wrong parsing of trade history.
