### PR TITLE
open orders contains transaction currency

### DIFF
--- a/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/KrakenAdapters.java
+++ b/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/KrakenAdapters.java
@@ -21,18 +21,6 @@
  */
 package com.xeiam.xchange.kraken;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import org.joda.money.BigMoney;
-import org.joda.money.CurrencyUnit;
-
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
@@ -46,6 +34,12 @@ import com.xeiam.xchange.dto.trade.Wallet;
 import com.xeiam.xchange.kraken.dto.account.KrakenBalanceResult;
 import com.xeiam.xchange.kraken.dto.marketdata.KrakenTicker;
 import com.xeiam.xchange.kraken.dto.trade.KrakenOpenOrder;
+import org.joda.money.BigMoney;
+import org.joda.money.CurrencyUnit;
+
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.Map.Entry;
 
 public class KrakenAdapters {
 
@@ -132,11 +126,17 @@ public class KrakenAdapters {
       String[] descriptionWords = krakenOrder.getValue().getDescription().getOrderDescription().split(" ");
       OrderType type = descriptionWords[0].equals("buy") ? OrderType.BID : OrderType.ASK;
       BigDecimal tradableAmount = krakenOrder.getValue().getVolume().subtract(krakenOrder.getValue().getVolumeExecuted());
-      String tradableIdentifier = KrakenUtils.getStandardCurrencyCode(descriptionWords[2].substring(0, 3));
-      String transactionCurrency = KrakenUtils.getStandardCurrencyCode(descriptionWords[2].substring(3));
+
+      int wordOffset = 0;
+      if (descriptionWords[2].startsWith("(") && descriptionWords[2].endsWith(")")) {
+          wordOffset = 1;
+      }
+
+      String tradableIdentifier = KrakenUtils.getStandardCurrencyCode(descriptionWords[2 + wordOffset].substring(0, 3));
+      String transactionCurrency = KrakenUtils.getStandardCurrencyCode(descriptionWords[2 + wordOffset].substring(3));
       String id = krakenOrder.getKey();
       Date timestamp = new Date((long) (krakenOrder.getValue().getOpentm() * 1000L));
-      BigMoney limitPrice = BigMoney.of(CurrencyUnit.of(transactionCurrency), new BigDecimal(descriptionWords[5]));
+      BigMoney limitPrice = BigMoney.of(CurrencyUnit.of(transactionCurrency), new BigDecimal(descriptionWords[5 + wordOffset]));
       LimitOrder order = new LimitOrder(type, tradableAmount, tradableIdentifier, transactionCurrency, id, timestamp, limitPrice);
       limitOrders.add(order);
     }

--- a/xchange-kraken/src/test/java/com/xeiam/xchange/kraken/service/KrakenAdaptersTest.java
+++ b/xchange-kraken/src/test/java/com/xeiam/xchange/kraken/service/KrakenAdaptersTest.java
@@ -21,19 +21,6 @@
  */
 package com.xeiam.xchange.kraken.service;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.math.BigDecimal;
-import java.util.Date;
-import java.util.List;
-
-import org.joda.money.BigMoney;
-import org.joda.money.CurrencyUnit;
-import org.junit.Assert;
-import org.junit.Test;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.xeiam.xchange.currency.Currencies;
 import com.xeiam.xchange.currency.CurrencyPair;
@@ -51,6 +38,18 @@ import com.xeiam.xchange.kraken.service.marketdata.KrakenAssetPairsJSONTest;
 import com.xeiam.xchange.kraken.service.marketdata.KrakenTickerJSONTest;
 import com.xeiam.xchange.kraken.service.marketdata.KrakenTradesJSONTest;
 import com.xeiam.xchange.kraken.service.trading.KrakenOpenOrdersTest;
+import org.joda.money.BigMoney;
+import org.joda.money.CurrencyUnit;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.List;
+
+import static org.fest.assertions.api.Assertions.assertThat;
 
 public class KrakenAdaptersTest {
 
@@ -138,4 +137,25 @@ public class KrakenAdaptersTest {
     assertThat(orders.getOpenOrders().get(0).getTransactionCurrency()).isEqualTo(Currencies.EUR);
 
   }
+
+  @Test
+  public void testAdaptOpenOrdersInTransactionCurrency() throws IOException {
+
+    // Read in the JSON from the example resources
+    InputStream is = KrakenOpenOrdersTest.class.getResourceAsStream("/trading/example-openorders-in-transaction-currency-data.json");
+
+    // Use Jackson to parse it
+    ObjectMapper mapper = new ObjectMapper();
+    KrakenOpenOrdersResult krakenResult = mapper.readValue(is, KrakenOpenOrdersResult.class);
+    OpenOrders orders = KrakenAdapters.adaptOpenOrders(krakenResult.getResult().getOrders());
+    // Verify that the example data was unmarshalled correctly
+    assertThat(orders.getOpenOrders()).hasSize(1);
+    assertThat(orders.getOpenOrders().get(0).getId()).isEqualTo("OR6QMM-BCKM4-Q6YHIN");
+    assertThat(orders.getOpenOrders().get(0).getLimitPrice().getAmount()).isEqualTo("1.00000");
+    assertThat(orders.getOpenOrders().get(0).getTradableAmount()).isEqualTo("1.00000000");
+    assertThat(orders.getOpenOrders().get(0).getTradableIdentifier()).isEqualTo(Currencies.BTC);
+    assertThat(orders.getOpenOrders().get(0).getTransactionCurrency()).isEqualTo(Currencies.EUR);
+
+  }
+
 }

--- a/xchange-kraken/src/test/resources/trading/example-openorders-in-transaction-currency-data.json
+++ b/xchange-kraken/src/test/resources/trading/example-openorders-in-transaction-currency-data.json
@@ -1,0 +1,27 @@
+{
+   "error":[
+
+   ],
+   "result":{
+      "open":{
+         "OR6QMM-BCKM4-Q6YHIN":{
+            "refid":null,
+            "userref":null,
+            "status":"open",
+            "opentm":1380586080.222,
+            "starttm":0,
+            "expiretm":0,
+            "descr":{
+               "order":"buy 1.00000000 (EUR) XBTEUR @ limit 1.00000"
+            },
+            "vol":"1.00000000",
+            "vol_exec":"0.00000000",
+            "cost":"0.00000",
+            "fee":"0.00000",
+            "price":"0.00000",
+            "misc":"",
+            "oflags":""
+         }
+      }
+   }
+}


### PR DESCRIPTION
add test and patch for Kraken open order description containing (EUR) when the transaction currency is EUR
