### PR TITLE
Fix Bter random ticker volume amounts.

### DIFF
--- a/xchange-bter/src/main/java/com/xeiam/xchange/bter/BTERAdapters.java
+++ b/xchange-bter/src/main/java/com/xeiam/xchange/bter/BTERAdapters.java
@@ -77,7 +77,7 @@ public final class BTERAdapters {
     BigDecimal last = bterTicker.getLast();
     BigDecimal low = bterTicker.getLow();
     BigDecimal high = bterTicker.getHigh();
-    BigDecimal volume = bterTicker.getTradeCurrencyVolume();
+    BigDecimal volume = bterTicker.getVolume(currencyPair.baseSymbol);
 
     return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withAsk(ask).withBid(bid).withLast(last).withLow(low).withHigh(high).withVolume(volume).build();
   }

--- a/xchange-bter/src/test/java/com/xeiam/xchange/bter/dto/marketdata/BTERMarketDataJsonTest.java
+++ b/xchange-bter/src/test/java/com/xeiam/xchange/bter/dto/marketdata/BTERMarketDataJsonTest.java
@@ -76,8 +76,8 @@ public class BTERMarketDataJsonTest {
     assertThat(ticker.getAvg()).isEqualTo("3456.54");
     assertThat(ticker.getSell()).isEqualTo("3400.17");
     assertThat(ticker.getBuy()).isEqualTo("3400.01");
-    assertThat(ticker.getTradeCurrencyVolume()).isEqualTo("347.2045");
-    assertThat(ticker.getPriceCurrencyVolume()).isEqualTo("1200127.03");
+    assertThat(ticker.getVolume("BTC")).isEqualTo("347.2045");
+    assertThat(ticker.getVolume("CNY")).isEqualTo("1200127.03");
 
     assertThat(ticker.isResult()).isTrue();
   }


### PR DESCRIPTION
I initially made a silly assumption that the json would always be ordered and always deserialized the trade volume as the first volume entry discovered.  It now forces the user (of raw classes) to provide the volume currency. For generic classes it reports the trade volume as normal.
