### PR TITLE
Fix btceV2 depth by lowercasing arguments

### DIFF
--- a/xchange-btce/src/main/java/com/xeiam/xchange/btce/v2/service/polling/BTCEPollingMarketDataService.java
+++ b/xchange-btce/src/main/java/com/xeiam/xchange/btce/v2/service/polling/BTCEPollingMarketDataService.java
@@ -80,7 +80,7 @@ public class BTCEPollingMarketDataService implements PollingMarketDataService {
 
     verify(tradableIdentifier, currency);
 
-    BTCEDepth btceDepth = btce.getDepth(tradableIdentifier, currency);
+    BTCEDepth btceDepth = btce.getDepth(tradableIdentifier.toLowerCase(), currency.toLowerCase());
     // Adapt to XChange DTOs
     List<LimitOrder> asks = BTCEAdapters.adaptOrders(btceDepth.getAsks(), tradableIdentifier, currency, "ask", "");
     List<LimitOrder> bids = BTCEAdapters.adaptOrders(btceDepth.getBids(), tradableIdentifier, currency, "bid", "");


### PR DESCRIPTION
For some reason this was missing, perhaps due to refactor to v2 and v3.
