### PR TITLE
Issue #459: Added support for Bitcurex authenticated getFunds account API call.

### DIFF
--- a/xchange-bitcurex/src/main/java/com/xeiam/xchange/bitcurex/BitcurexAdapters.java
+++ b/xchange-bitcurex/src/main/java/com/xeiam/xchange/bitcurex/BitcurexAdapters.java
@@ -23,19 +23,24 @@ package com.xeiam.xchange.bitcurex;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
+import com.xeiam.xchange.bitcurex.dto.marketdata.BitcurexFunds;
 import com.xeiam.xchange.bitcurex.dto.marketdata.BitcurexTicker;
 import com.xeiam.xchange.bitcurex.dto.marketdata.BitcurexTrade;
+import com.xeiam.xchange.currency.Currencies;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
+import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.Ticker;
 import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
 import com.xeiam.xchange.dto.trade.LimitOrder;
+import com.xeiam.xchange.dto.trade.Wallet;
 import com.xeiam.xchange.utils.DateUtils;
 
 /**
@@ -136,5 +141,22 @@ public final class BitcurexAdapters {
 
     return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withHigh(high).withLow(low).withBid(buy).withAsk(sell).withVolume(volume).build();
   }
+
+  /**
+   * Adapts a BitcurexFunds to an AccountInfo Object
+   * 
+   * @param bitcurexFunds
+   * @param user name for the accountInfo
+   * @return
+   */
+  public static AccountInfo adaptAccountInfo(BitcurexFunds funds, String userName) {
+
+	    // Adapt to XChange DTOs
+	    Wallet eurWallet = new Wallet(Currencies.EUR, funds.getEurs());
+	    Wallet btcWallet = new Wallet(Currencies.BTC, funds.getBtcs());
+
+	    return new AccountInfo( userName, null, 
+	    		                Arrays.asList(eurWallet, btcWallet));
+	  }
 
 }

--- a/xchange-bitcurex/src/main/java/com/xeiam/xchange/bitcurex/BitcurexAuthenticated.java
+++ b/xchange-bitcurex/src/main/java/com/xeiam/xchange/bitcurex/BitcurexAuthenticated.java
@@ -1,0 +1,25 @@
+package com.xeiam.xchange.bitcurex;
+
+import java.io.IOException;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+
+import si.mazi.rescu.ParamsDigest;
+
+import com.xeiam.xchange.bitcurex.dto.marketdata.BitcurexFunds;
+
+@Path( "api/0")
+@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+
+public interface BitcurexAuthenticated {
+	  @POST
+	  @Path("getFunds")
+	  public BitcurexFunds getFunds( @HeaderParam("Rest-Key") String apiKey, 
+			                         @HeaderParam("Rest-Sign") ParamsDigest signer, 
+			                         @FormParam("nonce") long nonce) throws IOException;
+}

--- a/xchange-bitcurex/src/main/java/com/xeiam/xchange/bitcurex/BitcurexExchange.java
+++ b/xchange-bitcurex/src/main/java/com/xeiam/xchange/bitcurex/BitcurexExchange.java
@@ -54,9 +54,8 @@ public class BitcurexExchange extends BaseExchange implements Exchange {
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
     ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass().getCanonicalName());
-    exchangeSpecification.setSslUri("https://bitcurex.com");
-    exchangeSpecification.setHost("bitcurex.com");
-    exchangeSpecification.setPort(80);
+    exchangeSpecification.setSslUri("https://eur.bitcurex.com");
+    exchangeSpecification.setHost("eur.bitcurex.com");
     exchangeSpecification.setExchangeName("Bitcurex");
     exchangeSpecification.setExchangeDescription("Bitcurex is a polish Bitcoin exchange");
 

--- a/xchange-bitcurex/src/main/java/com/xeiam/xchange/bitcurex/BitcurexUtils.java
+++ b/xchange-bitcurex/src/main/java/com/xeiam/xchange/bitcurex/BitcurexUtils.java
@@ -32,5 +32,9 @@ public final class BitcurexUtils {
   private BitcurexUtils() {
 
   }
+  
+  public static long getNonce() {
+	  return System.currentTimeMillis();
+	  }
 
 }

