### PR TITLE
Added tradingfee to accountinfo for bitstamp and mtgox

### DIFF
--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/BitstampAdapters.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/BitstampAdapters.java
@@ -21,16 +21,6 @@
  */
 package com.xeiam.xchange.bitstamp;
 
-import java.math.BigDecimal;
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-
-import org.joda.money.BigMoney;
-import org.joda.money.CurrencyUnit;
-
 import com.xeiam.xchange.bitstamp.dto.account.BitstampBalance;
 import com.xeiam.xchange.bitstamp.dto.marketdata.BitstampOrderBook;
 import com.xeiam.xchange.bitstamp.dto.marketdata.BitstampTicker;
@@ -49,6 +39,14 @@ import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.trade.LimitOrder;
 import com.xeiam.xchange.dto.trade.Wallet;
 import com.xeiam.xchange.utils.DateUtils;
+import java.math.BigDecimal;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import org.joda.money.BigMoney;
+import org.joda.money.CurrencyUnit;
 
 /**
  * Various adapters for converting from Bitstamp DTOs to XChange DTOs
@@ -64,7 +62,7 @@ public final class BitstampAdapters {
 
   /**
    * Adapts a BitstampBalance to a AccountInfo
-   * 
+   *
    * @param bitstampBalance The Bitstamp balance
    * @param userName The user name
    * @return The account info
@@ -75,12 +73,12 @@ public final class BitstampAdapters {
     Wallet usdWallet = Wallet.createInstance(Currencies.USD, bitstampBalance.getUsdBalance());
     Wallet btcWallet = Wallet.createInstance(Currencies.BTC, bitstampBalance.getBtcBalance());
 
-    return new AccountInfo(userName, Arrays.asList(usdWallet, btcWallet));
+    return new AccountInfo(userName, bitstampBalance.getFee(), Arrays.asList(usdWallet, btcWallet));
   }
 
   /**
    * Adapts a com.xeiam.xchange.bitstamp.api.model.OrderBook to a OrderBook Object
-   * 
+   *
    * @param bitstampOrderBook The bitstamp order book
    * @param tradableIdentifier The tradable identifier (e.g. BTC in BTC/USD)
    * @param currency The currency (e.g. USD in BTC/USD)
@@ -118,7 +116,7 @@ public final class BitstampAdapters {
 
   /**
    * Adapts a Transaction[] to a Trades Object
-   * 
+   *
    * @param transactions The Bitstamp transactions
    * @param tradableIdentifier The tradeable identifier (e.g. BTC in BTC/USD)
    * @param currency The currency (e.g. USD in BTC/USD)
@@ -136,7 +134,7 @@ public final class BitstampAdapters {
 
   /**
    * Adapts a BitstampTicker to a Ticker Object
-   * 
+   *
    * @param bitstampTicker The exchange specific ticker
    * @param tradableIdentifier The tradeable identifier (e.g. BTC in BTC/USD)
    * @param currency The currency (e.g. USD in BTC/USD)
@@ -159,7 +157,7 @@ public final class BitstampAdapters {
 
   /**
    * Adapt the user's trades
-   * 
+   *
    * @param bitstampUserTransactions
    * @return
    */

--- a/xchange-bitstamp/src/test/java/com/xeiam/xchange/bitstamp/BitstampAdapterTest.java
+++ b/xchange-bitstamp/src/test/java/com/xeiam/xchange/bitstamp/BitstampAdapterTest.java
@@ -1,16 +1,16 @@
 /**
  * Copyright (C) 2012 - 2013 Xeiam LLC http://xeiam.com
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
  * of the Software, and to permit persons to whom the Software is furnished to do
  * so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,16 +20,6 @@
  * SOFTWARE.
  */
 package com.xeiam.xchange.bitstamp;
-
-import static org.fest.assertions.api.Assertions.assertThat;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.math.BigDecimal;
-import java.text.SimpleDateFormat;
-import java.util.TimeZone;
-
-import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.xeiam.xchange.bitstamp.dto.account.BitstampBalance;
@@ -43,6 +33,13 @@ import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
 import com.xeiam.xchange.dto.marketdata.Trades;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+import static org.fest.assertions.api.Assertions.assertThat;
+import org.junit.Test;
 
 /**
  * Tests the BitstampAdapter class
@@ -61,6 +58,7 @@ public class BitstampAdapterTest {
 
     AccountInfo accountInfo = BitstampAdapters.adaptAccountInfo(bitstampBalance, "Joe Mama");
     assertThat(accountInfo.getUsername()).isEqualTo("Joe Mama");
+    assertThat(accountInfo.getTradingFee()).isEqualTo(new BigDecimal("0.5000"));
     assertThat(accountInfo.getWallets().get(0).getCurrency()).isEqualTo("USD");
     assertThat(accountInfo.getWallets().get(0).getBalance()).isEqualTo(MoneyUtils.parse("USD 172.87"));
     assertThat(accountInfo.getWallets().get(1).getCurrency()).isEqualTo("BTC");

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChinaAdapters.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChinaAdapters.java
@@ -21,15 +21,6 @@
  */
 package com.xeiam.xchange.btcchina;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
