### PR TITLE
Apply exchange specification parameters in default case

### DIFF
--- a/xchange-core/src/main/java/com/xeiam/xchange/BaseExchange.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/BaseExchange.java
@@ -66,6 +66,10 @@ public abstract class BaseExchange implements Exchange {
       }
       if (exchangeSpecification.getHost() == null) {
         exchangeSpecification.setHost(defaultSpecification.getHost());
+      } 
+      if (exchangeSpecification.getExchangeSpecificParameters() == null || 
+    	  exchangeSpecification.getExchangeSpecificParameters().size() <= 0) {
+          exchangeSpecification.setExchangeSpecificParameters(defaultSpecification.getExchangeSpecificParameters());
       }
       this.exchangeSpecification = exchangeSpecification;
     }


### PR DESCRIPTION
When instantiating an Exchange via `ExchangeFactory.INSTANCE.createExchange` then the default ExchangeSpecificParameters were not applied, which causes some failures for BTCChina or other exchanges using this.
