### PR TITLE
create single ValueFactory object in BaseExchange implementation, propag...

### DIFF
--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChinaExchange.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChinaExchange.java
@@ -3,6 +3,7 @@ package com.xeiam.xchange.btcchina;
 import com.xeiam.xchange.BaseExchange;
 import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.ExchangeSpecification;
+import com.xeiam.xchange.btcchina.service.BTCChinaTonceFactory;
 import com.xeiam.xchange.btcchina.service.polling.BTCChinaAccountService;
 import com.xeiam.xchange.btcchina.service.polling.BTCChinaMarketDataService;
 import com.xeiam.xchange.btcchina.service.polling.BTCChinaTradeService;
@@ -30,6 +31,8 @@ public class BTCChinaExchange extends BaseExchange implements Exchange {
    */
   public static final int BTC_SCALE = 4;
 
+  private final BTCChinaTonceFactory tonceFactory = new BTCChinaTonceFactory();
+
   /**
    * Default constructor for ExchangeFactory
    */
@@ -41,10 +44,10 @@ public class BTCChinaExchange extends BaseExchange implements Exchange {
   public void applySpecification(ExchangeSpecification exchangeSpecification) {
 
     super.applySpecification(exchangeSpecification);
-    this.pollingTradeService = new BTCChinaTradeService(exchangeSpecification);
-    this.pollingAccountService = new BTCChinaAccountService(exchangeSpecification);
+    this.pollingTradeService = new BTCChinaTradeService(exchangeSpecification, tonceFactory);
+    this.pollingAccountService = new BTCChinaAccountService(exchangeSpecification, tonceFactory);
     exchangeSpecification.setSslUri("https://data.btcchina.com");
-    this.pollingMarketDataService = new BTCChinaMarketDataService(exchangeSpecification);
+    this.pollingMarketDataService = new BTCChinaMarketDataService(exchangeSpecification, tonceFactory);
   }
 
   @Override

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaAccountService.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaAccountService.java
@@ -10,6 +10,7 @@ import com.xeiam.xchange.btcchina.dto.BTCChinaResponse;
 import com.xeiam.xchange.btcchina.dto.account.BTCChinaAccountInfo;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.service.polling.PollingAccountService;
+import si.mazi.rescu.ValueFactory;
 
 /**
  * Implementation of the account data service for BTCChina.
@@ -26,9 +27,9 @@ public class BTCChinaAccountService extends BTCChinaAccountServiceRaw implements
    * 
    * @param exchangeSpecification The {@link ExchangeSpecification}
    */
-  public BTCChinaAccountService(ExchangeSpecification exchangeSpecification) {
+  public BTCChinaAccountService(ExchangeSpecification exchangeSpecification, ValueFactory<Long> tonceFactory) {
 
-    super(exchangeSpecification);
+    super(exchangeSpecification, tonceFactory);
 
   }
 

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaAccountServiceRaw.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaAccountServiceRaw.java
@@ -19,6 +19,7 @@ import com.xeiam.xchange.btcchina.dto.account.response.BTCChinaGetDepositsRespon
 import com.xeiam.xchange.btcchina.dto.account.response.BTCChinaGetWithdrawalResponse;
 import com.xeiam.xchange.btcchina.dto.account.response.BTCChinaGetWithdrawalsResponse;
 import com.xeiam.xchange.btcchina.dto.account.response.BTCChinaRequestWithdrawalResponse;
+import si.mazi.rescu.ValueFactory;
 
 /**
  * Implementation of the account data service for BTCChina.
@@ -35,9 +36,9 @@ public class BTCChinaAccountServiceRaw extends BTCChinaBasePollingService<BTCChi
    * 
    * @param exchangeSpecification The {@link ExchangeSpecification}
    */
-  public BTCChinaAccountServiceRaw(ExchangeSpecification exchangeSpecification) {
+  public BTCChinaAccountServiceRaw(ExchangeSpecification exchangeSpecification, ValueFactory<Long> tonceFactory) {
 
-    super(BTCChina.class, exchangeSpecification);
+    super(BTCChina.class, exchangeSpecification, tonceFactory);
   }
 
   public BTCChinaGetAccountInfoResponse getBTCChinaAccountInfo() throws IOException {

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaBasePollingService.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaBasePollingService.java
@@ -18,7 +18,6 @@ import com.xeiam.xchange.btcchina.BTCChinaExchange;
 import com.xeiam.xchange.btcchina.dto.BTCChinaResponse;
 import com.xeiam.xchange.btcchina.dto.marketdata.BTCChinaTicker;
 import com.xeiam.xchange.btcchina.service.BTCChinaDigest;
-import com.xeiam.xchange.btcchina.service.BTCChinaTonceFactory;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.marketdata.Ticker;
 import com.xeiam.xchange.service.BaseExchangeService;
@@ -40,14 +39,14 @@ public class BTCChinaBasePollingService<T extends BTCChina> extends BaseExchange
    * 
    * @param exchangeSpecification
    */
-  public BTCChinaBasePollingService(Class<T> type, ExchangeSpecification exchangeSpecification) {
+  public BTCChinaBasePollingService(Class<T> type, ExchangeSpecification exchangeSpecification, ValueFactory<Long> tonceFactory) {
 
     super(exchangeSpecification);
     Assert.notNull(exchangeSpecification.getSslUri(), "Exchange specification URI cannot be null");
 
     this.btcChina = RestProxyFactory.createProxy(type, (String) exchangeSpecification.getSslUri());
     this.signatureCreator = BTCChinaDigest.createInstance(exchangeSpecification.getApiKey(), exchangeSpecification.getSecretKey());
-    this.tonce = new BTCChinaTonceFactory();
+    this.tonce = tonceFactory;
     this.currencyPairs = new HashSet<CurrencyPair>();
   }
 

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaMarketDataService.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaMarketDataService.java
@@ -15,6 +15,7 @@ import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.service.polling.PollingMarketDataService;
+import si.mazi.rescu.ValueFactory;
 
 /**
  * Implementation of the market data service for BTCChina.
@@ -33,9 +34,9 @@ public class BTCChinaMarketDataService extends BTCChinaMarketDataServiceRaw impl
    *
    * @param exchangeSpecification The {@link ExchangeSpecification}
    */
-  public BTCChinaMarketDataService(ExchangeSpecification exchangeSpecification) {
+  public BTCChinaMarketDataService(ExchangeSpecification exchangeSpecification, ValueFactory<Long> tonceFactory) {
 
-    super(exchangeSpecification);
+    super(exchangeSpecification, tonceFactory);
   }
 
   @Override

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaMarketDataServiceRaw.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaMarketDataServiceRaw.java
@@ -11,6 +11,7 @@ import com.xeiam.xchange.btcchina.dto.marketdata.BTCChinaDepth;
 import com.xeiam.xchange.btcchina.dto.marketdata.BTCChinaTicker;
 import com.xeiam.xchange.btcchina.dto.marketdata.BTCChinaTickerObject;
 import com.xeiam.xchange.btcchina.dto.marketdata.BTCChinaTrade;
+import si.mazi.rescu.ValueFactory;
 
 /**
  * Implementation of the market data service for BTCChina.
@@ -27,9 +28,9 @@ public class BTCChinaMarketDataServiceRaw extends BTCChinaBasePollingService<BTC
    *
    * @param exchangeSpecification The {@link ExchangeSpecification}
    */
-  public BTCChinaMarketDataServiceRaw(ExchangeSpecification exchangeSpecification) {
+  public BTCChinaMarketDataServiceRaw(ExchangeSpecification exchangeSpecification, ValueFactory<Long> tonceFactory) {
 
-    super(BTCChina.class, exchangeSpecification);
+    super(BTCChina.class, exchangeSpecification, tonceFactory);
   }
 
   public Map<String, BTCChinaTickerObject> getBTCChinaTickers() throws IOException {

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaTradeService.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaTradeService.java
@@ -22,6 +22,7 @@ import com.xeiam.xchange.dto.trade.LimitOrder;
 import com.xeiam.xchange.dto.trade.MarketOrder;
 import com.xeiam.xchange.dto.trade.OpenOrders;
 import com.xeiam.xchange.service.polling.PollingTradeService;
+import si.mazi.rescu.ValueFactory;
 
 /**
  * Implementation of the trade service for BTCChina.
@@ -40,9 +41,9 @@ public class BTCChinaTradeService extends BTCChinaTradeServiceRaw implements Pol
    * 
    * @param exchangeSpecification
    */
-  public BTCChinaTradeService(ExchangeSpecification exchangeSpecification) {
+  public BTCChinaTradeService(ExchangeSpecification exchangeSpecification, ValueFactory<Long> tonceFactory) {
 
-    super(exchangeSpecification);
+    super(exchangeSpecification, tonceFactory);
 
   }
 

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaTradeServiceRaw.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaTradeServiceRaw.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import si.mazi.rescu.HttpStatusIOException;
+import si.mazi.rescu.ValueFactory;
 
 import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.btcchina.BTCChina;
@@ -61,9 +62,9 @@ public class BTCChinaTradeServiceRaw extends BTCChinaBasePollingService<BTCChina
    * 
    * @param exchangeSpecification
    */
-  public BTCChinaTradeServiceRaw(ExchangeSpecification exchangeSpecification) {
+  public BTCChinaTradeServiceRaw(ExchangeSpecification exchangeSpecification, ValueFactory<Long> tonceFactory) {
 
-    super(BTCChina.class, exchangeSpecification);
+    super(BTCChina.class, exchangeSpecification, tonceFactory);
   }
 
   /**

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/HitbtcExchange.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/HitbtcExchange.java
@@ -6,11 +6,15 @@ import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.hitbtc.service.polling.HitbtcAccountService;
 import com.xeiam.xchange.hitbtc.service.polling.HitbtcMarketDataService;
 import com.xeiam.xchange.hitbtc.service.polling.HitbtcTradeService;
+import si.mazi.rescu.NonceFactory;
+import si.mazi.rescu.ValueFactory;
 
 /**
  * @author kpysniak
  */
 public class HitbtcExchange extends BaseExchange implements Exchange {
+
+  private final ValueFactory<Long> nonceFactory = new NonceFactory();
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
@@ -30,9 +34,9 @@ public class HitbtcExchange extends BaseExchange implements Exchange {
   public void applySpecification(ExchangeSpecification exchangeSpecification) {
 
     super.applySpecification(exchangeSpecification);
-    this.pollingMarketDataService = new HitbtcMarketDataService(exchangeSpecification);
-    this.pollingTradeService = new HitbtcTradeService(exchangeSpecification);
-    this.pollingAccountService = new HitbtcAccountService(exchangeSpecification);
+    this.pollingMarketDataService = new HitbtcMarketDataService(exchangeSpecification, nonceFactory);
+    this.pollingTradeService = new HitbtcTradeService(exchangeSpecification, nonceFactory);
+    this.pollingAccountService = new HitbtcAccountService(exchangeSpecification, nonceFactory);
   }
 
 }

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcAccountService.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcAccountService.java
@@ -9,12 +9,13 @@ import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.hitbtc.HitbtcAdapters;
 import com.xeiam.xchange.hitbtc.dto.account.HitbtcBalance;
 import com.xeiam.xchange.service.polling.PollingAccountService;
+import si.mazi.rescu.ValueFactory;
 
 public class HitbtcAccountService extends HitbtcAccountServiceRaw implements PollingAccountService {
 
-  public HitbtcAccountService(ExchangeSpecification exchangeSpecification) {
+  public HitbtcAccountService(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
-    super(exchangeSpecification);
+    super(exchangeSpecification, nonceFactory);
   }
 
   @Override

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcAccountServiceRaw.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcAccountServiceRaw.java
@@ -9,12 +9,13 @@ import com.xeiam.xchange.NotYetImplementedForExchangeException;
 import com.xeiam.xchange.hitbtc.HitbtcAuthenticated;
 import com.xeiam.xchange.hitbtc.dto.account.HitbtcBalance;
 import com.xeiam.xchange.hitbtc.dto.account.HitbtcBalanceResponse;
+import si.mazi.rescu.ValueFactory;
 
 public class HitbtcAccountServiceRaw extends HitbtcBasePollingService<HitbtcAuthenticated> {
 
-  public HitbtcAccountServiceRaw(ExchangeSpecification exchangeSpecification) {
+  public HitbtcAccountServiceRaw(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
-    super(HitbtcAuthenticated.class, exchangeSpecification);
+    super(HitbtcAuthenticated.class, exchangeSpecification, nonceFactory);
   }
 
   public HitbtcBalance[] getAccountInfoRaw() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcBasePollingService.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcBasePollingService.java
@@ -5,9 +5,9 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import si.mazi.rescu.NonceFactory;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.RestProxyFactory;
+import si.mazi.rescu.ValueFactory;
 
 import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.currency.CurrencyPair;
@@ -16,24 +16,13 @@ import com.xeiam.xchange.hitbtc.HitbtcAdapters;
 import com.xeiam.xchange.hitbtc.service.HitbtcHmacDigest;
 import com.xeiam.xchange.service.BaseExchangeService;
 import com.xeiam.xchange.service.polling.BasePollingService;
-import si.mazi.rescu.ValueFactory;
 
 /**
  * @author kpysniak, piotr.ladyzynski
  */
 public abstract class HitbtcBasePollingService<T extends Hitbtc> extends BaseExchangeService implements BasePollingService {
 
-  /*
-   * Workaround for bug reported here https://github.com/timmolter/XChange/pull/581.
-   * Pending fix in ResCU at https://github.com/mmazi/rescu/pull/43.
-   * TODO Replace with vanilla NonceFactory when fixed.
-   */
-  protected static final ValueFactory<Long> valueFactory = new NonceFactory() {
-    @Override
-    public String toString() {
-      return Long.toString(createValue());
-    }
-  };
+  protected final ValueFactory<Long> valueFactory;
 
   protected final T hitbtc;
   protected final String apiKey;
@@ -45,10 +34,11 @@ public abstract class HitbtcBasePollingService<T extends Hitbtc> extends BaseExc
    * 
    * @param exchangeSpecification The {@link com.xeiam.xchange.ExchangeSpecification}
    */
-  protected HitbtcBasePollingService(Class<T> hitbtcType, ExchangeSpecification exchangeSpecification) {
+  protected HitbtcBasePollingService(Class<T> hitbtcType, ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
     super(exchangeSpecification);
 
+    this.valueFactory = nonceFactory;
     this.hitbtc = RestProxyFactory.createProxy(hitbtcType, exchangeSpecification.getSslUri());
     this.apiKey = exchangeSpecification.getApiKey();
     String apiKey = exchangeSpecification.getSecretKey();

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcMarketDataService.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcMarketDataService.java
@@ -13,6 +13,7 @@ import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.hitbtc.HitbtcAdapters;
 import com.xeiam.xchange.hitbtc.dto.marketdata.HitbtcTrades.HitbtcTradesSortOrder;
 import com.xeiam.xchange.service.polling.PollingMarketDataService;
+import si.mazi.rescu.ValueFactory;
 
 /**
  * @author kpysniak
@@ -24,9 +25,9 @@ public class HitbtcMarketDataService extends HitbtcMarketDataServiceRaw implemen
    * 
    * @param exchangeSpecification The {@link com.xeiam.xchange.ExchangeSpecification}
    */
-  public HitbtcMarketDataService(ExchangeSpecification exchangeSpecification) {
+  public HitbtcMarketDataService(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
-    super(exchangeSpecification);
+    super(exchangeSpecification, nonceFactory);
   }
 
   @Override

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcMarketDataServiceRaw.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcMarketDataServiceRaw.java
@@ -9,6 +9,7 @@ import com.xeiam.xchange.hitbtc.dto.marketdata.HitbtcOrderBook;
 import com.xeiam.xchange.hitbtc.dto.marketdata.HitbtcSymbols;
 import com.xeiam.xchange.hitbtc.dto.marketdata.HitbtcTicker;
 import com.xeiam.xchange.hitbtc.dto.marketdata.HitbtcTrades;
+import si.mazi.rescu.ValueFactory;
 
 /**
  * @author kpysniak
@@ -20,9 +21,9 @@ public abstract class HitbtcMarketDataServiceRaw extends HitbtcBasePollingServic
    * 
    * @param exchangeSpecification The {@link com.xeiam.xchange.ExchangeSpecification}
    */
-  protected HitbtcMarketDataServiceRaw(ExchangeSpecification exchangeSpecification) {
+  protected HitbtcMarketDataServiceRaw(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
-    super(Hitbtc.class, exchangeSpecification);
+    super(Hitbtc.class, exchangeSpecification, nonceFactory);
   }
 
   public HitbtcTicker getHitbtcTicker(CurrencyPair currencyPair) throws IOException {

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcTradeService.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcTradeService.java
@@ -16,12 +16,13 @@ import com.xeiam.xchange.hitbtc.dto.trade.HitbtcExecutionReportResponse;
 import com.xeiam.xchange.hitbtc.dto.trade.HitbtcOrder;
 import com.xeiam.xchange.hitbtc.dto.trade.HitbtcOwnTrade;
 import com.xeiam.xchange.service.polling.PollingTradeService;
+import si.mazi.rescu.ValueFactory;
 
 public class HitbtcTradeService extends HitbtcTradeServiceRaw implements PollingTradeService {
 
-  public HitbtcTradeService(ExchangeSpecification exchangeSpecification) {
+  public HitbtcTradeService(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
-    super(exchangeSpecification);
+    super(exchangeSpecification, nonceFactory);
   }
 
   @Override

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcTradeServiceRaw.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcTradeServiceRaw.java
@@ -19,14 +19,15 @@ import com.xeiam.xchange.hitbtc.dto.trade.HitbtcOrder;
 import com.xeiam.xchange.hitbtc.dto.trade.HitbtcOrdersResponse;
 import com.xeiam.xchange.hitbtc.dto.trade.HitbtcOwnTrade;
 import com.xeiam.xchange.hitbtc.dto.trade.HitbtcTradeResponse;
+import si.mazi.rescu.ValueFactory;
 
 public class HitbtcTradeServiceRaw extends HitbtcBasePollingService<HitbtcAuthenticated> {
 
   private static final BigDecimal LOT_MULTIPLIER = new BigDecimal("100");
 
-  public HitbtcTradeServiceRaw(ExchangeSpecification exchangeSpecification) {
+  public HitbtcTradeServiceRaw(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
-    super(HitbtcAuthenticated.class, exchangeSpecification);
+    super(HitbtcAuthenticated.class, exchangeSpecification, nonceFactory);
   }
 
   public HitbtcOrdersResponse getOpenOrdersRawBaseResponse() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {

--- a/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/ItBitExchange.java
+++ b/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/ItBitExchange.java
@@ -6,6 +6,8 @@ import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.itbit.v1.service.polling.ItBitAccountService;
 import com.xeiam.xchange.itbit.v1.service.polling.ItBitMarketDataService;
 import com.xeiam.xchange.itbit.v1.service.polling.ItBitTradeService;
+import si.mazi.rescu.NonceFactory;
+import si.mazi.rescu.ValueFactory;
 
 /**
  * <p>
@@ -17,6 +19,8 @@ import com.xeiam.xchange.itbit.v1.service.polling.ItBitTradeService;
  */
 
 public class ItBitExchange extends BaseExchange implements Exchange {
+
+  private final ValueFactory<Long> nonceFactory = new NonceFactory();
 
   /**
    * Default constructor for ExchangeFactory
@@ -30,9 +34,9 @@ public class ItBitExchange extends BaseExchange implements Exchange {
 
     super.applySpecification(exchangeSpecification);
 
-    this.pollingMarketDataService = new ItBitMarketDataService(exchangeSpecification);
-    this.pollingAccountService = new ItBitAccountService(exchangeSpecification);
-    this.pollingTradeService = new ItBitTradeService(exchangeSpecification);
+    this.pollingMarketDataService = new ItBitMarketDataService(exchangeSpecification, nonceFactory);
+    this.pollingAccountService = new ItBitAccountService(exchangeSpecification, nonceFactory);
+    this.pollingTradeService = new ItBitTradeService(exchangeSpecification, nonceFactory);
   }
 
   @Override

--- a/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitAccountService.java
+++ b/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitAccountService.java
@@ -10,6 +10,7 @@ import com.xeiam.xchange.NotYetImplementedForExchangeException;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.itbit.v1.ItBitAdapters;
 import com.xeiam.xchange.service.polling.PollingAccountService;
+import si.mazi.rescu.ValueFactory;
 
 public class ItBitAccountService extends ItBitAccountServiceRaw implements PollingAccountService {
 
@@ -18,9 +19,9 @@ public class ItBitAccountService extends ItBitAccountServiceRaw implements Polli
    * 
    * @param exchangeSpecification The {@link ExchangeSpecification}
    */
-  public ItBitAccountService(ExchangeSpecification exchangeSpecification) {
+  public ItBitAccountService(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
-    super(exchangeSpecification);
+    super(exchangeSpecification, nonceFactory);
   }
 
   @Override

--- a/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitAccountServiceRaw.java
+++ b/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitAccountServiceRaw.java
@@ -7,6 +7,7 @@ import java.util.Date;
 import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.NotYetImplementedForExchangeException;
 import com.xeiam.xchange.itbit.v1.dto.account.ItBitAccountInfoReturn;
+import si.mazi.rescu.ValueFactory;
 
 public class ItBitAccountServiceRaw extends ItBitBasePollingService {
 
@@ -17,9 +18,9 @@ public class ItBitAccountServiceRaw extends ItBitBasePollingService {
    * 
    * @param exchangeSpecification The {@link ExchangeSpecification}
    */
-  public ItBitAccountServiceRaw(ExchangeSpecification exchangeSpecification) {
+  public ItBitAccountServiceRaw(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
-    super(exchangeSpecification);
+    super(exchangeSpecification, nonceFactory);
 
     this.userId = (String) exchangeSpecification.getExchangeSpecificParametersItem("userId");
   }

--- a/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitBasePollingService.java
+++ b/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitBasePollingService.java
@@ -3,7 +3,6 @@ package com.xeiam.xchange.itbit.v1.service.polling;
 import java.util.Arrays;
 import java.util.List;
 
-import si.mazi.rescu.NonceFactory;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.ValueFactory;
@@ -17,7 +16,7 @@ import com.xeiam.xchange.service.polling.BasePollingService;
 
 public class ItBitBasePollingService extends BaseExchangeService implements BasePollingService {
 
-  protected static final ValueFactory<Long> valueFactory = new NonceFactory();
+  protected final ValueFactory<Long> valueFactory;
 
   protected final String apiKey;
   protected final ItBitAuthenticated itBit;
@@ -30,11 +29,11 @@ public class ItBitBasePollingService extends BaseExchangeService implements Base
    * 
    * @param exchangeSpecification The {@link ExchangeSpecification}
    */
-  public ItBitBasePollingService(ExchangeSpecification exchangeSpecification) {
+  public ItBitBasePollingService(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
     super(exchangeSpecification);
+    this.valueFactory = nonceFactory;
     this.itBit = RestProxyFactory.createProxy(ItBitAuthenticated.class, (String) exchangeSpecification.getExchangeSpecificParametersItem("authHost"));
-
     this.apiKey = exchangeSpecification.getApiKey();
     this.signatureCreator = ItBitHmacPostBodyDigest.createInstance(apiKey, exchangeSpecification.getSecretKey());
   }

--- a/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitMarketDataService.java
+++ b/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitMarketDataService.java
@@ -14,15 +14,16 @@ import com.xeiam.xchange.itbit.v1.ItBitAdapters;
 import com.xeiam.xchange.itbit.v1.dto.marketdata.ItBitDepth;
 import com.xeiam.xchange.itbit.v1.dto.marketdata.ItBitTicker;
 import com.xeiam.xchange.service.polling.PollingMarketDataService;
+import si.mazi.rescu.ValueFactory;
 
 public class ItBitMarketDataService extends ItBitMarketDataServiceRaw implements PollingMarketDataService {
 
   /**
    * @param exchangeSpecification The {@link ExchangeSpecification}
    */
-  public ItBitMarketDataService(ExchangeSpecification exchangeSpecification) {
+  public ItBitMarketDataService(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
-    super(exchangeSpecification);
+    super(exchangeSpecification, nonceFactory);
   }
 
   @Override

--- a/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitMarketDataServiceRaw.java
+++ b/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitMarketDataServiceRaw.java
@@ -3,6 +3,7 @@ package com.xeiam.xchange.itbit.v1.service.polling;
 import java.io.IOException;
 
 import si.mazi.rescu.RestProxyFactory;
+import si.mazi.rescu.ValueFactory;
 
 import com.xeiam.xchange.ExchangeException;
 import com.xeiam.xchange.ExchangeSpecification;
@@ -21,9 +22,9 @@ public class ItBitMarketDataServiceRaw extends ItBitBasePollingService {
   /**
    * @param exchangeSpecification The {@link ExchangeSpecification}
    */
-  public ItBitMarketDataServiceRaw(ExchangeSpecification exchangeSpecification) {
+  public ItBitMarketDataServiceRaw(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
-    super(exchangeSpecification);
+    super(exchangeSpecification, nonceFactory);
     itBitPublic = RestProxyFactory.createProxy(ItBit.class, exchangeSpecification.getSslUri());
   }
   

--- a/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitTradeService.java
+++ b/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitTradeService.java
@@ -12,6 +12,7 @@ import com.xeiam.xchange.dto.trade.MarketOrder;
 import com.xeiam.xchange.dto.trade.OpenOrders;
 import com.xeiam.xchange.itbit.v1.ItBitAdapters;
 import com.xeiam.xchange.service.polling.PollingTradeService;
+import si.mazi.rescu.ValueFactory;
 
 public class ItBitTradeService extends ItBitTradeServiceRaw implements PollingTradeService {
 
@@ -21,9 +22,9 @@ public class ItBitTradeService extends ItBitTradeServiceRaw implements PollingTr
    * @param exchangeSpecification
    *          The {@link ExchangeSpecification}
    */
-  public ItBitTradeService(ExchangeSpecification exchangeSpecification) {
+  public ItBitTradeService(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
-    super(exchangeSpecification);
+    super(exchangeSpecification, nonceFactory);
   }
 
   @Override

--- a/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitTradeServiceRaw.java
+++ b/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitTradeServiceRaw.java
@@ -9,6 +9,7 @@ import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.trade.LimitOrder;
 import com.xeiam.xchange.itbit.v1.dto.trade.ItBitOrder;
 import com.xeiam.xchange.itbit.v1.dto.trade.ItBitPlaceOrderRequest;
+import si.mazi.rescu.ValueFactory;
 
 public class ItBitTradeServiceRaw extends ItBitBasePollingService {
 
@@ -21,9 +22,9 @@ public class ItBitTradeServiceRaw extends ItBitBasePollingService {
    * @param exchangeSpecification
    *          The {@link ExchangeSpecification}
    */
-  public ItBitTradeServiceRaw(ExchangeSpecification exchangeSpecification) {
+  public ItBitTradeServiceRaw(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
-    super(exchangeSpecification);
+    super(exchangeSpecification, nonceFactory);
 
     // wallet Id used for this instance.
     walletId = (String) exchangeSpecification.getExchangeSpecificParameters().get("walletId");

--- a/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/KrakenExchange.java
+++ b/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/KrakenExchange.java
@@ -6,20 +6,24 @@ import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.kraken.service.polling.KrakenAccountService;
 import com.xeiam.xchange.kraken.service.polling.KrakenMarketDataService;
 import com.xeiam.xchange.kraken.service.polling.KrakenTradeService;
+import si.mazi.rescu.NonceFactory;
+import si.mazi.rescu.ValueFactory;
 
 /**
  * @author Benedikt Bünz
  */
 public class KrakenExchange extends BaseExchange implements Exchange {
 
+  private final ValueFactory<Long> nonceFactory = new NonceFactory();
+
   @Override
   public void applySpecification(ExchangeSpecification exchangeSpecification) {
 
     super.applySpecification(exchangeSpecification);
     // Configure the basic services if configuration does not apply
-    this.pollingMarketDataService = new KrakenMarketDataService(exchangeSpecification);
-    this.pollingTradeService = new KrakenTradeService(exchangeSpecification);
-    this.pollingAccountService = new KrakenAccountService(exchangeSpecification);
+    this.pollingMarketDataService = new KrakenMarketDataService(exchangeSpecification, nonceFactory);
+    this.pollingTradeService = new KrakenTradeService(exchangeSpecification, nonceFactory);
+    this.pollingAccountService = new KrakenAccountService(exchangeSpecification, nonceFactory);
   }
 
   @Override

--- a/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenAccountService.java
+++ b/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenAccountService.java
@@ -8,12 +8,13 @@ import com.xeiam.xchange.NotAvailableFromExchangeException;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.kraken.KrakenAdapters;
 import com.xeiam.xchange.service.polling.PollingAccountService;
+import si.mazi.rescu.ValueFactory;
 
 public class KrakenAccountService extends KrakenAccountServiceRaw implements PollingAccountService {
 
-  public KrakenAccountService(ExchangeSpecification exchangeSpecification) {
+  public KrakenAccountService(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
-    super(exchangeSpecification);
+    super(exchangeSpecification, nonceFactory);
   }
 
   @Override

--- a/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenAccountServiceRaw.java
+++ b/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenAccountServiceRaw.java
@@ -16,15 +16,16 @@ import com.xeiam.xchange.kraken.dto.account.results.KrakenLedgerResult;
 import com.xeiam.xchange.kraken.dto.account.results.KrakenQueryLedgerResult;
 import com.xeiam.xchange.kraken.dto.account.results.KrakenTradeBalanceInfoResult;
 import com.xeiam.xchange.kraken.dto.account.results.KrakenTradeVolumeResult;
+import si.mazi.rescu.ValueFactory;
 
 /**
  * @author jamespedwards42
  */
 public class KrakenAccountServiceRaw extends KrakenBasePollingService<KrakenAuthenticated> {
 
-  public KrakenAccountServiceRaw(ExchangeSpecification exchangeSpecification) {
+  public KrakenAccountServiceRaw(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
-    super(KrakenAuthenticated.class, exchangeSpecification);
+    super(KrakenAuthenticated.class, exchangeSpecification, nonceFactory);
   }
 
   /**

--- a/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenBasePollingService.java
+++ b/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenBasePollingService.java
@@ -6,7 +6,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import si.mazi.rescu.NonceFactory;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.ValueFactory;
@@ -36,18 +35,19 @@ public class KrakenBasePollingService<T extends Kraken> extends BaseExchangeServ
 
   protected T kraken;
   protected ParamsDigest signatureCreator;
-  protected ValueFactory<Long> nonce = new NonceFactory();
+  protected ValueFactory<Long> nonce;
 
   /**
    * Constructor
    * 
    * @param exchangeSpecification
    */
-  public KrakenBasePollingService(Class<T> type, ExchangeSpecification exchangeSpecification) {
+  public KrakenBasePollingService(Class<T> type, ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
     super(exchangeSpecification);
     kraken = RestProxyFactory.createProxy(type, exchangeSpecification.getSslUri());
     signatureCreator = KrakenDigest.createInstance(exchangeSpecification.getSecretKey());
+    nonce = nonceFactory;
   }
 
   @Override

--- a/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenMarketDataService.java
+++ b/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenMarketDataService.java
@@ -12,12 +12,13 @@ import com.xeiam.xchange.kraken.KrakenAdapters;
 import com.xeiam.xchange.kraken.dto.marketdata.KrakenDepth;
 import com.xeiam.xchange.kraken.dto.marketdata.KrakenPublicTrades;
 import com.xeiam.xchange.service.polling.PollingMarketDataService;
+import si.mazi.rescu.ValueFactory;
 
 public class KrakenMarketDataService extends KrakenMarketDataServiceRaw implements PollingMarketDataService {
 
-  public KrakenMarketDataService(ExchangeSpecification exchangeSpecification) {
+  public KrakenMarketDataService(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
-    super(exchangeSpecification);
+    super(exchangeSpecification, nonceFactory);
   }
 
   @Override

--- a/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenMarketDataServiceRaw.java
+++ b/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenMarketDataServiceRaw.java
@@ -14,6 +14,7 @@ import com.xeiam.xchange.kraken.dto.marketdata.results.KrakenDepthResult;
 import com.xeiam.xchange.kraken.dto.marketdata.results.KrakenPublicTradesResult;
 import com.xeiam.xchange.kraken.dto.marketdata.results.KrakenSpreadsResult;
 import com.xeiam.xchange.kraken.dto.marketdata.results.KrakenTickerResult;
+import si.mazi.rescu.ValueFactory;
 
 public class KrakenMarketDataServiceRaw extends KrakenBasePollingService<Kraken> {
 
@@ -22,9 +23,9 @@ public class KrakenMarketDataServiceRaw extends KrakenBasePollingService<Kraken>
    * 
    * @param exchangeSpecification
    */
-  public KrakenMarketDataServiceRaw(ExchangeSpecification exchangeSpecification) {
+  public KrakenMarketDataServiceRaw(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
-    super(Kraken.class, exchangeSpecification);
+    super(Kraken.class, exchangeSpecification, nonceFactory);
   }
 
   public KrakenTicker getKrakenTicker(CurrencyPair currencyPair) throws IOException {

--- a/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenTradeService.java
+++ b/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenTradeService.java
@@ -9,12 +9,13 @@ import com.xeiam.xchange.dto.trade.MarketOrder;
 import com.xeiam.xchange.dto.trade.OpenOrders;
 import com.xeiam.xchange.kraken.KrakenAdapters;
 import com.xeiam.xchange.service.polling.PollingTradeService;
+import si.mazi.rescu.ValueFactory;
 
 public class KrakenTradeService extends KrakenTradeServiceRaw implements PollingTradeService {
 
-  public KrakenTradeService(ExchangeSpecification exchangeSpecification) {
+  public KrakenTradeService(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
-    super(exchangeSpecification);
+    super(exchangeSpecification, nonceFactory);
   }
 
   @Override

--- a/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenTradeServiceRaw.java
+++ b/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenTradeServiceRaw.java
@@ -23,6 +23,7 @@ import com.xeiam.xchange.kraken.dto.trade.results.KrakenOrderResult;
 import com.xeiam.xchange.kraken.dto.trade.results.KrakenQueryOrderResult;
 import com.xeiam.xchange.kraken.dto.trade.results.KrakenQueryTradeResult;
 import com.xeiam.xchange.kraken.dto.trade.results.KrakenTradeHistoryResult;
+import si.mazi.rescu.ValueFactory;
 
 public class KrakenTradeServiceRaw extends KrakenBasePollingService<KrakenAuthenticated> {
 
@@ -31,9 +32,9 @@ public class KrakenTradeServiceRaw extends KrakenBasePollingService<KrakenAuthen
    * 
    * @param exchangeSpecification
    */
-  public KrakenTradeServiceRaw(ExchangeSpecification exchangeSpecification) {
+  public KrakenTradeServiceRaw(ExchangeSpecification exchangeSpecification, ValueFactory<Long> nonceFactory) {
 
-    super(KrakenAuthenticated.class, exchangeSpecification);
+    super(KrakenAuthenticated.class, exchangeSpecification, nonceFactory);
   }
 
   public Map<String, KrakenOrder> getKrakenOpenOrders() throws IOException {


### PR DESCRIPTION
This patch moves creation of ValueFactory objects to BaseExchange implementations, and propagates the object to the services. Thanks to this, services share single ValueFactory and concurrent calls on different services (but the same exchange) are synchronized on the same ValueFactory.
