### PR TITLE
Issue #268 (https://github.com/timmolter/XChange/issues/268):

### DIFF
--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/dto/trade/BitstampErrorDeserializer.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/dto/trade/BitstampErrorDeserializer.java
@@ -1,0 +1,36 @@
+package com.xeiam.xchange.bitstamp.dto.trade;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+
+public class BitstampErrorDeserializer extends JsonDeserializer<String> {
+	@Override
+	public String deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+		ObjectCodec oc = jsonParser.getCodec();
+		JsonNode node = oc.readTree(jsonParser);
+		if (node.isTextual()) {
+			return node.textValue();
+		} else if (node.isObject()) {
+			JsonNode allNode = node.get("__all__");
+			if (allNode != null && allNode.isArray()) {
+				StringBuffer buf = new StringBuffer();
+				for (JsonNode msgNode : allNode) {
+					buf.append(msgNode.textValue());
+					buf.append(",");
+				}
+
+				return buf.length() > 0 ? buf.substring(0, buf.length() - 1) : buf.toString();
+			}
+
+			return node.toString();
+		}
+
+		return null;
+	}
+}

--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/dto/trade/BitstampOrder.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/dto/trade/BitstampOrder.java
@@ -26,6 +26,7 @@ import java.util.Date;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.xeiam.xchange.bitstamp.BitstampUtils;
 
 /**
@@ -39,6 +40,7 @@ public final class BitstampOrder {
   private final int type;
   private final BigDecimal price;
   private final BigDecimal amount;
+  private final String errorMessage;
 
   /**
    * Constructor
@@ -50,13 +52,14 @@ public final class BitstampOrder {
    * @param amount
    */
   public BitstampOrder(@JsonProperty("id") int id, @JsonProperty("datetime") String datetime, @JsonProperty("type") int type, @JsonProperty("price") BigDecimal price,
-      @JsonProperty("amount") BigDecimal amount) {
+      @JsonProperty("amount") BigDecimal amount, @JsonProperty("error") @JsonDeserialize(using = BitstampErrorDeserializer.class) String errorMessage) {
 
     this.id = id;
     this.datetime = datetime;
     this.type = type;
     this.price = price;
     this.amount = amount;
+    this.errorMessage = errorMessage;
   }
 
   public String getDatetime() {
@@ -90,9 +93,14 @@ public final class BitstampOrder {
     return BitstampUtils.parseDate(getDatetime());
   }
 
+  @JsonIgnore
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
   @Override
   public String toString() {
 
-    return String.format("Order{id=%s, datetime=%s, type=%s, price=%s, amount=%s}", id, datetime, type, price, amount);
+    return errorMessage != null ? errorMessage : String.format("Order{id=%s, datetime=%s, type=%s, price=%s, amount=%s}", id, datetime, type, price, amount);
   }
 }

--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/polling/BitstampTradeService.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/polling/BitstampTradeService.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.xeiam.xchange.ExchangeException;
 import org.joda.money.BigMoney;
 import org.joda.money.CurrencyUnit;
 
@@ -101,6 +102,10 @@ public class BitstampTradeService extends BasePollingExchangeService implements 
     else {
       bitstampOrder = bitstampAuthenticated.sell(exchangeSpecification.getApiKey(), signatureCreator, BitstampUtils.getNonce(), limitOrder.getTradableAmount(), limitOrder.getLimitPrice().getAmount());
     }
+    if (bitstampOrder.getErrorMessage() != null) {
+      throw new ExchangeException(bitstampOrder.getErrorMessage());
+    }
+
     return Integer.toString(bitstampOrder.getId());
   }
 

--- a/xchange-bitstamp/src/test/java/com/xeiam/xchange/bitstamp/service/trade/PlaceLimitOrderJSONTest.java
+++ b/xchange-bitstamp/src/test/java/com/xeiam/xchange/bitstamp/service/trade/PlaceLimitOrderJSONTest.java
@@ -52,4 +52,17 @@ public class PlaceLimitOrderJSONTest {
     assertThat(newOrder.getPrice()).isEqualTo(new BigDecimal("1.25"));
     assertThat(newOrder.getType()).isEqualTo(0);
   }
+
+  @Test
+  public void testError() throws IOException {
+
+    // Read in the JSON from the example resources
+    InputStream is = PlaceLimitOrderJSONTest.class.getResourceAsStream("/trade/example-place-limit-order-error.json");
+
+    // Use Jackson to parse it
+    ObjectMapper mapper = new ObjectMapper();
+    BitstampOrder response = mapper.readValue(is, BitstampOrder.class);
+
+    assertThat(response.getErrorMessage()).isEqualTo("Minimum order size is $1");
+  }
 }

--- a/xchange-bitstamp/src/test/resources/errors.json
+++ b/xchange-bitstamp/src/test/resources/errors.json
@@ -2,3 +2,4 @@
 {"error": "API access disabled. Check your user settings."}
 {"error": {"__all__": ["You need $1.26 to open that order. You have only $0.0 available. Check your account balance for details."]}}
 {"error": "Order not found"}
+{"error": {"__all__": ["Minimum order size is $1"]}}

--- a/xchange-bitstamp/src/test/resources/trade/example-place-limit-order-error.json
+++ b/xchange-bitstamp/src/test/resources/trade/example-place-limit-order-error.json
@@ -1,0 +1,1 @@
+{"error": {"__all__": ["Minimum order size is $1"]}}


### PR DESCRIPTION
-if the JSON returned from the server contains an "error" entry, deserialize this value and return it to the user.
-since it appears the server will sometimes return a single string containing an error message and other times may return an object containing an array of messages, a custom serializer was required to boil that down into a single string
