### PR TITLE
[Poloniex] add orderbook depth limit; trade history start/end time

### DIFF
--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/poloniex/marketdata/PoloniexMarketDataDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/poloniex/marketdata/PoloniexMarketDataDemo.java
@@ -1,6 +1,8 @@
 package com.xeiam.xchange.examples.poloniex.marketdata;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Date;
 
 import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.ExchangeFactory;
@@ -37,7 +39,10 @@ public class PoloniexMarketDataDemo {
     System.out.println(dataService.getExchangeSymbols());
     System.out.println(dataService.getTicker(currencyPair));
     System.out.println(dataService.getOrderBook(currencyPair));
+    System.out.println(dataService.getOrderBook(currencyPair, 3));
     System.out.println(dataService.getTrades(currencyPair));
+    long now = new Date().getTime() / 1000;
+    System.out.println(dataService.getTrades(currencyPair, now - 8*60*60, now));
   }
 
   private static void raw(PoloniexMarketDataServiceRaw dataService) throws IOException {
@@ -48,8 +53,12 @@ public class PoloniexMarketDataDemo {
     System.out.println(dataService.getAllPoloniexTickers());
     System.out.println(dataService.getPoloniexTicker(currencyPair));
     System.out.println(dataService.getAllPoloniexDepths());
+    System.out.println(dataService.getAllPoloniexDepths(3));
     System.out.println(dataService.getPoloniexDepth(currencyPair));
-    System.out.println(dataService.getPoloniexPublicTrades(currencyPair));
+    System.out.println(dataService.getPoloniexDepth(currencyPair, 3));
+    System.out.println(Arrays.asList(dataService.getPoloniexPublicTrades(currencyPair)));
+    long now = new Date().getTime() / 1000;
+    System.out.println(Arrays.asList(dataService.getPoloniexPublicTrades(currencyPair, now - 8*60*60, null)));
   }
 
 }

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/poloniex/trade/PoloniexTradeDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/poloniex/trade/PoloniexTradeDemo.java
@@ -3,6 +3,7 @@ package com.xeiam.xchange.examples.poloniex.trade;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Date;
 
 import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.ExchangeException;
