### PR TITLE
Nonce cleanup

### DIFF
--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/BTCChinaTonceFactory.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/BTCChinaTonceFactory.java
@@ -12,7 +12,7 @@ public class BTCChinaTonceFactory implements ValueFactory<Long> {
   @Override
   public Long createValue() {
 
-    return Long.valueOf(BTCChinaUtils.getNonce());
+    return BTCChinaUtils.getNonce();
   }
 
 }

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcBasePollingService.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcBasePollingService.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import si.mazi.rescu.NonceFactory;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.RestProxyFactory;
 
@@ -22,17 +23,17 @@ import si.mazi.rescu.ValueFactory;
  */
 public abstract class HitbtcBasePollingService<T extends Hitbtc> extends BaseExchangeService implements BasePollingService {
 
-    protected static final ValueFactory<Long> valueFactory = new ValueFactory<Long>() {
-        @Override
-        public Long createValue() {
-            return System.currentTimeMillis();
-        }
-
-        @Override
-        public String toString() {
-            return createValue() + "";
-        } 
-    };
+  /*
+   * Workaround for bug reported here https://github.com/timmolter/XChange/pull/581.
+   * Pending fix in ResCU at https://github.com/mmazi/rescu/pull/43.
+   * TODO Replace with vanilla NonceFactory when fixed.
+   */
+  protected static final ValueFactory<Long> valueFactory = new NonceFactory() {
+    @Override
+    public String toString() {
+      return Long.toString(createValue());
+    }
+  };
 
   protected final T hitbtc;
   protected final String apiKey;

--- a/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitBasePollingService.java
+++ b/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitBasePollingService.java
@@ -2,8 +2,8 @@ package com.xeiam.xchange.itbit.v1.service.polling;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 
+import si.mazi.rescu.NonceFactory;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.ValueFactory;
@@ -17,12 +17,7 @@ import com.xeiam.xchange.service.polling.BasePollingService;
 
 public class ItBitBasePollingService extends BaseExchangeService implements BasePollingService {
 
-  protected static final ValueFactory<Long> valueFactory = new ValueFactory<Long>() {
-      @Override
-      public Long createValue() {
-          return System.currentTimeMillis();
-      }
-  };
+  protected static final ValueFactory<Long> valueFactory = new NonceFactory();
 
   protected final String apiKey;
   protected final ItBitAuthenticated itBit;


### PR DESCRIPTION
Remove ValueFactory implementation from ItBitBasePollingService - same as NonceFactory.
Document workaround in HitbtcBasePollingService and extend NonceFactory.
