### PR TITLE
Remove Coinbase spot price history.

### DIFF
--- a/xchange-coinbase/src/main/java/com/xeiam/xchange/coinbase/Coinbase.java
+++ b/xchange-coinbase/src/main/java/com/xeiam/xchange/coinbase/Coinbase.java
@@ -39,7 +39,6 @@ import com.xeiam.xchange.coinbase.dto.account.CoinbaseUser;
 import com.xeiam.xchange.coinbase.dto.marketdata.CoinbaseCurrency;
 import com.xeiam.xchange.coinbase.dto.marketdata.CoinbaseMoney;
 import com.xeiam.xchange.coinbase.dto.marketdata.CoinbasePrice;
-import com.xeiam.xchange.coinbase.dto.marketdata.CoinbaseSpotPriceHistory;
 
 /**
  * @author jamespedwards42
@@ -68,10 +67,10 @@ public interface Coinbase {
   @Path("prices/spot_rate")
   CoinbaseMoney getSpotRate(@QueryParam("currency") String currency) throws IOException;
 
-  @GET
+/*  @GET
   @Path("prices/historical")
   CoinbaseSpotPriceHistory getHistoricalSpotRates(@QueryParam("page") Integer page) throws IOException;
-
+*/
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
   @Path("users")

--- a/xchange-coinbase/src/main/java/com/xeiam/xchange/coinbase/dto/marketdata/CoinbaseSpotPriceHistory.java
+++ b/xchange-coinbase/src/main/java/com/xeiam/xchange/coinbase/dto/marketdata/CoinbaseSpotPriceHistory.java
@@ -21,8 +21,6 @@
  */
 package com.xeiam.xchange.coinbase.dto.marketdata;
 
-import java.io.IOException;
-import java.io.Reader;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,18 +29,12 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.xeiam.xchange.coinbase.dto.marketdata.CoinbaseSpotPriceHistory.CoibaseSpotPriceHistoryDeserializer;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.xeiam.xchange.utils.DateUtils;
 
 /**
  * @author jamespedwards42
  */
