### PR TITLE
Obtain the id, method, params for signature from BTCRequest object directly rather than extract from request body by regular expression matcher, in BTCChinaDigest.

### DIFF
--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/BTCChinaDigest.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/BTCChinaDigest.java
@@ -1,9 +1,5 @@
 package com.xeiam.xchange.btcchina.service;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
-
 import javax.crypto.Mac;
 
 import org.apache.commons.lang3.StringUtils;
@@ -14,15 +10,13 @@ import si.mazi.rescu.BasicAuthCredentials;
 import si.mazi.rescu.RestInvocation;
 
 import com.xeiam.xchange.btcchina.BTCChinaUtils;
+import com.xeiam.xchange.btcchina.dto.BTCChinaRequest;
 import com.xeiam.xchange.service.BaseParamsDigest;
 
 /**
  * @author David Yam
  */
 public class BTCChinaDigest extends BaseParamsDigest {
-
-  private static final Pattern responsePattern = Pattern.compile("\\{\"id\":([0-9]*),\"method\":\"([^\"]*)\",\"params\":\\[([^\\]]*)\\]\\}", Pattern.DOTALL | Pattern.CASE_INSENSITIVE
-      | Pattern.UNICODE_CASE);
 
   private final Logger log = LoggerFactory.getLogger(BTCChinaDigest.class);
 
@@ -49,21 +43,23 @@ public class BTCChinaDigest extends BaseParamsDigest {
   public String digestParams(RestInvocation restInvocation) {
 
     String tonce = restInvocation.getHttpHeadersFromParams().get("Json-Rpc-Tonce");
-    String requestJson = restInvocation.getRequestBody();
 
-    String id = "", method = "", params = "";
-    try {
-      Matcher regexMatcher = responsePattern.matcher(requestJson);
-      if (regexMatcher.find()) {
-        id = regexMatcher.group(1);
-        method = regexMatcher.group(2);
-        params = stripParams(regexMatcher.group(3));
+    BTCChinaRequest request = null;
+    for (Object param : restInvocation.getUnannanotatedParams()) {
+      if (param instanceof BTCChinaRequest) {
+        request = (BTCChinaRequest) param;
       }
-    } catch (PatternSyntaxException ex) {
-      // Syntax error in the regular expression
     }
 
-    String signature = String.format("tonce=%s&accesskey=%s&requestmethod=%s&id=%s&method=%s&params=%s", tonce, exchangeAccessKey, "post", id, method, params);
+    if (request == null) {
+      throw new IllegalArgumentException("No BTCChinaRequest found.");
+    }
+
+    final long id = request.getId();
+    final String method = request.getMethod();
+    final String params = stripParams(request.getParams());
+
+    String signature = String.format("tonce=%s&accesskey=%s&requestmethod=%s&id=%d&method=%s&params=%s", tonce, exchangeAccessKey, "post", id, method, params);
     log.debug("signature message: {}", signature);
 
     Mac mac = getMac();
@@ -77,7 +73,7 @@ public class BTCChinaDigest extends BaseParamsDigest {
   /**
    * Strip the {@code params} for signature message.
    *
-   * @param params the {@code params} in the request body.
+   * @param params the value of {@link BTCChinaRequest#getParams()}.
    * @return the params string for signature message.
    * @see the note in
    *      <a href="http://btcchina.org/api-trade-documentation-en#faq">FAQ</a>
@@ -85,7 +81,7 @@ public class BTCChinaDigest extends BaseParamsDigest {
    */
   private String stripParams(final String params) {
 
-    final String[] original = params.split(",");
+    final String[] original = params.substring(1, params.length() -1).split(",");
     final String[] stripped = new String[original.length];
 
     for (int i = 0; i < original.length; i++) {

--- a/xchange-btcchina/src/test/java/com/xeiam/xchange/btcchina/service/BTCChinaDigestTest.java
+++ b/xchange-btcchina/src/test/java/com/xeiam/xchange/btcchina/service/BTCChinaDigestTest.java
@@ -12,15 +12,15 @@ public class BTCChinaDigestTest {
   @Test
   public void testStripParams() {
 
-    String params = "\"BTC\",true";
+    String params = "[\"BTC\",true]";
     String stripped = (String) PA.invokeMethod(digest, "stripParams(java.lang.String)", params);
     assertEquals("BTC,1", stripped);
 
-    params = "\"BTC\",false";
+    params = "[\"BTC\",false]";
     stripped = (String) PA.invokeMethod(digest, "stripParams(java.lang.String)", params);
     assertEquals("BTC,", stripped);
 
-    params = "\"BTC\",false,1";
+    params = "[\"BTC\",false,1]";
     stripped = (String) PA.invokeMethod(digest, "stripParams(java.lang.String)", params);
     assertEquals("BTC,,1", stripped);
   }


### PR DESCRIPTION
Fix issue #618 
