### PR TITLE
Implement BTCChina WebSocket API v1.2.2: Added 'grouporder' feed.

### DIFF
--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/streaming/BTCChinaSocketIOService.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/streaming/BTCChinaSocketIOService.java
@@ -1,6 +1,7 @@
 package com.xeiam.xchange.btcchina.service.streaming;
 
 import static com.xeiam.xchange.btcchina.service.streaming.BTCChinaSocketIOClientBuilder.EVENT_ACCOUNT_INFO;
+import static com.xeiam.xchange.btcchina.service.streaming.BTCChinaSocketIOClientBuilder.EVENT_GROUPORDER;
 import static com.xeiam.xchange.btcchina.service.streaming.BTCChinaSocketIOClientBuilder.EVENT_ORDER;
 import static com.xeiam.xchange.btcchina.service.streaming.BTCChinaSocketIOClientBuilder.EVENT_TICKER;
 import static com.xeiam.xchange.btcchina.service.streaming.BTCChinaSocketIOClientBuilder.EVENT_TRADE;
@@ -41,8 +42,8 @@ public class BTCChinaSocketIOService extends BaseExchangeService implements Stre
 
     socket =
         BTCChinaSocketIOClientBuilder.create().setUri(URI.create(uri)).setAccessKey(exchangeSpecification.getApiKey()).setSecretKey(exchangeSpecification.getSecretKey()).subscribeAccountInfo(
-            exchangeStreamingConfiguration.isSubscribeAccountInfo()).subscribeMarketData(exchangeStreamingConfiguration.getMarketDataCurrencyPairs()).subscribeOrderFeed(
-            exchangeStreamingConfiguration.getOrderFeedCurrencyPairs()).build();
+            exchangeStreamingConfiguration.isSubscribeAccountInfo()).subscribeMarketData(exchangeStreamingConfiguration.getMarketDataCurrencyPairs()).subscribeGrouporder(
+            exchangeStreamingConfiguration.getGrouporderCurrencyPairs()).subscribeOrderFeed(exchangeStreamingConfiguration.getOrderFeedCurrencyPairs()).build();
 
     listen();
   }
@@ -141,6 +142,16 @@ public class BTCChinaSocketIOService extends BaseExchangeService implements Stre
         JSONObject json = (JSONObject) args[0];
         log.debug("{}: {}", EVENT_TICKER, json);
         putEvent(ExchangeEventType.TICKER, json, BTCChinaJSONObjectAdapters.adaptTicker(json));
