### PR TITLE
Added live trades to Bitstamp streaming service

### DIFF
--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/BitstampAdapters.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/BitstampAdapters.java
@@ -81,6 +81,7 @@ public final class BitstampAdapters {
    * 
    * @param currencyPair (e.g. BTC/USD)
    * @param currency The currency (e.g. USD in BTC/USD)
+   * @param timeScale polled order books provide a timestamp in seconds, stream in ms
    * @return The XChange OrderBook
    */
   public static OrderBook adaptOrders(BitstampOrderBook bitstampOrderBook, CurrencyPair currencyPair, int timeScale) {
@@ -129,6 +130,21 @@ public final class BitstampAdapters {
     }
 
     return new Trades(trades, TradeSortType.SortByID);
+  }
+
+  /**
+   * Adapts a Transaction to a Trade Object
+   * 
+   * @param transactions The Bitstamp transaction
+   * @param currencyPair (e.g. BTC/USD)
+   * @param timeScale polled order books provide a timestamp in seconds, stream in ms
+   * @return The XChange Trade
+   */
+  public static Trade adaptTrade(BitstampTransaction tx, CurrencyPair currencyPair, int timeScale) {
+
+    final String tradeId = String.valueOf(tx.getTid());
+    Date date = DateUtils.fromMillisUtc(tx.getDate() * timeScale);// polled order books provide a timestamp in seconds, stream in ms
+    return new Trade(null, tx.getAmount(), currencyPair, tx.getPrice(), date, tradeId);
   }
 
   /**

--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/streaming/BitstampStreamingConfiguration.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/streaming/BitstampStreamingConfiguration.java
@@ -63,27 +63,28 @@ public class BitstampStreamingConfiguration implements ExchangeStreamingConfigur
     this.isEncryptedChannel = isEncryptedChannel;
     this.pusherKey = pusherKey;
     this.channels = channels;
-    this.pusherOpts = pusherOptions;
+    pusherOpts = pusherOptions;
   }
 
   public BitstampStreamingConfiguration() {
 
-    this.maxReconnectAttempts = 30; // 67 min
-    this.reconnectWaitTimeInMs = 135000; // 2:15
-    this.timeoutInMs = 120000; // 2:00
-    this.isEncryptedChannel = false; // data stream is public
-    this.pusherKey = "de504dc5763aeef9ff52"; // https://www.bitstamp.net/websocket/
-    this.channels = new HashSet<String>();
-    this.channels.add("order_book");
-    this.pusherOpts = new PusherOptions();
-    this.pusherOpts.setEncrypted(isEncryptedChannel);
-    this.pusherOpts.setActivityTimeout(4 * timeoutInMs); // Keep-alive interval
-    this.pusherOpts.setPongTimeout(timeoutInMs); // Response timeout
+    maxReconnectAttempts = 30; // 67 min
+    reconnectWaitTimeInMs = 135000; // 2:15
+    timeoutInMs = 120000; // 2:00
+    isEncryptedChannel = false; // data stream is public
+    pusherKey = "de504dc5763aeef9ff52"; // https://www.bitstamp.net/websocket/
+    channels = new HashSet<String>();
+    channels.add("live_trades");
+    channels.add("order_book");
+    pusherOpts = new PusherOptions();
+    pusherOpts.setEncrypted(isEncryptedChannel);
+    pusherOpts.setActivityTimeout(4 * timeoutInMs); // Keep-alive interval
+    pusherOpts.setPongTimeout(timeoutInMs); // Response timeout
   }
 
   public final PusherOptions pusherOptions() {
 
-    return this.pusherOpts;
+    return pusherOpts;
   }
 
   @Override

--- a/xchange-bitstamp/src/test/java/com/xeiam/xchange/bitstamp/BitstampAdapterTest.java
+++ b/xchange-bitstamp/src/test/java/com/xeiam/xchange/bitstamp/BitstampAdapterTest.java
@@ -42,6 +42,7 @@ import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
+import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 
 /**
@@ -94,6 +95,25 @@ public class BitstampAdapterTest {
 
   @Test
   public void testTradeAdapter() throws IOException {
+
+    // Read in the JSON from the example resources
+    InputStream is = BitstampAdapterTest.class.getResourceAsStream("/marketdata/example-trades-data.json");
+
+    // Use Jackson to parse it
+    ObjectMapper mapper = new ObjectMapper();
+    BitstampTransaction[] transactions = mapper.readValue(is, BitstampTransaction[].class);
+
+    Trade trade = BitstampAdapters.adaptTrade(transactions[3], CurrencyPair.BTC_USD, 1000);
+
+    // verify all fields filled
+    assertThat(trade.getPrice().toString()).isEqualTo("13.14");
+    assertThat(trade.getType()).isNull();
+    assertThat(trade.getTradableAmount()).isEqualTo(new BigDecimal("23.66362253"));
+    assertThat(trade.getCurrencyPair()).isEqualTo(CurrencyPair.BTC_USD);
+  }
+
+  @Test
+  public void testTradesAdapter() throws IOException {
 
     // Read in the JSON from the example resources
     InputStream is = BitstampAdapterTest.class.getResourceAsStream("/marketdata/example-trades-data.json");


### PR DESCRIPTION
Following ticket #375:
Live trades were not implemented in Bitstamp streaming API, I added them.