--- a/xchange-bitcurex/src/main/java/com/xeiam/xchange/bitcurex/dto/marketdata/BitcurexFunds.java
+++ b/xchange-bitcurex/src/main/java/com/xeiam/xchange/bitcurex/dto/marketdata/BitcurexFunds.java
@@ -1,0 +1,28 @@
+package com.xeiam.xchange.bitcurex.dto.marketdata;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class BitcurexFunds {
+	private final BigDecimal eurs;
+	private final BigDecimal btcs;
+	private final String address;
+	private final String error;
+	
+	  public BitcurexFunds( @JsonProperty("eurs") BigDecimal eurs, 
+			                @JsonProperty("btcs") BigDecimal btcs, 
+			                @JsonProperty("address") String address,
+			                @JsonProperty("error") String error ) 
+	  {
+		    this.eurs = eurs;
+		    this.btcs = btcs;
+		    this.address = address;
+		    this.error = error;
+	  }
+
+	  public BigDecimal getEurs() { return eurs; }
+	  public BigDecimal getBtcs() { return btcs; }
+	  public String getAddress() { return address; }
+	  public String getError() { return error; }
+}

--- a/xchange-bitcurex/src/main/java/com/xeiam/xchange/bitcurex/service/BitcurexDigest.java
+++ b/xchange-bitcurex/src/main/java/com/xeiam/xchange/bitcurex/service/BitcurexDigest.java
@@ -1,0 +1,49 @@
+package com.xeiam.xchange.bitcurex.service;
+
+import java.io.IOException;
+
+import javax.crypto.Mac;
+
+import si.mazi.rescu.RestInvocation;
+
+import com.xeiam.xchange.service.BaseParamsDigest;
+import com.xeiam.xchange.utils.Base64;
+import javax.xml.bind.DatatypeConverter;
+
+public class BitcurexDigest extends BaseParamsDigest {
+
+   /**
+	 * Constructor
+	 * 
+	 * @param secretKeyBase64
+	 * @param clientId
+     * @param apiKey @throws IllegalArgumentException if key is invalid (cannot be base-64-decoded or the decoded key is invalid).
+	 */
+	private BitcurexDigest(String secretKeyBase64, String apiKey) 
+			throws IOException {
+	  super( DatatypeConverter.parseBase64Binary(secretKeyBase64),
+						 HMAC_SHA_512 ); 
+ 	}
+
+	  public static BitcurexDigest createInstance( String secretKeyBase64, 
+			                                       String apiKey)
+			          throws IOException {
+	    return secretKeyBase64 == null ? null : 
+	    	new BitcurexDigest(secretKeyBase64, apiKey);
+	  }
+
+	  @Override
+	  public String digestParams(RestInvocation restInvocation) {
+		  String digest;
+		  byte[] signature;
+		  
+	    Mac sha512 = getMac();
+
+	    sha512.update(restInvocation.getRequestBody().getBytes());
+
+	    signature = sha512.doFinal();
+	    digest = Base64.encodeBytes( signature );
+
+	    return digest;
+	  }
+}

