### PR TITLE
Implement Cryptotrade public trade history.

### DIFF
--- a/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/CryptoTrade.java
+++ b/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/CryptoTrade.java
@@ -28,6 +28,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradeDepth;
+import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradePublicTrades;
 import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradeTicker;
 
 @Path("api/1")
@@ -41,5 +42,13 @@ public interface CryptoTrade {
   @GET
   @Path("ticker/{ident}_{currency}")
   CryptoTradeTicker getTicker(@PathParam("ident") String tradeableIdentifier, @PathParam("currency") String currency);
+
+  @GET
+  @Path("tradeshistory/{ident}_{currency}")
+  CryptoTradePublicTrades getTradeHistory(@PathParam("ident") String tradeableIdentifier, @PathParam("currency") String currency);
+
+  @GET
+  @Path("tradeshistory/{ident}_{currency}/{since}")
+  CryptoTradePublicTrades getTradeHistory(@PathParam("ident") String tradeableIdentifier, @PathParam("currency") String currency, @PathParam("since") long sinceTimestamp);
 
 }

--- a/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/CryptoTradeAdapters.java
+++ b/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/CryptoTradeAdapters.java
@@ -31,6 +31,7 @@ import com.xeiam.xchange.cryptotrade.dto.CryptoTradeOrderType;
 import com.xeiam.xchange.cryptotrade.dto.account.CryptoTradeAccountInfo;
 import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradeDepth;
 import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradePublicOrder;
+import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradePublicTrade;
 import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradeTicker;
 import com.xeiam.xchange.cryptotrade.dto.trade.CryptoTradeOrders;
 import com.xeiam.xchange.cryptotrade.dto.trade.CryptoTradeOrders.CryptoTradeOrder;
@@ -140,11 +141,39 @@ public final class CryptoTradeAdapters {
   public static Trades adaptTrades(CryptoTradeTrades cryptoTradeTrades) {
 
     List<Trade> tradeList = new ArrayList<Trade>();
+    long lastTradeId = 0;
     for (CryptoTradeTrade cryptoTradeTrade : cryptoTradeTrades.getTrades()) {
+      long tradeId = cryptoTradeTrade.getId();
+      if (tradeId > lastTradeId)
+        lastTradeId = tradeId;
       Trade trade = adaptTrade(cryptoTradeTrade);
       tradeList.add(trade);
     }
 
-    return new Trades(tradeList, TradeSortType.SortByTimestamp);
+    return new Trades(tradeList, lastTradeId, TradeSortType.SortByTimestamp);
   }
+
+  public static Trade adaptPublicTrade(CurrencyPair currencyPair, CryptoTradePublicTrade trade) {
+
+    OrderType orderType = adaptOrderType(trade.getType());
+    Date timestamp = new Date(trade.getTimestamp() * 1000);
+
+    return new Trade(orderType, trade.getOrderAmount(), currencyPair, trade.getRate(), timestamp, String.valueOf(trade.getId()));
+  }
+
+  public static Trades adaptPublicTradeHistory(CurrencyPair currencyPair, List<CryptoTradePublicTrade> publicTradeHistory) {
+
+    List<Trade> tradeList = new ArrayList<Trade>();
+    long lastTradeId = 0;
+    for (CryptoTradePublicTrade cryptoTradeTrade : publicTradeHistory) {
+      long tradeId = cryptoTradeTrade.getId();
+      if (tradeId > lastTradeId)
+        lastTradeId = tradeId;
+      Trade trade = adaptPublicTrade(currencyPair, cryptoTradeTrade);
+      tradeList.add(trade);
+    }
+
+    return new Trades(tradeList, lastTradeId, TradeSortType.SortByID);
+  }
+
 }

