### PR TITLE
Bitfinex public trade modified to have underlying timestamp as ID

### DIFF
--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/BitfinexAdapters.java
@@ -86,7 +86,7 @@ public final class BitfinexAdapters {
 		BigMoney price = MoneyUtils.parseMoney(currency, trade.getPrice());
 		Date date = DateUtils.fromMillisUtc((long)(trade.getTimestamp()*1000L));
 
-		return new Trade(orderType, amount, tradableIdentifier, currency, price, date, trade.hashCode());
+		return new Trade(orderType, amount, tradableIdentifier, currency, price, date, (int)trade.getTimestamp());
 	}
 
 	public static Trades adaptTrades(BitfinexTrade[] trades, String tradableIdentifier, String currency) {

--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/dto/marketdata/BitfinexTrade.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/dto/marketdata/BitfinexTrade.java
@@ -53,46 +53,6 @@ public class BitfinexTrade {
 		return exchange;
 	}
 	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((amount == null) ? 0 : amount.hashCode());
-		result = prime * result
-				+ ((exchange == null) ? 0 : exchange.hashCode());
-		result = prime * result + ((price == null) ? 0 : price.hashCode());
-		result = prime * result + Float.floatToIntBits(timestamp);
-		return result;
-	}
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		BitfinexTrade other = (BitfinexTrade) obj;
-		if (amount == null) {
-			if (other.amount != null)
-				return false;
-		} else if (!amount.equals(other.amount))
-			return false;
-		if (exchange == null) {
-			if (other.exchange != null)
-				return false;
-		} else if (!exchange.equals(other.exchange))
-			return false;
-		if (price == null) {
-			if (other.price != null)
-				return false;
-		} else if (!price.equals(other.price))
-			return false;
-		if (Float.floatToIntBits(timestamp) != Float
-				.floatToIntBits(other.timestamp))
-			return false;
-		return true;
-	}
-	@Override
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
 		builder.append("BitfinexTrade [price=");


### PR DESCRIPTION
As public trades have no ID, I currently set the id to the integer value of its timestamp in the adapter.
