### PR TITLE
changed how open orders at Kraken are fetched and parsed

### DIFF
--- a/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/dto/trade/KrakenOrderDescription.java
+++ b/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/dto/trade/KrakenOrderDescription.java
@@ -21,19 +21,42 @@
  */
 package com.xeiam.xchange.kraken.dto.trade;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenOrderDescription {
 
-  private String order;
+	private String pair;
+	private String type;
+	private String orderType;
+	private String price;
 
-  public KrakenOrderDescription(@JsonProperty("order") String order) {
+	public KrakenOrderDescription(@JsonProperty("pair") String pair,
+			@JsonProperty("type") String type,
+			@JsonProperty("ordertype") String orderType,
+			@JsonProperty("price") String price) {
 
-    this.order = order;
-  }
+		this.pair      = pair;
+		this.type      = type;
+		this.orderType = orderType;
+		this.price     = price;
+	}
 
-  public String getOrderDescription() {
+	public String getPair() {
+		return pair;
+	}
 
-    return order;
-  }
+	public String getType() {
+		return type;
+	}
+
+	public String getOrderType() {
+		return orderType;
+	}
+
+	public String getPrice() {
+		return price;
+	}
+	  
 }

--- a/xchange-kraken/src/test/java/com/xeiam/xchange/kraken/service/KrakenAdaptersTest.java
+++ b/xchange-kraken/src/test/java/com/xeiam/xchange/kraken/service/KrakenAdaptersTest.java
@@ -132,9 +132,9 @@ public class KrakenAdaptersTest {
     // Verify that the example data was unmarshalled correctly
     assertThat(orders.getOpenOrders()).hasSize(1);
     assertThat(orders.getOpenOrders().get(0).getId()).isEqualTo("OR6QMM-BCKM4-Q6YHIN");
-    assertThat(orders.getOpenOrders().get(0).getLimitPrice().getAmount()).isEqualTo("1.00000");
-    assertThat(orders.getOpenOrders().get(0).getTradableAmount()).isEqualTo("1.00000000");
-    assertThat(orders.getOpenOrders().get(0).getTradableIdentifier()).isEqualTo(Currencies.BTC);
+    assertThat(orders.getOpenOrders().get(0).getLimitPrice().getAmount()).isEqualTo("13.00000");
+    assertThat(orders.getOpenOrders().get(0).getTradableAmount()).isEqualTo("0.01000000");
+    assertThat(orders.getOpenOrders().get(0).getTradableIdentifier()).isEqualTo(Currencies.LTC);
     assertThat(orders.getOpenOrders().get(0).getTransactionCurrency()).isEqualTo(Currencies.EUR);
 
   }
@@ -152,7 +152,7 @@ public class KrakenAdaptersTest {
     // Verify that the example data was unmarshalled correctly
     assertThat(orders.getOpenOrders()).hasSize(1);
     assertThat(orders.getOpenOrders().get(0).getId()).isEqualTo("OR6QMM-BCKM4-Q6YHIN");
-    assertThat(orders.getOpenOrders().get(0).getLimitPrice().getAmount()).isEqualTo("1.00000");
+    assertThat(orders.getOpenOrders().get(0).getLimitPrice().getAmount()).isEqualTo("500.00000");
     assertThat(orders.getOpenOrders().get(0).getTradableAmount()).isEqualTo("1.00000000");
     assertThat(orders.getOpenOrders().get(0).getTradableIdentifier()).isEqualTo(Currencies.BTC);
     assertThat(orders.getOpenOrders().get(0).getTransactionCurrency()).isEqualTo(Currencies.EUR);

--- a/xchange-kraken/src/test/java/com/xeiam/xchange/kraken/service/trading/KrakenOpenOrdersTest.java
+++ b/xchange-kraken/src/test/java/com/xeiam/xchange/kraken/service/trading/KrakenOpenOrdersTest.java
@@ -50,7 +50,7 @@ public class KrakenOpenOrdersTest {
     // Verify that the example data was unmarshalled correctly
     assertThat(order).isNotNull();
     assertThat(order.getOpentm()).isEqualTo(1380586080.222);
-    assertThat(order.getVolume()).isEqualTo("1.00000000");
+    assertThat(order.getVolume()).isEqualTo("0.01000000");
     assertThat(order.getVolumeExecuted()).isEqualTo("0.00000000");
   }
 }

