### PR TITLE
Added Bittrex Trade History

### DIFF
--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/Bittrex.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/Bittrex.java
@@ -29,7 +29,7 @@ public interface Bittrex {
 
   @GET
   @Path("public/getorderbook/")
-  BittrexDepthResponse getBook(@QueryParam("market") String market, @QueryParam("type") String type, @QueryParam("count") long count) throws IOException;
+  BittrexDepthResponse getBook(@QueryParam("market") String market, @QueryParam("type") String type, @QueryParam("depth") long depth) throws IOException;
 
   @GET
   @Path("public/getmarkethistory/")

--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/BittrexAdapters.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/BittrexAdapters.java
@@ -15,6 +15,7 @@ import com.xeiam.xchange.bittrex.v1.dto.marketdata.BittrexSymbol;
 import com.xeiam.xchange.bittrex.v1.dto.marketdata.BittrexTicker;
 import com.xeiam.xchange.bittrex.v1.dto.marketdata.BittrexTrade;
 import com.xeiam.xchange.bittrex.v1.dto.trade.BittrexOpenOrder;
+import com.xeiam.xchange.bittrex.v1.dto.trade.BittrexUserTrade;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
@@ -134,6 +135,30 @@ public final class BittrexAdapters {
     }
 
     return new AccountInfo(null, wallets);
+  }
+  
+  public static List<Trade> adaptUserTrades(List<BittrexUserTrade> bittrexUserTrades) {
+
+    List<Trade> trades = new ArrayList<Trade>();
+
+    for (BittrexUserTrade bittrexTrade : bittrexUserTrades) {
+      trades.add(adaptUserTrade(bittrexTrade));
+    }
+    return trades;
+  }
+
+  public static Trade adaptUserTrade(BittrexUserTrade trade) {
+
+    String[] currencies = trade.getExchange().split("-");
+    CurrencyPair currencyPair = new CurrencyPair(currencies[1], currencies[0]);
+
+    OrderType orderType = trade.getOrderType().equalsIgnoreCase("LIMIT_BUY") ? OrderType.BID : OrderType.ASK;
+    BigDecimal amount = trade.getQuantity().subtract(trade.getQuantityRemaining());
+    BigDecimal price = trade.getPrice();
+    Date date = BittrexUtils.toDate(trade.getTimeStamp());
+    String tradeId = String.valueOf(trade.getOrderUuid());
+
+    return new Trade(orderType, amount, currencyPair, price, date, tradeId);
   }
 
 }

--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/BittrexAuthenticated.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/BittrexAuthenticated.java
@@ -16,6 +16,7 @@ import com.xeiam.xchange.bittrex.v1.dto.account.BittrexBalancesResponse;
 import com.xeiam.xchange.bittrex.v1.dto.account.BittrexDepositAddressResponse;
 import com.xeiam.xchange.bittrex.v1.dto.trade.BittrexCancelOrderResponse;
 import com.xeiam.xchange.bittrex.v1.dto.trade.BittrexOpenOrdersResponse;
+import com.xeiam.xchange.bittrex.v1.dto.trade.BittrexTradeHistoryResponse;
 import com.xeiam.xchange.bittrex.v1.dto.trade.BittrexTradeResponse;
 
 @Path("v1.1")
@@ -60,4 +61,8 @@ public interface BittrexAuthenticated extends Bittrex {
   @GET
   @Path("market/getopenorders")
   BittrexOpenOrdersResponse openorders(@QueryParam("apikey") String apiKey, @HeaderParam("apisign") ParamsDigest signature, @QueryParam("nonce") String nonce) throws IOException;
+
+  @GET
+  @Path("account/getorderhistory")
+  BittrexTradeHistoryResponse getorderhistory(@QueryParam("apikey") String apiKey, @HeaderParam("apisign") ParamsDigest signature, @QueryParam("nonce") String nonce) throws IOException;
 }

--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/dto/trade/BittrexTradeHistoryResponse.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/dto/trade/BittrexTradeHistoryResponse.java
@@ -1,0 +1,77 @@
+package com.xeiam.xchange.bittrex.v1.dto.trade;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({ "success", "message", "result" })
+public class BittrexTradeHistoryResponse {
+
+  @JsonProperty("success")
+  private Boolean success;
+  @JsonProperty("message")
+  private String message;
+  @JsonProperty("result")
+  private List<BittrexUserTrade> result = new ArrayList<BittrexUserTrade>();
+  @JsonIgnore
+  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+  @JsonProperty("success")
+  public Boolean getSuccess() {
+
+    return success;
+  }
+
+  @JsonProperty("success")
+  public void setSuccess(Boolean success) {
+
+    this.success = success;
+  }
+
+  @JsonProperty("message")
+  public String getMessage() {
+
+    return message;
+  }
+
+  @JsonProperty("message")
+  public void setMessage(String message) {
+
+    this.message = message;
+  }
+
+  @JsonProperty("result")
+  public List<BittrexUserTrade> getResult() {
+
+    return result;
+  }
+
+  @JsonProperty("result")
+  public void setResult(List<BittrexUserTrade> result) {
+
+    this.result = result;
+  }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+
+    return this.additionalProperties;
+  }
+
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+
+    this.additionalProperties.put(name, value);
+  }
+
+}

