### PR TITLE
Implement BTCChina Data API v1.3.1: Added two more return values "vwap" and "prev_close" for ticker API.

### DIFF
--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/dto/marketdata/BTCChinaTickerObject.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/dto/marketdata/BTCChinaTickerObject.java
@@ -16,19 +16,25 @@ public class BTCChinaTickerObject implements Serializable {
   private final BigDecimal sell;
   private final BigDecimal vol;
   private final long date;
+  private final BigDecimal vwap;
+  private final BigDecimal prevClose;
 
   /**
    * Constructor
    * 
-   * @param buy
-   * @param sell
-   * @param high
-   * @param low
-   * @param vol
-   * @param last
+   * @param buy Latest bid price.
+   * @param sell Latest ask price.
+   * @param high Highest price in last 24h.
+   * @param low Lowest price in last 24h.
+   * @param vol Total BTC(or LTC) volume in last 24h.
+   * @param last Last successful trade price
+   * @param date Last update timestamp.
+   * @param vwap Today's average filled price.
+   * @param prevClose Yesterday's closed price.
    */
   public BTCChinaTickerObject(@JsonProperty("buy") BigDecimal buy, @JsonProperty("sell") BigDecimal sell, @JsonProperty("high") BigDecimal high, @JsonProperty("low") BigDecimal low,
-      @JsonProperty("vol") BigDecimal vol, @JsonProperty("last") BigDecimal last, @JsonProperty("date") long date) {
+      @JsonProperty("vol") BigDecimal vol, @JsonProperty("last") BigDecimal last, @JsonProperty("date") long date,
+      @JsonProperty("vwap") BigDecimal vwap, @JsonProperty("prev_close") BigDecimal prevClose) {
 
     this.high = high;
     this.low = low;
@@ -37,6 +43,8 @@ public class BTCChinaTickerObject implements Serializable {
     this.buy = buy;
     this.sell = sell;
     this.date = date;
+    this.vwap = vwap;
+    this.prevClose = prevClose;
   }
 
   public BigDecimal getBuy() {
@@ -74,10 +82,32 @@ public class BTCChinaTickerObject implements Serializable {
     return date;
   }
 
+  /**
+   * Returns today's average filled price.
+   *
+   * @return today's average filled price.
+   * @since <a href="http://btcchina.org/api-market-data-documentation-en#data_api_v131">Data API v1.3.1</a>
+   */
+  public BigDecimal getVwap() {
+
+    return vwap;
+  }
+
+  /**
+   * Returns yesterday's closed price.
+   *
+   * @return Yesterday's closed price.
+   * @since <a href="http://btcchina.org/api-market-data-documentation-en#data_api_v131">Data API v1.3.1</a>
+   */
+  public BigDecimal getPrevClose() {
+
+    return prevClose;
+  }
+
   @Override
   public String toString() {
 
-    return "BTCChinaTicker [last=" + last + ", high=" + high + ", low=" + low + ", buy=" + buy + ", sell=" + sell + ", vol=" + vol + ", date=" + date + "]";
+    return "BTCChinaTicker [last=" + last + ", high=" + high + ", low=" + low + ", buy=" + buy + ", sell=" + sell + ", vol=" + vol + ", date=" + date + ", vwap=" + vwap + ", preClose=" + prevClose + "]";
 
   }
 }

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/btcchina/marketdata/BTCChinaTickerDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/btcchina/marketdata/BTCChinaTickerDemo.java
@@ -63,6 +63,9 @@ public class BTCChinaTickerDemo {
     System.out.println("High: " + ticker.getTicker().getHigh().toString());
     System.out.println("Low: " + ticker.getTicker().getLow().toString());
 
+    System.out.println("vwap: " + ticker.getTicker().getVwap());
+    System.out.println("prev_close: " + ticker.getTicker().getPrevClose());
+
     Map<String, BTCChinaTickerObject> tickers = marketDataServiceRaw.getBTCChinaTickers();
     System.out.println(tickers);
 


### PR DESCRIPTION
[Data API v1.3.1](http://btcchina.org/api-market-data-documentation-en#data_api_v131): 2014-08-21 Data API v1.3.1: Added two more return values “vwap” and “prev_close” for ticker API.
