### PR TITLE
[hitbtc] Add user's trade history to the generic service

### DIFF
--- a/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/ANXV2.java
+++ b/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/ANXV2.java
@@ -111,8 +111,8 @@ public interface ANXV2 {
    * @param apiKey
    * @param postBodySignatureCreator
    * @param nonce
-   * @param from
-   * @param to
+   * @param from                      optional Unix timestamp
+   * @param to                        optional Unix timestamp
    * @return
    * @throws ANXException
    * @throws IOException
@@ -121,23 +121,7 @@ public interface ANXV2 {
   @Path("money/trade/list")
   @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   ANXTradeResultWrapper getExecutedTrades(@HeaderParam("Rest-Key") String apiKey, @HeaderParam("Rest-Sign") ParamsDigest postBodySignatureCreator, @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
-      @FormParam("from") long from, @FormParam("to") long to) throws ANXException, IOException;
-
-  /**
-   * List of executed trades
-   *
-   * @param apiKey
-   * @param postBodySignatureCreator
-   * @param nonce
-   * @return
-   * @throws ANXException
-   * @throws IOException
-   */
-  @POST
-  @Path("money/trade/list")
-  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-  ANXTradeResultWrapper getExecutedTrades(@HeaderParam("Rest-Key") String apiKey, @HeaderParam("Rest-Sign") ParamsDigest postBodySignatureCreator, @FormParam("nonce") SynchronizedValueFactory<Long> nonce) throws ANXException,
-      IOException;
+      @FormParam("from") Long from, @FormParam("to") Long to) throws ANXException, IOException;
 
   /**
    * Status of the order

--- a/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/service/polling/ANXTradeService.java
+++ b/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/service/polling/ANXTradeService.java
@@ -4,9 +4,9 @@ import java.io.IOException;
 import java.math.BigDecimal;
 
 import com.xeiam.xchange.ExchangeSpecification;
-import com.xeiam.xchange.NotYetImplementedForExchangeException;
 import com.xeiam.xchange.anx.ANXUtils;
 import com.xeiam.xchange.anx.v2.ANXAdapters;
+import com.xeiam.xchange.anx.v2.dto.trade.polling.ANXTradeResultWrapper;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.trade.LimitOrder;
@@ -23,7 +23,7 @@ public class ANXTradeService extends ANXTradeServiceRaw implements PollingTradeS
 
   /**
    * Constructor
-   * 
+   *
    * @param exchangeSpecification The {@link com.xeiam.xchange.ExchangeSpecification}
    */
   public ANXTradeService(ExchangeSpecification exchangeSpecification, SynchronizedValueFactory<Long> nonceFactory) {
@@ -74,9 +74,25 @@ public class ANXTradeService extends ANXTradeServiceRaw implements PollingTradeS
     return cancelANXOrder(orderId, "BTC", "EUR").getResult().equals("success");
   }
 
+  /**
+   * @param args Accept zero or 2 parameters, both are unix time: Long from, Long to
+   */
   @Override
   public Trades getTradeHistory(Object... args) throws IOException {
 
-    throw new NotYetImplementedForExchangeException();
+    Long from = null;
+    Long to = null;
+    if (args.length > 0)
+      from = (Long) args[0];
+    if (args.length > 1)
+      to = (Long) args[1];
+
+    ANXTradeResultWrapper rawTrades = getExecutedANXTrades(from, to);
+    String error = rawTrades.getError();
+
+    if (error != null)
+      throw new IllegalStateException(error);
+
+    return ANXAdapters.adaptUserTrades(rawTrades.getAnxTradeResults());
   }
 }

--- a/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/service/polling/ANXTradeServiceRaw.java
+++ b/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/service/polling/ANXTradeServiceRaw.java
@@ -96,22 +96,11 @@ public class ANXTradeServiceRaw extends ANXBasePollingService {
     }
   }
 
-  public ANXTradeResultWrapper getExecutedANXTrades(long from, long to) throws IOException {
+  public ANXTradeResultWrapper getExecutedANXTrades(Long from, Long to) throws IOException {
 
     try {
 
       ANXTradeResultWrapper anxTradeResultWrapper = anxV2.getExecutedTrades(exchangeSpecification.getApiKey(), signatureCreator, getNonce(), from, to);
-      return anxTradeResultWrapper;
-    } catch (ANXException e) {
-      throw new ExchangeException("Error calling getExecutedANXTrades(): " + e.getError(), e);
-    }
-  }
-
-  public ANXTradeResultWrapper getExecutedANXTrades() throws IOException {
-
-    try {
-
-      ANXTradeResultWrapper anxTradeResultWrapper = anxV2.getExecutedTrades(exchangeSpecification.getApiKey(), signatureCreator, getNonce());
       return anxTradeResultWrapper;
     } catch (ANXException e) {
       throw new ExchangeException("Error calling getExecutedANXTrades(): " + e.getError(), e);

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/anx/v2/service/trade/polling/TradesDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/anx/v2/service/trade/polling/TradesDemo.java
@@ -1,0 +1,30 @@
+package com.xeiam.xchange.examples.anx.v2.service.trade.polling;
+
+import com.xeiam.xchange.Exchange;
+import com.xeiam.xchange.dto.marketdata.Trade;
+import com.xeiam.xchange.dto.marketdata.Trades;
+import com.xeiam.xchange.dto.trade.OpenOrders;
+import com.xeiam.xchange.examples.anx.v2.ANXExamplesUtils;
+import com.xeiam.xchange.service.polling.PollingTradeService;
+
+import java.io.IOException;
+
+/**
+ * Test requesting all open orders at MtGox
+ */
+public class TradesDemo {
+
+  public static void main(String[] args) throws IOException {
+
+    Exchange anx = ANXExamplesUtils.createExchange();
+
+    // Interested in the private trading functionality (authentication)
+    PollingTradeService tradeService = anx.getPollingTradeService();
+
+    Trades trades = tradeService.getTradeHistory();
+    for (Trade trade : trades.getTrades()) {
+      System.out.println(trade);
+    }
+  }
+
+}


### PR DESCRIPTION
Implement ANXTradeService.getTradeHistory() based on ANXV2.getExecutedTrades():
- price is computed as settlementCurrencyFillAmount/tradedCurrencyFillAmount scaled to 8 decimal places and with rounding to even (not sure if OK) so won't be equal to the one in LimitOrder
- lastId is a timestamp of the first trade in the result (the youngest)