-@JsonDeserialize(using = CoibaseSpotPriceHistoryDeserializer.class)
 public class CoinbaseSpotPriceHistory {
 
   private final List<CoinbaseHistoricalSpotPrice> spotPriceHistory;
@@ -63,38 +55,31 @@ public class CoinbaseSpotPriceHistory {
     return "CoinbaseSpotPriceHistory [spotPriceHistory=" + spotPriceHistory + "]";
   }
 
-  static class CoibaseSpotPriceHistoryDeserializer extends JsonDeserializer<CoinbaseSpotPriceHistory> {
+  private static final Pattern historicalRateStringPatternInReverse = Pattern.compile("(\\d{1,2}\\.\\d+),(\\d{2}:\\d{2}-\\d{2}:\\d{2}:\\d{2}T\\d{2}\\-\\d{2}-\\d{4})");
 
-    private static final Pattern historicalRateStringPatternInReverse = Pattern.compile("(\\d{1,2}\\.\\d+),(\\d{2}:\\d{2}-\\d{2}:\\d{2}:\\d{2}T\\d{2}\\-\\d{2}-\\d{4})");
+  public static CoinbaseSpotPriceHistory fromRawString(String spotPriceHistoryString) {
 
-    @Override
-    public CoinbaseSpotPriceHistory deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-
-      final List<CoinbaseHistoricalSpotPrice> historicalPrices = new ArrayList<CoinbaseHistoricalSpotPrice>();
-
-      // If there is a better way to get to the actual String returned please replace this section.
-      final Reader reader = (Reader) ctxt.getParser().getTokenLocation().getSourceRef();
-      reader.reset();
-      final StringBuilder historyStringBuilder = new StringBuilder();
-      for (int c = reader.read(); c > 0; c = reader.read())
-        historyStringBuilder.append((char) c);
-
-      // Parse in reverse because they are inconsistent with the number of decimals for the rates
-      // which makes it difficult to differentiate from the following year. Going in reverse
-      // we can rely on the comma.
-      final String entireHistoryString = historyStringBuilder.reverse().toString();
-      final Matcher matcher = historicalRateStringPatternInReverse.matcher(entireHistoryString);
-      while (matcher.find()) {
-        final String rateString = new StringBuilder(matcher.group(1)).reverse().toString();
-        final BigDecimal spotRate = new BigDecimal(rateString);
-        final String timestampString = new StringBuilder(matcher.group(2)).reverse().toString();
-        final Date timestamp = DateUtils.fromISO8601DateString(timestampString);
-
-        final CoinbaseHistoricalSpotPrice historicalSpotPrice = new CoinbaseHistoricalSpotPrice(timestamp, spotRate);
-        historicalPrices.add(historicalSpotPrice);
+    final List<CoinbaseHistoricalSpotPrice> historicalPrices = new ArrayList<CoinbaseHistoricalSpotPrice>();
+    // Parse in reverse because they are inconsistent with the number of decimals for the rates
+    // which makes it difficult to differentiate from the following year. Going in reverse
+    // we can rely on the comma.
+    final String entireHistoryString = new StringBuilder(spotPriceHistoryString).reverse().toString();
+    final Matcher matcher = historicalRateStringPatternInReverse.matcher(entireHistoryString);
+    while (matcher.find()) {
+      final String rateString = new StringBuilder(matcher.group(1)).reverse().toString();
+      final BigDecimal spotRate = new BigDecimal(rateString);
+      final String timestampString = new StringBuilder(matcher.group(2)).reverse().toString();
+      Date timestamp = null;
+      try {
+        timestamp = DateUtils.fromISO8601DateString(timestampString);
+      } catch (InvalidFormatException e) {
+        e.printStackTrace();
       }
-      Collections.sort(historicalPrices, Collections.reverseOrder());
-      return new CoinbaseSpotPriceHistory(historicalPrices);
+
+      final CoinbaseHistoricalSpotPrice historicalSpotPrice = new CoinbaseHistoricalSpotPrice(timestamp, spotRate);
+      historicalPrices.add(historicalSpotPrice);
     }
+    Collections.sort(historicalPrices, Collections.reverseOrder());
+    return new CoinbaseSpotPriceHistory(historicalPrices);
   }
 }

--- a/xchange-coinbase/src/main/java/com/xeiam/xchange/coinbase/service/polling/CoinbaseMarketDataService.java
+++ b/xchange-coinbase/src/main/java/com/xeiam/xchange/coinbase/service/polling/CoinbaseMarketDataService.java
@@ -66,8 +66,8 @@ public class CoinbaseMarketDataService extends CoinbaseMarketDataServiceRaw impl
     final CoinbasePrice sellPrice = super.getCoinbaseSellPrice(BigDecimal.ONE, currency);
     final CoinbaseMoney spotRate = super.getCoinbaseSpotRate(currency);
 
-    final CoinbaseSpotPriceHistory coinbaseSpotPriceHistory =
-        (args != null && args.length > 0 && args[0] != null && args[0] instanceof Boolean && (Boolean) args[0]) ? super.getCoinbaseHistoricalSpotRates() : null;
+    final CoinbaseSpotPriceHistory coinbaseSpotPriceHistory = null;
+     //   (args != null && args.length > 0 && args[0] != null && args[0] instanceof Boolean && (Boolean) args[0]) ? super.getCoinbaseHistoricalSpotRates() : null;
 
     return CoinbaseAdapters.adaptTicker(currencyPair, buyPrice, sellPrice, spotRate, coinbaseSpotPriceHistory);
   }

--- a/xchange-coinbase/src/main/java/com/xeiam/xchange/coinbase/service/polling/CoinbaseMarketDataServiceRaw.java
+++ b/xchange-coinbase/src/main/java/com/xeiam/xchange/coinbase/service/polling/CoinbaseMarketDataServiceRaw.java
@@ -29,7 +29,6 @@ import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.coinbase.Coinbase;
 import com.xeiam.xchange.coinbase.dto.marketdata.CoinbaseMoney;
 import com.xeiam.xchange.coinbase.dto.marketdata.CoinbasePrice;
-import com.xeiam.xchange.coinbase.dto.marketdata.CoinbaseSpotPriceHistory;
 
 /**
  * @author jamespedwards42
@@ -150,28 +149,28 @@ class CoinbaseMarketDataServiceRaw extends CoinbaseBasePollingService<Coinbase> 
     return coinbase.getSpotRate(currency);
   }
 
-  /**
+/*  *//**
    * Unauthenticated resource that displays historical spot rates for Bitcoin in USD.
    * This is a paged resource and will return the first page by default.
    * 
    * @see <a href="https://coinbase.com/api/doc/1.0/prices/historical.html">coinbase.com/api/doc/1.0/prices/historical.html</a>
    * @return One thousand historical spot prices representing page 1.
    * @throws IOException
-   */
+   *//*
   public CoinbaseSpotPriceHistory getCoinbaseHistoricalSpotRates() throws IOException {
 
     return getCoinbaseHistoricalSpotRates(null);
   }
 
-  /**
+  *//**
    * Unauthenticated resource that displays historical spot rates for Bitcoin in USD.
    * 
    * @param page Optional parameter to request a desired page of results. Will return page 1 if the supplied page is null or less than 1.
    * @return One thousand historical spot prices for the given page.
    * @throws IOException
-   */
+   *//*
   public CoinbaseSpotPriceHistory getCoinbaseHistoricalSpotRates(Integer page) throws IOException {
 
     return coinbase.getHistoricalSpotRates(page);
-  }
+  }*/
 }

