### PR TITLE
BtcChina: misplaced abs() in adaptTransaction()

### DIFF
--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChinaAdapters.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChinaAdapters.java
@@ -261,11 +261,11 @@ public final class BTCChinaAdapters {
 
     if(!transaction.getBtcAmount().equals(BigDecimal.ZERO)) {
       currencyPair = new CurrencyPair("BTC", "CNY");
-      price = transaction.getCnyAmount().abs().divide(transaction.getBtcAmount());
+      price = transaction.getCnyAmount().divide(transaction.getBtcAmount()).abs();
       amount = transaction.getBtcAmount().abs();
     } else {
       currencyPair = new CurrencyPair("LTC", "CNY");
-      price = transaction.getCnyAmount().abs().divide(transaction.getLtcAmount());
+      price = transaction.getCnyAmount().divide(transaction.getLtcAmount()).abs();
       amount = transaction.getLtcAmount().abs();
     }
 


### PR DESCRIPTION
should have gone in the previous PR. Leads to negative prices otherwise.
