### PR TITLE
BitstampPusherService: remove ReconnectService

### DIFF
--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/streaming/BitstampPusherService.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/streaming/BitstampPusherService.java
@@ -49,7 +49,7 @@ public class BitstampPusherService extends BitstampBasePollingService implements
 
   private Pusher client;
   private Map<String, Channel> channels;
-  private ReconnectService reconnectService;
+  //private ReconnectService reconnectService;
 
   /**
    * Constructor
@@ -62,7 +62,7 @@ public class BitstampPusherService extends BitstampBasePollingService implements
 
     this.configuration = configuration;
     client = new Pusher(configuration.getPusherKey(), configuration.pusherOptions());
-    reconnectService = new ReconnectService(this, configuration);
+    //reconnectService = new ReconnectService(this, configuration);
     channels = new HashMap<String, Channel>();
 
     streamObjectMapper = new ObjectMapper();


### PR DESCRIPTION
ReconnectService was instantiated but never used. On my platform it caused the application to hang on exit. I suspect the Timer or TimerTask within that class is the culprit.
Commenting the instantiation solved the hang issue on my end, with no loss of feature.
