### PR TITLE
Expose Bittrex getSymbols call through the raw service.

### DIFF
--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/service/polling/BittrexMarketDataServiceRaw.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/service/polling/BittrexMarketDataServiceRaw.java
@@ -8,6 +8,8 @@ import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.bittrex.v1.Bittrex;
 import com.xeiam.xchange.bittrex.v1.dto.marketdata.BittrexDepth;
 import com.xeiam.xchange.bittrex.v1.dto.marketdata.BittrexDepthResponse;
+import com.xeiam.xchange.bittrex.v1.dto.marketdata.BittrexSymbol;
+import com.xeiam.xchange.bittrex.v1.dto.marketdata.BittrexSymbolsResponse;
 import com.xeiam.xchange.bittrex.v1.dto.marketdata.BittrexTicker;
 import com.xeiam.xchange.bittrex.v1.dto.marketdata.BittrexTickerResponse;
 import com.xeiam.xchange.bittrex.v1.dto.marketdata.BittrexTickersResponse;
@@ -34,6 +36,19 @@ public class BittrexMarketDataServiceRaw extends BittrexBasePollingService<Bittr
     super(Bittrex.class, exchangeSpecification);
   }
 
+  public ArrayList<BittrexSymbol> getBittrexSymbols() throws IOException {
+
+    BittrexSymbolsResponse response = bittrex.getSymbols();
+
+    if (response.isSuccess()) {
+      return response.getSymbols();
+    }
+    else {
+      throw new ExchangeException(response.getMessage());
+    }
+
+  }
+  
   public BittrexTicker getBittrexTicker(String pair) throws IOException {
 
     BittrexTickerResponse response = bittrex.getTicker(pair);

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/bittrex/v1/marketdata/BittrexMarketDataDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/bittrex/v1/marketdata/BittrexMarketDataDemo.java
@@ -13,6 +13,7 @@ import com.xeiam.xchange.NotYetImplementedForExchangeException;
 import com.xeiam.xchange.bittrex.v1.BittrexExchange;
 import com.xeiam.xchange.bittrex.v1.BittrexUtils;
 import com.xeiam.xchange.bittrex.v1.dto.marketdata.BittrexDepth;
+import com.xeiam.xchange.bittrex.v1.dto.marketdata.BittrexSymbol;
 import com.xeiam.xchange.bittrex.v1.dto.marketdata.BittrexTicker;
 import com.xeiam.xchange.bittrex.v1.dto.marketdata.BittrexTrade;
 import com.xeiam.xchange.bittrex.v1.service.polling.BittrexMarketDataServiceRaw;
@@ -37,7 +38,7 @@ public class BittrexMarketDataDemo {
   private static void generic(PollingMarketDataService marketDataService) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
 
     System.out.println("----------GENERIC---------");
-
+    
     ArrayList<CurrencyPair> pairs = new ArrayList<CurrencyPair>(marketDataService.getExchangeSymbols());
     System.out.println(pairs);
 
@@ -58,6 +59,9 @@ public class BittrexMarketDataDemo {
 
     System.out.println("------------RAW-----------");
 
+    ArrayList<BittrexSymbol> symbols = marketDataService.getBittrexSymbols();
+    System.out.println(symbols);
+    
     ArrayList<CurrencyPair> pairs = new ArrayList<CurrencyPair>(marketDataService.getExchangeSymbols());
     System.out.println(pairs);
 


### PR DESCRIPTION
This will allow clients to filter inactive markets.
