### PR TITLE
Fix CryptonitAdapterTest get(0) on a List made from HashMap

### DIFF
--- a/xchange-cryptonit/src/main/java/com/xeiam/xchange/cryptonit/v2/CryptonitAdapters.java
+++ b/xchange-cryptonit/src/main/java/com/xeiam/xchange/cryptonit/v2/CryptonitAdapters.java
@@ -22,10 +22,7 @@
 package com.xeiam.xchange.cryptonit.v2;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import com.xeiam.xchange.cryptonit.v2.dto.marketdata.CryptonitOrder;
 import com.xeiam.xchange.cryptonit.v2.dto.marketdata.CryptonitOrders;
@@ -97,6 +94,7 @@ public final class CryptonitAdapters {
             .valueOf(trade.getKey())));
       }
     }
+    Collections.sort(limitOrders);
 
     return limitOrders;
   }

--- a/xchange-cryptonit/src/test/java/com/xeiam/xchange/cryptonit/v2/service/CryptonitAdapterTest.java
+++ b/xchange-cryptonit/src/test/java/com/xeiam/xchange/cryptonit/v2/service/CryptonitAdapterTest.java
@@ -22,12 +22,14 @@
 package com.xeiam.xchange.cryptonit.v2.service;
 
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -62,9 +64,9 @@ public class CryptonitAdapterTest {
     List<LimitOrder> asks = CryptonitAdapters.adaptOrders(cryptonitTrades, CurrencyPair.BTC_USD, "ask", "");
 
     // Verify all fields filled
-    assertThat(asks.get(0).getLimitPrice().doubleValue()).isEqualTo(700.0);
+    assertEquals(new BigDecimal("604.449"), asks.get(0).getLimitPrice().stripTrailingZeros());
     assertThat(asks.get(0).getType()).isEqualTo(OrderType.ASK);
-    assertThat(asks.get(0).getTradableAmount().doubleValue()).isEqualTo(0.00100);
+    assertEquals(new BigDecimal("0.16029"), asks.get(0).getTradableAmount().stripTrailingZeros());
     assertThat(asks.get(0).getCurrencyPair().baseSymbol).isEqualTo("BTC");
     assertThat(asks.get(0).getCurrencyPair().counterSymbol).isEqualTo("USD");
 


### PR DESCRIPTION
Current CryptonitAdapterTest fails every time on my machine.

The adapter was copying order data from Map to List without any ordering, and then the test was making assertions on the first element of that List

Iterating over a HashMap results in undefined order, but is usually consistent on a machine and JVM version.

Added sorting of resulting list to CryptonitAdapters.adaptOrders and updated the test.
