### PR TITLE
Fix BTCChina Market Data API Endpoint.

### DIFF
--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChinaExchange.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChinaExchange.java
@@ -49,9 +49,10 @@ public class BTCChinaExchange extends BaseExchange implements Exchange {
   public void applySpecification(ExchangeSpecification exchangeSpecification) {
 
     super.applySpecification(exchangeSpecification);
-    this.pollingMarketDataService = new BTCChinaMarketDataService(exchangeSpecification);
     this.pollingTradeService = new BTCChinaTradeService(exchangeSpecification);
     this.pollingAccountService = new BTCChinaAccountService(exchangeSpecification);
+    exchangeSpecification.setSslUri("https://data.btcchina.com");
+    this.pollingMarketDataService = new BTCChinaMarketDataService(exchangeSpecification);
   }
 
   @Override


### PR DESCRIPTION
Not sure what the best way to wire this up is?  We need to configure different urls for market data and trading/account info.  This change gets it done, but it feels like the wrong way to do it.
