### PR TITLE
Update BitstampTransaction.java

### DIFF
--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/dto/marketdata/BitstampTransaction.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/dto/marketdata/BitstampTransaction.java
@@ -22,7 +22,7 @@ public final class BitstampTransaction {
    * @param price BTC price
    * @param amount BTC amount
    */
-  public BitstampTransaction(@JsonProperty("date") long date, @JsonProperty("tid") int tid, @JsonProperty("price") BigDecimal price, @JsonProperty("amount") BigDecimal amount) {
+  public BitstampTransaction(@JsonProperty("date") long date, @JsonProperty("id") int tid, @JsonProperty("price") BigDecimal price, @JsonProperty("amount") BigDecimal amount) {
 
     this.date = date;
     this.tid = tid;


### PR DESCRIPTION
This allows the transaction ID for BitStamp trades to be properly parsed.
The example-trades-data.json file should be modified accordingly.

No other modifications required as far as I can tell.
