### PR TITLE
Updated WebSocketEventProducer message fragment logic

### DIFF
--- a/xchange-core/src/main/java/com/xeiam/xchange/service/streaming/WebSocketEventProducer.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/service/streaming/WebSocketEventProducer.java
@@ -108,8 +108,6 @@ public class WebSocketEventProducer extends WebSocketClient {
       throw new ExchangeException("Invalid frame recieved");
     }
 
-    System.out.println("---------------------------------------------" + frame.isFin());
-
     if (frame.isFin() == true) {
       try {
         onMessage(Charsetfunctions.stringUtf8(getLastFragmentedMessage().getPayloadData()));


### PR DESCRIPTION
Changed detection of last frame to use Fin flag rather than payload size. 

Detection of last frame should now correctly be deterministic.
