### PR TITLE
CexIO getOpendOrders Ignore Invalid CurrencyPair

### DIFF
--- a/xchange-cexio/src/main/java/com/xeiam/xchange/cexio/CexIOAuthenticated.java
+++ b/xchange-cexio/src/main/java/com/xeiam/xchange/cexio/CexIOAuthenticated.java
@@ -35,6 +35,7 @@ import javax.ws.rs.core.MediaType;
 import si.mazi.rescu.ParamsDigest;
 
 import com.xeiam.xchange.cexio.dto.account.CexIOBalanceInfo;
+import com.xeiam.xchange.cexio.dto.trade.CexIOOpenOrders;
 import com.xeiam.xchange.cexio.dto.trade.CexIOOrder;
 
 /**
@@ -53,7 +54,7 @@ public interface CexIOAuthenticated {
 
   @POST
   @Path("open_orders/{ident}/{currency}/")
-  CexIOOrder[] getOpenOrders(@PathParam("ident") String tradeableIdentifier, @PathParam("currency") String currency, @FormParam("key") String apiKey, @FormParam("signature") ParamsDigest signer,
+  CexIOOpenOrders getOpenOrders(@PathParam("ident") String tradeableIdentifier, @PathParam("currency") String currency, @FormParam("key") String apiKey, @FormParam("signature") ParamsDigest signer,
       @FormParam("nonce") long nonce) throws IOException;
 
   @POST

--- a/xchange-cexio/src/main/java/com/xeiam/xchange/cexio/dto/trade/CexIOOpenOrders.java
+++ b/xchange-cexio/src/main/java/com/xeiam/xchange/cexio/dto/trade/CexIOOpenOrders.java
@@ -1,0 +1,90 @@
+package com.xeiam.xchange.cexio.dto.trade;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.xeiam.xchange.ExchangeException;
+import com.xeiam.xchange.cexio.dto.trade.CexIOOpenOrders.CexIOOpenOrdersDeserializer;
+import com.xeiam.xchange.cexio.dto.trade.CexIOOrder.Type;
+
+@JsonDeserialize(using = CexIOOpenOrdersDeserializer.class)
+public class CexIOOpenOrders {
+
+  private final List<CexIOOrder> openOrders;
+
+  public CexIOOpenOrders(final List<CexIOOrder> openOrders) {
+
+    this.openOrders = openOrders;
+  }
+
+  public CexIOOpenOrders() {
+
+    this.openOrders = new ArrayList<CexIOOrder>();
+  }
+
+  public List<CexIOOrder> getOpenOrders() {
+
+    return openOrders;
+  }
+
+  public void addOpenOrders(final List<CexIOOrder> openOrders) {
+
+    this.openOrders.addAll(openOrders);
+  }
+
+  public void addOpenOrder(final CexIOOrder openOrder) {
+
+    this.openOrders.add(openOrder);
+  }
+
+  @Override
+  public String toString() {
+
+    return "CexIOOpenOrders [openOrders=" + openOrders + "]";
+  }
+
+  static class CexIOOpenOrdersDeserializer extends JsonDeserializer<CexIOOpenOrders> {
+
+    @Override
+    public CexIOOpenOrders deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+
+      final ObjectCodec oc = jp.getCodec();
+      final JsonNode openOrdersNode = oc.readTree(jp);
+
+      final JsonNode errorNode = openOrdersNode.path("error");
+      if (!errorNode.isMissingNode()) {
+        final String errorText = errorNode.asText();
+        if (errorText.equals("Invalid symbols pair")) {
+          return new CexIOOpenOrders();
+        }
+        else {
+          throw new ExchangeException("Unable to retrieve open orders because " + errorText);
+        }
+      }
+
+      final List<CexIOOrder> openOrders = new ArrayList<CexIOOrder>();
+      if (openOrdersNode.isArray()) {
+        for (JsonNode openOrderNode : openOrdersNode) {
+          final int id = openOrderNode.path("id").asInt();
+          final long time = openOrderNode.path("time").asLong();
+          final Type type = Type.valueOf(openOrderNode.path("type").asText());
+          final BigDecimal price = new BigDecimal(openOrderNode.path("price").asText());
+          final BigDecimal amount = new BigDecimal(openOrderNode.path("amount").asText());
+          final BigDecimal pending = new BigDecimal(openOrderNode.path("pending").asText());
+
+          openOrders.add(new CexIOOrder(id, time, type, price, amount, pending, null));
+        }
+      }
+      return new CexIOOpenOrders(openOrders);
+    }
+  }
+}

--- a/xchange-cexio/src/main/java/com/xeiam/xchange/cexio/service/CexIOBaseService.java
+++ b/xchange-cexio/src/main/java/com/xeiam/xchange/cexio/service/CexIOBaseService.java
@@ -33,31 +33,31 @@ import com.xeiam.xchange.service.BaseExchangeService;
  */
 public class CexIOBaseService extends BaseExchangeService {
 
-	public static final List<CurrencyPair> CURRENCY_PAIRS = Arrays.asList(
+  public static final List<CurrencyPair> CURRENCY_PAIRS = Arrays.asList(
 
-	new CurrencyPair("GHS", "BTC"),
+  new CurrencyPair("GHS", "BTC"),
 
-	new CurrencyPair("LTC", "BTC"),
+  new CurrencyPair("LTC", "BTC"),
 
-	new CurrencyPair("NMC", "BTC"),
+  new CurrencyPair("NMC", "BTC"),
 
-	new CurrencyPair("GHS", "NMC"),
+  new CurrencyPair("GHS", "NMC"),
 
-	new CurrencyPair("FHM", "BTC"));
+  new CurrencyPair("FHM", "BTC"));
 
-	/**
-	 * Constructor
-	 * 
-	 * @param exchangeSpecification
-	 */
-	public CexIOBaseService(ExchangeSpecification exchangeSpecification) {
+  /**
+   * Constructor
+   * 
+   * @param exchangeSpecification
+   */
+  public CexIOBaseService(ExchangeSpecification exchangeSpecification) {
 
-		super(exchangeSpecification);
-	}
+    super(exchangeSpecification);
+  }
 
-	@Override
-	public List<CurrencyPair> getExchangeSymbols() {
+  @Override
+  public List<CurrencyPair> getExchangeSymbols() {
 
-		return CURRENCY_PAIRS;
-	}
+    return CURRENCY_PAIRS;
+  }
 }

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/cexio/CexIODemoUtils.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/cexio/CexIODemoUtils.java
@@ -36,9 +36,9 @@ public class CexIODemoUtils {
   public static Exchange createExchange() {
 
     ExchangeSpecification exSpec = new ExchangeSpecification(CexIOExchange.class);
-    exSpec.setUserName("test42");
-    exSpec.setSecretKey("auzRkXAZ3xAfWAI1oAIurkeBjT8");
-    exSpec.setApiKey("3NG79UTjBDu89Ao6zQhMHVaA");
+    exSpec.setUserName("");
+    exSpec.setSecretKey("");
+    exSpec.setApiKey("");
     exSpec.setSslUri("https://cex.io");
     return ExchangeFactory.INSTANCE.createExchange(exSpec);
   }

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/cexio/trade/TradeDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/cexio/trade/TradeDemo.java
@@ -23,9 +23,14 @@ package com.xeiam.xchange.examples.cexio.trade;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.List;
 
 import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.ExchangeException;
+import com.xeiam.xchange.NotAvailableFromExchangeException;
+import com.xeiam.xchange.NotYetImplementedForExchangeException;
+import com.xeiam.xchange.cexio.dto.trade.CexIOOrder;
+import com.xeiam.xchange.cexio.service.polling.CexIOTradeServiceRaw;
 import com.xeiam.xchange.currency.Currencies;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order;
@@ -35,8 +40,7 @@ import com.xeiam.xchange.examples.cexio.CexIODemoUtils;
 import com.xeiam.xchange.service.polling.PollingTradeService;
 
 /**
- * Author: brox
- * Since: 2/6/14
+ * Author: brox Since: 2/6/14
  */
 
 public class TradeDemo {
@@ -45,6 +49,13 @@ public class TradeDemo {
 
     Exchange exchange = CexIODemoUtils.createExchange();
     PollingTradeService tradeService = exchange.getPollingTradeService();
+
+    generic(tradeService);
+    raw((CexIOTradeServiceRaw) tradeService);
+
+  }
+
+  private static void generic(PollingTradeService tradeService) throws NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
 
     printOpenOrders(tradeService);
 
@@ -67,10 +78,15 @@ public class TradeDemo {
     printOpenOrders(tradeService);
   }
 
+  private static void raw(CexIOTradeServiceRaw tradeService) throws IOException {
+
+    List<CexIOOrder> openOrders = tradeService.getCexIOOpenOrders(new CurrencyPair("NMC", "BTC"));
+    System.out.println(openOrders);
+  }
+
   private static void printOpenOrders(PollingTradeService tradeService) throws IOException {
 
     OpenOrders openOrders = tradeService.getOpenOrders();
     System.out.println(openOrders.toString());
   }
-
 }


### PR DESCRIPTION
following up on https://github.com/timmolter/XChange/issues/401.

Purpose of this change is to prevent further issues if/when CexIO removes currencies.  I updated the corresponding demo and tested with live open orders on the exchange.

Change Summary:
- Add a response wrapper (CexIOOpenOrders) with a custom deserializer to handle the difference between a map being returned for errors and an array being returned for order data.
- Return an empty list of orders if the exchange error response is "Invalid symbols pair" instead of a JsonMappingException.
- For all other exceptions throw an ExchangeException with the error message from CexIO instead of a JsonMappingException.
- Add a raw service method to get open orders for a single currency pair.

Sorry I went M.I.A. on this issue, every time i checked in you guys were ahead of me.

@lapoor let me know if you think other areas of CexIO need this same pattern implemented.
