### PR TITLE
fix TestCoinfloorAdapters (broken by a5641df)

### DIFF
--- a/xchange-coinfloor/src/main/java/com/xeiam/xchange/coinfloor/dto/streaming/marketdata/CoinfloorTicker.java
+++ b/xchange-coinfloor/src/main/java/com/xeiam/xchange/coinfloor/dto/streaming/marketdata/CoinfloorTicker.java
@@ -30,8 +30,8 @@ public class CoinfloorTicker{
 			  @JsonProperty("volume") int volume){
 		  this.tag = tag;
 		  this.errorCode = errorCode;
-		  this.base = CoinfloorUtils.getCurrency(base);
-		  this.counter = CoinfloorUtils.getCurrency(counter);
+    this.base = base == 0 ? "BTC" : CoinfloorUtils.getCurrency(base);
+    this.counter = counter == 0 ? "GBP" : CoinfloorUtils.getCurrency(counter);
     this.last = CoinfloorUtils.scalePriceToBigDecimal(this.base, this.counter, last);
     this.bid = CoinfloorUtils.scalePriceToBigDecimal(this.base, this.counter, bid);
     this.ask = CoinfloorUtils.scalePriceToBigDecimal(this.base, this.counter, ask);

--- a/xchange-coinfloor/src/test/java/com/xeiam/xchange/coinfloor/TestCoinfloorAdapters.java
+++ b/xchange-coinfloor/src/test/java/com/xeiam/xchange/coinfloor/TestCoinfloorAdapters.java
@@ -42,8 +42,8 @@ public class TestCoinfloorAdapters {
 	 		
 		Map<String, Object> testObj = coinfloorAdapters.adaptBalances(result);
 
-		Assert.assertEquals(new BigDecimal("10001.4718"), ((AccountInfo)testObj.get("generic")).getBalance("BTC"));
-		Assert.assertEquals(new BigDecimal("93.1913"), ((AccountInfo)testObj.get("generic")).getBalance("GBP"));
+    Assert.assertEquals(BigDecimal.valueOf(100014718, 4), ((AccountInfo) testObj.get("generic")).getBalance("BTC"));
+    Assert.assertEquals(BigDecimal.valueOf(931913, 2), ((AccountInfo) testObj.get("generic")).getBalance("GBP"));
 	}
 
 	@Test
@@ -60,7 +60,7 @@ public class TestCoinfloorAdapters {
 		
 		Map<String, Object> testObj = coinfloorAdapters.adaptOpenOrders(result);
 
-		Assert.assertEquals(new BigDecimal("1"), ((OpenOrders)testObj.get("generic")).getOpenOrders().get(0).getTradableAmount());
+    Assert.assertEquals(BigDecimal.valueOf(10000, 4), ((OpenOrders) testObj.get("generic")).getOpenOrders().get(0).getTradableAmount());
 		Assert.assertEquals("211118", ((OpenOrders)testObj.get("generic")).getOpenOrders().get(0).getId());
 		Assert.assertEquals("GBP", ((OpenOrders)testObj.get("generic")).getOpenOrders().get(0).getCurrencyPair().counterCurrency);
 		Assert.assertEquals("BTC", ((OpenOrders)testObj.get("generic")).getOpenOrders().get(0).getCurrencyPair().baseCurrency);
@@ -99,7 +99,7 @@ public class TestCoinfloorAdapters {
 		
 		Map<String, Object> testObj = coinfloorAdapters.adaptTradeVolume(result);
 		
-		Assert.assertEquals(new BigDecimal("4.007"), new BigDecimal(String.valueOf(testObj.get("generic"))));
+    Assert.assertEquals(BigDecimal.valueOf(40070, 4), new BigDecimal(String.valueOf(testObj.get("generic"))));
 	}
 
 	@Test
@@ -116,11 +116,11 @@ public class TestCoinfloorAdapters {
 		
 		Map<String, Object> testObj = coinfloorAdapters.adaptTicker(result);
 
-	    Assert.assertEquals(new BigDecimal("3.2"), ((Ticker) testObj.get("generic")).getLast());
-	    Assert.assertEquals(new BigDecimal(0), ((Ticker) testObj.get("generic")).getHigh());
-	    Assert.assertEquals(new BigDecimal(0), ((Ticker) testObj.get("generic")).getLow());
-	    Assert.assertEquals(new BigDecimal("3.3"), ((Ticker) testObj.get("generic")).getAsk());
-	    Assert.assertEquals(new BigDecimal("3.2"), ((Ticker) testObj.get("generic")).getBid());
+    Assert.assertEquals(BigDecimal.valueOf(32000, 2), ((Ticker) testObj.get("generic")).getLast());
+    Assert.assertEquals(BigDecimal.valueOf(0, 2), ((Ticker) testObj.get("generic")).getHigh());
+    Assert.assertEquals(BigDecimal.valueOf(0, 2), ((Ticker) testObj.get("generic")).getLow());
+    Assert.assertEquals(BigDecimal.valueOf(33000, 2), ((Ticker) testObj.get("generic")).getAsk());
+    Assert.assertEquals(BigDecimal.valueOf(32000, 2), ((Ticker) testObj.get("generic")).getBid());
 	}
 
 	@Test
@@ -149,11 +149,11 @@ public class TestCoinfloorAdapters {
 		
 		Map<String, Object> testObj = coinfloorAdapters.adaptTickerUpdate(result2);
 
-	    Assert.assertEquals(new BigDecimal("3.2"), ((Ticker) testObj.get("generic")).getLast());
-	    Assert.assertEquals(new BigDecimal("0"), ((Ticker) testObj.get("generic")).getHigh());
-	    Assert.assertEquals(new BigDecimal("0"), ((Ticker) testObj.get("generic")).getLow());
-	    Assert.assertEquals(new BigDecimal("3.1899"), ((Ticker) testObj.get("generic")).getAsk());
-	    Assert.assertEquals(new BigDecimal("3.2"), ((Ticker) testObj.get("generic")).getBid());
+    Assert.assertEquals(BigDecimal.valueOf(32000, 2), ((Ticker) testObj.get("generic")).getLast());
+    Assert.assertEquals(BigDecimal.valueOf(0, 2), ((Ticker) testObj.get("generic")).getHigh());
+    Assert.assertEquals(BigDecimal.valueOf(0, 2), ((Ticker) testObj.get("generic")).getLow());
+    Assert.assertEquals(BigDecimal.valueOf(31899, 2), ((Ticker) testObj.get("generic")).getAsk());
+    Assert.assertEquals(BigDecimal.valueOf(32000, 2), ((Ticker) testObj.get("generic")).getBid());
 	}
 
 	@Test
@@ -172,7 +172,7 @@ public class TestCoinfloorAdapters {
 
 		Assert.assertEquals(7, ((OrderBook) testObj.get("generic")).getAsks().size());
 		Assert.assertEquals(7, ((OrderBook) testObj.get("generic")).getBids().size());
-		Assert.assertEquals(new BigDecimal("0.9983"), ((OrderBook) testObj.get("generic")).getBids().get(0).getTradableAmount());
+    Assert.assertEquals(BigDecimal.valueOf(9983, 4), ((OrderBook) testObj.get("generic")).getBids().get(0).getTradableAmount());
 	}
 
 	@Test
@@ -189,7 +189,7 @@ public class TestCoinfloorAdapters {
 		
 		Map<String, Object> testObj = coinfloorAdapters.adaptOrderOpened(result);
 
-		Assert.assertEquals(new BigDecimal("1"), ((LimitOrder) testObj.get("generic")).getTradableAmount());
+    Assert.assertEquals(BigDecimal.valueOf(10000, 4), ((LimitOrder) testObj.get("generic")).getTradableAmount());
 		Assert.assertEquals("GBP", ((LimitOrder) testObj.get("generic")).getCurrencyPair().counterCurrency);
 		Assert.assertEquals("BTC", ((LimitOrder) testObj.get("generic")).getCurrencyPair().baseCurrency);
 	}
@@ -208,7 +208,7 @@ public class TestCoinfloorAdapters {
 		
 		Map<String, Object> testObj = coinfloorAdapters.adaptOrderClosed(result);
 
-		Assert.assertEquals(new BigDecimal("1"), ((LimitOrder) testObj.get("generic")).getTradableAmount());
+    Assert.assertEquals(BigDecimal.valueOf(10000, 4), ((LimitOrder) testObj.get("generic")).getTradableAmount());
 		Assert.assertEquals("GBP", ((LimitOrder) testObj.get("generic")).getCurrencyPair().counterCurrency);
 		Assert.assertEquals("BTC", ((LimitOrder) testObj.get("generic")).getCurrencyPair().baseCurrency);
 	}
@@ -228,7 +228,7 @@ public class TestCoinfloorAdapters {
 		Map<String, Object> testObj = coinfloorAdapters.adaptOrdersMatched(result);
 
 		Assert.assertEquals("211184", ((Trade) testObj.get("generic")).getId());
-		Assert.assertEquals(new BigDecimal("0.4768"), ((Trade) testObj.get("generic")).getTradableAmount());
+    Assert.assertEquals(BigDecimal.valueOf(4768, 4), ((Trade) testObj.get("generic")).getTradableAmount());
 		Assert.assertEquals("GBP", ((Trade) testObj.get("generic")).getCurrencyPair().counterCurrency);
 		Assert.assertEquals("BTC", ((Trade) testObj.get("generic")).getCurrencyPair().baseCurrency);
 		Assert.assertEquals(OrderType.ASK, ((Trade) testObj.get("generic")).getType());
@@ -250,7 +250,7 @@ public class TestCoinfloorAdapters {
 		
 		Map<String, Object> testObj = coinfloorAdapters.adaptBalancesChanged(result);
 		
-		Assert.assertEquals(new BigDecimal("99"), ((AccountInfo) testObj.get("generic")).getBalance("GBP"));
+    Assert.assertEquals(BigDecimal.valueOf(990000, 2), ((AccountInfo) testObj.get("generic")).getBalance("GBP"));
 	}
 	
 	/**


### PR DESCRIPTION
My previous change introduced test failures in `TestCoinfloorAdapters`. This commit fixes them.

It should be noted that the `CoinfloorTicker` DTO really cannot always be constructed in the absence of contextual information regarding the base and counter assets, which are not indicated in the response to the `WatchTicker` command but are indicated in the `TickerChanged` notifications. Since Coinfloor is presently only using BTC and GBP, assuming those is okay for now, but really the raw DTOs should hold the raw, integer values from the API, the XChange-cooked DTOs should hold the cooked, BigDecimal values, and the adapter should provide the necessary context to convert the raw values to the cooked values.
