### PR TITLE
correct scaling routines in CoinfloorUtils

### DIFF
--- a/xchange-coinfloor/src/main/java/com/xeiam/xchange/coinfloor/CoinfloorUtils.java
+++ b/xchange-coinfloor/src/main/java/com/xeiam/xchange/coinfloor/CoinfloorUtils.java
@@ -125,18 +125,26 @@ public class CoinfloorUtils {
 	  throw new ExchangeException("Currency " + currency + " not supported by coinfloor!");
   }
 
+  public static int getCurrencyScale(String currency) {
+
+    if (currency.equals("BTC")) {
+      return 4;
+    }
+    else if (currency.equals("GBP")) {
+      return 2;
+    }
+
+    throw new ExchangeException("Currency " + currency + " not supported by coinfloor!");
+  }
+
   public static BigDecimal scaleToBigDecimal(String currency, Integer amountToScale){
-	  if(currency.equals("BTC")){return new BigDecimal(amountToScale.toString()).divide(new BigDecimal("10000"));}
-	  else if(currency.equals("GBP")){return new BigDecimal(amountToScale.toString()).divide(new BigDecimal("10000"));}
-	  
-	  throw new ExchangeException("Currency " + currency + " not supported by coinfloor!");
+
+    return BigDecimal.valueOf(amountToScale, getCurrencyScale(currency));
   }
   
   public static int scaleToInt(String currency, BigDecimal amountToScale){
-	  if(currency.equals("BTC")){return amountToScale.multiply(new BigDecimal("10000")).intValue();}
-	  else if(currency.equals("GBP")){return amountToScale.multiply(new BigDecimal("10000")).intValue();}
-	  
-	  throw new ExchangeException("Currency " + currency + " not supported by coinfloor!");
+
+    return amountToScale.movePointRight(getCurrencyScale(currency)).intValue();
   }
 
   /**
@@ -144,8 +152,9 @@ public class CoinfloorUtils {
    * @param amountToScale The integer result recieved from API Call
    * @return BigDecimal representation of integer amount
    */
