### PR TITLE
Implement limit parameter for trade history.

### DIFF
--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChina.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChina.java
@@ -72,15 +72,64 @@ public interface BTCChina {
   @Path("data/orderbook")
   public BTCChinaDepth getFullDepth(@QueryParam("market") String market) throws IOException;
 
-  // (return last 100 trade records.)
+  /**
+   * Returns last 100 trade records.
+   *
+   * @param market
+   * @return
+   * @throws IOException
+   */
   @GET
   @Path("data/historydata")
-  public List<BTCChinaTrade> getTrades(@QueryParam("market") String market) throws IOException;
+  public List<BTCChinaTrade> getTrades(
+      @QueryParam("market") String market)
+          throws IOException;
 
-  // return 100 trade records starting from id $since.
+  /**
+   * Returns last {@code limit} trade records.
+   *
+   * @param market
+   * @param limit the range of limit is [0,5000].
+   * @return
+   * @throws IOException
+   */
   @GET
   @Path("data/historydata")
-  public List<BTCChinaTrade> getTrades(@QueryParam("market") String market, @QueryParam("since") Long transactionID) throws IOException;
+  public List<BTCChinaTrade> getTrades(
+      @QueryParam("market") String market,
+      @QueryParam("limit") int limit)
+          throws IOException;
+
+  /**
+   * Returns 100 trade records starting from id {@code since}.
+   *
+   * @param market
+   * @param since the starting trade ID(exclusive).
+   * @return
+   * @throws IOException
+   */
+  @GET
+  @Path("data/historydata")
+  public List<BTCChinaTrade> getTrades(
+      @QueryParam("market") String market,
+      @QueryParam("since") long since)
+          throws IOException;
+
+  /**
+   * Returns {@code limit} trades starting from id {@code since}
+   *
+   * @param market
+   * @param since the starting trade ID(exclusive).
+   * @param limit the range of limit is [0,5000].
+   * @return
+   * @throws IOException
+   */
+  @GET
+  @Path("data/historydata")
+  public List<BTCChinaTrade> getTrades(
+      @QueryParam("market") String market,
+      @QueryParam("since") long since,
+      @QueryParam("limit") int limit) throws IOException;
 
   @POST
   @Path("api_trade_v1.php")

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaMarketDataServiceRaw.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaMarketDataServiceRaw.java
@@ -68,14 +68,32 @@ public class BTCChinaMarketDataServiceRaw extends BTCChinaBasePollingService<BTC
     return btcChina.getFullDepth(market);
   }
 
-  public List<BTCChinaTrade> getBTCChinaTrades(String market, Long sinceTransactionID) throws IOException {
-
-    return btcChina.getTrades(market, sinceTransactionID);
-  }
-
-  public List<BTCChinaTrade> getBTCChinaTrades(String market) throws IOException {
+  public List<BTCChinaTrade> getBTCChinaTrades(
+      String market)
+          throws IOException {
 
     return btcChina.getTrades(market);
+  }
+
+  public List<BTCChinaTrade> getBTCChinaTrades(
+      String market, int limit)
+          throws IOException {
+
+    return btcChina.getTrades(market, limit);
+  }
+
+  public List<BTCChinaTrade> getBTCChinaTrades(
+      String market, long since)
+          throws IOException {
+
+    return btcChina.getTrades(market, since);
+  }
+
+  public List<BTCChinaTrade> getBTCChinaTrades(
+      String market, long since, int limit)
+          throws IOException {
+
+    return btcChina.getTrades(market, since, limit);
   }
 
 }

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/btcchina/marketdata/BTCChinaTradesDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/btcchina/marketdata/BTCChinaTradesDemo.java
@@ -59,13 +59,26 @@ public class BTCChinaTradesDemo {
     // Get the latest trade data for BTC/CNY
     Trades trades = marketDataService.getTrades(CurrencyPair.BTC_CNY);
 
-    System.out.println(trades.toString());
+    System.out.println(trades);
+    System.out.println("NumTrades=" + trades.getTrades().size());
+
+    // Get the latest trade data for BTC/CNY, limit 10
+    trades = marketDataService.getTrades(CurrencyPair.BTC_CNY, null, 10);
+    System.out.println(trades);
     System.out.println("NumTrades=" + trades.getTrades().size());
 
     // Get the offset trade data for BTC/CNY
     trades = marketDataService.getTrades(CurrencyPair.BTC_CNY, 6097616);
 
-    System.out.println(trades.toString());
+    System.out.println(trades);
+    System.out.println("NumTrades=" + trades.getTrades().size());
+
+    System.out.println("LastId=" + trades.getlastID());
+
+    // Get the offset trade data for BTC/CNY, limit 10
+    trades = marketDataService.getTrades(CurrencyPair.BTC_CNY, 6097616, 10);
+
+    System.out.println(trades);
     System.out.println("NumTrades=" + trades.getTrades().size());
 
     System.out.println("LastId=" + trades.getlastID());


### PR DESCRIPTION
BTCChina market data API Trade History supports using `limit` parameter to specify the number of records fetched per result.