--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/dto/trade/BittrexUserTrade.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/dto/trade/BittrexUserTrade.java
@@ -1,0 +1,241 @@
+package com.xeiam.xchange.bittrex.v1.dto.trade;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({ "OrderUuid", "Exchange", "TimeStamp", "OrderType", "Limit", "Quantity", "QuantityRemaining", "Commission", "Price", "PricePerUnit", "IsConditional", "Condition",
+    "ConditionTarget", "ImmediateOrCancel" })
+public class BittrexUserTrade {
+
+  @JsonProperty("OrderUuid")
+  private String orderUuid;
+  @JsonProperty("Exchange")
+  private String exchange;
+  @JsonProperty("TimeStamp")
+  private String timeStamp;
+  @JsonProperty("OrderType")
+  private String orderType;
+  @JsonProperty("Limit")
+  private BigDecimal limit;
+  @JsonProperty("Quantity")
+  private BigDecimal quantity;
+  @JsonProperty("QuantityRemaining")
+  private BigDecimal quantityRemaining;
+  @JsonProperty("Commission")
+  private BigDecimal commission;
+  @JsonProperty("Price")
+  private BigDecimal price;
+  @JsonProperty("PricePerUnit")
+  private BigDecimal pricePerUnit;
+  @JsonProperty("IsConditional")
+  private Boolean isConditional;
+  @JsonProperty("Condition")
+  private Object condition;
+  @JsonProperty("ConditionTarget")
+  private Object conditionTarget;
+  @JsonProperty("ImmediateOrCancel")
+  private Boolean immediateOrCancel;
+  @JsonIgnore
+  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+  @JsonProperty("OrderUuid")
+  public String getOrderUuid() {
+
+    return orderUuid;
+  }
+
+  @JsonProperty("OrderUuid")
+  public void setOrderUuid(String orderUuid) {
+
+    this.orderUuid = orderUuid;
+  }
+
+  @JsonProperty("Exchange")
+  public String getExchange() {
+
+    return exchange;
+  }
+
+  @JsonProperty("Exchange")
+  public void setExchange(String exchange) {
+
+    this.exchange = exchange;
+  }
+
+  @JsonProperty("TimeStamp")
+  public String getTimeStamp() {
+
+    return timeStamp;
+  }
+
+  @JsonProperty("TimeStamp")
+  public void setTimeStamp(String timeStamp) {
+
+    this.timeStamp = timeStamp;
+  }
+
+  @JsonProperty("OrderType")
+  public String getOrderType() {
+
+    return orderType;
+  }
+
+  @JsonProperty("OrderType")
+  public void setOrderType(String orderType) {
+
+    this.orderType = orderType;
+  }
+
+  @JsonProperty("Limit")
+  public BigDecimal getLimit() {
+
+    return limit;
+  }
+
+  @JsonProperty("Limit")
+  public void setLimit(BigDecimal limit) {
+
+    this.limit = limit;
+  }
+
+  @JsonProperty("Quantity")
+  public BigDecimal getQuantity() {
+
+    return quantity;
+  }
+
+  @JsonProperty("Quantity")
+  public void setQuantity(BigDecimal quantity) {
+
+    this.quantity = quantity;
+  }
+
+  @JsonProperty("QuantityRemaining")
+  public BigDecimal getQuantityRemaining() {
+
+    return quantityRemaining;
+  }
+
+  @JsonProperty("QuantityRemaining")
+  public void setQuantityRemaining(BigDecimal quantityRemaining) {
+
+    this.quantityRemaining = quantityRemaining;
+  }
+
+  @JsonProperty("Commission")
+  public BigDecimal getCommission() {
+
+    return commission;
+  }
+
+  @JsonProperty("Commission")
+  public void setCommission(BigDecimal commission) {
+
+    this.commission = commission;
+  }
+
+  @JsonProperty("Price")
+  public BigDecimal getPrice() {
+
+    return price;
+  }
+
+  @JsonProperty("Price")
+  public void setPrice(BigDecimal price) {
+
+    this.price = price;
+  }
+
+  @JsonProperty("PricePerUnit")
+  public BigDecimal getPricePerUnit() {
+
+    return pricePerUnit;
+  }
+
+  @JsonProperty("PricePerUnit")
+  public void setPricePerUnit(BigDecimal pricePerUnit) {
+
+    this.pricePerUnit = pricePerUnit;
+  }
+
+  @JsonProperty("IsConditional")
+  public Boolean getIsConditional() {
+
+    return isConditional;
+  }
+
+  @JsonProperty("IsConditional")
+  public void setIsConditional(Boolean isConditional) {
+
+    this.isConditional = isConditional;
+  }
+
+  @JsonProperty("Condition")
+  public Object getCondition() {
+
+    return condition;
+  }
+
+  @JsonProperty("Condition")
+  public void setCondition(Object condition) {
+
+    this.condition = condition;
+  }
+
+  @JsonProperty("ConditionTarget")
+  public Object getConditionTarget() {
+
+    return conditionTarget;
+  }
+
+  @JsonProperty("ConditionTarget")
+  public void setConditionTarget(Object conditionTarget) {
+
+    this.conditionTarget = conditionTarget;
+  }
+
+  @JsonProperty("ImmediateOrCancel")
+  public Boolean getImmediateOrCancel() {
+
+    return immediateOrCancel;
+  }
+
+  @JsonProperty("ImmediateOrCancel")
+  public void setImmediateOrCancel(Boolean immediateOrCancel) {
+
+    this.immediateOrCancel = immediateOrCancel;
+  }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+
+    return this.additionalProperties;
+  }
+
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+
+    this.additionalProperties.put(name, value);
+  }
+
+  @Override
+  public String toString() {
+
+    return "BittrexUserTrade [orderUuid=" + orderUuid + ", exchange=" + exchange + ", timeStamp=" + timeStamp + ", orderType=" + orderType + ", limit=" + limit + ", quantity=" + quantity
+        + ", quantityRemaining=" + quantityRemaining + ", commission=" + commission + ", price=" + price + ", pricePerUnit=" + pricePerUnit + ", isConditional=" + isConditional + ", condition="
+        + condition + ", conditionTarget=" + conditionTarget + ", immediateOrCancel=" + immediateOrCancel + ", additionalProperties=" + additionalProperties + "]";
+  }
+
+}

