### PR TITLE
Change Xeiam Ticker Volume to reflect the base currency volume.

### DIFF
--- a/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/BTCEAdapters.java
+++ b/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/BTCEAdapters.java
@@ -159,7 +159,7 @@ public final class BTCEAdapters {
     BigDecimal ask = bTCETicker.getBuy();
     BigDecimal high = bTCETicker.getHigh();
     BigDecimal low = bTCETicker.getLow();
-    BigDecimal volume = bTCETicker.getVolCur();
+    BigDecimal volume = bTCETicker.getVol();
     Date timestamp = DateUtils.fromMillisUtc(bTCETicker.getUpdated() * 1000L);
 
     return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withVolume(volume).withTimestamp(timestamp).build();

--- a/xchange-btce/src/test/java/com/xeiam/xchange/btce/v3/service/BTCEAdapterTest.java
+++ b/xchange-btce/src/test/java/com/xeiam/xchange/btce/v3/service/BTCEAdapterTest.java
@@ -115,7 +115,7 @@ public class BTCEAdapterTest {
     assertThat(ticker.getLast().toString()).isEqualTo("757");
     assertThat(ticker.getLow().toString()).isEqualTo("655");
     assertThat(ticker.getHigh().toString()).isEqualTo("770");
-    assertThat(ticker.getVolume()).isEqualTo(new BigDecimal("24620.6561"));
+    assertThat(ticker.getVolume()).isEqualTo(new BigDecimal("17512163.25736"));
     assertThat(DateUtils.toUTCString(ticker.getTimestamp())).isEqualTo("2013-11-23 11:13:39 GMT");
 
   }

--- a/xchange-bter/src/main/java/com/xeiam/xchange/bter/BTERAdapters.java
+++ b/xchange-bter/src/main/java/com/xeiam/xchange/bter/BTERAdapters.java
@@ -77,7 +77,7 @@ public final class BTERAdapters {
     BigDecimal last = bterTicker.getLast();
     BigDecimal low = bterTicker.getLow();
     BigDecimal high = bterTicker.getHigh();
-    BigDecimal volume = bterTicker.getPriceCurrencyVolume();
+    BigDecimal volume = bterTicker.getTradeCurrencyVolume();
 
     return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withAsk(ask).withBid(bid).withLast(last).withLow(low).withHigh(high).withVolume(volume).build();
   }

--- a/xchange-bter/src/test/java/com/xeiam/xchange/bter/dto/BTERAdapterTests.java
+++ b/xchange-bter/src/test/java/com/xeiam/xchange/bter/dto/BTERAdapterTests.java
@@ -156,7 +156,7 @@ public class BTERAdapterTests {
     assertThat(ticker.getLow()).isEqualTo("3400.01");
     assertThat(ticker.getAsk()).isEqualTo("3400.17");
     assertThat(ticker.getBid()).isEqualTo("3400.01");
-    assertThat(ticker.getVolume()).isEqualTo("1200127.03");
+    assertThat(ticker.getVolume()).isEqualTo("347.2045");
   }
 
   @Test

--- a/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/CryptoTradeAdapters.java
+++ b/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/CryptoTradeAdapters.java
@@ -97,7 +97,7 @@ public final class CryptoTradeAdapters {
     BigDecimal last = cryptoTradeTicker.getLast();
     BigDecimal low = cryptoTradeTicker.getLow();
     BigDecimal high = cryptoTradeTicker.getHigh();
-    BigDecimal volume = cryptoTradeTicker.getVolumePriceCurrency();
+    BigDecimal volume = cryptoTradeTicker.getVolumeTradeCurrency();
 
     return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withAsk(ask).withBid(bid).withLast(last).withLow(low).withHigh(high).withVolume(volume).build();
   }

--- a/xchange-cryptotrade/src/test/java/com/xeiam/xchange/cryptotrade/dto/CryptoTradeAdapterTests.java
+++ b/xchange-cryptotrade/src/test/java/com/xeiam/xchange/cryptotrade/dto/CryptoTradeAdapterTests.java
@@ -68,7 +68,7 @@ public class CryptoTradeAdapterTests {
     assertThat(adaptedTicker.getLast()).isEqualTo(new BigDecimal("128"));
     assertThat(adaptedTicker.getLow()).isEqualTo(new BigDecimal("127.9999"));
     assertThat(adaptedTicker.getHigh()).isEqualTo(new BigDecimal("129.1"));
-    assertThat(adaptedTicker.getVolume()).isEqualTo("693.8199");
+    assertThat(adaptedTicker.getVolume()).isEqualTo("5.4");
     assertThat(adaptedTicker.getAsk()).isEqualTo(new BigDecimal("129.1"));
     assertThat(adaptedTicker.getBid()).isEqualTo(new BigDecimal("128"));
     assertThat(adaptedTicker.getCurrencyPair().baseSymbol).isEqualTo(Currencies.BTC);


### PR DESCRIPTION
This change will unify the currency that the ticker volume is quoted in for all exchanges.  I confirmed with exchanges that only report a single volume (kraken, bitstamp, justcoin, vault of satoshi and btcchina) that they all report their volume using the base asset.  I'm still unsure about bitfinex, but I have sent them an email to confirm.
