### PR TITLE
Merge of existing and default specs when instantiating exchange

### DIFF
--- a/xchange-core/src/main/java/com/xeiam/xchange/BaseExchange.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/BaseExchange.java
@@ -51,10 +51,14 @@ public abstract class BaseExchange implements Exchange {
       if (exchangeSpecification.getPlainTextUri() == null) {
         exchangeSpecification.setPlainTextUri(defaultSpecification.getPlainTextUri());
       }
-      // add default value unless it is overriden by current spec
-      for(Map.Entry<String, Object> entry : defaultSpecification.getExchangeSpecificParameters().entrySet()) {
-        if(exchangeSpecification.getExchangeSpecificParametersItem(entry.getKey()) == null) {
-          exchangeSpecification.setExchangeSpecificParametersItem(entry.getKey(), entry.getValue());
+      if (exchangeSpecification.getExchangeSpecificParameters() == null) {
+        exchangeSpecification.setExchangeSpecificParameters(defaultSpecification.getExchangeSpecificParameters());
+      } else {
+        // add default value unless it is overriden by current spec
+        for(Map.Entry<String, Object> entry : defaultSpecification.getExchangeSpecificParameters().entrySet()) {
+          if(exchangeSpecification.getExchangeSpecificParametersItem(entry.getKey()) == null) {
+            exchangeSpecification.setExchangeSpecificParametersItem(entry.getKey(), entry.getValue());
+          }
         }
       }
 


### PR DESCRIPTION
When an exchange contains a lot of existing default exchange specific params then previously we override all of them if we provided any additional exchange specific params. This patch will merge custom exchange specific params and default params (when instantiating an exchange via reflection i.e.:

```
ExchangeSpecification exSpec = new ExchangeSpecification(SomeExchange.class);
....add custom exchange specific params...then
Exchange exchange = ExchangeFactory.INSTANCE.createExchange(exSpec);
```