--- a/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/dto/marketdata/CryptoTradePublicTrade.java
+++ b/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/dto/marketdata/CryptoTradePublicTrade.java
@@ -1,0 +1,84 @@
+/**
+Copyright (C) 2012 - 2014 Xeiam LLC http://xeiam.com
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+ *
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+ *
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+package com.xeiam.xchange.cryptotrade.dto.marketdata;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.xeiam.xchange.cryptotrade.dto.CryptoTradeOrderType;
+
+public class CryptoTradePublicTrade {
+
+  private final long id;
+  private final long timestamp;
+  private final String assetPair;
+  private final CryptoTradeOrderType type;
+  private final BigDecimal orderAmount;
+  private final BigDecimal rate;
+
+  public CryptoTradePublicTrade(@JsonProperty("id") long id, @JsonProperty("timestamp") long timestamp, @JsonProperty("pair") String assetPair, @JsonProperty("type") CryptoTradeOrderType type, @JsonProperty("amount") BigDecimal orderAmount,
+      @JsonProperty("rate") BigDecimal rate) {
+
+    this.id = id;
+    this.timestamp = timestamp;
+    this.assetPair = assetPair;
+    this.type = type;
+    this.orderAmount = orderAmount;
+    this.rate = rate;
+  }
+
+  public long getId() {
+
+    return id;
+  }
+
+  public long getTimestamp() {
+
+    return timestamp;
+  }
+
+  public String getAssetPair() {
+
+    return assetPair;
+  }
+
+  public CryptoTradeOrderType getType() {
+
+    return type;
+  }
+
+  public BigDecimal getOrderAmount() {
+
+    return orderAmount;
+  }
+
+  public BigDecimal getRate() {
+
+    return rate;
+  }
+
+  @Override
+  public String toString() {
+
+    return "CryptoTradePublicTrade [id=" + id + ", timestamp=" + timestamp + ", assetPair=" + assetPair + ", type=" + type + ", orderAmount=" + orderAmount + ", rate=" + rate + "]";
+  }
+}

--- a/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/dto/marketdata/CryptoTradePublicTrades.java
+++ b/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/dto/marketdata/CryptoTradePublicTrades.java
@@ -1,0 +1,49 @@
+/**
+Copyright (C) 2012 - 2014 Xeiam LLC http://xeiam.com
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+ *
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+ *
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+package com.xeiam.xchange.cryptotrade.dto.marketdata;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.xeiam.xchange.cryptotrade.dto.CryptoTradeBaseResponse;
+
+public class CryptoTradePublicTrades extends CryptoTradeBaseResponse {
+
+  private final List<CryptoTradePublicTrade> publicTrades;
+
+  public CryptoTradePublicTrades(@JsonProperty("status") String status, @JsonProperty("error") String error, @JsonProperty("data") List<CryptoTradePublicTrade> publicTrades) {
+
+    super(status, error);
+    this.publicTrades = publicTrades;
+  }
+
+  public List<CryptoTradePublicTrade> getPublicTrades() {
+
+    return publicTrades;
+  }
+
+  @Override
+  public String toString() {
+
+    return "CryptoTradePublicTrades [publicTrades=" + publicTrades + "]";
+  }
+}

--- a/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/service/polling/CryptoTradeBasePollingService.java
+++ b/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/service/polling/CryptoTradeBasePollingService.java
@@ -77,8 +77,15 @@ public class CryptoTradeBasePollingService<T extends CryptoTrade> extends BaseEx
   public static final List<CurrencyPair> CURRENCY_PAIRS = new ArrayList<CurrencyPair>();
 
   static {
+    CURRENCY_PAIRS.add(new CurrencyPair("BC", "USD"));
+    CURRENCY_PAIRS.add(new CurrencyPair("BC", "BTC"));
     CURRENCY_PAIRS.add(CurrencyPair.BTC_USD);
     CURRENCY_PAIRS.add(CurrencyPair.BTC_EUR);
+    CURRENCY_PAIRS.add(new CurrencyPair("CINNI", "USD"));
+    CURRENCY_PAIRS.add(new CurrencyPair("CINNI", "BTC"));
+    CURRENCY_PAIRS.add(CurrencyPair.DGC_BTC);
+    CURRENCY_PAIRS.add(new CurrencyPair("DRK", "BTC"));
+    CURRENCY_PAIRS.add(new CurrencyPair("DRK", "USD"));
     CURRENCY_PAIRS.add(CurrencyPair.LTC_USD);
     CURRENCY_PAIRS.add(CurrencyPair.LTC_EUR);
     CURRENCY_PAIRS.add(CurrencyPair.LTC_BTC);
@@ -95,15 +102,10 @@ public class CryptoTradeBasePollingService<T extends CryptoTrade> extends BaseEx
     CURRENCY_PAIRS.add(CurrencyPair.DVC_BTC);
     CURRENCY_PAIRS.add(CurrencyPair.WDC_USD);
     CURRENCY_PAIRS.add(CurrencyPair.WDC_BTC);
-    CURRENCY_PAIRS.add(CurrencyPair.DGC_BTC);
     CURRENCY_PAIRS.add(CurrencyPair.UTC_USD);
     CURRENCY_PAIRS.add(CurrencyPair.UTC_EUR);
     CURRENCY_PAIRS.add(CurrencyPair.UTC_BTC);
     CURRENCY_PAIRS.add(CurrencyPair.UTC_LTC);
-    CURRENCY_PAIRS.add(new CurrencyPair("CINNI"));
-    CURRENCY_PAIRS.add(new CurrencyPair("BC"));
-    CURRENCY_PAIRS.add(new CurrencyPair("CINNI", "BTC"));
-    CURRENCY_PAIRS.add(new CurrencyPair("BC", "BTC"));
   }
 
   @Override

--- a/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/service/polling/CryptoTradeMarketDataService.java
+++ b/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/service/polling/CryptoTradeMarketDataService.java
@@ -22,11 +22,13 @@
 package com.xeiam.xchange.cryptotrade.service.polling;
 
 import java.io.IOException;
+import java.util.List;
 
+import com.xeiam.xchange.ExchangeException;
 import com.xeiam.xchange.ExchangeSpecification;
-import com.xeiam.xchange.NotAvailableFromExchangeException;
 import com.xeiam.xchange.cryptotrade.CryptoTradeAdapters;
 import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradeDepth;
+import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradePublicTrade;
 import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradeTicker;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
@@ -73,7 +75,19 @@ public class CryptoTradeMarketDataService extends CryptoTradeMarketDataServiceRa
   @Override
   public Trades getTrades(CurrencyPair currencyPair, Object... args) throws IOException {
 
-    throw new NotAvailableFromExchangeException();
+    long sinceTimestamp = 0;
+
+    if (args.length > 0) {
+      Object arg0 = args[0];
+      if (!(arg0 instanceof Number)) {
+        throw new ExchangeException("arg[0] must be a Number used to represent an epoch timestamp in seconds from which to retreive trades since.");
+      }
+      sinceTimestamp = ((Number) arg0).longValue();
+    }
+
+    List<CryptoTradePublicTrade> publicTradeHistory = sinceTimestamp == 0 ? super.getCryptoTradeTradeHistory(currencyPair) : super.getCryptoTradeTradeHistory(currencyPair, sinceTimestamp);
+
+    return CryptoTradeAdapters.adaptPublicTradeHistory(currencyPair, publicTradeHistory);
   }
 
 }

--- a/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/service/polling/CryptoTradeMarketDataServiceRaw.java
+++ b/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/service/polling/CryptoTradeMarketDataServiceRaw.java
@@ -22,10 +22,13 @@
 package com.xeiam.xchange.cryptotrade.service.polling;
 
 import java.io.IOException;
+import java.util.List;
 
 import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.cryptotrade.CryptoTrade;
 import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradeDepth;
+import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradePublicTrade;
+import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradePublicTrades;
 import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradeTicker;
 import com.xeiam.xchange.currency.CurrencyPair;
 
@@ -61,6 +64,20 @@ public class CryptoTradeMarketDataServiceRaw extends CryptoTradeBasePollingServi
     CryptoTradeDepth cryptoTradeDepth = cryptoTradeProxy.getFullDepth(currencyPair.baseSymbol.toLowerCase(), currencyPair.counterSymbol.toLowerCase());
 
     return handleResponse(cryptoTradeDepth);
+  }
+  
+  public List<CryptoTradePublicTrade> getCryptoTradeTradeHistory(CurrencyPair currencyPair) throws IOException {
+
+    CryptoTradePublicTrades cryptoTradeDepth = cryptoTradeProxy.getTradeHistory(currencyPair.baseSymbol.toLowerCase(), currencyPair.counterSymbol.toLowerCase());
+
+    return handleResponse(cryptoTradeDepth).getPublicTrades();
+  }
+  
+  public List<CryptoTradePublicTrade> getCryptoTradeTradeHistory(CurrencyPair currencyPair, long sinceTimestamp) throws IOException {
+
+    CryptoTradePublicTrades cryptoTradeDepth = cryptoTradeProxy.getTradeHistory(currencyPair.baseSymbol.toLowerCase(), currencyPair.counterSymbol.toLowerCase(), sinceTimestamp);
+
+    return handleResponse(cryptoTradeDepth).getPublicTrades();
   }
 
 }

--- a/xchange-cryptotrade/src/test/java/com/xeiam/xchange/cryptotrade/dto/CryptoTradeAdapterTest.java
+++ b/xchange-cryptotrade/src/test/java/com/xeiam/xchange/cryptotrade/dto/CryptoTradeAdapterTest.java
@@ -35,6 +35,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.xeiam.xchange.cryptotrade.CryptoTradeAdapters;
 import com.xeiam.xchange.cryptotrade.dto.account.CryptoTradeAccountInfo;
 import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradeDepth;
+import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradeMarketDataJsonTest;
+import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradePublicTrades;
 import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradeTicker;
 import com.xeiam.xchange.cryptotrade.dto.trade.CryptoTradeOrders;
 import com.xeiam.xchange.cryptotrade.dto.trade.CryptoTradeTradeJsonTest;
@@ -160,7 +162,9 @@ public class CryptoTradeAdapterTest {
 
     Trades trades = CryptoTradeAdapters.adaptTrades(tradeHistory);
 
+    assertThat(trades.getlastID()).isEqualTo(17);
     assertThat(trades.getTrades()).hasSize(2);
+    
     Trade trade = trades.getTrades().get(1);
     assertThat(trade.getPrice()).isEqualTo("128");
     assertThat(trade.getType()).isEqualTo(OrderType.ASK);
@@ -168,5 +172,31 @@ public class CryptoTradeAdapterTest {
     assertThat(trade.getTradableAmount()).isEqualTo("0.1");
     assertThat(trade.getId()).isEqualTo("17");
     assertThat(trade.getOrderId()).isEqualTo("1");
+  }
+  
+  @Test
+  public void testAdaptPublicTrades() throws IOException {
+
+    // Read in the JSON from the example resources
+    InputStream is = CryptoTradeMarketDataJsonTest.class.getResourceAsStream("/marketdata/example-trades-data.json");
+
+    // Use Jackson to parse it
+    ObjectMapper mapper = new ObjectMapper();
+    CryptoTradePublicTrades publicTradeHistory = mapper.readValue(is, CryptoTradePublicTrades.class);
+
+    Trades trades = CryptoTradeAdapters.adaptPublicTradeHistory(CurrencyPair.BTC_USD, publicTradeHistory.getPublicTrades());
+    
+    assertThat(trades.getlastID()).isEqualTo(399394);
+    
+    List<Trade> tradeList = trades.getTrades();
+    assertThat(tradeList).hasSize(2);
+    
+    Trade trade = tradeList.get(0);
+    assertThat(trade.getId()).isEqualTo("399328");
+    assertThat(trade.getTimestamp().getTime()).isEqualTo(1405856801000L);
+    assertThat(trade.getCurrencyPair()).isEqualTo(CurrencyPair.BTC_USD);
+    assertThat(trade.getType()).isEqualTo(OrderType.ASK);
+    assertThat(trade.getTradableAmount()).isEqualTo("0.08540439");
+    assertThat(trade.getPrice()).isEqualTo("618.19");
   }
 }

--- a/xchange-cryptotrade/src/test/java/com/xeiam/xchange/cryptotrade/dto/marketdata/CryptoTradeMarketDataJsonTest.java
+++ b/xchange-cryptotrade/src/test/java/com/xeiam/xchange/cryptotrade/dto/marketdata/CryptoTradeMarketDataJsonTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xeiam.xchange.cryptotrade.dto.CryptoTradeOrderType;
 
 public class CryptoTradeMarketDataJsonTest {
 
@@ -71,5 +72,27 @@ public class CryptoTradeMarketDataJsonTest {
     CryptoTradePublicOrder ask = asks.get(0);
     assertThat(ask.getPrice()).isEqualTo("102");
     assertThat(ask.getAmount()).isEqualTo("0.81718312");
+  }
+  
+  @Test
+  public void testDeserializePublicTrades() throws IOException {
+
+    // Read in the JSON from the example resources
+    InputStream is = CryptoTradeMarketDataJsonTest.class.getResourceAsStream("/marketdata/example-trades-data.json");
+
+    // Use Jackson to parse it
+    ObjectMapper mapper = new ObjectMapper();
+    CryptoTradePublicTrades trades = mapper.readValue(is, CryptoTradePublicTrades.class);
+
+    List<CryptoTradePublicTrade> tradeList = trades.getPublicTrades();
+    assertThat(tradeList).hasSize(2);
+
+    CryptoTradePublicTrade trade = tradeList.get(0);
+    assertThat(trade.getId()).isEqualTo(399328);
+    assertThat(trade.getTimestamp()).isEqualTo(1405856801);
+    assertThat(trade.getAssetPair()).isEqualTo("btc_usd");
+    assertThat(trade.getType()).isEqualTo(CryptoTradeOrderType.Sell);
+    assertThat(trade.getOrderAmount()).isEqualTo("0.08540439");
+    assertThat(trade.getRate()).isEqualTo("618.19");
   }
 }

--- a/xchange-cryptotrade/src/test/resources/marketdata/example-trades-data.json
+++ b/xchange-cryptotrade/src/test/resources/marketdata/example-trades-data.json
@@ -1,0 +1,21 @@
+{
+   "status":"success",
+   "data":[
+      {
+         "id":"399328",
+         "timestamp":"1405856801",
+         "pair":"btc_usd",
+         "type":"Sell",
+         "amount":"0.08540439",
+         "rate":"618.19"
+      },
+      {
+         "id":"399394",
+         "timestamp":"1405876982",
+         "pair":"btc_usd",
+         "type":"Buy",
+         "amount":"0.01",
+         "rate":"624.999999"
+      }
+   ]
+}

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/cryptotrade/marketdata/CryptoTradeMarketDataDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/cryptotrade/marketdata/CryptoTradeMarketDataDemo.java
@@ -28,11 +28,13 @@ import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.ExchangeFactory;
 import com.xeiam.xchange.cryptotrade.CryptoTradeExchange;
 import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradeDepth;
+import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradePublicTrade;
 import com.xeiam.xchange.cryptotrade.dto.marketdata.CryptoTradeTicker;
 import com.xeiam.xchange.cryptotrade.service.polling.CryptoTradeMarketDataServiceRaw;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
+import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.service.polling.PollingMarketDataService;
 import com.xeiam.xchange.utils.CertHelper;
 
@@ -56,6 +58,9 @@ public class CryptoTradeMarketDataDemo {
 
     OrderBook orderBook = marketDataService.getOrderBook(CurrencyPair.BTC_USD);
     System.out.println(orderBook);
+    
+    Trades publicTradeHistory = marketDataService.getTrades(CurrencyPair.BTC_USD, 1405805427);
+    System.out.println(publicTradeHistory);
   }
 
   private static void raw(CryptoTradeMarketDataServiceRaw marketDataService) throws IOException {
@@ -68,5 +73,8 @@ public class CryptoTradeMarketDataDemo {
 
     CryptoTradeDepth marketDepth = marketDataService.getCryptoTradeOrderBook(CurrencyPair.BTC_USD);
     System.out.println(marketDepth);
+    
+    List<CryptoTradePublicTrade> publicTradeHistory = marketDataService.getCryptoTradeTradeHistory(CurrencyPair.BTC_USD, 1405805427);
+    System.out.println(publicTradeHistory);
   }
 }


### PR DESCRIPTION
- Public trade history implementation with unit tests.
- Update demos.
- Add last trade id to private trades.
- Add DRK/USD, DRK/BTC currency pairs.
