### PR TITLE
Move BTCChinaDepth to OrderBook adapting to BTCChinaAdapters

### DIFF
--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChina.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChina.java
@@ -94,7 +94,7 @@ public interface BTCChina {
    * @param market
    * @param limit the range of limit is [0,5000].
    * @throws IOException
-   * @deprecated Use {@link #getHistoryData(String, int) instead.
+   * @deprecated Use {@link #getHistoryData(String, int)} instead.
    */
   @Deprecated
   @GET

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChinaAdapters.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChinaAdapters.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import com.xeiam.xchange.btcchina.dto.BTCChinaResponse;
 import com.xeiam.xchange.btcchina.dto.BTCChinaValue;
 import com.xeiam.xchange.btcchina.dto.account.BTCChinaAccountInfo;
+import com.xeiam.xchange.btcchina.dto.marketdata.BTCChinaDepth;
 import com.xeiam.xchange.btcchina.dto.marketdata.BTCChinaTicker;
 import com.xeiam.xchange.btcchina.dto.marketdata.BTCChinaTickerObject;
 import com.xeiam.xchange.btcchina.dto.marketdata.BTCChinaTrade;
@@ -192,6 +193,21 @@ public final class BTCChinaAdapters {
     else {
       return null;
     }
+  }
+
+  /**
+   * Adapts {@link BTCChinaDepth} to {@link OrderBook}.
+   * 
+   * @param btcChinaDepth {@link BTCChinaDepth}
+   * @param currencyPair the currency pair of the depth.
+   * @return {@link OrderBook}
+   */
+  public static OrderBook adaptOrderBook(BTCChinaDepth btcChinaDepth, CurrencyPair currencyPair) {
+    List<LimitOrder> asks = BTCChinaAdapters.adaptOrders(btcChinaDepth.getAsksArray(), currencyPair, OrderType.ASK);
+    Collections.reverse(asks);
+    List<LimitOrder> bids = BTCChinaAdapters.adaptOrders(btcChinaDepth.getBidsArray(), currencyPair, OrderType.BID);
+
+    return new OrderBook(BTCChinaAdapters.adaptDate(btcChinaDepth.getDate()), asks, bids);
   }
 
   public static OrderBook adaptOrderBook(BTCChinaMarketDepth marketDepth, CurrencyPair currencyPair) {

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/dto/account/BTCChinaProfile.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/dto/account/BTCChinaProfile.java
@@ -25,9 +25,7 @@ public class BTCChinaProfile extends LinkedHashMap<String, String> {
    * @param tradePasswordEnabled
    * @param otpEnabled
    * @param tradeFee
-   * @param dailyBtcLimit
-   * @param btcDepositAddress
-   * @param btcWithdrawalAddress
+   * @param apiKeyPermission
    */
   public BTCChinaProfile(@JsonProperty("username") String username, @JsonProperty("trade_password_enabled") Boolean tradePasswordEnabled, @JsonProperty("otp_enabled") Boolean otpEnabled,
       @JsonProperty("trade_fee") BigDecimal tradeFee, @JsonProperty("api_key_permission") int apiKeyPermission) {
@@ -61,7 +59,7 @@ public class BTCChinaProfile extends LinkedHashMap<String, String> {
 
   /**
    * @param currencyPair cnyltc, btcltc
-   * @return
+   * @return the trade fee of the specified market.
    */
   public BigDecimal getTradeFee(String currencyPair) {
 

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/dto/marketdata/BTCChinaDepth.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/dto/marketdata/BTCChinaDepth.java
@@ -64,6 +64,6 @@ public final class BTCChinaDepth {
   @Override
   public String toString() {
 
-    return "BTCChinaDepth [asks=" + asks.toString() + ", bids=" + bids.toString() + ", date=" + date + "]";
+    return "BTCChinaDepth [asks=" + asks + ", bids=" + bids + ", date=" + date + "]";
   }
 }

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaMarketDataService.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaMarketDataService.java
@@ -1,8 +1,6 @@
 package com.xeiam.xchange.btcchina.service.polling;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,11 +11,9 @@ import com.xeiam.xchange.btcchina.dto.marketdata.BTCChinaDepth;
 import com.xeiam.xchange.btcchina.dto.marketdata.BTCChinaTicker;
 import com.xeiam.xchange.btcchina.dto.marketdata.BTCChinaTrade;
 import com.xeiam.xchange.currency.CurrencyPair;
-import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
 import com.xeiam.xchange.dto.marketdata.Trades;
-import com.xeiam.xchange.dto.trade.LimitOrder;
 import com.xeiam.xchange.service.polling.PollingMarketDataService;
 
 /**
@@ -59,11 +55,7 @@ public class BTCChinaMarketDataService extends BTCChinaMarketDataServiceRaw impl
     BTCChinaDepth btcChinaDepth = getBTCChinaOrderBook(BTCChinaAdapters.adaptMarket(currencyPair));
 
     // Adapt to XChange DTOs
-    List<LimitOrder> asks = BTCChinaAdapters.adaptOrders(btcChinaDepth.getAsksArray(), currencyPair, OrderType.ASK);
-    Collections.reverse(asks);
-    List<LimitOrder> bids = BTCChinaAdapters.adaptOrders(btcChinaDepth.getBidsArray(), currencyPair, OrderType.BID);
-
-    return new OrderBook(BTCChinaAdapters.adaptDate(btcChinaDepth.getDate()), asks, bids);
+    return BTCChinaAdapters.adaptOrderBook(btcChinaDepth, currencyPair);
   }
 
   /**

--- a/xchange-btcchina/src/test/java/com/xeiam/xchange/btcchina/BTCChinaAdaptersTest.java
+++ b/xchange-btcchina/src/test/java/com/xeiam/xchange/btcchina/BTCChinaAdaptersTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xeiam.xchange.btcchina.dto.marketdata.BTCChinaDepth;
 import com.xeiam.xchange.btcchina.dto.marketdata.BTCChinaTicker;
 import com.xeiam.xchange.btcchina.dto.trade.BTCChinaTransaction;
 import com.xeiam.xchange.btcchina.dto.trade.response.BTCChinaGetMarketDepthResponse;
@@ -68,6 +69,32 @@ public class BTCChinaAdaptersTest {
   }
 
   @Test
+  public void testAdaptOrderBookBTCChinaDepth() throws IOException {
+
+    BTCChinaDepth btcChinaDepth = mapper.readValue(getClass().getResource("/marketdata/example-depth-data.json"), BTCChinaDepth.class);
+    OrderBook orderBook = BTCChinaAdapters.adaptOrderBook(btcChinaDepth, CurrencyPair.BTC_CNY);
+
+    List<LimitOrder> bids = orderBook.getBids();
+    List<LimitOrder> asks = orderBook.getAsks();
+
+    // bid 4.51@544.83
+    assertEquals(new BigDecimal("544.83"), bids.get(0).getLimitPrice());
+    assertEquals(new BigDecimal("4.51"), bids.get(0).getTradableAmount());
+
+    // bid 4.19@543.38
+    assertEquals(new BigDecimal("543.38"), bids.get(1).getLimitPrice());
+    assertEquals(new BigDecimal("4.19"), bids.get(1).getTradableAmount());
+
+    // ask 49.234@546
+    assertEquals(new BigDecimal("546"), asks.get(0).getLimitPrice());
+    assertEquals(new BigDecimal("49.234"), asks.get(0).getTradableAmount());
+
+    // ask 10.934@547
+    assertEquals(new BigDecimal("547"), asks.get(1).getLimitPrice());
+    assertEquals(new BigDecimal("10.934"), asks.get(1).getTradableAmount());
+  }
+
+  @Test
   public void testAdaptOrderBook() throws IOException {
 
     BTCChinaGetMarketDepthResponse response = mapper.readValue(getClass().getResourceAsStream("dto/trade/response/getMarketDepth2.json"), BTCChinaGetMarketDepthResponse.class);
@@ -77,21 +104,25 @@ public class BTCChinaAdaptersTest {
     assertEquals(2, bids.size());
     assertEquals(2, asks.size());
 
+    // bid 1@99
     assertEquals(new BigDecimal("99"), bids.get(0).getLimitPrice());
     assertEquals(new BigDecimal("1"), bids.get(0).getTradableAmount());
     assertEquals(CurrencyPair.BTC_CNY, bids.get(0).getCurrencyPair());
     assertEquals(OrderType.BID, bids.get(0).getType());
-    
+
+    // bid 2@98
     assertEquals(new BigDecimal("98"), bids.get(1).getLimitPrice());
     assertEquals(new BigDecimal("2"), bids.get(1).getTradableAmount());
     assertEquals(CurrencyPair.BTC_CNY, bids.get(1).getCurrencyPair());
     assertEquals(OrderType.BID, bids.get(1).getType());
 
+    // ask 0.997@100
     assertEquals(new BigDecimal("100"), asks.get(0).getLimitPrice());
     assertEquals(new BigDecimal("0.997"), asks.get(0).getTradableAmount());
     assertEquals(CurrencyPair.BTC_CNY, asks.get(0).getCurrencyPair());
     assertEquals(OrderType.ASK, asks.get(0).getType());
 
+    // ask 2@101
     assertEquals(new BigDecimal("101"), asks.get(1).getLimitPrice());
     assertEquals(new BigDecimal("2"), asks.get(1).getTradableAmount());
     assertEquals(CurrencyPair.BTC_CNY, asks.get(1).getCurrencyPair());

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/btcchina/marketdata/BTCChinaDepthDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/btcchina/marketdata/BTCChinaDepthDemo.java
@@ -2,6 +2,7 @@ package com.xeiam.xchange.examples.btcchina.marketdata;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.List;
 
 import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.ExchangeException;
@@ -13,6 +14,7 @@ import com.xeiam.xchange.btcchina.dto.marketdata.BTCChinaDepth;
 import com.xeiam.xchange.btcchina.service.polling.BTCChinaMarketDataServiceRaw;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
+import com.xeiam.xchange.dto.trade.LimitOrder;
 import com.xeiam.xchange.service.polling.PollingMarketDataService;
 
 /**
@@ -41,11 +43,22 @@ public class BTCChinaDepthDemo {
     // System.out.println(orderBook.toString());
     System.out.println("Date: " + orderBook.getTimeStamp());
 
-    System.out.println("lowestAsk: " + orderBook.getAsks().get(0));
-    System.out.println("asks Size: " + orderBook.getAsks().size());
-    System.out.println("highestBid: " + orderBook.getBids().get(0));
-    System.out.println("bids Size: " + orderBook.getBids().size());
+    List<LimitOrder> asks = orderBook.getAsks();
+    List<LimitOrder> bids = orderBook.getBids();
 
+    System.out.println("lowestAsk: " + asks.get(0));
+    System.out.println("asks Size: " + asks.size());
+    System.out.println("highestBid: " + bids.get(0));
+    System.out.println("bids Size: " + bids.size());
+
+    if (asks.size() >= 2) {
+      boolean lower = asks.get(0).getLimitPrice().compareTo(asks.get(1).getLimitPrice()) < 0;
+      assert lower : "asks should be sorted ascending";
+    }
+    if (bids.size() >= 2) {
+      boolean higher = bids.get(0).getLimitPrice().compareTo(bids.get(1).getLimitPrice()) > 0;
+      assert higher : "bids should be sorted deascending";
+    }
   }
 
   public static void raw() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {


### PR DESCRIPTION
add a test case to ensure the asks/bids orders are sorted correctly.
