### PR TITLE
Hitbtc: report cash+reserved for account balance

### DIFF
--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/HitbtcAdapters.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/HitbtcAdapters.java
@@ -187,7 +187,7 @@ public class HitbtcAdapters {
     for (int i = 0; i < accountInfoRaw.length; i++) {
       HitbtcBalance balance = accountInfoRaw[i];
 
-      Wallet wallet = new Wallet(balance.getCurrencyCode(), balance.getCash(), balance.getCurrencyCode());
+      Wallet wallet = new Wallet(balance.getCurrencyCode(), balance.getCash().add(balance.getReserved()), balance.getCurrencyCode());
       wallets.add(wallet);
 
     }


### PR DESCRIPTION
Hitbtc reports money currently in open orders under a different value in their account balance. XChange only reported on the cash part which lead to fluctuating account balances.
