### PR TITLE
Added missing dep for Maven

### DIFF
--- a/xchange-examples/pom.xml
+++ b/xchange-examples/pom.xml
@@ -149,6 +149,10 @@
 			<groupId>com.xeiam.xchart</groupId>
 			<artifactId>xchart</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.github.mmazi</groupId>
+			<artifactId>rescu</artifactId>
+		</dependency>
 
 	</dependencies>
 


### PR DESCRIPTION
There are missing deps in the other modules, but with this can at least build with just core and examples. Using Maven in NetBeans 7.4.
