### PR TITLE
Only "exchange" balances on Bitfinex are relevant in the context of XChange

### DIFF
--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/BitfinexAdapters.java
@@ -212,7 +212,9 @@ public final class BitfinexAdapters {
     List<Wallet> wallets = new ArrayList<Wallet>(response.length);
 
     for (BitfinexBalancesResponse balance : response) {
-      wallets.add(new Wallet(balance.getCurrency().toUpperCase(), balance.getAmount(), balance.getType()));
+      if ("exchange".equals(balance.getType())) {
+        wallets.add(new Wallet(balance.getCurrency().toUpperCase(), balance.getAmount()));
+      }
     }
 
     return new AccountInfo(null, wallets);


### PR DESCRIPTION
The way it worked before, eg. when USD balance was requested, you'd randomly get either "trading", "exchange" or "deposit" USD balance (these are 3 balance type on Bitfinex). I think only the "exchange" type is relevant in the context of XChange since this is what is used for exchange trading.

All three types of balances are still available via the raw interface.
