### PR TITLE
add markets Cinnicoin (CINNI), Blackcoin (BC)

### DIFF
--- a/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/service/polling/CryptoTradeBasePollingService.java
+++ b/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/service/polling/CryptoTradeBasePollingService.java
@@ -98,6 +98,10 @@ public class CryptoTradeBasePollingService<T extends CryptoTrade> extends BaseEx
     CURRENCY_PAIRS.add(CurrencyPair.UTC_EUR);
     CURRENCY_PAIRS.add(CurrencyPair.UTC_BTC);
     CURRENCY_PAIRS.add(CurrencyPair.UTC_LTC);
+    CURRENCY_PAIRS.add(new CurrencyPair("CINNI"));
+    CURRENCY_PAIRS.add(new CurrencyPair("BC"));
+    CURRENCY_PAIRS.add(new CurrencyPair("CINNI", "BTC"));
+    CURRENCY_PAIRS.add(new CurrencyPair("BC", "BTC"));
   }
 
   @Override


### PR DESCRIPTION
Crypto-Trade has added CINNI and BC

CinniCoin - https://crypto-trade.com/news/54
Blackcoin - https://crypto-trade.com/news/55
