### PR TITLE
Hitbtc: sort trade history latest trades first

### DIFF
--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/HitbtcAuthenticated.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/HitbtcAuthenticated.java
@@ -48,7 +48,7 @@ public interface HitbtcAuthenticated extends Hitbtc {
   @GET
   @Path("trading/orders/active")
   public HitbtcOrdersResponse getHitbtcActiveOrders(@HeaderParam("X-Signature") ParamsDigest signature, @QueryParam("nonce") long nonce, @QueryParam("apikey") String apiKey
-  /* @QueryParam("symbols") String symbols */) throws IOException;
+      /* @QueryParam("symbols") String symbols */) throws IOException;
 
   @POST
   @Path("trading/new_order")
@@ -63,16 +63,13 @@ public interface HitbtcAuthenticated extends Hitbtc {
   @Produces(MediaType.APPLICATION_FORM_URLENCODED)
   public HitbtcExecutionReportResponse postHitbtcCancelOrder(@HeaderParam("X-Signature") ParamsDigest signature, @QueryParam("nonce") long nonce, @QueryParam("apikey") String apiKey,
       @FormParam("clientOrderId") String clientOrderId, @FormParam("cancelRequestClientOrderId") String cancelRequestClientOrderId, @FormParam("symbol") String symbol, @FormParam("side") String side)
-      throws IOException;
+          throws IOException;
 
   @GET
   @Path("trading/trades")
   public HitbtcTradeResponse getHitbtcTrades(@HeaderParam("X-Signature") ParamsDigest signature, @QueryParam("nonce") long nonce, @QueryParam("apikey") String apiKey, @QueryParam("by") String by,
-      @QueryParam("start_index") int start_index, @QueryParam("max_results") int max_results, @QueryParam("symbols") String symbols
-  // @QueryParam("sort") String sort,
-  // @QueryParam("from") String from,
-  // @QueryParam("till") String till
-      ) throws IOException;
+      @QueryParam("start_index") int start_index, @QueryParam("max_results") int max_results, @QueryParam("symbols") String symbols, @QueryParam("sort") String sort, @QueryParam("from") String from, 
+      @QueryParam("till") String till) throws IOException;
 
   @GET
   @Path("trading/balance")

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcTradeServiceRaw.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcTradeServiceRaw.java
@@ -90,7 +90,17 @@ public class HitbtcTradeServiceRaw extends HitbtcBasePollingService<HitbtcAuthen
   public HitbtcOwnTrade[] getTradeHistoryRaw(int startIndex, int maxResults, String symbols) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException,
       IOException {
 
-    HitbtcTradeResponse hitbtcTrades = hitbtc.getHitbtcTrades(signatureCreator, nextNonce(), apiKey, "ts", startIndex, maxResults, symbols); // TODO
+    HitbtcTradeResponse hitbtcTrades = hitbtc.getHitbtcTrades(
+        signatureCreator, 
+        nextNonce(), 
+        apiKey, 
+        "ts", 
+        startIndex, 
+        maxResults, 
+        symbols,
+        "desc",
+        null,
+        null);
 
     return hitbtcTrades.getTrades();
   }


### PR DESCRIPTION
Only 1000 trades can be received in the trade history, makes sense to get them latest first. There's more filtering/sorting options for the trade history, will/can introduce them later on.
