### PR TITLE
Added getOpenOrders to BTERPollingTradeService

### DIFF
--- a/xchange-bter/src/main/java/com/xeiam/xchange/bter/BTERAdapters.java
+++ b/xchange-bter/src/main/java/com/xeiam/xchange/bter/BTERAdapters.java
@@ -21,26 +21,29 @@
  */
 package com.xeiam.xchange.bter;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import org.joda.money.BigMoney;
-import org.joda.money.CurrencyUnit;
-import org.joda.money.IllegalCurrencyException;
-
 import com.xeiam.xchange.bter.dto.account.BTERAccountInfoReturn;
 import com.xeiam.xchange.currency.MoneyUtils;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.trade.LimitOrder;
 import com.xeiam.xchange.dto.trade.Wallet;
+import org.joda.money.BigMoney;
+import org.joda.money.CurrencyUnit;
+import org.joda.money.IllegalCurrencyException;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Various adapters for converting from Bter DTOs to XChange DTOs
  */
 public final class BTERAdapters {
+
+  // BTER specific bid/ask syntax
+  public static final String BTER_BID = "buy";
+  public static final String BTER_ASK = "sell";
 
   /**
    * private Constructor
@@ -62,11 +65,11 @@ public final class BTERAdapters {
   public static LimitOrder adaptOrder(BigDecimal amount, BigDecimal price, String tradableIdentifier, String currency, String orderTypeString, String id) {
 
     // place a limit order
-    OrderType orderType = orderTypeString.equalsIgnoreCase("bid") ? OrderType.BID : OrderType.ASK;
+    OrderType orderType = orderTypeString.equalsIgnoreCase(BTER_BID) ? OrderType.BID : OrderType.ASK;
     BigMoney limitPrice;
     limitPrice = MoneyUtils.parse(currency + " " + price);
 
-    return new LimitOrder(orderType, amount, tradableIdentifier, currency, "", null, limitPrice);
+    return new LimitOrder(orderType, amount, tradableIdentifier, currency, id, null, limitPrice);
   }
 
   /**
@@ -85,7 +88,7 @@ public final class BTERAdapters {
     // Bid orderbook is reversed order. Insert at index 0 instead of
     for (BigDecimal[] bterOrder : orders) {
       // appending
-      if (orderType.equalsIgnoreCase("bid")) {
+      if (orderType.equalsIgnoreCase(BTER_BID)) {
         limitOrders.add(0, adaptOrder(bterOrder[1], bterOrder[0], tradableIdentifier, currency, orderType, id));
       }
       else {

--- a/xchange-bter/src/main/java/com/xeiam/xchange/bter/BTERAuthenticated.java
+++ b/xchange-bter/src/main/java/com/xeiam/xchange/bter/BTERAuthenticated.java
@@ -31,6 +31,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import com.xeiam.xchange.bter.dto.trade.BTEROpenOrdersReturn;
+import com.xeiam.xchange.bter.dto.trade.BTEROrderStatusReturn;
 import si.mazi.rescu.ParamsDigest;
 
 import com.xeiam.xchange.bter.dto.account.BTERAccountInfoReturn;
@@ -51,4 +53,12 @@ public interface BTERAuthenticated {
   BTERPlaceOrderReturn Trade(@HeaderParam("KEY") String apiKey, @HeaderParam("SIGN") ParamsDigest signer, @FormParam("nonce") int nonce, @FormParam("pair") String pair,
       @FormParam("type") BTEROrder.Type type, @FormParam("rate") BigDecimal rate, @FormParam("amount") BigDecimal amount);
 
+  @POST
+  @Path("orderlist")
+  BTEROpenOrdersReturn getOpenOrders(@HeaderParam("KEY") String apiKey, @HeaderParam("SIGN") ParamsDigest signer, @FormParam("nonce") int nonce);
+
+  @POST
+  @Path("getorder")
+  BTEROrderStatusReturn getOrderStatus(@HeaderParam("KEY") String apiKey, @HeaderParam("SIGN") ParamsDigest signer, @FormParam("nonce") int nonce,
+                                       @FormParam("order_id") String orderId);
 }

--- a/xchange-bter/src/main/java/com/xeiam/xchange/bter/BTERUtils.java
+++ b/xchange-bter/src/main/java/com/xeiam/xchange/bter/BTERUtils.java
@@ -22,6 +22,10 @@
 package com.xeiam.xchange.bter;
 
 
+import com.xeiam.xchange.ExchangeException;
+import com.xeiam.xchange.bter.service.BTERBaseService;
+import com.xeiam.xchange.currency.CurrencyPair;
+
 /**
  * A central place for shared Bter properties
  */
@@ -32,6 +36,20 @@ public final class BTERUtils {
    */
   private BTERUtils() {
 
+  }
+
+  public static CurrencyPair parseCurrencyPairString(String currencyPairString) {
+
+    String baseCurrency = currencyPairString.split("_")[0];
+    String counterCurrency = currencyPairString.split("_")[1];
+
+    CurrencyPair currencyPair = new CurrencyPair(baseCurrency.toUpperCase(), counterCurrency.toUpperCase());
+
+    if (BTERBaseService.CURRENCY_PAIRS.contains(currencyPair)) {
+      return currencyPair;
+    } else {
+      throw new ExchangeException("No support for currency pair: " + currencyPair);
+    }
   }
 
 }

--- a/xchange-bter/src/main/java/com/xeiam/xchange/bter/dto/trade/BTEROpenOrderSummary.java
+++ b/xchange-bter/src/main/java/com/xeiam/xchange/bter/dto/trade/BTEROpenOrderSummary.java
@@ -1,0 +1,65 @@
+package com.xeiam.xchange.bter.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+
+/**
+ * Created by David Henry on 2/19/14.
+ */
+public class BTEROpenOrderSummary {
+  private final String id;
+  private final String sellCode;
+  private final String buyCode;
+  private final BigDecimal sellAmount;
+  private final BigDecimal buyAmount;
+
+  /**
+   * Constructor
+   *
+   * @param id orderId
+   * @param sellCode sell currency code String representation
+   * @param buyCode buy currency code String representation
+   * @param sellAmount amount to sell
+   * @param buyAmount amount to buy
+   */
+  public BTEROpenOrderSummary(@JsonProperty("id") String id, @JsonProperty("sell_type") String sellCode, @JsonProperty("buy_type") String buyCode,
+                              @JsonProperty("sell_amount") BigDecimal sellAmount, @JsonProperty("buy_amount") BigDecimal buyAmount) {
+    this.id = id;
+    this.sellCode = sellCode;
+    this.buyCode = buyCode;
+    this.sellAmount = sellAmount;
+    this.buyAmount = buyAmount;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getSellCode() {
+    return sellCode;
+  }
+
+  public String getBuyCode() {
+    return buyCode;
+  }
+
+  public BigDecimal getSellAmount() {
+    return sellAmount;
+  }
+
+  public BigDecimal getBuyAmount() {
+    return buyAmount;
+  }
+
+  @Override
+  public String toString() {
+    return "BTEROpenOrderSummary{" +
+            "id='" + id + '\'' +
+            ", sellCode='" + sellCode + '\'' +
+            ", buyCode='" + buyCode + '\'' +
+            ", sellAmount=" + sellAmount +
+            ", buyAmount=" + buyAmount +
+            '}';
+  }
+}

--- a/xchange-bter/src/main/java/com/xeiam/xchange/bter/dto/trade/BTEROpenOrdersReturn.java
+++ b/xchange-bter/src/main/java/com/xeiam/xchange/bter/dto/trade/BTEROpenOrdersReturn.java
@@ -1,0 +1,51 @@
+package com.xeiam.xchange.bter.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Created by David Henry on 2/19/14.
+ */
+public class BTEROpenOrdersReturn {
+
+  private final Boolean result;
+  private final List<BTEROpenOrderSummary> orders;
+  private final String msg;
+
+  /**
+   * Constructor
+   *
+   * @param result
+   * @param orders
+   * @param msg
+   */
+  public BTEROpenOrdersReturn(@JsonProperty("result") Boolean result, @JsonProperty("orders") List<BTEROpenOrderSummary> orders,
+                              @JsonProperty("msg") String msg) {
+    this.result = result;
+    this.orders = orders;
+    this.msg = msg;
+  }
+
+  public Boolean isResult() {
+    return result;
+  }
+
+  public List<BTEROpenOrderSummary> getOrders() {
+    return orders;
+  }
+
+  public String getMsg() {
+    return msg;
+  }
+
+  @Override
+  public String toString() {
+    return "BTEROpenOrdersReturn{" +
+            "result=" + result +
+            ", orders=" + orders +
+            ", msg='" + msg + '\'' +
+            '}';
+  }
+
+}

--- a/xchange-bter/src/main/java/com/xeiam/xchange/bter/dto/trade/BTEROrderStatus.java
+++ b/xchange-bter/src/main/java/com/xeiam/xchange/bter/dto/trade/BTEROrderStatus.java
@@ -1,0 +1,79 @@
+package com.xeiam.xchange.bter.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+
+/**
+ * Created by David Henry on 2/19/14.
+ */
+public class BTEROrderStatus {
+
+  private final String id;
+  private final String status;
+  private final String tradePair;
+  private final String type;
+  private final BigDecimal rate;
+  private final BigDecimal amount;
+  private final BigDecimal initialRate;
+  private final BigDecimal initialAmount;
+
+  public BTEROrderStatus(@JsonProperty("id") String id, @JsonProperty("status") String status, @JsonProperty("pair") String tradePair,
+                         @JsonProperty("type") String type, @JsonProperty("rate") BigDecimal rate, @JsonProperty("amount") BigDecimal amount,
+                         @JsonProperty("initial_rate") BigDecimal initialRate, @JsonProperty("initial_amount") BigDecimal initialAmount) {
+    this.id = id;
+    this.status = status;
+    this.tradePair = tradePair;
+    this.type = type;
+    this.rate = rate;
+    this.amount = amount;
+    this.initialRate = initialRate;
+    this.initialAmount = initialAmount;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public String getTradePair() {
+    return tradePair;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public BigDecimal getRate() {
+    return rate;
+  }
+
+  public BigDecimal getAmount() {
+    return amount;
+  }
+
+  public BigDecimal getInitialRate() {
+    return initialRate;
+  }
+
+  public BigDecimal getInitialAmount() {
+    return initialAmount;
+  }
+
+  @Override
+  public String toString() {
+    return "BTEROrderStatus{" +
+            "id='" + id + '\'' +
+            ", status='" + status + '\'' +
+            ", tradePair='" + tradePair + '\'' +
+            ", type='" + type + '\'' +
+            ", rate=" + rate +
+            ", amount=" + amount +
+            ", initialRate=" + initialRate +
+            ", initialAmount=" + initialAmount +
+            '}';
+  }
+}

--- a/xchange-bter/src/main/java/com/xeiam/xchange/bter/dto/trade/BTEROrderStatusReturn.java
+++ b/xchange-bter/src/main/java/com/xeiam/xchange/bter/dto/trade/BTEROrderStatusReturn.java
@@ -1,0 +1,32 @@
+package com.xeiam.xchange.bter.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Created by David Henry on 2/19/14.
+ */
+public class BTEROrderStatusReturn {
+
+  private final boolean result;
+  private final BTEROrderStatus bterOrderStatus;
+  private final String msg;
+
+  public BTEROrderStatusReturn(@JsonProperty("result") boolean result,@JsonProperty("order") BTEROrderStatus bterOrderStatus,
+                               @JsonProperty("msg") String msg) {
+    this.result = result;
+    this.bterOrderStatus = bterOrderStatus;
+    this.msg = msg;
+  }
+
+  public boolean isResult() {
+    return result;
+  }
+
+  public BTEROrderStatus getBterOrderStatus() {
+    return bterOrderStatus;
+  }
+
+  public String getMsg() {
+    return msg;
+  }
+}

--- a/xchange-bter/src/main/java/com/xeiam/xchange/bter/service/polling/BTERBasePollingService.java
+++ b/xchange-bter/src/main/java/com/xeiam/xchange/bter/service/polling/BTERBasePollingService.java
@@ -36,7 +36,7 @@ public class BTERBasePollingService extends BTERBaseService {
   private static final long START_MILLIS = 1356998400000L; // Jan 1st, 2013 in milliseconds from epoch
 
   final String apiKey;
-  final BTERAuthenticated bter;
+  final BTERAuthenticated bterAuthenticated;
   final ParamsDigest signatureCreator;
 
   /**
@@ -48,7 +48,7 @@ public class BTERBasePollingService extends BTERBaseService {
 
     super(exchangeSpecification);
 
-    this.bter = RestProxyFactory.createProxy(BTERAuthenticated.class, exchangeSpecification.getSslUri());
+    this.bterAuthenticated = RestProxyFactory.createProxy(BTERAuthenticated.class, exchangeSpecification.getSslUri());
     this.apiKey = exchangeSpecification.getApiKey();
     this.signatureCreator = BTERHmacPostBodyDigest.createInstance(exchangeSpecification.getSecretKey());
   }

--- a/xchange-bter/src/main/java/com/xeiam/xchange/bter/service/polling/BTERPollingAccountServiceRaw.java
+++ b/xchange-bter/src/main/java/com/xeiam/xchange/bter/service/polling/BTERPollingAccountServiceRaw.java
@@ -33,9 +33,6 @@ import com.xeiam.xchange.bter.service.BTERHmacPostBodyDigest;
 
 public class BTERPollingAccountServiceRaw extends BTERBasePollingService {
 
-  private ExchangeSpecification exchangeSpecification;
-  private BTERAuthenticated bterAuthenticated;
-  private ParamsDigest signatureCreator;
 
   /**
    * Constructor
@@ -45,10 +42,6 @@ public class BTERPollingAccountServiceRaw extends BTERBasePollingService {
   public BTERPollingAccountServiceRaw(ExchangeSpecification exchangeSpecification) {
 
     super(exchangeSpecification);
-
-    this.exchangeSpecification = exchangeSpecification;
-    this.bterAuthenticated = RestProxyFactory.createProxy(BTERAuthenticated.class, exchangeSpecification.getSslUri());
-    this.signatureCreator = BTERHmacPostBodyDigest.createInstance(exchangeSpecification.getSecretKey());
   }
 
   public BTERAccountInfoReturn getBTERAccountInfo() throws IOException {

--- a/xchange-bter/src/main/java/com/xeiam/xchange/bter/service/polling/BTERPollingMarketDataService.java
+++ b/xchange-bter/src/main/java/com/xeiam/xchange/bter/service/polling/BTERPollingMarketDataService.java
@@ -62,8 +62,8 @@ public class BTERPollingMarketDataService extends BTERPollingMarketDataServiceRa
     BTERDepth btceDepth = getBTEROrderBook(tradableIdentifier, currency);
 
     // Adapt to XChange DTOs
-    List<LimitOrder> asks = BTERAdapters.adaptOrders(btceDepth.getAsks(), tradableIdentifier, currency, "ask", "");
-    List<LimitOrder> bids = BTERAdapters.adaptOrders(btceDepth.getBids(), tradableIdentifier, currency, "bid", "");
+    List<LimitOrder> asks = BTERAdapters.adaptOrders(btceDepth.getAsks(), tradableIdentifier, currency, BTERAdapters.BTER_ASK, "");
+    List<LimitOrder> bids = BTERAdapters.adaptOrders(btceDepth.getBids(), tradableIdentifier, currency, BTERAdapters.BTER_BID, "");
 
     return new OrderBook(null, asks, bids);
   }

--- a/xchange-bter/src/main/java/com/xeiam/xchange/bter/service/polling/BTERPollingTradeService.java
+++ b/xchange-bter/src/main/java/com/xeiam/xchange/bter/service/polling/BTERPollingTradeService.java
@@ -47,7 +47,7 @@ public class BTERPollingTradeService extends BTERPollingTradeServiceRaw implemen
   @Override
   public OpenOrders getOpenOrders() throws IOException {
 
-    throw new NotYetImplementedForExchangeException();
+    return getBTEROpenOrders();
   }
 
   @Override


### PR DESCRIPTION
This isn't very good performance wise. The way BTER has structured their API means that getOpenOrders() requires one call to get a list of order summaries for a user, then one call per summary to get the detailed info about the order.
