### PR TITLE
Fixes incidental incorrect hmac signature for Bitfinex

### DIFF
--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/service/BitfinexHmacPostBodyDigest.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/service/BitfinexHmacPostBodyDigest.java
@@ -70,6 +70,6 @@ public class BitfinexHmacPostBodyDigest implements ParamsDigest {
     String postBody = restInvocation.getRequestBody();
     mac.update(Base64.encodeBytes(postBody.getBytes()).getBytes());
 
-    return String.format("%064x", new BigInteger(1, mac.doFinal()));
+    return String.format("%096x", new BigInteger(1, mac.doFinal()));
   }
 }


### PR DESCRIPTION
I didn't see this bug was reported yet, but the param digest returned a too short signature whenever it started with 4 or more zeros, leading to invalid signature response from the server. This changes the minimum width for the signature in hexadecimal base from 64
to 96, because the SHA384 algo uses 384 = 4*96 bit keys. This way leading zeros
don't get trimmed anymore.
