### PR TITLE
Add subscribing account balance changes support for BTCChina streaming service.

### DIFF
--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/dto/trade/streaming/BTCChinaBalance.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/dto/trade/streaming/BTCChinaBalance.java
@@ -1,0 +1,58 @@
+package com.xeiam.xchange.btcchina.dto.trade.streaming;
+
+import java.math.BigDecimal;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+public class BTCChinaBalance {
+
+  private final BigDecimal amountInteger;
+  private final BigDecimal amount;
+  private final String symbol;
+  private final int amountDecimal;
+  private final String currency;
+
+  public BTCChinaBalance(BigDecimal amountInteger, BigDecimal amount, String symbol, int amountDecimal, String currency) {
+
+    this.amountInteger = amountInteger;
+    this.amount = amount;
+    this.symbol = symbol;
+    this.amountDecimal = amountDecimal;
+    this.currency = currency;
+  }
+
+  public BigDecimal getAmountInteger() {
+
+    return amountInteger;
+  }
+
+  public BigDecimal getAmount() {
+
+    return amount;
+  }
+
+  public String getSymbol() {
+
+    return symbol;
+  }
+
+  public int getAmountDecimal() {
+
+    return amountDecimal;
+  }
+
+  public String getCurrency() {
+
+    return currency;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String toString() {
+
+    return ToStringBuilder.reflectionToString(this);
+  }
+
+}

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/dto/trade/streaming/request/BTCChinaPayload.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/dto/trade/streaming/request/BTCChinaPayload.java
@@ -1,0 +1,62 @@
+package com.xeiam.xchange.btcchina.dto.trade.streaming.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+
+@JsonPropertyOrder({ "tonce", "accessKey", "requestMethod", "id", "method", "params" })
+public class BTCChinaPayload {
+
+  private final long tonce;
+  private final String accessKey;
+  private final String requestMethod;
+  private final long id;
+  private final String method;
+  private final String[] params;
+
+  public BTCChinaPayload(long tonce, String accessKey, String requestMethod, String method, String[] params) {
+
+    this.tonce = tonce;
+    this.accessKey = accessKey;
+    this.requestMethod = requestMethod;
+    this.id = tonce;
+    this.method = method;
+    this.params = params;
+  }
+
+  @JsonSerialize(using = ToStringSerializer.class)
+  public long getTonce() {
+
+    return tonce;
+  }
+
+  @JsonProperty("accesskey")
+  public String getAccessKey() {
+
+    return accessKey;
+  }
+
+  @JsonProperty("requestmethod")
+  public String getRequestMethod() {
+
+    return requestMethod;
+  }
+
+  @JsonSerialize(using = ToStringSerializer.class)
+  public long getId() {
+
+    return id;
+  }
+
+  public String getMethod() {
+
+    return method;
+  }
+
+  public String[] getParams() {
+
+    return params;
+  }
+
+}

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/dto/trade/streaming/request/package-info.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/dto/trade/streaming/request/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Streaming request DTO.
+ */
+package com.xeiam.xchange.btcchina.dto.trade.streaming.request;

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/streaming/BTCChinaExchangeEvent.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/streaming/BTCChinaExchangeEvent.java
@@ -1,0 +1,29 @@
+package com.xeiam.xchange.btcchina.service.streaming;
+
+import org.json.JSONObject;
+
+import com.xeiam.xchange.service.streaming.DefaultExchangeEvent;
+import com.xeiam.xchange.service.streaming.ExchangeEventType;
+
+public class BTCChinaExchangeEvent extends DefaultExchangeEvent {
+
+  private final JSONObject jsonObject;
+
+  public BTCChinaExchangeEvent(ExchangeEventType exchangeEventType) {
+
+    super(exchangeEventType, null);
+    this.jsonObject = null;
+  }
+
+  public BTCChinaExchangeEvent(ExchangeEventType exchangeEventType, JSONObject jsonObject, Object payload) {
+
+    super(exchangeEventType, jsonObject.toString(), payload);
+    this.jsonObject = jsonObject;
+  }
+
+  public JSONObject getJsonObject() {
+
+    return jsonObject;
+  }
+
+}

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/streaming/BTCChinaJSONObjectAdapters.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/streaming/BTCChinaJSONObjectAdapters.java
@@ -6,6 +6,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import com.xeiam.xchange.btcchina.BTCChinaAdapters;
+import com.xeiam.xchange.btcchina.dto.trade.streaming.BTCChinaBalance;
 import com.xeiam.xchange.btcchina.dto.trade.streaming.BTCChinaOrder;
 import com.xeiam.xchange.dto.marketdata.Ticker;
 import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
@@ -70,6 +71,22 @@ public class BTCChinaJSONObjectAdapters {
     return new BTCChinaOrder(BTCChinaAdapters.adaptOrderType(orderJsonObject.getString("type")), new BigDecimal(orderJsonObject.getString("amount")),
         BTCChinaAdapters.adaptCurrencyPair(orderJsonObject.getString("market")), String.valueOf(orderJsonObject.getLong("id")), BTCChinaAdapters.adaptDate(orderJsonObject.getLong("date")),
         new BigDecimal(orderJsonObject.getString("price")), new BigDecimal(orderJsonObject.getString("amount_original")), BTCChinaAdapters.adaptOrderStatus(orderJsonObject.getString("status")));
+  }
+
+  public static BTCChinaBalance adaptBalance(JSONObject jsonObject) {
+
+    try {
+      return internalAdaptBalance(jsonObject);
+    } catch (JSONException e) {
+      throw new IllegalArgumentException("data: " + jsonObject, e);
+    }
+  }
+
+  private static BTCChinaBalance internalAdaptBalance(JSONObject jsonObject) throws JSONException {
+
+    JSONObject balanceJsonObject = jsonObject.getJSONObject("balance");
+    return new BTCChinaBalance(new BigDecimal(balanceJsonObject.getString("amount_integer")), new BigDecimal(balanceJsonObject.getString("amount")), balanceJsonObject.getString("symbol"),
+        balanceJsonObject.getInt("amount_decimal"), balanceJsonObject.getString("currency"));
   }
 
 }

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/streaming/BTCChinaStreamingConfiguration.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/streaming/BTCChinaStreamingConfiguration.java
@@ -8,9 +8,14 @@ public class BTCChinaStreamingConfiguration implements ExchangeStreamingConfigur
   private final CurrencyPair[] marketDataCurrencyPairs;
   private final CurrencyPair[] orderFeedCurrencyPairs;
 
