### PR TITLE
Bitfinex: active positions query

### DIFF
--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/BitfinexAuthenticated.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/BitfinexAuthenticated.java
@@ -16,6 +16,7 @@ import com.xeiam.xchange.bitfinex.v1.dto.account.BitfinexBalancesResponse;
 import com.xeiam.xchange.bitfinex.v1.dto.account.BitfinexMarginInfosRequest;
 import com.xeiam.xchange.bitfinex.v1.dto.account.BitfinexMarginInfosResponse;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexActiveCreditsRequest;
+import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexActivePositionsResponse;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexCancelOfferRequest;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexCancelOrderRequest;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexCreditResponse;
@@ -67,6 +68,11 @@ public interface BitfinexAuthenticated extends Bitfinex {
   @POST
   @Path("offers")
   BitfinexOfferStatusResponse[] activeOffers(@HeaderParam("X-BFX-APIKEY") String apiKey, @HeaderParam("X-BFX-PAYLOAD") ParamsDigest payload, @HeaderParam("X-BFX-SIGNATURE") ParamsDigest signature,
+      BitfinexNonceOnlyRequest nonceOnlyRequest) throws IOException;
+
+  @POST
+  @Path("positions")
+  BitfinexActivePositionsResponse[] activePositions(@HeaderParam("X-BFX-APIKEY") String apiKey, @HeaderParam("X-BFX-PAYLOAD") ParamsDigest payload, @HeaderParam("X-BFX-SIGNATURE") ParamsDigest signature,
       BitfinexNonceOnlyRequest nonceOnlyRequest) throws IOException;
 
   @POST

--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/dto/trade/BitfinexActivePositionsResponse.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/dto/trade/BitfinexActivePositionsResponse.java
@@ -1,0 +1,104 @@
+package com.xeiam.xchange.bitfinex.v1.dto.trade;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.xeiam.xchange.dto.Order.OrderType;
+
+public class BitfinexActivePositionsResponse {
+  private final int id;
+  private final String symbol;
+  private final String status;
+  private final BigDecimal base;
+  private final BigDecimal amount;
+  private final float timestamp;
+  private final BigDecimal swap;
+  private final BigDecimal pnl;
+  private final OrderType orderType;
+
+  public BitfinexActivePositionsResponse( @JsonProperty("id") int id, @JsonProperty("symbol")String symbol,  @JsonProperty("status")String status, @JsonProperty("base") BigDecimal base, 
+      @JsonProperty("amount")BigDecimal amount, @JsonProperty("timestamp")float timestamp,  @JsonProperty("swap")BigDecimal swap,  @JsonProperty("pl")BigDecimal pnl) {
+
+    this.id = id;
+    this.symbol = symbol;
+    this.status = status;
+    this.base = base;
+    this.amount = amount;
+    this.timestamp = timestamp;
+    this.swap = swap;
+    this.pnl = pnl;
+
+    this.orderType = amount.signum() < 0 ? OrderType.ASK : OrderType.BID;
+  }
+
+  
+  public int getId() {
+    return id;
+  }
+
+  
+  public String getSymbol() {
+    return symbol;
+  }
+
+  
+  public String getStatus() {
+    return status;
+  }
+
+  
+  public BigDecimal getBase() {
+    return base;
+  }
+
+  
+  public BigDecimal getAmount() {
+    return amount;
+  }
+
+  
+  public float getTimestamp() {
+    return timestamp;
+  }
+
+  
+  public BigDecimal getSwap() {
+    return swap;
+  }
+
+  
+  public BigDecimal getPnl() {
+    return pnl;
+  }
+
+  
+  public OrderType getOrderType() {
+    return orderType;
+  }
+
+  @Override
+  public String toString() {
+
+    StringBuilder builder = new StringBuilder();
+    builder.append("BitfinexActivePositionsResponse [id=");
+    builder.append(id);
+    builder.append(", symbol=");
+    builder.append(symbol);
+    builder.append(", status=");
+    builder.append(status);
+    builder.append(", base=");
+    builder.append(base);
+    builder.append(", amount=");
+    builder.append(amount);
+    builder.append(", timestamp=");
+    builder.append(timestamp);
+    builder.append(", swap=");
+    builder.append(swap);
+    builder.append(", pnl=");
+    builder.append(pnl);
+    builder.append(", orderType=");
+    builder.append(orderType);
+    builder.append("]");
+    return builder.toString();
+  }  
+}

--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/service/polling/BitfinexTradeServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/service/polling/BitfinexTradeServiceRaw.java
@@ -8,6 +8,7 @@ import com.xeiam.xchange.bitfinex.v1.BitfinexAuthenticated;
 import com.xeiam.xchange.bitfinex.v1.BitfinexOrderType;
 import com.xeiam.xchange.bitfinex.v1.BitfinexUtils;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexActiveCreditsRequest;
+import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexActivePositionsResponse;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexCancelOfferRequest;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexCancelOrderRequest;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexCreditResponse;
@@ -47,12 +48,12 @@ public class BitfinexTradeServiceRaw extends BitfinexBasePollingService<Bitfinex
   }
 
   public BitfinexOfferStatusResponse[] getBitfinexOpenOffers() throws IOException {
-    
+
     BitfinexOfferStatusResponse[] activeOffers = bitfinex.activeOffers(apiKey, payloadCreator, signatureCreator, new BitfinexNonceOnlyRequest("/v1/offers", String.valueOf(nextNonce())));
-    
+
     return activeOffers;
   }
