### PR TITLE
Remove sorting of orders from OrderBook

### DIFF
--- a/xchange-btctrade/src/main/java/com/xeiam/xchange/btctrade/BTCTradeAdapters.java
+++ b/xchange-btctrade/src/main/java/com/xeiam/xchange/btctrade/BTCTradeAdapters.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -60,6 +61,7 @@ public final class BTCTradeAdapters {
   public static OrderBook adaptOrderBook(BTCTradeDepth btcTradeDepth, CurrencyPair currencyPair) {
 
     List<LimitOrder> asks = adaptLimitOrders(btcTradeDepth.getAsks(), currencyPair, OrderType.ASK);
+    Collections.reverse(asks);
     List<LimitOrder> bids = adaptLimitOrders(btcTradeDepth.getBids(), currencyPair, OrderType.BID);
     return new OrderBook(null, asks, bids);
   }

--- a/xchange-bter/src/main/java/com/xeiam/xchange/bter/BTERAdapters.java
+++ b/xchange-bter/src/main/java/com/xeiam/xchange/bter/BTERAdapters.java
@@ -2,10 +2,7 @@ package com.xeiam.xchange.bter;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 import java.util.Map.Entry;
 
 import com.xeiam.xchange.bter.dto.BTEROrderType;
@@ -81,6 +78,7 @@ public final class BTERAdapters {
   public static OrderBook adaptOrderBook(BTERDepth depth, CurrencyPair currencyPair) {
 
     List<LimitOrder> asks = BTERAdapters.adaptOrders(depth.getAsks(), currencyPair, OrderType.ASK);
+    Collections.reverse(asks);
     List<LimitOrder> bids = BTERAdapters.adaptOrders(depth.getBids(), currencyPair, OrderType.BID);
 
     return new OrderBook(null, asks, bids);


### PR DESCRIPTION
This patch removes sorting of orders or replaces it with injection at the right index.

Update methods use Collections.binarySearch to find the right index.
Newly created OrderBooks rely on the drivers to sort the orders, only two exchanges require reverting the ordering of asks.

I also added getOrders(OrderType) that returns either asks or bids depending on the parameter.

Remarks:
- OrderBook.update(OrderBookUpdate) removes order if the OrderBookUpdate.totalVolume == ZERO but update(LimitOrder) doesn't. Shouldn't they behave consistently? Just asking.
- I've added static withAmount() that copies a LimitOrder changing tradableAmount (the prototype pattern). Not sure if it should stay in OrderBook or should I move it to LimitOrder or Order