+  /**
+   * Indicates to subscribe account balance changes.
+   */
+  private final boolean subscribeAccountInfo;
+
   public BTCChinaStreamingConfiguration() {
 
-    this(true, true, CurrencyPair.BTC_CNY, CurrencyPair.LTC_CNY, CurrencyPair.LTC_BTC);
+    this(true, true, true, CurrencyPair.BTC_CNY, CurrencyPair.LTC_CNY, CurrencyPair.LTC_BTC);
   }
 
   /**
@@ -22,13 +27,24 @@ public class BTCChinaStreamingConfiguration implements ExchangeStreamingConfigur
    */
   public BTCChinaStreamingConfiguration(boolean subscribeMarktData, boolean subscribeOrderFeed, CurrencyPair... currencyPairs) {
 
-    this(subscribeMarktData ? currencyPairs : null, subscribeOrderFeed ? currencyPairs : null);
+    this(subscribeMarktData, subscribeOrderFeed, true, currencyPairs);
+  }
+
+  public BTCChinaStreamingConfiguration(boolean subscribeMarktData, boolean subscribeOrderFeed, boolean subscribeAccountInfo, CurrencyPair... currencyPairs) {
+
+    this(subscribeMarktData ? currencyPairs : null, subscribeOrderFeed ? currencyPairs : null, subscribeAccountInfo);
   }
 
   public BTCChinaStreamingConfiguration(CurrencyPair[] marketDataCurrencyPairs, CurrencyPair[] orderFeedCurrencyPairs) {
 
+    this(marketDataCurrencyPairs, orderFeedCurrencyPairs, true);
+  }
+
+  public BTCChinaStreamingConfiguration(CurrencyPair[] marketDataCurrencyPairs, CurrencyPair[] orderFeedCurrencyPairs, boolean subscribeAccountInfo) {
+
     this.marketDataCurrencyPairs = marketDataCurrencyPairs == null ? new CurrencyPair[0] : marketDataCurrencyPairs;
     this.orderFeedCurrencyPairs = orderFeedCurrencyPairs == null ? new CurrencyPair[0] : orderFeedCurrencyPairs;
+    this.subscribeAccountInfo = subscribeAccountInfo;
   }
 
   /**
@@ -92,6 +108,11 @@ public class BTCChinaStreamingConfiguration implements ExchangeStreamingConfigur
   public CurrencyPair[] getCurrencyPairs() {
 
     return marketDataCurrencyPairs;
+  }
+
+  public boolean isSubscribeAccountInfo() {
+
+    return subscribeAccountInfo;
   }
 
   public CurrencyPair[] getMarketDataCurrencyPairs() {

--- a/xchange-btcchina/src/test/java/com/xeiam/xchange/btcchina/dto/trade/streaming/request/BTCChinaPayloadTest.java
+++ b/xchange-btcchina/src/test/java/com/xeiam/xchange/btcchina/dto/trade/streaming/request/BTCChinaPayloadTest.java
@@ -1,0 +1,30 @@
+package com.xeiam.xchange.btcchina.dto.trade.streaming.request;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class BTCChinaPayloadTest {
+
+  private ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  public void test() throws JsonProcessingException {
+
+    final long tonce = 0;
+    final String accessKey = "myAccessKey";
+    final String market = "cnybtc";
+
+    BTCChinaPayload payload = new BTCChinaPayload(0, "myAccessKey", "post", "subscribe", new String[] { "order_cnybtc" });
+    String payloadString = mapper.writeValueAsString(payload);
+
+    String postdata = String.format("{\"tonce\":\"%1$d\",\"accesskey\":\"%2$s\",\"requestmethod\":\"post\",\"id\":\"%1$s\",\"method\":\"subscribe\",\"params\":[\"order_%3$s\"]}",
+        tonce, accessKey, market);
+
+    assertEquals(postdata, payloadString);
+  }
+
+}

--- a/xchange-btcchina/src/test/java/com/xeiam/xchange/btcchina/service/streaming/BTCChinaJSONObjectAdaptersTest.java
+++ b/xchange-btcchina/src/test/java/com/xeiam/xchange/btcchina/service/streaming/BTCChinaJSONObjectAdaptersTest.java
@@ -1,6 +1,6 @@
 package com.xeiam.xchange.btcchina.service.streaming;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -11,6 +11,7 @@ import org.json.JSONObject;
 import org.junit.Test;
 
 import com.xeiam.xchange.btcchina.dto.trade.BTCChinaOrderStatus;
+import com.xeiam.xchange.btcchina.dto.trade.streaming.BTCChinaBalance;
 import com.xeiam.xchange.btcchina.dto.trade.streaming.BTCChinaOrder;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
@@ -60,6 +61,30 @@ public class BTCChinaJSONObjectAdaptersTest {
     assertEquals(1411924393000L, order.getTimestamp().getTime());
     assertEquals(OrderType.ASK, order.getType());
     assertEquals(new BigDecimal("0.01"), order.getAmountOriginal());
+  }
+
+  @Test
+  public void testAdaptBalanceBTC() throws JSONException, IOException {
+
+    JSONObject jsonObject = new JSONObject(IOUtils.toString(getClass().getResource("account_info-balance-BTC.json")));
+    BTCChinaBalance balance = BTCChinaJSONObjectAdapters.adaptBalance(jsonObject);
+    assertEquals(new BigDecimal("196441900"), balance.getAmountInteger());
+    assertEquals(new BigDecimal("1.964419"), balance.getAmount());
+    assertEquals("฿", balance.getSymbol());
+    assertEquals(8, balance.getAmountDecimal());
+    assertEquals("BTC", balance.getCurrency());
+  }
+
+  @Test
+  public void testAdaptBalanceCNY() throws JSONException, IOException {
+
+    JSONObject jsonObject = new JSONObject(IOUtils.toString(getClass().getResource("account_info-balance-CNY.json")));
+    BTCChinaBalance balance = BTCChinaJSONObjectAdapters.adaptBalance(jsonObject);
+    assertEquals(new BigDecimal("4.2609492000000005E9"), balance.getAmountInteger());
+    assertEquals(new BigDecimal("42.609492"), balance.getAmount());
+    assertEquals("¥", balance.getSymbol());
+    assertEquals(8, balance.getAmountDecimal());
+    assertEquals("CNY", balance.getCurrency());
   }
 
 }

--- a/xchange-btcchina/src/test/resources/com/xeiam/xchange/btcchina/service/streaming/account_info-balance-BTC.json
+++ b/xchange-btcchina/src/test/resources/com/xeiam/xchange/btcchina/service/streaming/account_info-balance-BTC.json
@@ -1,0 +1,9 @@
+{
+	"balance": {
+		"amount_integer": 196441900,
+		"amount": 1.964419,
+		"symbol": "฿",
+		"amount_decimal": 8,
+		"currency": "BTC"
+	}
+}

--- a/xchange-btcchina/src/test/resources/com/xeiam/xchange/btcchina/service/streaming/account_info-balance-CNY.json
+++ b/xchange-btcchina/src/test/resources/com/xeiam/xchange/btcchina/service/streaming/account_info-balance-CNY.json
@@ -1,0 +1,9 @@
+{
+	"balance": {
+		"amount_integer": 4.2609492000000005E9,
+		"amount": 42.609492,
+		"symbol": "¥",
+		"amount_decimal": 8,
+		"currency": "CNY"
+	}
+}


### PR DESCRIPTION
[WEBSOCKET API V1.2.1](http://btcchina.org/websocket-api-market-data-documentation-en#websocket_api_v121): 2014-09-30 Websocket API v1.2.1 Added 'account_info', added Java sample code for 'account_info' method and Ruby sample code for 'order' and 'account_info' methods.