--- a/xchange-coinbase/src/test/java/com/xeiam/xchange/coinbase/CoinbaseAdapterTest.java
+++ b/xchange-coinbase/src/test/java/com/xeiam/xchange/coinbase/CoinbaseAdapterTest.java
@@ -29,16 +29,23 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Scanner;
 
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.xeiam.xchange.coinbase.dto.account.CoinbaseUser;
 import com.xeiam.xchange.coinbase.dto.account.CoinbaseUsers;
+import com.xeiam.xchange.coinbase.dto.marketdata.CoinbaseMoney;
+import com.xeiam.xchange.coinbase.dto.marketdata.CoinbasePrice;
+import com.xeiam.xchange.coinbase.dto.marketdata.CoinbaseSpotPriceHistory;
 import com.xeiam.xchange.coinbase.dto.trade.CoinbaseTransfers;
+import com.xeiam.xchange.currency.Currencies;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
+import com.xeiam.xchange.dto.marketdata.Ticker;
+import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.trade.Wallet;
@@ -94,32 +101,33 @@ public class CoinbaseAdapterTest {
     assertThat(trade).isEqualsToByComparingFields(expectedTrade);
   }
 
-  // @Test
-  // public void testAdaptTicker() throws IOException {
-  //
-  // Ticker expectedTicker =
-  // TickerBuilder.newInstance().withCurrencyPair(CurrencyPair.BTC_USD).withAsk(new BigDecimal("723.09")).withBid(new BigDecimal("723.09")).withLast(new BigDecimal("719.79")).withLow(
-  // new BigDecimal("718.2")).withHigh(new BigDecimal("723.11")).build();
-  //
-  // InputStream is = CoinbaseAdapterTest.class.getResourceAsStream("/marketdata/example-price-data.json");
-  // ObjectMapper mapper = new ObjectMapper();
-  // CoinbasePrice price = mapper.readValue(is, CoinbasePrice.class);
-  //
-  // CoinbaseMoney spotPrice = new CoinbaseMoney(Currencies.USD, new BigDecimal("719.79"));
-  //
-  // is = CoinbaseAdapterTest.class.getResourceAsStream("/marketdata/example-spot-rate-history-data.json");
-  // String spotPriceHistoryString;
-  // Scanner scanner = null;
-  // try {
-  // scanner = new Scanner(is);
-  // spotPriceHistoryString = scanner.useDelimiter("\\A").next();
-  // } finally {
-  // scanner.close();
-  // }
-  // CoinbaseSpotPriceHistory spotPriceHistory = mapper.readValue(spotPriceHistoryString, CoinbaseSpotPriceHistory.class);
-  //
-  // Ticker ticker = CoinbaseAdapters.adaptTicker(CurrencyPair.BTC_USD, price, price, spotPrice, spotPriceHistory);
-  //
-  // assertThat(ticker).isEqualsToByComparingFields(expectedTicker);
-  // }
+   @Test
+   public void testAdaptTicker() throws IOException {
+  
+   Ticker expectedTicker =
+   TickerBuilder.newInstance().withCurrencyPair(CurrencyPair.BTC_USD).withAsk(new BigDecimal("723.09")).withBid(new BigDecimal("723.09")).withLast(new BigDecimal("719.79")).withLow(
+   new BigDecimal("718.2")).withHigh(new BigDecimal("723.11")).build();
+  
+   InputStream is = CoinbaseAdapterTest.class.getResourceAsStream("/marketdata/example-price-data.json");
+   ObjectMapper mapper = new ObjectMapper();
+   CoinbasePrice price = mapper.readValue(is, CoinbasePrice.class);
+  
+   CoinbaseMoney spotPrice = new CoinbaseMoney(Currencies.USD, new BigDecimal("719.79"));
+  
+   is = CoinbaseAdapterTest.class.getResourceAsStream("/marketdata/example-spot-rate-history-data.json");
+   String spotPriceHistoryString;
+   Scanner scanner = null;
+   try {
+   scanner = new Scanner(is);
+   spotPriceHistoryString = scanner.useDelimiter("\\A").next();
+   } finally {
+   scanner.close();
+   }
+
+   CoinbaseSpotPriceHistory spotPriceHistory = CoinbaseSpotPriceHistory.fromRawString(spotPriceHistoryString);
+  
+   Ticker ticker = CoinbaseAdapters.adaptTicker(CurrencyPair.BTC_USD, price, price, spotPrice, spotPriceHistory);
+  
+   assertThat(ticker).isEqualsToByComparingFields(expectedTicker);
+   }
 }