--- a/xchange-bitcurex/src/main/java/com/xeiam/xchange/bitcurex/service/polling/BitcurexAccountService.java
+++ b/xchange-bitcurex/src/main/java/com/xeiam/xchange/bitcurex/service/polling/BitcurexAccountService.java
@@ -1,0 +1,46 @@
+package com.xeiam.xchange.bitcurex.service.polling;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+import com.xeiam.xchange.ExchangeException;
+import com.xeiam.xchange.ExchangeSpecification;
+import com.xeiam.xchange.NotAvailableFromExchangeException;
+import com.xeiam.xchange.NotYetImplementedForExchangeException;
+import com.xeiam.xchange.bitcurex.BitcurexAdapters;
+import com.xeiam.xchange.dto.account.AccountInfo;
+import com.xeiam.xchange.service.polling.PollingAccountService;
+
+public class BitcurexAccountService extends BitcurexAccountServiceRaw 
+                                    implements PollingAccountService {
+
+	public BitcurexAccountService(ExchangeSpecification exchangeSpecification)
+			throws IOException {
+		super(exchangeSpecification);
+	}
+
+	@Override
+	public AccountInfo getAccountInfo() throws ExchangeException,
+			NotAvailableFromExchangeException,
+			NotYetImplementedForExchangeException, IOException {
+	    return BitcurexAdapters.adaptAccountInfo(getFunds(), 
+	    		exchangeSpecification.getUserName());
+	}
+
+	@Override
+	public String withdrawFunds(String currency, BigDecimal amount,
+			String address) throws ExchangeException,
+			NotAvailableFromExchangeException,
+			NotYetImplementedForExchangeException, IOException {
+		throw new NotYetImplementedForExchangeException();
+	}
+
+	@Override
+	public String requestDepositAddress(String currency, String... args)
+			throws ExchangeException, NotAvailableFromExchangeException,
+			NotYetImplementedForExchangeException, IOException 
+	{
+		return getFunds().getAddress();
+	}
+
+}

--- a/xchange-bitcurex/src/main/java/com/xeiam/xchange/bitcurex/service/polling/BitcurexAccountServiceRaw.java
+++ b/xchange-bitcurex/src/main/java/com/xeiam/xchange/bitcurex/service/polling/BitcurexAccountServiceRaw.java
@@ -1,0 +1,38 @@
+package com.xeiam.xchange.bitcurex.service.polling;
+
+import java.io.IOException;
+
+import si.mazi.rescu.RestProxyFactory;
+
+import com.xeiam.xchange.ExchangeException;
+import com.xeiam.xchange.ExchangeSpecification;
+import com.xeiam.xchange.bitcurex.BitcurexAuthenticated;
+import com.xeiam.xchange.bitcurex.BitcurexUtils;
+import com.xeiam.xchange.bitcurex.dto.marketdata.BitcurexFunds;
+import com.xeiam.xchange.bitcurex.service.BitcurexDigest;
+
+public class BitcurexAccountServiceRaw extends BitcurexBasePollingService {
+	private final BitcurexDigest signatureCreator;
+	private final BitcurexAuthenticated bitcurexAuthenticated;
+
+	public BitcurexAccountServiceRaw(ExchangeSpecification exchangeSpecification) throws IOException {
+		super(exchangeSpecification);
+		
+	    this.bitcurexAuthenticated = RestProxyFactory.createProxy( BitcurexAuthenticated.class, 
+	    		                                                   exchangeSpecification.getSslUri() );
+	    this.signatureCreator = BitcurexDigest.createInstance( exchangeSpecification.getSecretKey(), 
+	    		                                               exchangeSpecification.getApiKey());
+	}
+
+	  public BitcurexFunds getFunds() throws IOException, ExchangeException {
+
+		  BitcurexFunds bitcurexFunds = bitcurexAuthenticated.getFunds( exchangeSpecification.getApiKey(), 
+				                                                        signatureCreator, 
+				                                                        BitcurexUtils.getNonce());
+		    if (bitcurexFunds.getError() != null) {
+		      throw new ExchangeException("Error getting balance. " + bitcurexFunds.getError());
+		    }
+		    return bitcurexFunds;
+		  }
+
+}

--- a/xchange-bitcurex/src/test/java/com/xeiam/xchange/bitcurex/service/BitcurexAdapterTest.java
+++ b/xchange-bitcurex/src/test/java/com/xeiam/xchange/bitcurex/service/BitcurexAdapterTest.java
@@ -33,13 +33,16 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.xeiam.xchange.bitcurex.BitcurexAdapters;
 import com.xeiam.xchange.bitcurex.dto.marketdata.BitcurexDepth;
