### PR TITLE
Updated Vircurex Uri

### DIFF
--- a/xchange-vircurex/src/main/java/com/xeiam/xchange/vircurex/VircurexExchange.java
+++ b/xchange-vircurex/src/main/java/com/xeiam/xchange/vircurex/VircurexExchange.java
@@ -59,7 +59,7 @@ public class VircurexExchange extends BaseExchange implements Exchange {
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
     ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass().getCanonicalName());
-    exchangeSpecification.setSslUri("https://vircurex.com");
+    exchangeSpecification.setSslUri("https://api.vircurex.com");
     exchangeSpecification.setExchangeName("Vircurex");
 
     return exchangeSpecification;


### PR DESCRIPTION
Looks like the Uri has been changed. As Per the Vircurex docs:

The server name for API calls is https://api.vircurex.com.
Please do not make API calls against https://vircurex.com, this will be discontinued from February 2014 onwards.

https://vircurex.com/welcome/api?locale=en