@@ -49,6 +50,10 @@ public class PoloniexTradeDemo {
     System.out.println("----------GENERIC----------");
 
     System.out.println(tradeService.getTradeHistory(currencyPair));
+    long startTime = (new Date().getTime() / 1000) - 8*60*60;
+    System.out.println(tradeService.getTradeHistory(currencyPair, startTime));
+    long endTime = startTime + 4*60*60;
+    System.out.println(tradeService.getTradeHistory(currencyPair, startTime, endTime));
 
     LimitOrder order = new LimitOrder.Builder(OrderType.BID, currencyPair).setTradableAmount(new BigDecimal(".01")).setLimitPrice(xmrBuyRate).build();
     String orderId = tradeService.placeLimitOrder(order);
@@ -75,6 +80,10 @@ public class PoloniexTradeDemo {
 
     System.out.println("------------RAW------------");
     System.out.println(Arrays.asList(tradeService.returnTradeHistory(currencyPair)));
+    long startTime = (new Date().getTime() / 1000) - 8*60*60;
+    System.out.println(Arrays.asList(tradeService.returnTradeHistory(currencyPair, startTime, null)));
+    long endTime = new Date().getTime() / 1000;
+    System.out.println(Arrays.asList(tradeService.returnTradeHistory(currencyPair, startTime, endTime)));
 
     LimitOrder order = new LimitOrder.Builder(OrderType.BID, currencyPair).setTradableAmount(new BigDecimal("1")).setLimitPrice(xmrBuyRate).build();
     String orderId = tradeService.buy(order);

--- a/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/Poloniex.java
+++ b/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/Poloniex.java
@@ -33,8 +33,12 @@ public interface Poloniex {
   PoloniexDepth getOrderBook(@QueryParam("command") String command, @QueryParam("currencyPair") String currencyPair) throws IOException;
 
   @GET
-  Map<String, PoloniexDepth> getAllOrderBooks(@QueryParam("command") String command, @QueryParam("currencyPair") String all) throws IOException;
+  PoloniexDepth getOrderBook(@QueryParam("command") String command, @QueryParam("currencyPair") String currencyPair, @QueryParam("depth") Integer depth) throws IOException;
 
   @GET
-  PoloniexPublicTrade[] getTrades(@QueryParam("command") String command, @QueryParam("currencyPair") String currencyPair) throws IOException;
+  PoloniexPublicTrade[] getTrades(@QueryParam("command") String command, @QueryParam("currencyPair") String currencyPair, @QueryParam("start") Long startTime, @QueryParam("end") Long endTime) throws IOException;
+
+  @GET
+  Map<String, PoloniexDepth> getAllOrderBooks(@QueryParam("command") String command, @QueryParam("currencyPair") String pair, @QueryParam("depth") Integer depth) throws IOException;
+
 }

--- a/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/PoloniexAdapters.java
+++ b/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/PoloniexAdapters.java
@@ -1,6 +1,5 @@
 package com.xeiam.xchange.poloniex;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Date;
@@ -49,7 +48,7 @@ public class PoloniexAdapters {
 
   }
 
-  public static OrderBook adaptPoloniexDepth(PoloniexDepth depth, CurrencyPair currencyPair) throws IOException {
+  public static OrderBook adaptPoloniexDepth(PoloniexDepth depth, CurrencyPair currencyPair) {
 
     List<LimitOrder> asks = adaptPoloniexPublicOrders(depth.getAsks(), OrderType.ASK, currencyPair);
     List<LimitOrder> bids = adaptPoloniexPublicOrders(depth.getBids(), OrderType.BID, currencyPair);
@@ -57,7 +56,7 @@ public class PoloniexAdapters {
     return new OrderBook(new Date(), asks, bids);
   }
 
-  public static List<LimitOrder> adaptPoloniexPublicOrders(List<List<BigDecimal>> rawLevels, OrderType orderType, CurrencyPair currencyPair) throws IOException {
+  public static List<LimitOrder> adaptPoloniexPublicOrders(List<List<BigDecimal>> rawLevels, OrderType orderType, CurrencyPair currencyPair) {
 
     List<PoloniexLevel> levels = new ArrayList<PoloniexLevel>();
 

--- a/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/PoloniexAuthenticated.java
+++ b/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/PoloniexAuthenticated.java
@@ -41,7 +41,7 @@ public interface PoloniexAuthenticated extends Poloniex {
   @POST
   @FormParam("command")
   PoloniexUserTrade[] returnTradeHistory(@HeaderParam("Key") String apiKey, @HeaderParam("Sign") ParamsDigest signature, @FormParam("nonce") String nonce,
-      @FormParam("currencyPair") String currencyPair) throws IOException;
+      @FormParam("currencyPair") String currencyPair, @FormParam("start") Long startTime, @FormParam("end") Long endTime) throws IOException;
 
   @POST
   @FormParam("command")

--- a/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/dto/marketdata/PoloniexPublicTrade.java
+++ b/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/dto/marketdata/PoloniexPublicTrade.java
@@ -117,4 +117,8 @@ public class PoloniexPublicTrade {
     this.additionalProperties.put(name, value);
   }
 
+  @Override
+  public String toString() {
+    return "PoloniexPublicTrade [tradeID=" + tradeID + ", date=" + date + ", type=" + type + ", amount=" + amount + ", rate=" + rate+ ", total=" + total + "" + ", additionalProperties=" + additionalProperties + "]";
+  }
 }

--- a/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/service/polling/PoloniexMarketDataService.java
+++ b/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/service/polling/PoloniexMarketDataService.java
@@ -36,18 +36,51 @@ public class PoloniexMarketDataService extends PoloniexMarketDataServiceRaw impl
   }
 
   @Override
-  public OrderBook getOrderBook(CurrencyPair currencyPair, Object... args) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+  public OrderBook getOrderBook(CurrencyPair currencyPair, Object... args) throws ExchangeException, IOException {
 
-    PoloniexDepth depth = getPoloniexDepth(currencyPair);
+    PoloniexDepth depth = null;
+
+    if (args != null && args.length > 0) {
+      if (args[0] instanceof Integer) {
+        int depthLimit = (Integer) args[0];
+        depth = getPoloniexDepth(currencyPair, depthLimit);
+      } else {
+        throw new ExchangeException("Orderbook size argument must be an Integer!");
+      }
+    }
+    if (depth == null) {
+      depth = getPoloniexDepth(currencyPair);
+    }
     OrderBook orderBook = PoloniexAdapters.adaptPoloniexDepth(depth, currencyPair);
     return orderBook;
   }
 
   @Override
-  public Trades getTrades(CurrencyPair currencyPair, Object... args) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+  public Trades getTrades(CurrencyPair currencyPair, Object... args) throws ExchangeException, IOException {
 
-    PoloniexPublicTrade[] poloniexPublicTrades = getPoloniexPublicTrades(currencyPair);
-    return PoloniexAdapters.adaptPoloniexPublicTrades(poloniexPublicTrades, currencyPair);
+    Long startTime = null;
+    Long endTime = null;
+
+    if (args != null) {
+      switch (args.length) {
+      case 2:
+        if (args[1] != null && args[1] instanceof Long) {
+          endTime = (Long) args[1];
+        }
+      case 1:
+        if (args[0] != null && args[0] instanceof Long) {
+          startTime = (Long) args[0];
+        }
+      }
+    }
+    PoloniexPublicTrade[] poloniexPublicTrades = null;
+    if (startTime == null && endTime == null) {
+      poloniexPublicTrades = getPoloniexPublicTrades(currencyPair);
+    } else {
+      poloniexPublicTrades = getPoloniexPublicTrades(currencyPair, startTime, endTime);
+    }
+    Trades trades = PoloniexAdapters.adaptPoloniexPublicTrades(poloniexPublicTrades, currencyPair);
+    return trades;
   }
 
 }

--- a/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/service/polling/PoloniexMarketDataServiceRaw.java
+++ b/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/service/polling/PoloniexMarketDataServiceRaw.java
@@ -76,13 +76,31 @@ public class PoloniexMarketDataServiceRaw extends PoloniexBasePollingService<Pol
     return depth;
   }
 
+  public PoloniexDepth getPoloniexDepth(CurrencyPair currencyPair, int depth) throws IOException {
+
+    String command = "returnOrderBook";
+    String pairString = PoloniexUtils.toPairString(currencyPair);
+
+    PoloniexDepth limitDepth = poloniex.getOrderBook(command, pairString, depth);
+    return limitDepth;
+  }
+
   public Map<String, PoloniexDepth> getAllPoloniexDepths() throws IOException {
 
     String command = "returnOrderBook";
-    
-    Map<String, PoloniexDepth> depths = poloniex.getAllOrderBooks(command, "all");
+
+    Map<String, PoloniexDepth> depths = poloniex.getAllOrderBooks(command, "all", null);
 
     return depths;
+  }
+
+  public Map<String, PoloniexDepth> getAllPoloniexDepths(int depth) throws IOException {
+
+   String command = "returnOrderBook";
+
+   Map<String, PoloniexDepth> depths = poloniex.getAllOrderBooks(command, "all", depth);
+
+   return depths;
   }
 
   public PoloniexPublicTrade[] getPoloniexPublicTrades(CurrencyPair currencyPair) throws IOException {
@@ -90,7 +108,16 @@ public class PoloniexMarketDataServiceRaw extends PoloniexBasePollingService<Pol
     String command = "returnTradeHistory";
     String pairString = PoloniexUtils.toPairString(currencyPair);
 
-    PoloniexPublicTrade[] trades = poloniex.getTrades(command, pairString);
+    PoloniexPublicTrade[] trades = poloniex.getTrades(command, pairString, null, null);
+    return trades;
+  }
+
+  public PoloniexPublicTrade[] getPoloniexPublicTrades(CurrencyPair currencyPair, Long startTime, Long endTime) throws IOException {
+
+    String command = "returnTradeHistory";
+    String pairString = PoloniexUtils.toPairString(currencyPair);
+
+    PoloniexPublicTrade[] trades = poloniex.getTrades(command, pairString, startTime, endTime);
     return trades;
   }
 

--- a/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/service/polling/PoloniexTradeService.java
+++ b/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/service/polling/PoloniexTradeService.java
@@ -66,23 +66,43 @@ public class PoloniexTradeService extends PoloniexTradeServiceRaw implements Pol
   @Override
   public Trades getTradeHistory(Object... arguments) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
 
-    if (arguments.length == 0) {
-      throw new IOException("Poloniex requires a currency pair for trade history");
-    }
-    else if (!(arguments[0] instanceof CurrencyPair)) {
-      throw new IOException("Poloniex requires a currency pair for trade history");
-    }
-    else {
-      CurrencyPair currencyPair = (CurrencyPair) arguments[0];
-      List<Trade> trades = new ArrayList<Trade>();
-      PoloniexUserTrade[] poloniexUserTrades = returnTradeHistory(currencyPair);
+    CurrencyPair currencyPair = null;
+    Long startTime = null;
+    Long endTime = null;
 
-      for (PoloniexUserTrade poloniexUserTrade : poloniexUserTrades) {
-        trades.add(PoloniexAdapters.adaptPoloniexUserTrade(poloniexUserTrade, currencyPair));
+    if (arguments != null) {
+      switch (arguments.length) {
+      case 3:
+        if (arguments[2] != null && arguments[2] instanceof Long) {
+          endTime = (Long) arguments[2];
+        }
+      case 2:
+        if (arguments[1] != null && arguments[1] instanceof Long) {
+          startTime = (Long) arguments[1];
+        }
+      case 1:
+        if (arguments[0] != null && arguments[0] instanceof CurrencyPair) {
+          currencyPair = (CurrencyPair) arguments[0];
+        }
       }
-
-      return new Trades(trades, TradeSortType.SortByTimestamp);
     }
+    if (currencyPair == null) {
+      throw new ExchangeException("Poloniex requires a CurrencyPair for trade history");
+    }
+
+    PoloniexUserTrade[] poloniexUserTrades = null;
+    if (startTime == null && endTime == null) {
+      poloniexUserTrades = returnTradeHistory(currencyPair);
+    } else {
+      poloniexUserTrades = returnTradeHistory(currencyPair, startTime, endTime);
+    }
+
+    List<Trade> trades = new ArrayList<Trade>();
+    for (PoloniexUserTrade poloniexUserTrade : poloniexUserTrades) {
+      trades.add(PoloniexAdapters.adaptPoloniexUserTrade(poloniexUserTrade, currencyPair));
+    }
+
+    return new Trades(trades, TradeSortType.SortByTimestamp);
   }
 
 }

--- a/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/service/polling/PoloniexTradeServiceRaw.java
+++ b/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/service/polling/PoloniexTradeServiceRaw.java
@@ -32,7 +32,13 @@ public class PoloniexTradeServiceRaw extends PoloniexBasePollingService<Poloniex
 
   public PoloniexUserTrade[] returnTradeHistory(CurrencyPair currencyPair) throws IOException {
 
-    return poloniex.returnTradeHistory(apiKey, signatureCreator, String.valueOf(nextNonce()), PoloniexUtils.toPairString(currencyPair));
+    return poloniex.returnTradeHistory(apiKey, signatureCreator, String.valueOf(nextNonce()), PoloniexUtils.toPairString(currencyPair), null, null);
+  }
+
+  public PoloniexUserTrade[] returnTradeHistory(CurrencyPair currencyPair, Long startTime, Long endTime) throws IOException {
+
+    return poloniex.returnTradeHistory(apiKey, signatureCreator, String.valueOf(nextNonce()), PoloniexUtils.toPairString(currencyPair),
+        startTime, endTime);
   }
 
   public String buy(LimitOrder limitOrder) throws IOException {


### PR DESCRIPTION
#666
- added OrderBook depth limit
- public/private Trades start and end UNIX time parameters
- remove IOException in PoloniexAdapters class (seems to be unnecessary)
- updated examples