+import com.xeiam.xchange.bitcurex.dto.marketdata.BitcurexFunds;
 import com.xeiam.xchange.bitcurex.dto.marketdata.BitcurexTicker;
 import com.xeiam.xchange.bitcurex.dto.marketdata.BitcurexTrade;
+import com.xeiam.xchange.bitcurex.service.marketdata.BitcurexAccountJSONTest;
 import com.xeiam.xchange.bitcurex.service.marketdata.BitcurexDepthJSONTest;
 import com.xeiam.xchange.bitcurex.service.marketdata.BitcurexTickerJSONTest;
 import com.xeiam.xchange.bitcurex.service.marketdata.BitcurexTradesJSONTest;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
+import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.Ticker;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.trade.LimitOrder;
@@ -108,4 +111,23 @@ public class BitcurexAdapterTest {
     assertThat(ticker.getVolume()).isEqualTo(new BigDecimal("103.23546591"));
 
   }
+
+  @Test
+  public void testAccountFundsAdapter() throws IOException {
+
+    // Read in the JSON from the example resources
+    InputStream is = BitcurexAccountJSONTest.class.getResourceAsStream("/marketdata/example-funds-data.json");
+
+    // Use Jackson to parse it
+    ObjectMapper mapper = new ObjectMapper();
+    BitcurexFunds bitcurexFunds = mapper.readValue(is, BitcurexFunds.class);
+
+    AccountInfo accountInfo = BitcurexAdapters.adaptAccountInfo(bitcurexFunds, "demo");
+    System.out.println(accountInfo.toString());
+
+    assertThat(accountInfo.getBalance("BTC").compareTo( new BigDecimal("2.59033845"))==0);
+    assertThat(accountInfo.getBalance("EUR").compareTo( new BigDecimal("6160.06838790"))==0);
+    assertThat(accountInfo.getUsername().toString()).isEqualTo("demo");
+  }
+
 }

--- a/xchange-bitcurex/src/test/java/com/xeiam/xchange/bitcurex/service/marketdata/BitcurexAccountJSONTest.java
+++ b/xchange-bitcurex/src/test/java/com/xeiam/xchange/bitcurex/service/marketdata/BitcurexAccountJSONTest.java
@@ -1,0 +1,32 @@
+package com.xeiam.xchange.bitcurex.service.marketdata;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xeiam.xchange.bitcurex.dto.marketdata.BitcurexFunds;
+
+public class BitcurexAccountJSONTest {
+
+	  @Test
+	  public void testUnmarshal() throws IOException {
+
+	    // Read in the JSON from the example resources
+	    InputStream is = BitcurexAccountJSONTest.class.getResourceAsStream("/marketdata/example-funds-data.json");
+
+	    // Use Jackson to parse it
+	    ObjectMapper mapper = new ObjectMapper();
+	    BitcurexFunds bitcurexFunds = mapper.readValue(is, BitcurexFunds.class);
+
+	    // Verify that the example data was unmarshalled correctly
+	    assertThat(bitcurexFunds.getAddress().equals( "1ABcdEfgKEqBPMQ6D2ocuYNJNsXgKPcfV7" ) );
+	    assertThat(bitcurexFunds.getBtcs().compareTo(new BigDecimal("2.59033845")) == 0);
+	    assertThat(bitcurexFunds.getEurs().compareTo(new BigDecimal("6160.06838790")) == 0);
+	}
+
+}

--- a/xchange-bitcurex/src/test/resources/marketdata/example-funds-data.json
+++ b/xchange-bitcurex/src/test/resources/marketdata/example-funds-data.json
@@ -1,0 +1,1 @@
+{"eurs":"6160.06838790","btcs":"2.59033845","address":"1ABcdEfgKEqBPMQ6D2ocuYNJNsXgKPcfV7"}


### PR DESCRIPTION
Modeled on Bitstamp implementation.
Should make implementing other authenticated calls fairly easy.