--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/service/polling/BittrexAccountServiceRaw.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/service/polling/BittrexAccountServiceRaw.java
@@ -30,7 +30,7 @@ public class BittrexAccountServiceRaw extends BittrexBasePollingService<BittrexA
       return response.getResult();
     }
     else {
-      throw new ExchangeException(response.getMessage());
+      throw new ExchangeException("Bittrex returned an error: " + response.getMessage());
     }
   }
 
@@ -41,7 +41,7 @@ public class BittrexAccountServiceRaw extends BittrexBasePollingService<BittrexA
       return response.getResult().getAddress();
     }
     else {
-      throw new ExchangeException(response.getMessage());
+      throw new ExchangeException("Bittrex returned an error: " + response.getMessage());
     }
   }
 

--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/service/polling/BittrexMarketDataServiceRaw.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/service/polling/BittrexMarketDataServiceRaw.java
@@ -46,7 +46,7 @@ public class BittrexMarketDataServiceRaw extends BittrexBasePollingService<Bittr
       return response.getCurrencies();
     }
     else {
-      throw new ExchangeException(response.getMessage());
+      throw new ExchangeException("Bittrex returned an error: " + response.getMessage());
     }
 
   }
@@ -59,7 +59,7 @@ public class BittrexMarketDataServiceRaw extends BittrexBasePollingService<Bittr
       return response.getSymbols();
     }
     else {
-      throw new ExchangeException(response.getMessage());
+      throw new ExchangeException("Bittrex returned an error: " + response.getMessage());
     }
 
   }
@@ -72,7 +72,7 @@ public class BittrexMarketDataServiceRaw extends BittrexBasePollingService<Bittr
       return response.getTicker();
     }
     else {
-      throw new ExchangeException(response.getMessage());
+      throw new ExchangeException("Bittrex returned an error: " + response.getMessage());
     }
 
   }
@@ -85,7 +85,7 @@ public class BittrexMarketDataServiceRaw extends BittrexBasePollingService<Bittr
       return response.getTickers();
     }
     else {
-      throw new ExchangeException(response.getMessage());
+      throw new ExchangeException("Bittrex returned an error: " + response.getMessage());
     }
 
   }
@@ -100,7 +100,7 @@ public class BittrexMarketDataServiceRaw extends BittrexBasePollingService<Bittr
       return bittrexDepth;
     }
     else {
-      throw new ExchangeException(response.getMessage());
+      throw new ExchangeException("Bittrex returned an error: " + response.getMessage());
     }
   }
 
@@ -118,7 +118,7 @@ public class BittrexMarketDataServiceRaw extends BittrexBasePollingService<Bittr
       return bittrexTrades;
     }
     else {
-      throw new ExchangeException(response.getMessage());
+      throw new ExchangeException("Bittrex returned an error: " + response.getMessage());
     }
   }
 }