-  public static BigDecimal scalePriceToBigDecimal(Integer amountToScale){
-	  return new BigDecimal(amountToScale.toString()).divide(new BigDecimal(10000));
+  public static BigDecimal scalePriceToBigDecimal(String baseCurrency, String counterCurrency, Integer amountToScale) {
+
+    return BigDecimal.valueOf(amountToScale, getCurrencyScale(counterCurrency) - getCurrencyScale(baseCurrency) + 4);
   }
   
 
@@ -154,7 +163,8 @@ public class CoinfloorUtils {
    * @param amountToScale The integer result recieved from API Call
    * @return BigDecimal representation of integer amount
    */
-  public static int scalePriceToInt(BigDecimal amountToScale){
-	  return amountToScale.multiply(new BigDecimal(10000)).intValue();
+  public static int scalePriceToInt(String baseCurrency, String counterCurrency, BigDecimal amountToScale) {
+
+    return amountToScale.movePointRight(getCurrencyScale(counterCurrency) - getCurrencyScale(baseCurrency) + 4).intValue();
   }
 }

--- a/xchange-coinfloor/src/main/java/com/xeiam/xchange/coinfloor/dto/streaming/CoinfloorOrder.java
+++ b/xchange-coinfloor/src/main/java/com/xeiam/xchange/coinfloor/dto/streaming/CoinfloorOrder.java
@@ -40,7 +40,7 @@ public class CoinfloorOrder{
 		  this.base = (base == 0 ? "BTC" : CoinfloorUtils.getCurrency(base));
 		  this.counter = (counter == 0 ? "GBP" : CoinfloorUtils.getCurrency(counter));
 		  this.baseQty = CoinfloorUtils.scaleToBigDecimal(this.base, baseQty);;
-		  this.price = CoinfloorUtils.scalePriceToBigDecimal(price);;
+    this.price = CoinfloorUtils.scalePriceToBigDecimal(this.base, this.counter, price);
 		  this.counterQty = CoinfloorUtils.scaleToBigDecimal(this.counter, counterQty);
 		  this.bidRem = CoinfloorUtils.scaleToBigDecimal(this.base, bidRem);
 		  this.askRem = CoinfloorUtils.scaleToBigDecimal(this.counter, askRem);

--- a/xchange-coinfloor/src/main/java/com/xeiam/xchange/coinfloor/dto/streaming/marketdata/CoinfloorTicker.java
+++ b/xchange-coinfloor/src/main/java/com/xeiam/xchange/coinfloor/dto/streaming/marketdata/CoinfloorTicker.java
@@ -32,11 +32,11 @@ public class CoinfloorTicker{
 		  this.errorCode = errorCode;
 		  this.base = CoinfloorUtils.getCurrency(base);
 		  this.counter = CoinfloorUtils.getCurrency(counter);
-		  this.last = CoinfloorUtils.scalePriceToBigDecimal(last);
-		  this.bid = CoinfloorUtils.scalePriceToBigDecimal(bid);
-		  this.ask = CoinfloorUtils.scalePriceToBigDecimal(ask);
-		  this.low = CoinfloorUtils.scalePriceToBigDecimal(low);
-		  this.high = CoinfloorUtils.scalePriceToBigDecimal(high);
+    this.last = CoinfloorUtils.scalePriceToBigDecimal(this.base, this.counter, last);
+    this.bid = CoinfloorUtils.scalePriceToBigDecimal(this.base, this.counter, bid);
+    this.ask = CoinfloorUtils.scalePriceToBigDecimal(this.base, this.counter, ask);
+    this.low = CoinfloorUtils.scalePriceToBigDecimal(this.base, this.counter, low);
+    this.high = CoinfloorUtils.scalePriceToBigDecimal(this.base, this.counter, high);
 		  this.volume = CoinfloorUtils.scaleToBigDecimal("BTC", volume);
 	  }
 

--- a/xchange-coinfloor/src/main/java/com/xeiam/xchange/coinfloor/dto/streaming/trade/CoinfloorCancelOrder.java
+++ b/xchange-coinfloor/src/main/java/com/xeiam/xchange/coinfloor/dto/streaming/trade/CoinfloorCancelOrder.java
@@ -27,7 +27,7 @@ public class CoinfloorCancelOrder{
 		  this.base = CoinfloorUtils.getCurrency(base);
 		  this.counter = CoinfloorUtils.getCurrency(counter);
 		  this.quantity = CoinfloorUtils.scaleToBigDecimal(CoinfloorUtils.getCurrency(base), quantity);
-		  this.price = CoinfloorUtils.scalePriceToBigDecimal(price);
+    this.price = CoinfloorUtils.scalePriceToBigDecimal(this.base, this.counter, price);
 	  }
 
 	  public int getTag(){

--- a/xchange-coinfloor/src/main/java/com/xeiam/xchange/coinfloor/streaming/RequestFactory.java
+++ b/xchange-coinfloor/src/main/java/com/xeiam/xchange/coinfloor/streaming/RequestFactory.java
@@ -109,7 +109,7 @@ public class RequestFactory {
 			else {this.quantity = CoinfloorUtils.scaleToInt(order.getCurrencyPair().baseCurrency, order.getTradableAmount());}
 			
 			if(order instanceof LimitOrder){
-				this.price = CoinfloorUtils.scalePriceToInt(((LimitOrder) order).getLimitPrice());
+        this.price = CoinfloorUtils.scalePriceToInt(order.getCurrencyPair().baseCurrency, order.getCurrencyPair().counterCurrency, ((LimitOrder) order).getLimitPrice());
 			}
 			else{
 				this.price = (Integer) null;

--- a/xchange-coinfloor/src/test/java/com/xeiam/xchange/coinfloor/TestCoinfloorUtils.java
+++ b/xchange-coinfloor/src/test/java/com/xeiam/xchange/coinfloor/TestCoinfloorUtils.java
@@ -71,12 +71,12 @@ public class TestCoinfloorUtils {
   @Test
   public void verifyScaling() {
 
-    Assert.assertEquals(new BigDecimal(1), CoinfloorUtils.scaleToBigDecimal("BTC", 10000));
-    Assert.assertEquals(new BigDecimal(1), CoinfloorUtils.scaleToBigDecimal("GBP", 10000));
-    Assert.assertEquals(new BigDecimal(1), CoinfloorUtils.scalePriceToBigDecimal(10000));
-    Assert.assertEquals(10000, CoinfloorUtils.scaleToInt("BTC", new BigDecimal(1)));
-    Assert.assertEquals(10000, CoinfloorUtils.scaleToInt("GBP", new BigDecimal(1)));
-    Assert.assertEquals(10000, CoinfloorUtils.scalePriceToInt(new BigDecimal(1)));
+    Assert.assertEquals(BigDecimal.valueOf(10000, 4), CoinfloorUtils.scaleToBigDecimal("BTC", 10000));
+    Assert.assertEquals(BigDecimal.valueOf(100, 2), CoinfloorUtils.scaleToBigDecimal("GBP", 100));
+    Assert.assertEquals(BigDecimal.valueOf(100, 2), CoinfloorUtils.scalePriceToBigDecimal("BTC", "GBP", 100));
+    Assert.assertEquals(10000, CoinfloorUtils.scaleToInt("BTC", BigDecimal.valueOf(1)));
+    Assert.assertEquals(100, CoinfloorUtils.scaleToInt("GBP", BigDecimal.valueOf(1)));
+    Assert.assertEquals(100, CoinfloorUtils.scalePriceToInt("BTC", "GBP", BigDecimal.valueOf(1)));
   }
   
   @Test (expected = ExchangeException.class)


### PR DESCRIPTION
The scaling factors were wrong. Coinfloor scales BTC quantities by 10000 and GBP quantities by 100. Prices are expressed in units of the counter asset per unit of the base asset and then scaled by 10000.

> Ƀ12.3456 <=> 123456
> £987.65 <=> 98765
> £512.34/BTC <=> 51234

To understand the last line, consider that £512.34 is 51234 units of the GBP currency, and Ƀ1 is 10000 units of the BTC currency. Divide 51234 by 10000, and you get a price of 5.1234. Scale this price by 10000, and you get 51234, which is how Coinfloor expresses this price.

As another illustrative example, consider a hypothetical future in which Coinfloor adds support for JPY with a scaling factor of 1 and DOGE with a scaling factor of 100. Then:

> Đ1234.56 <=> 123456
> ¥98765 <=> 98765
> ¥5.1234/DOGE <=> 51234

¥5.1234 is 512.34 units of the JPY currency, and Đ1 is 100 units of the DOGE currency. Divide 512.34 by 100, and you get a price of 5.1234. Scale this price by 10000, and you get 51234.