+      }
+    }).on(EVENT_GROUPORDER, new Emitter.Listener() {
+
+      @Override
+      public void call(Object... args) {
+
+        // receive the market depth feed
+        JSONObject json = (JSONObject) args[0];
+        log.debug("{}: {}", EVENT_GROUPORDER, json);
+        putEvent(ExchangeEventType.DEPTH, json, BTCChinaJSONObjectAdapters.adaptDepth(json));
       }
     }).on(EVENT_ORDER, new Emitter.Listener() {
 

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/streaming/BTCChinaStreamingConfiguration.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/streaming/BTCChinaStreamingConfiguration.java
@@ -6,6 +6,7 @@ import com.xeiam.xchange.service.streaming.ExchangeStreamingConfiguration;
 public class BTCChinaStreamingConfiguration implements ExchangeStreamingConfiguration {
 
   private final CurrencyPair[] marketDataCurrencyPairs;
+  private final CurrencyPair[] grouporderCurrencyPairs;
   private final CurrencyPair[] orderFeedCurrencyPairs;
 
   /**
@@ -32,7 +33,15 @@ public class BTCChinaStreamingConfiguration implements ExchangeStreamingConfigur
 
   public BTCChinaStreamingConfiguration(boolean subscribeMarktData, boolean subscribeOrderFeed, boolean subscribeAccountInfo, CurrencyPair... currencyPairs) {
 
-    this(subscribeMarktData ? currencyPairs : null, subscribeOrderFeed ? currencyPairs : null, subscribeAccountInfo);
+    this(subscribeMarktData, true, subscribeOrderFeed, subscribeAccountInfo);
+  }
+
+  /**
+   * @since <a href="http://btcchina.org/websocket-api-market-data-documentation-en#websocket_api_v122">WebSocket API v1.2.2</a>
+   */
+  public BTCChinaStreamingConfiguration(boolean subscribeMarktData, boolean subscribeGrouporder, boolean subscribeOrderFeed, boolean subscribeAccountInfo, CurrencyPair... currencyPairs) {
+
+    this(subscribeMarktData ? currencyPairs : null, subscribeGrouporder ? currencyPairs : null, subscribeOrderFeed ? currencyPairs : null, subscribeAccountInfo);
   }
 
   public BTCChinaStreamingConfiguration(CurrencyPair[] marketDataCurrencyPairs, CurrencyPair[] orderFeedCurrencyPairs) {
@@ -42,7 +51,16 @@ public class BTCChinaStreamingConfiguration implements ExchangeStreamingConfigur
 
   public BTCChinaStreamingConfiguration(CurrencyPair[] marketDataCurrencyPairs, CurrencyPair[] orderFeedCurrencyPairs, boolean subscribeAccountInfo) {
 
+    this(marketDataCurrencyPairs, null, orderFeedCurrencyPairs, subscribeAccountInfo);
+  }
+
+  /**
+   * @since <a href="http://btcchina.org/websocket-api-market-data-documentation-en#websocket_api_v122">WebSocket API v1.2.2</a>
+   */
+  public BTCChinaStreamingConfiguration(CurrencyPair[] marketDataCurrencyPairs, CurrencyPair[] grouporderCurrencyPairs, CurrencyPair[] orderFeedCurrencyPairs, boolean subscribeAccountInfo) {
+
     this.marketDataCurrencyPairs = marketDataCurrencyPairs == null ? new CurrencyPair[0] : marketDataCurrencyPairs;
+    this.grouporderCurrencyPairs = grouporderCurrencyPairs == null ? new CurrencyPair[0] : grouporderCurrencyPairs;
     this.orderFeedCurrencyPairs = orderFeedCurrencyPairs == null ? new CurrencyPair[0] : orderFeedCurrencyPairs;
     this.subscribeAccountInfo = subscribeAccountInfo;
   }
@@ -118,6 +136,14 @@ public class BTCChinaStreamingConfiguration implements ExchangeStreamingConfigur
   public CurrencyPair[] getMarketDataCurrencyPairs() {
 
     return marketDataCurrencyPairs;
+  }
+
+  /**
+   * @since <a href="http://btcchina.org/websocket-api-market-data-documentation-en#websocket_api_v122">WebSocket API v1.2.2</a>
+   */
+  public CurrencyPair[] getGrouporderCurrencyPairs() {
+
+    return grouporderCurrencyPairs;
   }
 
   public CurrencyPair[] getOrderFeedCurrencyPairs() {

--- a/xchange-btcchina/src/test/java/com/xeiam/xchange/btcchina/service/streaming/BTCChinaJSONObjectAdaptersTest.java
+++ b/xchange-btcchina/src/test/java/com/xeiam/xchange/btcchina/service/streaming/BTCChinaJSONObjectAdaptersTest.java
@@ -16,6 +16,7 @@ import com.xeiam.xchange.btcchina.dto.trade.streaming.BTCChinaBalance;
 import com.xeiam.xchange.btcchina.dto.trade.streaming.BTCChinaOrder;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
+import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
 import com.xeiam.xchange.dto.marketdata.Trade;
 
@@ -86,6 +87,31 @@ public class BTCChinaJSONObjectAdaptersTest {
     assertEquals("¥", balance.getSymbol());
     assertEquals(8, balance.getAmountDecimal());
     assertEquals("CNY", balance.getCurrency());
+  }
+
+  @Test
+  public void testAdaptDepth() throws JSONException, IOException {
+
+    JSONObject jsonObject = new JSONObject(IOUtils.toString(getClass().getResource("grouporder.json"), Charsets.UTF_8));
+    OrderBook depth = BTCChinaJSONObjectAdapters.adaptDepth(jsonObject);
+
+    // asks should be sorted ascending
+    assertEquals(OrderType.ASK, depth.getAsks().get(0).getType());
+    assertEquals(new BigDecimal("2403.37"), depth.getAsks().get(0).getLimitPrice());
+    assertEquals(new BigDecimal("0.113"), depth.getAsks().get(0).getTradableAmount());
+
+    assertEquals(OrderType.ASK, depth.getAsks().get(1).getType());
+    assertEquals(new BigDecimal("2403.39"), depth.getAsks().get(1).getLimitPrice());
+    assertEquals(new BigDecimal("4.9328"), depth.getAsks().get(1).getTradableAmount());
+
+    // bids should be sorted descending
+    assertEquals(OrderType.BID, depth.getBids().get(0).getType());
+    assertEquals(new BigDecimal("2401.8"), depth.getBids().get(0).getLimitPrice());
+    assertEquals(new BigDecimal("3.2666"), depth.getBids().get(0).getTradableAmount());
+
+    assertEquals(OrderType.BID, depth.getBids().get(1).getType());
+    assertEquals(new BigDecimal("2401.73"), depth.getBids().get(1).getLimitPrice());
+    assertEquals(new BigDecimal("0.6024"), depth.getBids().get(1).getTradableAmount());
   }
 
 }

--- a/xchange-btcchina/src/test/resources/com/xeiam/xchange/btcchina/service/streaming/grouporder.json
+++ b/xchange-btcchina/src/test/resources/com/xeiam/xchange/btcchina/service/streaming/grouporder.json
@@ -1,0 +1,47 @@
+{
+	"grouporder": {
+		"market": "btccny",
+		"ask": [{
+			"price": 2404.94,
+			"type": "ask",
+			"totalamount": 1.0853
+		}, {
+			"price": 2403.7,
+			"type": "ask",
+			"totalamount": 3
+		}, {
+			"price": 2403.4,
+			"type": "ask",
+			"totalamount": 0.0016
+		}, {
+			"price": 2403.39,
+			"type": "ask",
+			"totalamount": 4.9328
+		}, {
+			"price": 2403.37,
+			"type": "ask",
+			"totalamount": 0.113
+		}],
+		"bid": [{
+			"price": 2401.8,
+			"type": "bid",
+			"totalamount": 3.2666
+		}, {
+			"price": 2401.73,
+			"type": "bid",
+			"totalamount": 0.6024
+		}, {
+			"price": 2401.33,
+			"type": "bid",
+			"totalamount": 0.02
+		}, {
+			"price": 2401.29,
+			"type": "bid",
+			"totalamount": 0.008
+		}, {
+			"price": 2400.96,
+			"type": "bid",
+			"totalamount": 0.0012
+		}]
+	}
+}

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/btcchina/marketdata/BTCChinaDepthDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/btcchina/marketdata/BTCChinaDepthDemo.java
@@ -57,7 +57,7 @@ public class BTCChinaDepthDemo {
     }
     if (bids.size() >= 2) {
       boolean higher = bids.get(0).getLimitPrice().compareTo(bids.get(1).getLimitPrice()) > 0;
-      assert higher : "bids should be sorted deascending";
+      assert higher : "bids should be sorted descending";
     }
   }
 

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/btcchina/streaming/BTCChinaSocketIOServiceDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/btcchina/streaming/BTCChinaSocketIOServiceDemo.java
@@ -18,7 +18,7 @@ public class BTCChinaSocketIOServiceDemo {
 
   public static void main(String[] args) throws InterruptedException {
 
-    final BTCChinaStreamingConfiguration configuration = new BTCChinaStreamingConfiguration(true, true, CurrencyPair.BTC_CNY, CurrencyPair.LTC_CNY, CurrencyPair.LTC_BTC);
+    final BTCChinaStreamingConfiguration configuration = new BTCChinaStreamingConfiguration(true, true, true, true, CurrencyPair.BTC_CNY, CurrencyPair.LTC_CNY, CurrencyPair.LTC_BTC);
     final Exchange exchange = BTCChinaExamplesUtils.getExchange();
     final StreamingExchangeService service = exchange.getStreamingExchangeService(configuration);
 


### PR DESCRIPTION
2014-10-15 [Websocket API v1.2.2](http://btcchina.org/websocket-api-market-data-documentation-en#websocket_api_v122) Added 'grouporder' feed.