--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/service/polling/BittrexTradeService.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/service/polling/BittrexTradeService.java
@@ -8,6 +8,7 @@ import com.xeiam.xchange.NotAvailableFromExchangeException;
 import com.xeiam.xchange.NotYetImplementedForExchangeException;
 import com.xeiam.xchange.bittrex.v1.BittrexAdapters;
 import com.xeiam.xchange.dto.marketdata.Trades;
+import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
 import com.xeiam.xchange.dto.trade.LimitOrder;
 import com.xeiam.xchange.dto.trade.MarketOrder;
 import com.xeiam.xchange.dto.trade.OpenOrders;
@@ -56,7 +57,7 @@ public class BittrexTradeService extends BittrexTradeServiceRaw implements Polli
   @Override
   public Trades getTradeHistory(Object... arguments) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
 
-    throw new NotYetImplementedForExchangeException();
+    return new Trades(BittrexAdapters.adaptUserTrades(getBittrexTradeHistory()), TradeSortType.SortByTimestamp);
   }
 
 }

--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/service/polling/BittrexTradeServiceRaw.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/service/polling/BittrexTradeServiceRaw.java
@@ -10,7 +10,9 @@ import com.xeiam.xchange.bittrex.v1.BittrexUtils;
 import com.xeiam.xchange.bittrex.v1.dto.trade.BittrexCancelOrderResponse;
 import com.xeiam.xchange.bittrex.v1.dto.trade.BittrexOpenOrder;
 import com.xeiam.xchange.bittrex.v1.dto.trade.BittrexOpenOrdersResponse;
+import com.xeiam.xchange.bittrex.v1.dto.trade.BittrexTradeHistoryResponse;
 import com.xeiam.xchange.bittrex.v1.dto.trade.BittrexTradeResponse;
+import com.xeiam.xchange.bittrex.v1.dto.trade.BittrexUserTrade;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.trade.LimitOrder;
 import com.xeiam.xchange.dto.trade.MarketOrder;
@@ -39,7 +41,7 @@ public class BittrexTradeServiceRaw extends BittrexBasePollingService<BittrexAut
         return response.getResult().getUuid();
       }
       else {
-        throw new ExchangeException(response.getMessage());
+        throw new ExchangeException("Bittrex returned an error: " + response.getMessage());
       }
 
     }
@@ -51,7 +53,7 @@ public class BittrexTradeServiceRaw extends BittrexBasePollingService<BittrexAut
         return response.getResult().getUuid();
       }
       else {
-        throw new ExchangeException(response.getMessage());
+        throw new ExchangeException("Bittrex returned an error: " + response.getMessage());
       }
 
     }
@@ -69,7 +71,7 @@ public class BittrexTradeServiceRaw extends BittrexBasePollingService<BittrexAut
         return response.getResult().getUuid();
       }
       else {
-        throw new ExchangeException(response.getMessage());
+        throw new ExchangeException("Bittrex returned an error: " + response.getMessage());
       }
 
     }
@@ -81,7 +83,7 @@ public class BittrexTradeServiceRaw extends BittrexBasePollingService<BittrexAut
         return response.getResult().getUuid();
       }
       else {
-        throw new ExchangeException(response.getMessage());
+        throw new ExchangeException("Bittrex returned an error: " + response.getMessage());
       }
     }
   }
@@ -94,7 +96,7 @@ public class BittrexTradeServiceRaw extends BittrexBasePollingService<BittrexAut
       return true;
     }
     else {
-      throw new ExchangeException(response.getMessage());
+      throw new ExchangeException("Bittrex returned an error: " + response.getMessage());
     }
 
   }
@@ -107,8 +109,20 @@ public class BittrexTradeServiceRaw extends BittrexBasePollingService<BittrexAut
       return response.getBittrexOpenOrders();
     }
     else {
-      throw new ExchangeException(response.getMessage());
+      throw new ExchangeException("Bittrex returned an error: " + response.getMessage());
     }
 
+  }
+
+  public List<BittrexUserTrade> getBittrexTradeHistory() throws IOException {
+
+    BittrexTradeHistoryResponse response = bittrex.getorderhistory(apiKey, signatureCreator, String.valueOf(nextNonce()));
+
+    if (response.getSuccess()) {
+      return response.getResult();
+    }
+    else {
+      throw new ExchangeException("Bittrex returned an error: " + "Bittrex returned an error: " + response.getMessage());
+    }
   }
 }


### PR DESCRIPTION
Fully implemented trade history for Bittrex. They report this
differently from other exchanges in that they send back a list of all
orders you have placed, with a Quantity and a QuantityRemaining for
each. In order to get the amount traded I just subtracted
QuantityRemaining from Quantity.

I also added the option to specify the length of the order book/trades.
