### PR TITLE
Implement BTCChina Trade API v2.0.1: Added two more parameters for getTransactions API method: "since" and "sincetype".

### DIFF
--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/dto/trade/request/BTCChinaTransactionsRequest.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/dto/trade/request/BTCChinaTransactionsRequest.java
@@ -16,6 +16,15 @@ public class BTCChinaTransactionsRequest extends BTCChinaRequest {
   }
 
   /**
+   * @deprecated Use {@link #BTCChinaTransactionsRequest(String, Integer, Integer, Integer, String)} instead.
+   */
+  @Deprecated
+  public BTCChinaTransactionsRequest(String type, Integer limit, Integer offset) {
+
+    this(type, limit, offset, null, null);
+  }
+
+  /**
    * Constructs a getting transactions log request.
    *
    * @param type Fetch transactions by type.
@@ -24,11 +33,14 @@ public class BTCChinaTransactionsRequest extends BTCChinaRequest {
    *          | refundmoney | buybtc | sellbtc | buyltc | sellltc | tradefee | rebate '
    * @param limit Limit the number of transactions, default value is 10.
    * @param offset Start index used for pagination, default value is 0.
+   * @param since To fetch the transactions from this point, which can either be an order id or a unix timestamp, default value is 0.
+   * @param sincetype Specify the type of 'since' parameter, can either be 'id' or 'time'. default value is 'time'.
    */
-  public BTCChinaTransactionsRequest(String type, Integer limit, Integer offset) {
+  public BTCChinaTransactionsRequest(String type, Integer limit, Integer offset, Integer since, String sincetype) {
 
     method = "getTransactions";
-    params = String.format("[\"%1$s\",%2$d,%3$d]", type == null ? TYPE_ALL : type, limit == null ? 10 : limit.intValue(), offset == null ? 0 : offset.intValue());
+    params = String.format("[\"%s\",%d,%d,%d,\"%s\"]", type == null ? TYPE_ALL : type, limit == null ? 10 : limit.intValue(), offset == null ? 0 : offset.intValue(),
+        since == null ? 0 : since.intValue(), sincetype == null ? "time" : sincetype);
   }
 
   @Override

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaTradeService.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaTradeService.java
@@ -130,6 +130,8 @@ public class BTCChinaTradeService extends BTCChinaTradeServiceRaw implements Pol
    *          <ol>
    *          <li>limit: limit the number of transactions, default value is 10 if null.</li>
    *          <li>offset: start index used for pagination, default value is 0 if null.</li>
+   *          <li>since: to fetch the transactions from this point, which can either be an order id or a unix timestamp, default value is 0.</li>
+   *          <li>sincetype: specify the type of 'since' parameter, can either be 'id' or 'time'. default value is 'time'.</li>
    *          </ol>
    */
   @Override
@@ -138,10 +140,12 @@ public class BTCChinaTradeService extends BTCChinaTradeServiceRaw implements Pol
     final String type = BTCChinaTransactionsRequest.TYPE_ALL;
     final Integer limit = args.length > 0 ? ((Number) args[0]).intValue() : null;
     final Integer offset = args.length > 1 ? ((Number) args[1]).intValue() : null;
+    final Integer since = args.length > 2 ?  ((Number) args[2]).intValue() : null;
+    final String sincetype = args.length > 3 ?  ((String) args[3]) : null;
 
-    log.debug("type: {}, limit: {}, offset: {}", type, limit, offset);
+    log.debug("type: {}, limit: {}, offset: {}, since: {}, sincetype: {}", type, limit, offset, since, sincetype);
 
-    final BTCChinaTransactionsResponse response = getTransactions(type, limit, offset);
+    final BTCChinaTransactionsResponse response = getTransactions(type, limit, offset, since, sincetype);
     return BTCChinaAdapters.adaptTransactions(response.getResult().getTransactions());
   }
 

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaTradeServiceRaw.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaTradeServiceRaw.java
@@ -261,11 +261,20 @@ public class BTCChinaTradeServiceRaw extends BTCChinaBasePollingService<BTCChina
   }
 
   /**
-   * @see BTCChinaTransactionsRequest#BTCChinaTransactionsRequest(String, Integer, Integer)
+   * @deprecated Use {@link #getTransactions(String, Integer, Integer, Integer, String)} instead.
    */