--- a/xchange-kraken/src/test/resources/trading/example-openorders-data.json
+++ b/xchange-kraken/src/test/resources/trading/example-openorders-data.json
@@ -1,27 +1,57 @@
 {
-   "error":[
-
-   ],
-   "result":{
-      "open":{
-         "OR6QMM-BCKM4-Q6YHIN":{
-            "refid":null,
-            "userref":null,
-            "status":"open",
-            "opentm":1380586080.222,
-            "starttm":0,
-            "expiretm":0,
-            "descr":{
-               "order":"buy 1.00000000 XBTEUR @ limit 1.00000"
-            },
-            "vol":"1.00000000",
-            "vol_exec":"0.00000000",
-            "cost":"0.00000",
-            "fee":"0.00000",
-            "price":"0.00000",
-            "misc":"",
-            "oflags":""
-         }
-      }
-   }
+	"error":[
+	
+	],
+	"result":{
+		"open":{
+		    "OR6QMM-BCKM4-Q6YHIN":{
+				"refid":null,
+				"userref":null,
+				"status":"open",
+				"opentm":1380586080.222,
+				"starttm":0,
+				"expiretm":0,
+				"descr":{
+					"pair":"LTCEUR",
+					"type":"buy",
+					"ordertype":"limit",
+					"price":"13.00000",
+					"price2":"0",
+					"leverage":"none",
+					"order":"buy 0.01000000 LTCEUR @ limit 13.00000"
+				},
+				"vol":"0.01000000",
+				"vol_exec":"0.00000000",
+				"cost":"0.00000",
+				"fee":"0.00000",
+				"price":"0.00000",
+				"misc":"",
+				"oflags":""
+			},
+			"OWY4RO-RLFMH-7FB7IY":{
+				"refid":null,
+				"userref":null,
+				"status":"open",
+				"opentm":1390467544.1734,
+				"starttm":0,
+				"expiretm":0,
+				"descr":{
+					"pair":"LTCEUR",
+					"type":"buy",
+					"ordertype":"take-profit-limit",
+					"price":"10.00000",
+					"price2":"10.00000",
+					"leverage":"none",
+					"order":"buy 0.10000000 LTCEUR @ take profit 10.00000 -> limit 10.00000"
+				},
+				"vol":"0.10000000",
+				"vol_exec":"0.00000000",
+				"cost":"0.00000",
+				"fee":"0.00000",
+				"price":"0.00000",
+				"misc":"",
+				"oflags":""
+			}
+		}
+	}
 }

--- a/xchange-kraken/src/test/resources/trading/example-openorders-in-transaction-currency-data.json
+++ b/xchange-kraken/src/test/resources/trading/example-openorders-in-transaction-currency-data.json
@@ -1,27 +1,32 @@
 {
-   "error":[
-
-   ],
-   "result":{
-      "open":{
-         "OR6QMM-BCKM4-Q6YHIN":{
-            "refid":null,
-            "userref":null,
-            "status":"open",
-            "opentm":1380586080.222,
-            "starttm":0,
-            "expiretm":0,
-            "descr":{
-               "order":"buy 1.00000000 (EUR) XBTEUR @ limit 1.00000"
-            },
-            "vol":"1.00000000",
-            "vol_exec":"0.00000000",
-            "cost":"0.00000",
-            "fee":"0.00000",
-            "price":"0.00000",
-            "misc":"",
-            "oflags":""
-         }
-      }
-   }
+	"error":[
+	
+	],
+	"result":{
+		"open":{
+			"OR6QMM-BCKM4-Q6YHIN":{
+				"refid":null,
+				"userref":null,
+				"status":"open",
+				"opentm":1390686242.2557,
+				"starttm":0,
+				"expiretm":0,
+				"descr":{
+					"pair":"XBTEUR",
+					"type":"buy",
+					"ordertype":"limit",
+					"price":"500.00000",
+					"price2":"0",
+					"leverage":"none",
+					"order":"buy 1.00000000 (EUR) XBTEUR @ limit 500.00000"},
+					"vol":"1.00000000",
+					"vol_exec":"0.00000000",
+					"cost":"0.00000",
+					"fee":"0.00000",
+					"price":"0.00000",
+					"misc":"",
+					"oflags":"viqc"
+			}
+		}
+	}
 }


### PR DESCRIPTION
As a followup to issue #280: Change the way we parse Kraken's result into an open order.
