### PR TITLE
Allow retrieving of wallets other than btc,usd on bitfinex

### DIFF
--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/BitfinexAdapters.java
@@ -119,9 +119,7 @@ public final class BitfinexAdapters {
     List<Wallet> wallets = new ArrayList<Wallet>();
 
     for (BitfinexBalancesResponse balance : response) {
-      if (balance.getCurrency().equals("usd") || balance.getCurrency().equals("btc")) {
         wallets.add(new Wallet(balance.getCurrency().toUpperCase(), balance.getAmount(), balance.getType()));
-      }
     }
 
     return new AccountInfo(null, wallets);


### PR DESCRIPTION
LTC wallet is ignored.

If there is no good reason to filter out other wallets than btc and usd, i think it is good to remove the if statement and retrieve all existing wallets.

Thanks,