+  @Deprecated
   public BTCChinaTransactionsResponse getTransactions(String type, Integer limit, Integer offset) throws IOException {
 
-    BTCChinaTransactionsRequest request = new BTCChinaTransactionsRequest(type, limit, offset);
+    return getTransactions(type, limit, offset, null, null);
+  }
+
+  /**
+   * @see BTCChinaTransactionsRequest#BTCChinaTransactionsRequest(String, Integer, Integer, Integer, String)
+   */
+  public BTCChinaTransactionsResponse getTransactions(String type, Integer limit, Integer offset, Integer since, String sincetype) throws IOException {
+
+    BTCChinaTransactionsRequest request = new BTCChinaTransactionsRequest(type, limit, offset, since, sincetype);
     BTCChinaTransactionsResponse response = btcChina.getTransactions(signatureCreator, BTCChinaUtils.getNonce(), request);
     return checkResult(response);
   }

--- a/xchange-btcchina/src/test/java/com/xeiam/xchange/btcchina/dto/trade/request/BTCChinaTransactionsRequestTest.java
+++ b/xchange-btcchina/src/test/java/com/xeiam/xchange/btcchina/dto/trade/request/BTCChinaTransactionsRequestTest.java
@@ -7,11 +7,15 @@ import org.junit.Test;
 public class BTCChinaTransactionsRequestTest {
 
   @Test
-  public void testBTCChinaTransactionsRequestStringIntegerInteger() {
+  public void testBTCChinaTransactionsRequest() {
 
-    assertEquals("[\"all\",10,0]", new BTCChinaTransactionsRequest(null, null, null).getParams());
-    assertEquals("[\"buybtc\",2,0]", new BTCChinaTransactionsRequest("buybtc", 2, null).getParams());
-    assertEquals("[\"all\",100,5]", new BTCChinaTransactionsRequest("all", 100, 5).getParams());
+    assertEquals("[\"all\",10,0,0,\"time\"]", new BTCChinaTransactionsRequest(null, null, null, null, null).getParams());
+    assertEquals("[\"buybtc\",2,0,0,\"time\"]", new BTCChinaTransactionsRequest("buybtc", 2, null, null, null).getParams());
+    assertEquals("[\"all\",100,5,0,\"time\"]", new BTCChinaTransactionsRequest("all", 100, 5, null, null).getParams());
+    assertEquals("[\"all\",100,5,0,\"time\"]", new BTCChinaTransactionsRequest("all", 100, 5, null, null).getParams());
+    assertEquals("[\"all\",100,5,1,\"time\"]", new BTCChinaTransactionsRequest("all", 100, 5, 1, null).getParams());
+    assertEquals("[\"all\",100,5,0,\"id\"]", new BTCChinaTransactionsRequest("all", 100, 5, null, "id").getParams());
+    assertEquals("[\"all\",100,5,1,\"id\"]", new BTCChinaTransactionsRequest("all", 100, 5, 1, "id").getParams());
   }
 
 }

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/btcchina/trade/BTCChinaGetTradeHistoryDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/btcchina/trade/BTCChinaGetTradeHistoryDemo.java
@@ -40,7 +40,7 @@ public class BTCChinaGetTradeHistoryDemo {
 
   private static void raw() throws IOException {
 
-    BTCChinaTransactionsResponse response = tradeServiceRaw.getTransactions("all", 10, null);
+    BTCChinaTransactionsResponse response = tradeServiceRaw.getTransactions("all", 10, null, null, null);
     System.out.println("BTCChinaTransactionsResponse: " + response);
     for (BTCChinaTransaction transaction : response.getResult().getTransactions()) {
       System.out.println(ToStringBuilder.reflectionToString(transaction));


### PR DESCRIPTION
[Trade API v2.0.1](http://btcchina.org/api-trade-documentation-en#trade_api_v201): 2014-08-21 Added two more parameters for getTransactions API method: “since” and “sincetype”.
