### PR TITLE
Bitfinex Support for Trade ID and last timestamp in trade query

### DIFF
--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/Bitfinex.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/Bitfinex.java
@@ -48,7 +48,7 @@ public interface Bitfinex {
 
   @GET
   @Path("trades/{symbol}")
-  BitfinexTrade[] getTrades(@PathParam("symbol") String symbol) throws IOException;
+  BitfinexTrade[] getTrades(@PathParam("symbol") String symbol, @QueryParam("timestamp") long timestamp) throws IOException;
 
   @GET
   @Path("symbols")

--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/BitfinexAdapters.java
@@ -86,8 +86,8 @@ public final class BitfinexAdapters {
     OrderType orderType = null;
     BigDecimal amount = trade.getAmount();
     BigDecimal price = trade.getPrice();
-    Date date = DateUtils.fromMillisUtc((long) (trade.getTimestamp() * 1000L));
-    final String tradeId = String.valueOf(trade.getTimestamp());
+    Date date = DateUtils.fromMillisUtc(trade.getTimestamp() * 1000L); // Bitfinex uses Unix timestamps
+    final String tradeId = String.valueOf(trade.getTradeId());
     return new Trade(orderType, amount, currencyPair, price, date, tradeId);
   }
 

--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/dto/marketdata/BitfinexTrade.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/dto/marketdata/BitfinexTrade.java
@@ -29,8 +29,10 @@ public class BitfinexTrade {
 
   private final BigDecimal price;
   private final BigDecimal amount;
-  private final float timestamp;
+  private final long timestamp;
   private final String exchange;
+  private final long tradeId;
+
 
   /**
    * Constructor
@@ -39,13 +41,15 @@ public class BitfinexTrade {
    * @param amount
    * @param timestamp
    * @param exchange
+   * @param tradeId
    */
-  public BitfinexTrade(@JsonProperty("price") BigDecimal price, @JsonProperty("amount") BigDecimal amount, @JsonProperty("timestamp") float timestamp, @JsonProperty("exchange") String exchange) {
+  public BitfinexTrade(@JsonProperty("price") BigDecimal price, @JsonProperty("amount") BigDecimal amount, @JsonProperty("timestamp") long timestamp, @JsonProperty("exchange") String exchange, @JsonProperty("tid") long tradeId) {
 
     this.price = price;
     this.amount = amount;
     this.timestamp = timestamp;
     this.exchange = exchange;
+    this.tradeId = tradeId;
   }
 
   public BigDecimal getPrice() {
@@ -58,7 +62,7 @@ public class BitfinexTrade {
     return amount;
   }
 
-  public float getTimestamp() {
+  public long getTimestamp() {
 
     return timestamp;
   }
@@ -66,6 +70,10 @@ public class BitfinexTrade {
   public String getExchange() {
 
     return exchange;
+  }
+
+  public long getTradeId() {
+      return tradeId;
   }
 
   @Override
@@ -80,7 +88,11 @@ public class BitfinexTrade {
     builder.append(timestamp);
     builder.append(", exchange=");
     builder.append(exchange);
+    builder.append(", tid=");
+    builder.append(tradeId);
     builder.append("]");
     return builder.toString();
   }
+
+
 }

--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/service/polling/BitfinexMarketDataServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/service/polling/BitfinexMarketDataServiceRaw.java
@@ -68,9 +68,9 @@ public class BitfinexMarketDataServiceRaw extends BitfinexBasePollingService {
     return btceDepth;
   }
 
-  public BitfinexTrade[] getBitfinexTrades(String pair) throws IOException {
+  public BitfinexTrade[] getBitfinexTrades(String pair, long sinceTimestamp) throws IOException {
 
-    BitfinexTrade[] trades = bitfinex.getTrades(pair);
+    BitfinexTrade[] trades = bitfinex.getTrades(pair,sinceTimestamp);
 
     return trades;
   }


### PR DESCRIPTION
These changes enhance Bitfinex support of the trades() query:
- The Bitfinex "tid" field is now parsed as a long and used as the XChange tradeId.
- The Bitfinex getTrades() call supports an additional parameter which is the last timestamp from which to query trades.
