### PR TITLE
Fix ordering of LimitOrders in OrderBook for Bitfinex, Btc-E, Cex.io and...

### DIFF
--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/BitfinexAdapters.java
@@ -55,25 +55,19 @@ public final class BitfinexAdapters {
     return new CurrencyPair(tradableIdentifier, transactionCurrency);
   }
 
-  public static List<LimitOrder> adaptOrders(BitfinexLevel[] orders, CurrencyPair currencyPair, String orderType, String id) {
+  public static List<LimitOrder> adaptOrders(BitfinexLevel[] orders, CurrencyPair currencyPair, String orderTypeString, String id) {
 
     List<LimitOrder> limitOrders = new ArrayList<LimitOrder>(orders.length);
+    OrderType orderType = orderTypeString.equalsIgnoreCase("bid") ? OrderType.BID : OrderType.ASK;
 
     for (BitfinexLevel order : orders) {
-      // Bid orderbook is reversed order. Insert at index 0 instead of appending
-      if (orderType.equalsIgnoreCase("bid")) {
-        limitOrders.add(0, adaptOrder(order.getAmount(), order.getPrice(), currencyPair, orderType, id));
-      } else {
-        limitOrders.add(adaptOrder(order.getAmount(), order.getPrice(), currencyPair, orderType, id));
-      }
+      limitOrders.add(adaptOrder(order.getAmount(), order.getPrice(), currencyPair, orderType, id));
     }
 
     return limitOrders;
   }
 
-  public static LimitOrder adaptOrder(BigDecimal amount, BigDecimal price, CurrencyPair currencyPair, String orderTypeString, String id) {
-
-    OrderType orderType = orderTypeString.equalsIgnoreCase("bid") ? OrderType.BID : OrderType.ASK;
+  public static LimitOrder adaptOrder(BigDecimal amount, BigDecimal price, CurrencyPair currencyPair, OrderType orderType, String id) {
 
     return new LimitOrder(orderType, amount, currencyPair, id, null, price);
   }

--- a/xchange-bitfinex/src/test/java/com/xeiam/xchange/bitfinex/v1/service/marketdata/BitfinexMarketDataJSONTest.java
+++ b/xchange-bitfinex/src/test/java/com/xeiam/xchange/bitfinex/v1/service/marketdata/BitfinexMarketDataJSONTest.java
@@ -26,7 +26,13 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigDecimal;
+import java.util.List;
 
+import com.xeiam.xchange.bitfinex.v1.BitfinexAdapters;
+import com.xeiam.xchange.bitfinex.v1.dto.marketdata.BitfinexDepth;
+import com.xeiam.xchange.currency.CurrencyPair;
+import com.xeiam.xchange.dto.trade.LimitOrder;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,5 +48,16 @@ public class BitfinexMarketDataJSONTest {
     
     assertEquals(lendDepth.getAsks().length, 50);
     assertEquals(lendDepth.getBids().length, 50);
+  }
+
+  @Test
+  public void testMarketDepth() throws Exception {
+    InputStream resourceAsStream = BitfinexMarketDataJSONTest.class.getResourceAsStream("/v1/marketdata/example-marketdepth-data.json");
+    BitfinexDepth depthRaw = new ObjectMapper().readValue(resourceAsStream, BitfinexDepth.class);
+    List<LimitOrder> asks = BitfinexAdapters.adaptOrders(depthRaw.getAsks(), CurrencyPair.BTC_EUR, "ask", "");
+    List<LimitOrder> bids = BitfinexAdapters.adaptOrders(depthRaw.getBids(), CurrencyPair.BTC_EUR, "bid", "");
+
+    assertEquals(new BigDecimal("851.87"), asks.get(0).getLimitPrice());
+    assertEquals(new BigDecimal("849.59"), bids.get(0).getLimitPrice());
   }
 }

--- a/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/BTCEAdapters.java
+++ b/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/BTCEAdapters.java
@@ -46,23 +46,18 @@ public final class BTCEAdapters {
    * Adapts a List of BTCEOrders to a List of LimitOrders
    * 
    * @param bTCEOrders
-   * @param currency
-   * @param orderType
+   * @param currencyPair
+   * @param orderTypeString
    * @param id
    * @return
    */
-  public static List<LimitOrder> adaptOrders(List<BigDecimal[]> bTCEOrders, CurrencyPair currencyPair, String orderType, String id) {
+  public static List<LimitOrder> adaptOrders(List<BigDecimal[]> bTCEOrders, CurrencyPair currencyPair, String orderTypeString, String id) {
 
     List<LimitOrder> limitOrders = new ArrayList<LimitOrder>();
+    OrderType orderType = orderTypeString.equalsIgnoreCase("bid") ? OrderType.BID : OrderType.ASK;
 
     for (BigDecimal[] btceOrder : bTCEOrders) {
-      // Bid orderbook is reversed order. Insert at index 0 instead of appending
-      if (orderType.equalsIgnoreCase("bid")) {
-        limitOrders.add(0, adaptOrder(btceOrder[1], btceOrder[0], currencyPair, orderType, id));
-      }
-      else {
-        limitOrders.add(adaptOrder(btceOrder[1], btceOrder[0], currencyPair, orderType, id));
-      }
+      limitOrders.add(adaptOrder(btceOrder[1], btceOrder[0], currencyPair, orderType, id));
     }
 
     return limitOrders;
@@ -73,15 +68,12 @@ public final class BTCEAdapters {
    * 
    * @param amount
    * @param price
-   * @param currency
-   * @param orderTypeString
+   * @param currencyPair
+   * @param orderType
    * @param id
    * @return
    */
-  public static LimitOrder adaptOrder(BigDecimal amount, BigDecimal price, CurrencyPair currencyPair, String orderTypeString, String id) {
-
-    // place a limit order
-    OrderType orderType = orderTypeString.equalsIgnoreCase("bid") ? OrderType.BID : OrderType.ASK;
+  public static LimitOrder adaptOrder(BigDecimal amount, BigDecimal price, CurrencyPair currencyPair, OrderType orderType, String id) {
 
     return new LimitOrder(orderType, amount, currencyPair, id, null, price);
   }

--- a/xchange-btce/src/test/java/com/xeiam/xchange/btce/v3/service/BTCEAdapterTest.java
+++ b/xchange-btce/src/test/java/com/xeiam/xchange/btce/v3/service/BTCEAdapterTest.java
@@ -1,12 +1,14 @@
 package com.xeiam.xchange.btce.v3.service;
 
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.util.List;
 
+import com.xeiam.xchange.btce.v3.dto.marketdata.BTCEDepth;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -43,12 +45,23 @@ public class BTCEAdapterTest {
     ObjectMapper mapper = new ObjectMapper();
     BTCEDepthWrapper bTCEDepthWrapper = mapper.readValue(is, BTCEDepthWrapper.class);
 
-    List<LimitOrder> asks = BTCEAdapters.adaptOrders(bTCEDepthWrapper.getDepth(BTCEUtils.getPair(CurrencyPair.BTC_USD)).getAsks(), CurrencyPair.BTC_USD, "ask", "");
+    BTCEDepth depthRaw = bTCEDepthWrapper.getDepth(BTCEUtils.getPair(CurrencyPair.BTC_USD));
+    List<LimitOrder> asks = BTCEAdapters.adaptOrders(depthRaw.getAsks(), CurrencyPair.BTC_USD, "ask", "");
 
     // verify all fields filled
     assertThat(asks.get(0).getType()).isEqualTo(OrderType.ASK);
     assertThat(asks.get(0).getCurrencyPair()).isEqualTo(CurrencyPair.BTC_USD);
     assertThat(asks.get(0).getTimestamp()).isNull();
+    assertEquals(new BigDecimal("760.98"),asks.get(0).getLimitPrice());
+
+    List<LimitOrder> bids = BTCEAdapters.adaptOrders(depthRaw.getBids(), CurrencyPair.BTC_USD, "bid", "");
+
+    // verify all fields filled
+    LimitOrder bid1 = bids.get(0);
+    assertThat(bid1.getType()).isEqualTo(OrderType.BID);
+    assertThat(bid1.getCurrencyPair()).isEqualTo(CurrencyPair.BTC_USD);
+    assertThat(bid1.getTimestamp()).isNull();
+    assertEquals(new BigDecimal("758.99"),bid1.getLimitPrice());
 
   }
 

--- a/xchange-cexio/src/main/java/com/xeiam/xchange/cexio/CexIOAdapters.java
+++ b/xchange-cexio/src/main/java/com/xeiam/xchange/cexio/CexIOAdapters.java
@@ -3,6 +3,7 @@ package com.xeiam.xchange.cexio;
 import java.math.BigDecimal;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -103,6 +104,7 @@ public class CexIOAdapters {
   public static OrderBook adaptOrderBook(CexIODepth depth, CurrencyPair currencyPair) {
 
     List<LimitOrder> asks = createOrders(currencyPair, Order.OrderType.ASK, depth.getAsks());
+    Collections.reverse(asks);
     List<LimitOrder> bids = createOrders(currencyPair, Order.OrderType.BID, depth.getBids());
     Date date = new Date(depth.getTimestamp() * 1000);
     return new OrderBook(date, asks, bids);

--- a/xchange-vircurex/src/main/java/com/xeiam/xchange/vircurex/VircurexAdapters.java
+++ b/xchange-vircurex/src/main/java/com/xeiam/xchange/vircurex/VircurexAdapters.java
@@ -30,26 +30,19 @@ public final class VircurexAdapters {
 
   }
 
-  public static LimitOrder adaptOrder(BigDecimal amount, BigDecimal price, CurrencyPair currencyPair, String orderTypeString, String id) {
+  public static LimitOrder adaptOrder(BigDecimal amount, BigDecimal price, CurrencyPair currencyPair, OrderType orderType, String id) {
 
     // place a limit order
-    OrderType orderType = orderTypeString.equalsIgnoreCase("bid") ? OrderType.BID : OrderType.ASK;
     return new LimitOrder(orderType, amount, currencyPair, "", null, price);
   }
 
-  public static List<LimitOrder> adaptOrders(List<BigDecimal[]> someOrders, CurrencyPair currencyPair, String orderType, String id) {
+  public static List<LimitOrder> adaptOrders(List<BigDecimal[]> someOrders, CurrencyPair currencyPair, String orderTypeString, String id) {
 
     List<LimitOrder> limitOrders = new ArrayList<LimitOrder>();
+    OrderType orderType = orderTypeString.equalsIgnoreCase("bid") ? OrderType.BID : OrderType.ASK;
 
-    // Bid orderbook is reversed order. Insert at index 0 instead of
     for (BigDecimal[] order : someOrders) {
-      // appending
-      if (orderType.equalsIgnoreCase("bid")) {
-        limitOrders.add(0, adaptOrder(order[1], order[0], currencyPair, orderType, id));
-      }
-      else {
-        limitOrders.add(adaptOrder(order[1], order[0], currencyPair, orderType, id));
-      }
+      limitOrders.add(adaptOrder(order[1], order[0], currencyPair, orderType, id));
     }
 
     return limitOrders;


### PR DESCRIPTION
There are no tests for Cex.io nor Vircurex. I've changed them without testing. @veken0m would you please check it?

Also see my comment at #590