--- a/xchange-coinbase/src/test/java/com/xeiam/xchange/coinbase/dto/account/CoinbaseAccountJsonTest.java
+++ b/xchange-coinbase/src/test/java/com/xeiam/xchange/coinbase/dto/account/CoinbaseAccountJsonTest.java
@@ -241,7 +241,7 @@ public class CoinbaseAccountJsonTest {
     assertThat(recurringPayment.getTimesRun()).isEqualTo(0);
     assertThat(recurringPayment.getRepeat()).isEqualTo(CoinbaseRepeat.MONTHLY);
     assertThat(recurringPayment.getLastRun()).isNull();
-    // assertThat(recurringPayment.getNextRun()).isEqualTo(DateUtils.fromISO8601DateString("2014-03-01T07:00:00-08:00"));
+    assertThat(recurringPayment.getNextRun()).isEqualTo(DateUtils.fromISO8601DateString("2014-03-01T07:00:00-08:00"));
     assertThat(recurringPayment.getNotes()).isEqualTo("For Demo");
     assertThat(recurringPayment.getDescription()).isEqualTo("Buy 0.01 BTC");
     assertThat(recurringPayment.getAmount()).isEqualsToByComparingFields(new CoinbaseMoney("BTC", new BigDecimal("0.01000000")));

--- a/xchange-coinbase/src/test/java/com/xeiam/xchange/coinbase/dto/marketdata/CoinbaseMarketDataJsonTest.java
+++ b/xchange-coinbase/src/test/java/com/xeiam/xchange/coinbase/dto/marketdata/CoinbaseMarketDataJsonTest.java
@@ -29,12 +29,14 @@ import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Scanner;
 
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
 import com.fasterxml.jackson.databind.type.MapLikeType;
+import com.xeiam.xchange.utils.DateUtils;
 
 /**
  * @author jamespedwards42
@@ -92,29 +94,27 @@ public class CoinbaseMarketDataJsonTest {
     assertThat(price.getTotal()).isEqualsToByComparingFields(new CoinbaseMoney("USD", new BigDecimal("730.47")));
   }
 
-  // @Test
-  // public void testDeserializeSpotRateHistory() throws IOException {
-  //
-  // // Read in the JSON from the example resources
-  // InputStream is = CoinbaseMarketDataJsonTest.class.getResourceAsStream("/marketdata/example-spot-rate-history-data.json");
-  // String spotPriceHistoryString;
-  // Scanner scanner = null;
-  // try {
-  // scanner = new Scanner(is);
-  // spotPriceHistoryString = scanner.useDelimiter("\\A").next();
-  // } finally {
-  // scanner.close();
-  // }
-  //
-  // // Use Jackson to parse it
-  // ObjectMapper mapper = new ObjectMapper();
-  // CoinbaseSpotPriceHistory spotPriceHistory = mapper.readValue(spotPriceHistoryString, CoinbaseSpotPriceHistory.class);
-  //
-  // List<CoinbaseHistoricalSpotPrice> spotPriceHistoryList = spotPriceHistory.getSpotPriceHistory();
-  // assertThat(spotPriceHistoryList.size()).isEqualTo(10);
-  //
-  // CoinbaseHistoricalSpotPrice historicalSpotPrice = spotPriceHistoryList.get(0);
-  // assertThat(historicalSpotPrice.getSpotRate()).isEqualTo("719.79");
-  // assertThat(historicalSpotPrice.getTimestamp()).isEqualTo(DateUtils.fromISO8601DateString("2014-02-08T13:21:51-08:00"));
-  // }
+  @Test
+  public void testDeserializeSpotRateHistory() throws IOException {
+
+    // Read in the JSON from the example resources
+    InputStream is = CoinbaseMarketDataJsonTest.class.getResourceAsStream("/marketdata/example-spot-rate-history-data.json");
+    String spotPriceHistoryString;
+    Scanner scanner = null;
+    try {
+      scanner = new Scanner(is);
+      spotPriceHistoryString = scanner.useDelimiter("\\A").next();
+    } finally {
+      scanner.close();
+    }
+
+    CoinbaseSpotPriceHistory spotPriceHistory = CoinbaseSpotPriceHistory.fromRawString(spotPriceHistoryString);
+
+    List<CoinbaseHistoricalSpotPrice> spotPriceHistoryList = spotPriceHistory.getSpotPriceHistory();
+    assertThat(spotPriceHistoryList.size()).isEqualTo(10);
+
+    CoinbaseHistoricalSpotPrice historicalSpotPrice = spotPriceHistoryList.get(0);
+    assertThat(historicalSpotPrice.getSpotRate()).isEqualTo("719.79");
+    assertThat(historicalSpotPrice.getTimestamp()).isEqualTo(DateUtils.fromISO8601DateString("2014-02-08T13:21:51-08:00"));
+  }
 }

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/coinbase/marketdata/CoinbaseMarketDataDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/coinbase/marketdata/CoinbaseMarketDataDemo.java
@@ -30,10 +30,8 @@ import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.ExchangeFactory;
 import com.xeiam.xchange.coinbase.CoinbaseExchange;
 import com.xeiam.xchange.coinbase.dto.marketdata.CoinbaseCurrency;
-import com.xeiam.xchange.coinbase.dto.marketdata.CoinbaseHistoricalSpotPrice;
 import com.xeiam.xchange.coinbase.dto.marketdata.CoinbaseMoney;
 import com.xeiam.xchange.coinbase.dto.marketdata.CoinbasePrice;
-import com.xeiam.xchange.coinbase.dto.marketdata.CoinbaseSpotPriceHistory;
 import com.xeiam.xchange.coinbase.service.polling.CoinbaseMarketDataService;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.marketdata.Ticker;
@@ -77,12 +75,12 @@ public class CoinbaseMarketDataDemo {
     CoinbaseMoney spotRate = marketDataService.getCoinbaseSpotRate("EUR");
     System.out.println("Spot Rate: " + spotRate);
 
-    int page = 2;
+/*    int page = 2;
     CoinbaseSpotPriceHistory spotPriceHistory = marketDataService.getCoinbaseHistoricalSpotRates(page);
     List<CoinbaseHistoricalSpotPrice> spotPriceHistoryList = spotPriceHistory.getSpotPriceHistory();
     for (CoinbaseHistoricalSpotPrice coinbaseHistoricalSpotPrice : spotPriceHistoryList) {
       System.out.println(coinbaseHistoricalSpotPrice);
     }
-    System.out.println("...Retrieved " + spotPriceHistoryList.size() + " historical spot rates.");
+    System.out.println("...Retrieved " + spotPriceHistoryList.size() + " historical spot rates.");*/
   }
 }


### PR DESCRIPTION
removed CoinbaseSpotPriceHistory until we can figure how to get a raw string result using Rescu or revert the jackson version.  

I've updated the tests to serve as a proof of concept for how I can deserialize this if I can get access to the raw String.
