### PR TITLE
Use api.btcchina.com instead of data.btcchina.com in trading, otherwise ...

### DIFF
--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChinaExchange.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChinaExchange.java
@@ -21,9 +21,6 @@
  */
 package com.xeiam.xchange.btcchina;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.xeiam.xchange.BaseExchange;
 import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.ExchangeSpecification;
@@ -66,12 +63,6 @@ public class BTCChinaExchange extends BaseExchange implements Exchange {
     exchangeSpecification.setPort(80);
     exchangeSpecification.setExchangeName("BTCChina");
     exchangeSpecification.setExchangeDescription("BTCChina is a Bitcoin exchange located in China.");
-
-    final Map<String, Object> exchangeSpecificParameters = new HashMap<String, Object>();
-    exchangeSpecificParameters.put("dataSslUri", "https://data.btcchina.com");
-
-    exchangeSpecification.setExchangeSpecificParameters(exchangeSpecificParameters);
-
     return exchangeSpecification;
   }
 }

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaBasePollingService.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaBasePollingService.java
@@ -59,7 +59,7 @@ public class BTCChinaBasePollingService<T extends BTCChina> extends BaseExchange
     super(exchangeSpecification);
     Assert.notNull(exchangeSpecification.getSslUri(), "Exchange specification URI cannot be null");
     
-    this.btcChina = RestProxyFactory.createProxy(type, (String) exchangeSpecification.getExchangeSpecificParameters().get("dataSslUri"));
+    this.btcChina = RestProxyFactory.createProxy(type, (String) exchangeSpecification.getSslUri());
     this.signatureCreator = BTCChinaDigest.createInstance(exchangeSpecification.getApiKey(), exchangeSpecification.getSecretKey());
     this.currencyPairs = new HashSet<CurrencyPair>();
   }


### PR DESCRIPTION
...we will get "Internal error"(error code -32000) in placing a sufficient balance order.

Deleted the dataSslUri from configuration, as I have searched in whole code, it is not in use anymore.