-import org.joda.money.BigMoney;
-import org.joda.money.CurrencyUnit;
-
 import com.xeiam.xchange.btcchina.dto.BTCChinaResponse;
 import com.xeiam.xchange.btcchina.dto.BTCChinaValue;
 import com.xeiam.xchange.btcchina.dto.account.BTCChinaAccountInfo;
@@ -49,6 +40,13 @@ import com.xeiam.xchange.dto.trade.LimitOrder;
 import com.xeiam.xchange.dto.trade.OpenOrders;
 import com.xeiam.xchange.dto.trade.Wallet;
 import com.xeiam.xchange.utils.DateUtils;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import org.joda.money.BigMoney;
+import org.joda.money.CurrencyUnit;
 
 /**
  * Various adapters for converting from BTCChina DTOs to XChange DTOs
@@ -64,7 +62,7 @@ public final class BTCChinaAdapters {
 
   /**
    * Adapts a List of btcchinaOrders to a List of LimitOrders
-   * 
+   *
    * @param btcchinaOrders
    * @param currency
    * @param orderType
@@ -84,7 +82,7 @@ public final class BTCChinaAdapters {
 
   /**
    * Adapts a BTCChinaOrder to a LimitOrder
-   * 
+   *
    * @param amount
    * @param price
    * @param currency
@@ -104,7 +102,7 @@ public final class BTCChinaAdapters {
 
   /**
    * Adapts a BTCChinaTrade to a Trade Object
-   * 
+   *
    * @param btcChinaTrade A BTCChina trade
    * @return The XChange Trade
    */
@@ -119,7 +117,7 @@ public final class BTCChinaAdapters {
 
   /**
    * Adapts a BTCChinaTrade[] to a Trades Object
-   * 
+   *
    * @param btcchinaTrades The BTCChina trade data
    * @return The trades
    */
@@ -139,7 +137,7 @@ public final class BTCChinaAdapters {
 
   /**
    * Adapts a BTCChinaTicker to a Ticker Object
-   * 
+   *
    * @param btcChinaTicker
    * @return
    */
@@ -157,14 +155,14 @@ public final class BTCChinaAdapters {
 
   /**
    * Adapts a BTCChinaAccountInfoResponse to AccountInfo Object
-   * 
+   *
    * @param response
    * @return
    */
   public static AccountInfo adaptAccountInfo(BTCChinaResponse<BTCChinaAccountInfo> response) {
 
     BTCChinaAccountInfo result = response.getResult();
-    return new AccountInfo(result.getProfile().getUsername(), BTCChinaAdapters.adaptWallets(result.getBalances(), result.getFrozens()));
+    return new AccountInfo(result.getProfile().getUsername(), result.getProfile().getTradeFee(), BTCChinaAdapters.adaptWallets(result.getBalances(), result.getFrozens()));
   }
 
   // /**
@@ -200,7 +198,7 @@ public final class BTCChinaAdapters {
 
   /**
    * Adapts BTCChinaValue balance, BTCChinaValue frozen to wallet
-   * 
+   *
    * @param balance
    * @param frozen
    * @return
@@ -249,7 +247,7 @@ public final class BTCChinaAdapters {
 
   /**
    * Adapts BTCChinaOrder to LimitOrder
-   * 
+   *
    * @param order
    * @return
    */

--- a/xchange-core/src/main/java/com/xeiam/xchange/dto/account/AccountInfo.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/dto/account/AccountInfo.java
@@ -21,12 +21,11 @@
  */
 package com.xeiam.xchange.dto.account;
 
+import com.xeiam.xchange.dto.trade.Wallet;
+import java.math.BigDecimal;
 import java.util.List;
-
 import org.joda.money.BigMoney;
 import org.joda.money.CurrencyUnit;
-
-import com.xeiam.xchange.dto.trade.Wallet;
 
 /**
  * <p>
@@ -39,6 +38,7 @@ import com.xeiam.xchange.dto.trade.Wallet;
 public final class AccountInfo {
 
   private final String username;
+  private final BigDecimal tradingFee;
   private final List<Wallet> wallets;
 
   /**
@@ -46,8 +46,17 @@ public final class AccountInfo {
    * @param wallets The available wallets
    */
   public AccountInfo(String username, List<Wallet> wallets) {
+    this(username, null, wallets);
+  }
 
+  /**
+   * @param username The user name
+   * @param tradingFee the trading fee
+   * @param wallets The available wallets
+   */
+  public AccountInfo(String username, BigDecimal tradingFee, List<Wallet> wallets) {
     this.username = username;
+    this.tradingFee = tradingFee;
     this.wallets = wallets;
   }
 
@@ -68,8 +77,19 @@ public final class AccountInfo {
   }
 
   /**
+   * Returns the current trading fee
+   *
+   * @return The trading fee
+   */
+  public BigDecimal getTradingFee() {
+
+    return tradingFee;
+  }
+
+
+  /**
    * Utility method to locate an exchange balance in the given currency
-   * 
+   *
    * @param currencyUnit A valid currency unit (e.g. CurrencyUnit.USD or CurrencyUnit.of("BTC"))
    * @return The balance, or zero if not found
    */


### PR DESCRIPTION
I think it is useful to add the tradingfee as a field to accountinfo. Currently the tradingfee can be obtained from MtGox and from Bitstamp.
