### PR TITLE
Fix the order ID in the response of buyOrder2 and sellOrder2 of BTCChina

### DIFF
--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChina.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChina.java
@@ -48,6 +48,7 @@ import com.xeiam.xchange.btcchina.dto.trade.request.BTCChinaSellOrderRequest;
 import com.xeiam.xchange.btcchina.dto.trade.request.BTCChinaTransactionsRequest;
 import com.xeiam.xchange.btcchina.dto.trade.response.BTCChinaBooleanResponse;
 import com.xeiam.xchange.btcchina.dto.trade.response.BTCChinaGetOrdersResponse;
+import com.xeiam.xchange.btcchina.dto.trade.response.BTCChinaIntegerResponse;
 import com.xeiam.xchange.btcchina.dto.trade.response.BTCChinaTransactionsResponse;
 
 @Path("/")
@@ -99,13 +100,13 @@ public interface BTCChina {
   @POST
   @Path("api_trade_v1.php")
   @Consumes(MediaType.APPLICATION_JSON)
-  public BTCChinaBooleanResponse buyOrder2(@HeaderParam("Authorization") ParamsDigest authorization, @HeaderParam("Json-Rpc-Tonce") long jsonRpcTonce, BTCChinaBuyOrderRequest buyOrderRequest)
+  public BTCChinaIntegerResponse buyOrder2(@HeaderParam("Authorization") ParamsDigest authorization, @HeaderParam("Json-Rpc-Tonce") long jsonRpcTonce, BTCChinaBuyOrderRequest buyOrderRequest)
       throws IOException;
 
   @POST
   @Path("api_trade_v1.php")
   @Consumes(MediaType.APPLICATION_JSON)
-  public BTCChinaBooleanResponse sellOrder2(@HeaderParam("Authorization") ParamsDigest authorization, @HeaderParam("Json-Rpc-Tonce") long jsonRpcTonce, BTCChinaSellOrderRequest sellOrderRequest)
+  public BTCChinaIntegerResponse sellOrder2(@HeaderParam("Authorization") ParamsDigest authorization, @HeaderParam("Json-Rpc-Tonce") long jsonRpcTonce, BTCChinaSellOrderRequest sellOrderRequest)
       throws IOException;
 
   @POST

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/dto/trade/response/BTCChinaIntegerResponse.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/dto/trade/response/BTCChinaIntegerResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2012 - 2014 Xeiam LLC http://xeiam.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.xeiam.xchange.btcchina.dto.trade.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.xeiam.xchange.btcchina.dto.BTCChinaResponse;
+
+/**
+ * @author Joe Zhou
+ */
+public class BTCChinaIntegerResponse extends BTCChinaResponse<Integer> {
+
+  /**
+   * Constructor
+   * 
+   * @param id
+   * @param result
+   */
+  public BTCChinaIntegerResponse(@JsonProperty("id") String id, @JsonProperty("result") Integer result) {
+
+    super(id, result);
+  }
+
+}

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaTradeService.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaTradeService.java
@@ -29,6 +29,7 @@ import com.xeiam.xchange.btcchina.BTCChinaAdapters;
 import com.xeiam.xchange.btcchina.dto.BTCChinaResponse;
 import com.xeiam.xchange.btcchina.dto.trade.BTCChinaOrders;
 import com.xeiam.xchange.btcchina.dto.trade.response.BTCChinaBooleanResponse;
+import com.xeiam.xchange.btcchina.dto.trade.response.BTCChinaIntegerResponse;
 import com.xeiam.xchange.btcchina.dto.trade.response.BTCChinaTransactionsResponse;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.trade.LimitOrder;
@@ -76,9 +77,9 @@ public class BTCChinaTradeService extends BTCChinaTradeServiceRaw implements Pol
 
     verify(limitOrder.getCurrencyPair());
 
-    BTCChinaBooleanResponse response = placeBTCChinaLimitOrder(limitOrder.getLimitPrice(), limitOrder.getTradableAmount(), limitOrder.getType());
+    BTCChinaIntegerResponse response = placeBTCChinaLimitOrder(limitOrder.getLimitPrice(), limitOrder.getTradableAmount(), limitOrder.getType());
 
-    return response.getId();
+    return response.getResult().toString();
   }
 
   @Override

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaTradeServiceRaw.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaTradeServiceRaw.java
@@ -38,6 +38,7 @@ import com.xeiam.xchange.btcchina.dto.trade.request.BTCChinaGetOrdersRequest;
 import com.xeiam.xchange.btcchina.dto.trade.request.BTCChinaSellOrderRequest;
 import com.xeiam.xchange.btcchina.dto.trade.request.BTCChinaTransactionsRequest;
 import com.xeiam.xchange.btcchina.dto.trade.response.BTCChinaBooleanResponse;
+import com.xeiam.xchange.btcchina.dto.trade.response.BTCChinaIntegerResponse;
 import com.xeiam.xchange.btcchina.dto.trade.response.BTCChinaTransactionsResponse;
 import com.xeiam.xchange.btcchina.service.BTCChinaBaseService;
 import com.xeiam.xchange.btcchina.service.BTCChinaDigest;
@@ -85,11 +86,11 @@ public class BTCChinaTradeServiceRaw extends BTCChinaBaseService {
   }
 
   /**
-   * @return BTCChinaBooleanResponse of new limit order status.
+   * @return BTCChinaIntegerResponse of new limit order status.
    */
-  public BTCChinaBooleanResponse placeBTCChinaLimitOrder(BigDecimal price, BigDecimal amount, OrderType orderType) throws IOException {
+  public BTCChinaIntegerResponse placeBTCChinaLimitOrder(BigDecimal price, BigDecimal amount, OrderType orderType) throws IOException {
 
-    BTCChinaBooleanResponse response = null;
+    BTCChinaIntegerResponse response = null;
 
     if (orderType == OrderType.BID) {
 

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/btcchina/trade/BTCChinaTradeDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/btcchina/trade/BTCChinaTradeDemo.java
@@ -29,6 +29,7 @@ import com.xeiam.xchange.btcchina.dto.BTCChinaResponse;
 import com.xeiam.xchange.btcchina.dto.trade.BTCChinaOrder;
 import com.xeiam.xchange.btcchina.dto.trade.BTCChinaOrders;
 import com.xeiam.xchange.btcchina.dto.trade.response.BTCChinaBooleanResponse;
+import com.xeiam.xchange.btcchina.dto.trade.response.BTCChinaIntegerResponse;
 import com.xeiam.xchange.btcchina.service.polling.BTCChinaTradeServiceRaw;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
@@ -99,7 +100,7 @@ public class BTCChinaTradeDemo {
 
     // place a limit buy order
     LimitOrder limitOrder = new LimitOrder((OrderType.BID), BigDecimal.ONE, CurrencyPair.BTC_CNY, "", null, new BigDecimal("0.01"));
-    BTCChinaBooleanResponse limitOrderReturnValue = ((BTCChinaTradeServiceRaw) tradeService).placeBTCChinaLimitOrder(new BigDecimal("0.01"), BigDecimal.ONE, OrderType.BID);
+    BTCChinaIntegerResponse limitOrderReturnValue = ((BTCChinaTradeServiceRaw) tradeService).placeBTCChinaLimitOrder(new BigDecimal("0.01"), BigDecimal.ONE, OrderType.BID);
     System.out.println("Limit Order return value: " + limitOrderReturnValue);
 
     Thread.sleep(1500);


### PR DESCRIPTION
The "result" of the response of buyOrder2 and sellOrder2 is Integer, not Boolean. And the Order ID is stored in the "result", not the "id".