-  
+
   public BitfinexOrderStatusResponse placeBitfinexMarketOrder(MarketOrder marketOrder) throws IOException {
 
     String pair = BitfinexUtils.toPairString(marketOrder.getCurrencyPair());
@@ -78,24 +79,24 @@ public class BitfinexTradeServiceRaw extends BitfinexBasePollingService<Bitfinex
 
     return newOrder;
   }
-  
+
   public BitfinexOfferStatusResponse placeBitfinexFixedRateLoanOrder(FixedRateLoanOrder loanOrder, BitfinexOrderType orderType) throws IOException {
-    
+
     String direction = loanOrder.getType() == OrderType.BID ? "loan" : "lend";
-    
+
     BitfinexOfferStatusResponse newOrderResponse = bitfinex.newOffer(apiKey, payloadCreator, signatureCreator, 
         new BitfinexNewOfferRequest(String.valueOf(nextNonce()), loanOrder.getCurrency(), loanOrder.getTradableAmount(), loanOrder.getRate(), loanOrder.getDayPeriod(), direction));
-    
+
     return newOrderResponse;
   }
-  
-public BitfinexOfferStatusResponse placeBitfinexFloatingRateLoanOrder(FloatingRateLoanOrder loanOrder, BitfinexOrderType orderType) throws IOException {
-    
+
+  public BitfinexOfferStatusResponse placeBitfinexFloatingRateLoanOrder(FloatingRateLoanOrder loanOrder, BitfinexOrderType orderType) throws IOException {
+
     String direction = loanOrder.getType() == OrderType.BID ? "loan" : "lend";
-    
+
     BitfinexOfferStatusResponse newOrderResponse = bitfinex.newOffer(apiKey, payloadCreator, signatureCreator, 
         new BitfinexNewOfferRequest(String.valueOf(nextNonce()), loanOrder.getCurrency(), loanOrder.getTradableAmount(), new BigDecimal("0.0"), loanOrder.getDayPeriod(), direction));
-    
+
     return newOrderResponse;
   }
 
@@ -105,11 +106,11 @@ public BitfinexOfferStatusResponse placeBitfinexFloatingRateLoanOrder(FloatingRa
 
     return cancelResponse;
   }
-  
+
   public BitfinexOfferStatusResponse cancelBitfinexOffer(String offerId) throws IOException {
-    
+
     BitfinexOfferStatusResponse cancelResponse = bitfinex.cancelOffer(apiKey, payloadCreator, signatureCreator, new BitfinexCancelOfferRequest(String.valueOf(nextNonce()), Integer.valueOf(offerId)));
-    
+
     return cancelResponse;
   }
 
@@ -120,11 +121,11 @@ public BitfinexOfferStatusResponse placeBitfinexFloatingRateLoanOrder(FloatingRa
     return orderStatus;
 
   }
-  
+
   public BitfinexOfferStatusResponse getBitfinexOfferStatusResponse(String offerId) throws IOException {
-    
+
     BitfinexOfferStatusResponse offerStatus = bitfinex.offerStatus(apiKey, payloadCreator, signatureCreator, new BitfinexOfferStatusRequest(String.valueOf(nextNonce()), Integer.valueOf(offerId)));
-  
+
     return offerStatus;
   }
 
@@ -134,12 +135,18 @@ public BitfinexOfferStatusResponse placeBitfinexFloatingRateLoanOrder(FloatingRa
 
     return trades;
   }
-  
+
   public BitfinexCreditResponse[] getBitfinexActiveCredits() throws IOException {
-  
+
     BitfinexCreditResponse[] credits = bitfinex.activeCredits(apiKey, payloadCreator, signatureCreator, new BitfinexActiveCreditsRequest(String.valueOf(nextNonce())));
-    
+
     return credits;
   }
-  
+
+  public BitfinexActivePositionsResponse[] getBitfinexActivePositions() throws IOException {
+
+    BitfinexActivePositionsResponse[] activePositions = bitfinex.activePositions(apiKey, payloadCreator, signatureCreator, new BitfinexNonceOnlyRequest("/v1/positions", String.valueOf(nextNonce())));
+    return activePositions;
+  }
+
 }


### PR DESCRIPTION
Added Raw method for querying currently active margin positions. Including derived field for order type.

`BitfinexActivePositionsResponse [id=199537, symbol=btcusd, status=ACTIVE, base=476.755, amount=-0.01, timestamp=1.40950848E9, swap=0.0, pnl=-0.0292244, orderType=ASK]`
