### PR TITLE
Implement BTCChina Data API v1.3: parameter of "limit" for order book API is added.

### DIFF
--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChina.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChina.java
@@ -68,9 +68,32 @@ public interface BTCChina {
   @Path("data/ticker")
   BTCChinaTicker getTicker(@QueryParam("market") String market) throws IOException;
 
+  /**
+   * Returns all the open orders from the specified {@code market}.
+   * 
+   * @param market the market could be {@code btccny}, {@code ltccny}, {@code ltcbtc}.
+   * @return the order book.
+   * @throws IOException indicates I/O exception.
+   * @see #getOrderBook(String, int)
+   */
   @GET
   @Path("data/orderbook")
   BTCChinaDepth getFullDepth(@QueryParam("market") String market) throws IOException;
+
+  /**
+   * Order book default contains all open ask and bid orders. Set 'limit' parameter to specify the number of records fetched per request.
+   * 
+   * <p>Bid orders are {@code limit} orders with highest price while ask with lowest, and orders are descendingly sorted by price.</p>
+   * 
+   * @param market market could be {@code btccny}, {@code ltccny}, {@code ltcbtc}.
+   * @param limit number of records fetched per request.
+   * @return the order book.
+   * @throws IOException indicates I/O exception.
+   * @see #getFullDepth(String)
+   */
+  @GET
+  @Path("data/orderbook")
+  BTCChinaDepth getOrderBook(@QueryParam("market") String market, @QueryParam("limit") int limit) throws IOException;
 
   /**
    * Returns last 100 trade records.

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaMarketDataService.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaMarketDataService.java
@@ -52,7 +52,15 @@ public class BTCChinaMarketDataService extends BTCChinaMarketDataServiceRaw impl
   public OrderBook getOrderBook(CurrencyPair currencyPair, Object... args) throws IOException {
 
     // Request data
-    BTCChinaDepth btcChinaDepth = getBTCChinaOrderBook(BTCChinaAdapters.adaptMarket(currencyPair));
+    final BTCChinaDepth btcChinaDepth;
+    final String market = BTCChinaAdapters.adaptMarket(currencyPair);
+
+    if (args.length == 0) {
+      btcChinaDepth = getBTCChinaOrderBook(market);
+    } else {
+      int limit = ((Number) args[0]).intValue();
+      btcChinaDepth = getBTCChinaOrderBook(market, limit);
+    }
 
     // Adapt to XChange DTOs
     return BTCChinaAdapters.adaptOrderBook(btcChinaDepth, currencyPair);

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaMarketDataServiceRaw.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaMarketDataServiceRaw.java
@@ -47,6 +47,10 @@ public class BTCChinaMarketDataServiceRaw extends BTCChinaBasePollingService<BTC
     return btcChina.getFullDepth(market);
   }
 
+  public BTCChinaDepth getBTCChinaOrderBook(String market, int limit) throws IOException {
+    return btcChina.getOrderBook(market, limit);
+  }
+
   /**
    * @deprecated Use {@link #getBTCChinaHistoryData(String)} instead.
    */

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/btcchina/marketdata/BTCChinaDepthDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/btcchina/marketdata/BTCChinaDepthDemo.java
@@ -38,7 +38,7 @@ public class BTCChinaDepthDemo {
   public static void generic() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
 
     // Get the latest order book data for BTC/CNY
-    OrderBook orderBook = marketDataService.getOrderBook(CurrencyPair.BTC_CNY);
+    OrderBook orderBook = marketDataService.getOrderBook(CurrencyPair.BTC_CNY, 10);
 
     // System.out.println(orderBook.toString());
     System.out.println("Date: " + orderBook.getTimeStamp());
@@ -64,7 +64,7 @@ public class BTCChinaDepthDemo {
   public static void raw() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
 
     // Get the latest order book data for BTC/CNY
-    BTCChinaDepth orderBook = ((BTCChinaMarketDataServiceRaw) marketDataService).getBTCChinaOrderBook(BTCChinaExchange.DEFAULT_MARKET);
+    BTCChinaDepth orderBook = ((BTCChinaMarketDataServiceRaw) marketDataService).getBTCChinaOrderBook(BTCChinaExchange.DEFAULT_MARKET, 10);
 
     System.out.println("Date: " + orderBook.getDate());
     System.out.println(orderBook.toString());
@@ -72,6 +72,14 @@ public class BTCChinaDepthDemo {
     // first item in each BigDecial[] will be price (in RMB), and second will be volume/depth.
     System.out.println("Asks:");
     for (BigDecimal[] currRow : orderBook.getAsks()) {
+      for (BigDecimal currItem : currRow) {
+        System.out.print(currItem.toPlainString() + ", ");
+      }
+      System.out.println();
+    }
+
+    System.out.println("Bids:");
+    for (BigDecimal[] currRow : orderBook.getBids()) {
       for (BigDecimal currItem : currRow) {
         System.out.print(currItem.toPlainString() + ", ");
       }


### PR DESCRIPTION
[Data API v1.3](http://btcchina.org/api-market-data-documentation-en#data_api_v13)
