### PR TITLE
Hitbtc: change sorting order for public trades 

### DIFF
--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/Hitbtc.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/Hitbtc.java
@@ -57,7 +57,7 @@ public interface Hitbtc {
 
   @GET
   @Path("public/{currencyPair}/trades")
-  public HitbtcTrades getTrades(@PathParam("currencyPair") String currencyPair, @QueryParam("from") String from, @QueryParam("by") String sortBy, @QueryParam("start_index") String startIndex,
+  public HitbtcTrades getTrades(@PathParam("currencyPair") String currencyPair, @QueryParam("from") String from, @QueryParam("by") String sortBy, @QueryParam("sort") String sort, @QueryParam("start_index") String startIndex,
       @QueryParam("max_results") String max_results, @DefaultValue("object") @QueryParam("format_item") String format_item) throws IOException;
 
   @GET

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcMarketDataServiceRaw.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcMarketDataServiceRaw.java
@@ -58,7 +58,7 @@ public abstract class HitbtcMarketDataServiceRaw extends HitbtcBasePollingServic
 
   public HitbtcTrades getHitbtcTrades(CurrencyPair currencyPair, long from, HitbtcTrades.HitbtcTradesSortOrder sortBy, long startIndex, long maxResults) throws IOException {
 
-    return hitbtc.getTrades(currencyPair.baseSymbol.toUpperCase() + currencyPair.counterSymbol.toString(), from + "", sortBy.toString(), startIndex + "", maxResults + "", "object");
+    return hitbtc.getTrades(currencyPair.baseSymbol.toUpperCase() + currencyPair.counterSymbol.toString(), String.valueOf(from), sortBy.toString(), "desc", String.valueOf(startIndex), String.valueOf(maxResults), "object");
   }
 
   public HitbtcSymbols getHitbtcSymbols() throws IOException {


### PR DESCRIPTION
If we do not sort descending then you must first figure out a timestamp or an order id for which you want to filter from to get current trades (since otherwise it starts returning trades from December). With this change you can call:

```
marketDataService.getTrades(CurrencyPair.BTC_USD, 0L, HitbtcTradesSortOrder.SORT_BY_TRADE_ID, 0L, 1000L);
```

to get the latest 1000 trades. Also I don't think `start_index` is ever anything else but 0.
