### PR TITLE
Fix for systems with locale other than US: Method fromRfc1123DateString ...

### DIFF
--- a/xchange-core/src/main/java/com/xeiam/xchange/utils/DateUtils.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/utils/DateUtils.java
@@ -24,6 +24,7 @@ package com.xeiam.xchange.utils;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
@@ -113,9 +114,9 @@ public class DateUtils {
    * @return Date
    * @throws InvalidFormatException
    */
-  public static Date fromRfc1123DateString(String rfc1123FormattedDate) throws InvalidFormatException {
+  public static Date fromRfc1123DateString(String rfc1123FormattedDate, Locale locale) throws InvalidFormatException {
 
-    SimpleDateFormat rfc1123DateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz");
+    SimpleDateFormat rfc1123DateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", locale);
     try {
       return rfc1123DateFormat.parse(rfc1123FormattedDate);
     } catch (ParseException e) {

--- a/xchange-core/src/main/java/com/xeiam/xchange/utils/jackson/Rfc1123DateDeserializer.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/utils/jackson/Rfc1123DateDeserializer.java
@@ -23,6 +23,7 @@ package com.xeiam.xchange.utils.jackson;
 
 import java.io.IOException;
 import java.util.Date;
+import java.util.Locale;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -41,7 +42,7 @@ public class Rfc1123DateDeserializer extends JsonDeserializer<Date> {
   @Override
   public Date deserialize(final JsonParser jp, final DeserializationContext ctxt) throws IOException, JsonProcessingException {
 
-    return DateUtils.fromRfc1123DateString(jp.getValueAsString());
+    return DateUtils.fromRfc1123DateString(jp.getValueAsString(), Locale.US);
   }
 
 }

--- a/xchange-kraken/src/test/java/com/xeiam/xchange/kraken/service/marketdata/KrakenServerTimeJSONTest.java
+++ b/xchange-kraken/src/test/java/com/xeiam/xchange/kraken/service/marketdata/KrakenServerTimeJSONTest.java
@@ -25,6 +25,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Locale;
 
 import org.junit.Test;
 
@@ -47,6 +48,6 @@ public class KrakenServerTimeJSONTest {
     KrakenServerTime serverTime = krakenResult.getResult();
 
     assertThat(serverTime.getUnixTime()).isEqualTo(1391835876);
-    assertThat(serverTime.getRfc1123Time()).isEqualTo(DateUtils.fromRfc1123DateString("Sat,  8 Feb 14 05:04:36 +0000"));
+    assertThat(serverTime.getRfc1123Time()).isEqualTo(DateUtils.fromRfc1123DateString("Sat,  8 Feb 14 05:04:36 +0000", Locale.US));
   }
 }


### PR DESCRIPTION
...in DateUtils.java with Locale parameter. Method call in other classes adjusted.
