### PR TITLE
Fixed Cryptsy getExchangeSymbols

### DIFF
--- a/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/Cryptsy.java
+++ b/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/Cryptsy.java
@@ -6,6 +6,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
+import com.xeiam.xchange.cryptsy.dto.marketdata.CryptsyCurrencyPairsReturn;
 import com.xeiam.xchange.cryptsy.dto.marketdata.CryptsyPublicMarketDataReturn;
 import com.xeiam.xchange.cryptsy.dto.marketdata.CryptsyPublicOrderbookReturn;
 
@@ -30,4 +31,8 @@ public interface Cryptsy {
   @GET
   @Path("api.php?method=singleorderdata&marketid={marketid}")
   CryptsyPublicOrderbookReturn getOrderbookData(@PathParam("marketid") int marketId) throws IOException;
+  
+  @GET
+  @Path("api.php?method=orderdatav2")
+  CryptsyCurrencyPairsReturn getCryptsyCurrencyPairs() throws IOException;
 }

--- a/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/dto/marketdata/CryptsyCurrencyPairsReturn.java
+++ b/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/dto/marketdata/CryptsyCurrencyPairsReturn.java
@@ -1,0 +1,21 @@
+package com.xeiam.xchange.cryptsy.dto.marketdata;
+
+import java.util.HashMap;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.xeiam.xchange.cryptsy.dto.CryptsyGenericReturn;
+
+public class CryptsyCurrencyPairsReturn extends CryptsyGenericReturn<HashMap<String, CryptsyMarketId>> {
+
+  /**
+   * Constructor
+   * 
+   * @param success
+   * @param value
+   * @param error
+   */
+  public CryptsyCurrencyPairsReturn(@JsonProperty("success") int success, @JsonProperty("return") HashMap<String, CryptsyMarketId> value, @JsonProperty("error") String error) {
+
+    super(success, (value == null ? new HashMap<String, CryptsyMarketId>() : value), error);
+  }
+}

--- a/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/dto/marketdata/CryptsyMarketId.java
+++ b/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/dto/marketdata/CryptsyMarketId.java
@@ -1,0 +1,31 @@
+package com.xeiam.xchange.cryptsy.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CryptsyMarketId {
+
+  @JsonProperty("marketid")
+  String marketid;
+
+  public CryptsyMarketId(@JsonProperty("marketid") String marketid) {
+
+    this.marketid = marketid;
+  }
+
+  public String getMarketid() {
+
+    return marketid;
+  }
+
+  public void setMarketid(String marketid) {
+
+    this.marketid = marketid;
+  }
+
+  @Override
+  public String toString() {
+
+    return "CryptsyMarketId [marketid=" + marketid + "]";
+  }
+
+}

--- a/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/service/polling/CryptsyPublicMarketDataServiceRaw.java
+++ b/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/service/polling/CryptsyPublicMarketDataServiceRaw.java
@@ -8,6 +8,7 @@ import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.cryptsy.Cryptsy;
 import com.xeiam.xchange.cryptsy.CryptsyAdapters;
 import com.xeiam.xchange.cryptsy.CryptsyExchange;
+import com.xeiam.xchange.cryptsy.dto.marketdata.CryptsyCurrencyPairsReturn;
 import com.xeiam.xchange.cryptsy.dto.marketdata.CryptsyPublicMarketData;
 import com.xeiam.xchange.cryptsy.dto.marketdata.CryptsyPublicOrderbook;
 
@@ -41,5 +42,10 @@ public class CryptsyPublicMarketDataServiceRaw extends CryptsyBasePollingService
   public Map<Integer, CryptsyPublicOrderbook> getCryptsyOrderBook(int marketId) throws IOException, ExchangeException {
 
     return CryptsyAdapters.adaptPublicOrderBookMap(checkResult(cryptsy.getOrderbookData(marketId)).getReturnValue());
+  }
+  
+  public CryptsyCurrencyPairsReturn getCryptsyCurrencyPairs() throws IOException {
+    
+    return checkResult(cryptsy.getCryptsyCurrencyPairs());
   }
 }


### PR DESCRIPTION
Moved from all public market data to just order book data. Should
resolve out of memory error on phones.
