### PR TITLE
normalize Ticker and LimitOrder builders

### DIFF
--- a/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/ANXAdapters.java
+++ b/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/ANXAdapters.java
@@ -17,7 +17,6 @@ import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -209,7 +208,7 @@ public final class ANXAdapters {
 
     CurrencyPair currencyPair = adaptCurrencyPair(anxTicker.getVol().getCurrency(), anxTicker.getAvg().getCurrency());
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withVolume(volume).withTimestamp(timestamp).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).high(high).low(low).volume(volume).timestamp(timestamp).build();
 
   }
 

--- a/xchange-bitbay/src/main/java/com/xeiam/xchange/bitbay/BitbayAdapters.java
+++ b/xchange-bitbay/src/main/java/com/xeiam/xchange/bitbay/BitbayAdapters.java
@@ -45,7 +45,7 @@ public class BitbayAdapters {
     BigDecimal last = bitbayTicker.getLast();
     Date timestamp = new Date();
 
-    return Ticker.TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withVolume(volume).withTimestamp(timestamp).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).high(high).low(low).volume(volume).timestamp(timestamp).build();
   }
 
   /**

--- a/xchange-bitcoinaverage/src/main/java/com/xeiam/xchange/bitcoinaverage/BitcoinAverageAdapters.java
+++ b/xchange-bitcoinaverage/src/main/java/com/xeiam/xchange/bitcoinaverage/BitcoinAverageAdapters.java
@@ -6,7 +6,6 @@ import java.util.Date;
 import com.xeiam.xchange.bitcoinaverage.dto.marketdata.BitcoinAverageTicker;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 
 /**
  * Various adapters for converting from BitcoinAverage DTOs to XChange DTOs
@@ -36,7 +35,7 @@ public final class BitcoinAverageAdapters {
     Date timestamp = bitcoinAverageTicker.getTimestamp();
     BigDecimal volume = bitcoinAverageTicker.getVolume();
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withBid(bid).withAsk(ask).withVolume(volume).withTimestamp(timestamp).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).volume(volume).timestamp(timestamp).build();
   }
 
 }

--- a/xchange-bitcoincharts/src/main/java/com/xeiam/xchange/bitcoincharts/BitcoinChartsAdapters.java
+++ b/xchange-bitcoincharts/src/main/java/com/xeiam/xchange/bitcoincharts/BitcoinChartsAdapters.java
@@ -6,7 +6,6 @@ import java.util.Date;
 import com.xeiam.xchange.bitcoincharts.dto.marketdata.BitcoinChartsTicker;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 
 /**
  * Various adapters for converting from BitcoinCharts DTOs to XChange DTOs
@@ -40,7 +39,7 @@ public final class BitcoinChartsAdapters {
         BigDecimal volume = bitcoinChartsTickers[i].getVolume();
         Date timeStamp = new Date(bitcoinChartsTickers[i].getLatestTrade() * 1000L);
 
-        return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withVolume(volume).withTimestamp(timeStamp).build();
+        return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).high(high).low(low).volume(volume).timestamp(timeStamp).build();
 
       }
     }

--- a/xchange-bitcoinium/src/main/java/com/xeiam/xchange/bitcoinium/BitcoiniumAdapters.java
+++ b/xchange-bitcoinium/src/main/java/com/xeiam/xchange/bitcoinium/BitcoiniumAdapters.java
@@ -12,7 +12,6 @@ import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.trade.LimitOrder;
 
 /**
@@ -42,7 +41,7 @@ public final class BitcoiniumAdapters {
     BigDecimal bid = bitcoiniumTicker.getBid();
     BigDecimal volume = bitcoiniumTicker.getVolume();
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withHigh(high).withLow(low).withVolume(volume).withAsk(ask).withBid(bid).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).high(high).low(low).volume(volume).ask(ask).bid(bid).build();
   }
 
   /**

--- a/xchange-bitcurex/src/main/java/com/xeiam/xchange/bitcurex/BitcurexAdapters.java
+++ b/xchange-bitcurex/src/main/java/com/xeiam/xchange/bitcurex/BitcurexAdapters.java
@@ -13,7 +13,6 @@ import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -121,7 +120,7 @@ public final class BitcurexAdapters {
     BigDecimal sell = bitcurexTicker.getAsk();
     BigDecimal volume = bitcurexTicker.getVolume();
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withHigh(high).withLow(low).withBid(buy).withAsk(sell).withVolume(volume).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).high(high).low(low).bid(buy).ask(sell).volume(volume).build();
   }
 
   /**

--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/BitfinexAdapters.java
@@ -22,7 +22,6 @@ import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -204,7 +203,7 @@ public final class BitfinexAdapters {
 
     Date timestamp = DateUtils.fromMillisUtc((long) (bitfinexTicker.getTimestamp() * 1000L));
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withVolume(volume).withTimestamp(timestamp).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).high(high).low(low).volume(volume).timestamp(timestamp).build();
   }
 
   public static AccountInfo adaptAccountInfo(BitfinexBalancesResponse[] response) {

--- a/xchange-bitkonan/src/main/java/com/xeiam/xchange/bitkonan/BitKonanAdapters.java
+++ b/xchange-bitkonan/src/main/java/com/xeiam/xchange/bitkonan/BitKonanAdapters.java
@@ -46,7 +46,7 @@ public class BitKonanAdapters {
     // no timestamp from BitKonan
     Date timestamp = null;
 
-    return Ticker.TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withVolume(volume).withTimestamp(timestamp).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).high(high).low(low).volume(volume).timestamp(timestamp).build();
   }
 
   public static OrderBook adaptOrderBook(BitKonanOrderBook bitKonanOrderBook) {

--- a/xchange-bitmarket/src/main/java/com/xeiam/xchange/bitmarket/BitMarketAdapters.java
+++ b/xchange-bitmarket/src/main/java/com/xeiam/xchange/bitmarket/BitMarketAdapters.java
@@ -44,7 +44,7 @@ public class BitMarketAdapters {
     BigDecimal volume = bitMarketTicker.getVolume();
     BigDecimal last = bitMarketTicker.getLast();
 
-    return Ticker.TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withVolume(volume).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).high(high).low(low).volume(volume).build();
   }
 
   private static List<LimitOrder> transformArrayToLimitOrders(BigDecimal[][] orders, OrderType orderType, CurrencyPair currencyPair) {

--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/BitstampAdapters.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/BitstampAdapters.java
@@ -19,7 +19,6 @@ import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -146,7 +145,7 @@ public final class BitstampAdapters {
     BigDecimal volume = bitstampTicker.getVolume();
     Date timestamp = new Date(bitstampTicker.getTimestamp() * 1000L);
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withVolume(volume).withTimestamp(timestamp).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).high(high).low(low).volume(volume).timestamp(timestamp).build();
 
   }
 

--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/BittrexAdapters.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/BittrexAdapters.java
@@ -20,7 +20,6 @@ import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -123,7 +122,7 @@ public final class BittrexAdapters {
 
     Date timestamp = BittrexUtils.toDate(bittrexTicker.getTimeStamp());
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withVolume(volume).withTimestamp(timestamp).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).high(high).low(low).volume(volume).timestamp(timestamp).build();
   }
 
   public static AccountInfo adaptAccountInfo(List<BittrexBalance> balances) {

--- a/xchange-bitvc/src/main/java/com/xeiam/xchange/bitvc/BitVcAdapters.java
+++ b/xchange-bitvc/src/main/java/com/xeiam/xchange/bitvc/BitVcAdapters.java
@@ -31,7 +31,6 @@ import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.trade.LimitOrder;
@@ -48,8 +47,9 @@ public final class BitVcAdapters {
   public static Ticker adaptTicker(BitVcTicker BitVcTicker, CurrencyPair currencyPair) {
 
     BitVcTickerObject ticker = BitVcTicker.getTicker();
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(ticker.getLast()).withBid(ticker.getBuy()).withAsk(ticker.getSell()).withHigh(ticker.getHigh()).withLow(ticker.getLow())
-        .withVolume(ticker.getVol()).withTimestamp(new Date()).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(ticker.getLast()).bid(ticker.getBuy())
+        .ask(ticker.getSell()).high(ticker.getHigh()).low(ticker.getLow())
+        .volume(ticker.getVol()).timestamp(new Date()).build();
   }
 
   public static OrderBook adaptOrderBook(BitVcDepth BitVcDepth, CurrencyPair currencyPair) {

--- a/xchange-btccentral/src/main/java/com/xeiam/xchange/btccentral/BTCCentralAdapters.java
+++ b/xchange-btccentral/src/main/java/com/xeiam/xchange/btccentral/BTCCentralAdapters.java
@@ -47,7 +47,7 @@ public class BTCCentralAdapters {
     BigDecimal volume = btcCentralTicker.getVolume();
     Date timestamp = new Date(btcCentralTicker.getAt() * 1000L);
 
-    return Ticker.TickerBuilder.newInstance().withCurrencyPair(currencyPair).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withLast(last).withVolume(volume).withTimestamp(timestamp).build();
+    return new Ticker.Builder().currencyPair(currencyPair).bid(bid).ask(ask).high(high).low(low).last(last).volume(volume).timestamp(timestamp).build();
   }
 
   /**

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChinaAdapters.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChinaAdapters.java
@@ -27,7 +27,6 @@ import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -144,7 +143,7 @@ public final class BTCChinaAdapters {
     BigDecimal volume = ticker.getVol();
     Date date = adaptDate(ticker.getDate());
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withHigh(high).withLow(low).withBid(buy).withAsk(sell).withVolume(volume).withTimestamp(date).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).high(high).low(low).bid(buy).ask(sell).volume(volume).timestamp(date).build();
   }
 
   public static Map<CurrencyPair, Ticker> adaptTickers(BTCChinaTicker btcChinaTicker) {
@@ -234,7 +233,7 @@ public final class BTCChinaAdapters {
 
   public static LimitOrder adaptLimitOrder(BTCChinaMarketDepthOrder order, OrderType orderType, CurrencyPair currencyPair) {
 
-    return new LimitOrder.Builder(orderType, currencyPair).setLimitPrice(order.getPrice()).setTradableAmount(order.getAmount()).build();
+    return new LimitOrder.Builder(orderType, currencyPair).limitPrice(order.getPrice()).tradableAmount(order.getAmount()).build();
   }
 
   /**

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/fix/BTCChinaFIXAdapters.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/fix/BTCChinaFIXAdapters.java
@@ -24,7 +24,6 @@ import quickfix.fix44.MarketDataSnapshotFullRefresh;
 
 import com.xeiam.xchange.btcchina.BTCChinaAdapters;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 
 /**
  * Various adapters for converting from {@link Message} to XChange DTOs.
@@ -36,10 +35,10 @@ public final class BTCChinaFIXAdapters {
 
   public static Ticker adaptTicker(MarketDataSnapshotFullRefresh message) throws FieldNotFound {
 
-    TickerBuilder tickerBuilder = TickerBuilder.newInstance();
+    Ticker.Builder tickerBuilder = new Ticker.Builder();
 
     String symbol = message.getSymbol().getValue();
-    tickerBuilder.withCurrencyPair(BTCChinaAdapters.adaptCurrencyPair(symbol));
+    tickerBuilder.currencyPair(BTCChinaAdapters.adaptCurrencyPair(symbol));
 
     int noMDEntries = message.getNoMDEntries().getValue();
     for (int i = 1; i <= noMDEntries; i++) {
@@ -53,9 +52,9 @@ public final class BTCChinaFIXAdapters {
 
   public static Ticker adaptUpdate(Ticker ticker, MarketDataIncrementalRefresh message) throws FieldNotFound {
 
-    TickerBuilder tickerBuilder =
-        TickerBuilder.newInstance().withCurrencyPair(ticker.getCurrencyPair()).withTimestamp(ticker.getTimestamp()).withBid(ticker.getBid()).withAsk(ticker.getAsk()).withLast(ticker.getLast())
-            .withHigh(ticker.getHigh()).withLow(ticker.getLow()).withVolume(ticker.getVolume());
+    Ticker.Builder tickerBuilder =
+        new Ticker.Builder().currencyPair(ticker.getCurrencyPair()).timestamp(ticker.getTimestamp()).bid(ticker.getBid()).ask(ticker.getAsk()).last(ticker.getLast())
+            .high(ticker.getHigh()).low(ticker.getLow()).volume(ticker.getVolume());
 
     int noMDEntries = message.getNoMDEntries().getValue();
     for (int i = 1; i <= noMDEntries; i++) {
@@ -66,7 +65,7 @@ public final class BTCChinaFIXAdapters {
     return tickerBuilder.build();
   }
 
-  private static void adapt(TickerBuilder tickerBuilder, Group group) throws FieldNotFound {
+  private static void adapt(Ticker.Builder tickerBuilder, Group group) throws FieldNotFound {
 
     char type = group.getChar(MDEntryType.FIELD);
 
@@ -75,33 +74,33 @@ public final class BTCChinaFIXAdapters {
     switch (type) {
     case MDEntryType.BID:
       px = group.getDecimal(MDEntryPx.FIELD);
-      tickerBuilder.withBid(px);
+      tickerBuilder.bid(px);
       break;
     case MDEntryType.OFFER:
       px = group.getDecimal(MDEntryPx.FIELD);
-      tickerBuilder.withAsk(px);
+      tickerBuilder.ask(px);
       break;
     case MDEntryType.TRADE:
       px = group.getDecimal(MDEntryPx.FIELD);
-      tickerBuilder.withLast(px);
+      tickerBuilder.last(px);
       break;
     case MDEntryType.CLOSING_PRICE:
       // no closing price in XChange's ticker
       break;
     case MDEntryType.TRADING_SESSION_HIGH_PRICE:
       px = group.getDecimal(MDEntryPx.FIELD);
-      tickerBuilder.withHigh(px);
+      tickerBuilder.high(px);
       break;
     case MDEntryType.TRADING_SESSION_LOW_PRICE:
       px = group.getDecimal(MDEntryPx.FIELD);
-      tickerBuilder.withLow(px);
+      tickerBuilder.low(px);
       break;
     case MDEntryType.TRADING_SESSION_VWAP_PRICE:
       // no vwap price in XChange's ticker
       break;
     case MDEntryType.TRADE_VOLUME:
       size = group.getDecimal(MDEntrySize.FIELD);
-      tickerBuilder.withVolume(size);
+      tickerBuilder.volume(size);
 
       break;
     }
@@ -118,7 +117,7 @@ public final class BTCChinaFIXAdapters {
     dateCal.set(SECOND, timeCal.get(SECOND));
     dateCal.set(MILLISECOND, timeCal.get(MILLISECOND));
 
-    tickerBuilder.withTimestamp(dateCal.getTime());
+    tickerBuilder.timestamp(dateCal.getTime());
   }
 
 }

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/streaming/BTCChinaJSONObjectAdapters.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/streaming/BTCChinaJSONObjectAdapters.java
@@ -16,7 +16,6 @@ import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.trade.LimitOrder;
 
@@ -37,10 +36,10 @@ public class BTCChinaJSONObjectAdapters {
   private static Ticker internalAdaptTicker(JSONObject jsonObject) throws JSONException {
 
     JSONObject tickerJsonObject = jsonObject.getJSONObject("ticker");
-    return TickerBuilder.newInstance().withHigh(new BigDecimal(tickerJsonObject.getString("high"))).withLow(new BigDecimal(tickerJsonObject.getString("low"))).withBid(
-        new BigDecimal(tickerJsonObject.getString("buy"))).withAsk(new BigDecimal(tickerJsonObject.getString("sell"))).withLast(new BigDecimal(tickerJsonObject.getString("last"))).withVolume(
-        new BigDecimal(tickerJsonObject.getString("vol"))).withTimestamp(BTCChinaAdapters.adaptDate(tickerJsonObject.getLong("date"))).withCurrencyPair(
-        BTCChinaAdapters.adaptCurrencyPair(tickerJsonObject.getString("market"))).build();
+    return new Ticker.Builder().high(new BigDecimal(tickerJsonObject.getString("high"))).low(new BigDecimal(tickerJsonObject.getString("low"))).bid(
+            new BigDecimal(tickerJsonObject.getString("buy"))).ask(new BigDecimal(tickerJsonObject.getString("sell"))).last(new BigDecimal(tickerJsonObject.getString("last"))).volume(
+            new BigDecimal(tickerJsonObject.getString("vol"))).timestamp(BTCChinaAdapters.adaptDate(tickerJsonObject.getLong("date"))).currencyPair(
+            BTCChinaAdapters.adaptCurrencyPair(tickerJsonObject.getString("market"))).build();
   }
 
   public static Trade adaptTrade(JSONObject jsonObject) {
@@ -129,7 +128,7 @@ public class BTCChinaJSONObjectAdapters {
       String price = groupedOrder.getString("price");
       // String type = groupedOrder.getString("type");
       String totalamount = groupedOrder.getString("totalamount");
-      asks.add(new LimitOrder.Builder(OrderType.ASK, currencyPair).setLimitPrice(new BigDecimal(price)).setTradableAmount(new BigDecimal(totalamount)).build());
+      asks.add(new LimitOrder.Builder(OrderType.ASK, currencyPair).limitPrice(new BigDecimal(price)).tradableAmount(new BigDecimal(totalamount)).build());
     }
 
     for (int i = 0; i < bidLength; i++) {
@@ -137,7 +136,7 @@ public class BTCChinaJSONObjectAdapters {
       String price = groupedOrder.getString("price");
       // String type = groupedOrder.getString("type");
       String totalamount = groupedOrder.getString("totalamount");
-      bids.add(new LimitOrder.Builder(OrderType.BID, currencyPair).setLimitPrice(new BigDecimal(price)).setTradableAmount(new BigDecimal(totalamount)).build());
+      bids.add(new LimitOrder.Builder(OrderType.BID, currencyPair).limitPrice(new BigDecimal(price)).tradableAmount(new BigDecimal(totalamount)).build());
     }
 
     return new OrderBook(new Date(), asks, bids);

--- a/xchange-btce/src/main/java/com/xeiam/xchange/btce/v2/BTCEAdapters.java
+++ b/xchange-btce/src/main/java/com/xeiam/xchange/btce/v2/BTCEAdapters.java
@@ -19,7 +19,6 @@ import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -142,7 +141,7 @@ public final class BTCEAdapters {
     BigDecimal volume = bTCETicker.getTicker().getVolCur();
     Date timestamp = DateUtils.fromMillisUtc(bTCETicker.getTicker().getServerTime() * 1000L);
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withVolume(volume).withTimestamp(timestamp).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).high(high).low(low).volume(volume).timestamp(timestamp).build();
   }
 
   public static AccountInfo adaptAccountInfo(BTCEAccountInfo btceAccountInfo) {

--- a/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/BTCEAdapters.java
+++ b/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/BTCEAdapters.java
@@ -19,7 +19,6 @@ import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -135,7 +134,7 @@ public final class BTCEAdapters {
     BigDecimal volume = bTCETicker.getVolCur();
     Date timestamp = DateUtils.fromMillisUtc(bTCETicker.getUpdated() * 1000L);
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withVolume(volume).withTimestamp(timestamp).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).high(high).low(low).volume(volume).timestamp(timestamp).build();
   }
 
   public static AccountInfo adaptAccountInfo(BTCEAccountInfo btceAccountInfo) {

--- a/xchange-btctrade/src/main/java/com/xeiam/xchange/btctrade/BTCTradeAdapters.java
+++ b/xchange-btctrade/src/main/java/com/xeiam/xchange/btctrade/BTCTradeAdapters.java
@@ -26,7 +26,6 @@ import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -79,8 +78,9 @@ public final class BTCTradeAdapters {
 
   public static Ticker adaptTicker(BTCTradeTicker btcTradeTicker, CurrencyPair currencyPair) {
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withHigh(btcTradeTicker.getHigh()).withLow(btcTradeTicker.getLow()).withBid(btcTradeTicker.getBuy()).withAsk(
-        btcTradeTicker.getSell()).withLast(btcTradeTicker.getLast()).withVolume(btcTradeTicker.getVol()).build();
+    return new Ticker.Builder().currencyPair(currencyPair).high(btcTradeTicker.getHigh()).low(btcTradeTicker.getLow())
+            .bid(btcTradeTicker.getBuy()).ask(btcTradeTicker.getSell()).last(btcTradeTicker.getLast())
+            .volume(btcTradeTicker.getVol()).build();
   }
 
   public static OrderBook adaptOrderBook(BTCTradeDepth btcTradeDepth, CurrencyPair currencyPair) {

--- a/xchange-bter/src/main/java/com/xeiam/xchange/bter/BTERAdapters.java
+++ b/xchange-bter/src/main/java/com/xeiam/xchange/bter/BTERAdapters.java
@@ -24,7 +24,6 @@ import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -60,7 +59,7 @@ public final class BTERAdapters {
     BigDecimal high = bterTicker.getHigh();
     BigDecimal volume = bterTicker.getVolume(currencyPair.baseSymbol);
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withAsk(ask).withBid(bid).withLast(last).withLow(low).withHigh(high).withVolume(volume).build();
+    return new Ticker.Builder().currencyPair(currencyPair).ask(ask).bid(bid).last(last).low(low).high(high).volume(volume).build();
   }
 
   public static LimitOrder adaptOrder(BTERPublicOrder order, CurrencyPair currencyPair, OrderType orderType) {

--- a/xchange-campbx/src/main/java/com/xeiam/xchange/campbx/CampBXAdapters.java
+++ b/xchange-campbx/src/main/java/com/xeiam/xchange/campbx/CampBXAdapters.java
@@ -11,7 +11,6 @@ import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.trade.LimitOrder;
 
 /**
@@ -68,7 +67,7 @@ public final class CampBXAdapters {
     BigDecimal bid = campbxTicker.getBid();
     BigDecimal ask = campbxTicker.getAsk();
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withBid(bid).withAsk(ask).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).build();
 
   }
 

--- a/xchange-cavirtex/src/main/java/com/xeiam/xchange/virtex/v1/VirtExAdapters.java
+++ b/xchange-cavirtex/src/main/java/com/xeiam/xchange/virtex/v1/VirtExAdapters.java
@@ -9,7 +9,6 @@ import com.xeiam.xchange.currency.Currencies;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -114,7 +113,7 @@ public final class VirtExAdapters {
     BigDecimal low = virtExTicker.getLow();
     BigDecimal volume = virtExTicker.getVolume();
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withHigh(high).withLow(low).withVolume(volume).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).high(high).low(low).volume(volume).build();
   }
 
 }

--- a/xchange-cavirtex/src/main/java/com/xeiam/xchange/virtex/v2/VirtExAdapters.java
+++ b/xchange-cavirtex/src/main/java/com/xeiam/xchange/virtex/v2/VirtExAdapters.java
@@ -8,7 +8,6 @@ import java.util.List;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -111,7 +110,7 @@ public final class VirtExAdapters {
     BigDecimal buy = virtExTicker.getBuy();
     BigDecimal sell = virtExTicker.getSell();
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withHigh(high).withLow(low).withAsk(sell).withBid(buy).withVolume(volume).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).high(high).low(low).ask(sell).bid(buy).volume(volume).build();
   }
 
 }

--- a/xchange-cexio/src/main/java/com/xeiam/xchange/cexio/CexIOAdapters.java
+++ b/xchange-cexio/src/main/java/com/xeiam/xchange/cexio/CexIOAdapters.java
@@ -89,7 +89,7 @@ public class CexIOAdapters {
     BigDecimal volume = ticker.getVolume();
     Date timestamp = new Date(ticker.getTimestamp() * 1000L);
 
-    return Ticker.TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withVolume(volume).withTimestamp(timestamp).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).high(high).low(low).volume(volume).timestamp(timestamp).build();
   }
 
   /**

--- a/xchange-coinbase/src/main/java/com/xeiam/xchange/coinbase/CoinbaseAdapters.java
+++ b/xchange-coinbase/src/main/java/com/xeiam/xchange/coinbase/CoinbaseAdapters.java
@@ -18,7 +18,6 @@ import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -87,8 +86,8 @@ public final class CoinbaseAdapters {
   public static Ticker adaptTicker(final CurrencyPair currencyPair, final CoinbasePrice buyPrice, final CoinbasePrice sellPrice, final CoinbaseMoney spotRate,
       final CoinbaseSpotPriceHistory coinbaseSpotPriceHistory) {
 
-    final TickerBuilder tickerBuilder =
-        TickerBuilder.newInstance().withCurrencyPair(currencyPair).withAsk(buyPrice.getSubTotal().getAmount()).withBid(sellPrice.getSubTotal().getAmount()).withLast(spotRate.getAmount());
+    final Ticker.Builder tickerBuilder =
+        new Ticker.Builder().currencyPair(currencyPair).ask(buyPrice.getSubTotal().getAmount()).bid(sellPrice.getSubTotal().getAmount()).last(spotRate.getAmount());
 
     // Get the 24 hour high and low spot price if the history is provided.
     if (coinbaseSpotPriceHistory != null) {
@@ -109,7 +108,7 @@ public final class CoinbaseAdapters {
         else if (spotPriceAmount.compareTo(observedHigh) > 0)
           observedHigh = spotPriceAmount;
       }
-      tickerBuilder.withHigh(observedHigh).withLow(observedLow);
+      tickerBuilder.high(observedHigh).low(observedLow);
     }
 
     return tickerBuilder.build();

--- a/xchange-coinbase/src/test/java/com/xeiam/xchange/coinbase/CoinbaseAdapterTest.java
+++ b/xchange-coinbase/src/test/java/com/xeiam/xchange/coinbase/CoinbaseAdapterTest.java
@@ -24,7 +24,6 @@ import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.trade.Wallet;
@@ -84,8 +83,8 @@ public class CoinbaseAdapterTest {
   public void testAdaptTicker() throws IOException {
 
     Ticker expectedTicker =
-        TickerBuilder.newInstance().withCurrencyPair(CurrencyPair.BTC_USD).withAsk(new BigDecimal("723.09")).withBid(new BigDecimal("723.09")).withLast(new BigDecimal("719.79")).withLow(
-            new BigDecimal("718.2")).withHigh(new BigDecimal("723.11")).build();
+        new Ticker.Builder().currencyPair(CurrencyPair.BTC_USD).ask(new BigDecimal("723.09")).bid(new BigDecimal("723.09")).last(new BigDecimal("719.79")).low(
+                new BigDecimal("718.2")).high(new BigDecimal("723.11")).build();
 
     InputStream is = CoinbaseAdapterTest.class.getResourceAsStream("/marketdata/example-price-data.json");
     ObjectMapper mapper = new ObjectMapper();

--- a/xchange-coinfloor/src/main/java/com/xeiam/xchange/coinfloor/CoinfloorAdapters.java
+++ b/xchange-coinfloor/src/main/java/com/xeiam/xchange/coinfloor/CoinfloorAdapters.java
@@ -211,7 +211,7 @@ public class CoinfloorAdapters {
     BigDecimal low = rawRetObj.getLow();
     BigDecimal high = rawRetObj.getHigh();
     Ticker genericTicker =
-        new Ticker.TickerBuilder().withVolume(rawRetObj.getVolume()).withAsk(ask).withCurrencyPair(new CurrencyPair("BTC", "GBP")).withBid(bid).withHigh(high).withLow(low).withLast(last).build();
+        new Ticker.Builder().volume(rawRetObj.getVolume()).ask(ask).currencyPair(new CurrencyPair("BTC", "GBP")).bid(bid).high(high).low(low).last(last).build();
 
     synchronized (cachedDataSynchronizationObject) {
       cachedTicker = genericTicker;
@@ -245,8 +245,8 @@ public class CoinfloorAdapters {
       BigDecimal volume = (rawRetObj.getVolume().doubleValue() == 0 ? cachedTicker.getVolume() : rawRetObj.getVolume());
 
       genericTicker =
-          new Ticker.TickerBuilder().withCurrencyPair(new CurrencyPair(rawRetObj.getBase().toString(), rawRetObj.getCounter().toString())).withLast(last).withBid(bid).withAsk(ask).withLow(low)
-              .withHigh(high).withVolume(volume).build();
+          new Ticker.Builder().currencyPair(new CurrencyPair(rawRetObj.getBase().toString(), rawRetObj.getCounter().toString())).last(last).bid(bid).ask(ask).low(low)
+              .high(high).volume(volume).build();
       cachedTicker = genericTicker;
     }
 

--- a/xchange-coinsetter/src/main/java/com/xeiam/xchange/coinsetter/CoinsetterAdapters.java
+++ b/xchange-coinsetter/src/main/java/com/xeiam/xchange/coinsetter/CoinsetterAdapters.java
@@ -21,7 +21,6 @@ import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.trade.LimitOrder;
 import com.xeiam.xchange.dto.trade.OpenOrders;
 import com.xeiam.xchange.dto.trade.Wallet;
@@ -63,8 +62,10 @@ public final class CoinsetterAdapters {
    */
   public static Ticker adaptTicker(CoinsetterTicker coinsetterTicker) {
 
-    return TickerBuilder.newInstance().withCurrencyPair(CurrencyPair.BTC_USD).withTimestamp(new Date(coinsetterTicker.getLast().getTimeStamp())).withAsk(coinsetterTicker.getAsk().getPrice()).withBid(
-        coinsetterTicker.getBid().getPrice()).withLast(coinsetterTicker.getLast().getPrice()).withVolume(coinsetterTicker.getVolume()).build();
+    return new Ticker.Builder().currencyPair(CurrencyPair.BTC_USD)
+            .timestamp(new Date(coinsetterTicker.getLast().getTimeStamp())).ask(coinsetterTicker.getAsk().getPrice())
+            .bid(coinsetterTicker.getBid().getPrice()).last(coinsetterTicker.getLast().getPrice())
+            .volume(coinsetterTicker.getVolume()).build();
   }
 
   /**
@@ -86,8 +87,8 @@ public final class CoinsetterAdapters {
       for (CoinsetterPair coinsetterPair : coinsetterPairs) {
         CoinsetterTrade ask = coinsetterPair.getAsk();
         CoinsetterTrade bid = coinsetterPair.getBid();
-        asks.add(new LimitOrder.Builder(OrderType.ASK, CurrencyPair.BTC_USD).setLimitPrice(ask.getPrice()).setTradableAmount(ask.getSize()).build());
-        bids.add(new LimitOrder.Builder(OrderType.BID, CurrencyPair.BTC_USD).setLimitPrice(bid.getPrice()).setTradableAmount(bid.getSize()).build());
+        asks.add(new LimitOrder.Builder(OrderType.ASK, CurrencyPair.BTC_USD).limitPrice(ask.getPrice()).tradableAmount(ask.getSize()).build());
+        bids.add(new LimitOrder.Builder(OrderType.BID, CurrencyPair.BTC_USD).limitPrice(bid.getPrice()).tradableAmount(bid.getSize()).build());
       }
     } else {
       timeStamp = new Date();
@@ -118,13 +119,13 @@ public final class CoinsetterAdapters {
 
     for (int i = asksLength - 1; i >= 0; i--) {
       BigDecimal[] ask = asks[i];
-      LimitOrder order = new LimitOrder.Builder(OrderType.ASK, CurrencyPair.BTC_USD).setLimitPrice(ask[0]).setTradableAmount(ask[1]).build();
+      LimitOrder order = new LimitOrder.Builder(OrderType.ASK, CurrencyPair.BTC_USD).limitPrice(ask[0]).tradableAmount(ask[1]).build();
       askOrders.add(order);
     }
 
     for (int i = 0; i < bidsLength; i++) {
       BigDecimal[] bid = bids[i];
-      LimitOrder order = new LimitOrder.Builder(OrderType.BID, CurrencyPair.BTC_USD).setLimitPrice(bid[0]).setTradableAmount(bid[1]).build();
+      LimitOrder order = new LimitOrder.Builder(OrderType.BID, CurrencyPair.BTC_USD).limitPrice(bid[0]).tradableAmount(bid[1]).build();
       bidOrders.add(order);
     }
 
@@ -147,8 +148,9 @@ public final class CoinsetterAdapters {
 
   public static LimitOrder adaptLimitOrder(CoinsetterOrder order) {
 
-    return new LimitOrder.Builder(adaptSide(order.getSide()), adaptCurrencyPair(order.getSymbol())).setId(order.getUuid().toString()).setTimestamp(order.getCreateDate()).setLimitPrice(
-        order.getRequestedPrice()).setTradableAmount(order.getOpenQuantity()).build();
+    return new LimitOrder.Builder(adaptSide(order.getSide()), adaptCurrencyPair(order.getSymbol()))
+            .id(order.getUuid().toString()).timestamp(order.getCreateDate()).limitPrice(order.getRequestedPrice())
+            .tradableAmount(order.getOpenQuantity()).build();
   }
 
 }

--- a/xchange-core/src/main/java/com/xeiam/xchange/dto/marketdata/Ticker.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/dto/marketdata/Ticker.java
@@ -103,7 +103,7 @@ public final class Ticker {
    * </ul>
    *  
    */
-  public static class TickerBuilder {
+  public static class Builder {
 
     private CurrencyPair currencyPair;
     private BigDecimal last;
@@ -113,14 +113,6 @@ public final class Ticker {
     private BigDecimal low;
     private BigDecimal volume;
     private Date timestamp;
-
-    /**
-     * @return A new instance of the builder
-     */
-    public static TickerBuilder newInstance() {
-
-      return new TickerBuilder();
-    }
 
     // Prevent repeat builds
     private boolean isBuilt = false;
@@ -143,49 +135,49 @@ public final class Ticker {
       }
     }
 
-    public TickerBuilder withCurrencyPair(CurrencyPair currencyPair) {
+    public Builder currencyPair(CurrencyPair currencyPair) {
 
       this.currencyPair = currencyPair;
       return this;
     }
 
-    public TickerBuilder withLast(BigDecimal last) {
+    public Builder last(BigDecimal last) {
 
       this.last = last;
       return this;
     }
 
-    public TickerBuilder withBid(BigDecimal bid) {
+    public Builder bid(BigDecimal bid) {
 
       this.bid = bid;
       return this;
     }
 
-    public TickerBuilder withAsk(BigDecimal ask) {
+    public Builder ask(BigDecimal ask) {
 
       this.ask = ask;
       return this;
     }
 
-    public TickerBuilder withHigh(BigDecimal high) {
+    public Builder high(BigDecimal high) {
 
       this.high = high;
       return this;
     }
 
-    public TickerBuilder withLow(BigDecimal low) {
+    public Builder low(BigDecimal low) {
 
       this.low = low;
       return this;
     }
 
-    public TickerBuilder withVolume(BigDecimal volume) {
+    public Builder volume(BigDecimal volume) {
 
       this.volume = volume;
       return this;
     }
 
-    public TickerBuilder withTimestamp(Date timestamp) {
+    public Builder timestamp(Date timestamp) {
 
       this.timestamp = timestamp;
       return this;

--- a/xchange-core/src/main/java/com/xeiam/xchange/dto/trade/LimitOrder.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/dto/trade/LimitOrder.java
@@ -36,12 +36,6 @@ public final class LimitOrder extends Order implements Comparable<LimitOrder> {
     this.limitPrice = limitPrice;
   }
 
-  public LimitOrder(Builder builder) {
-
-    super(builder.getOrderType(), builder.getTradableAmount(), builder.getCurrencyPair(), builder.getId(), builder.getTimestamp());
-    this.limitPrice = builder.getLimitPrice();
-  }
-
   /**
    * @return The limit price
    */
@@ -105,67 +99,37 @@ public final class LimitOrder extends Order implements Comparable<LimitOrder> {
       this.limitPrice = null;
     }
 
-    public OrderType getOrderType() {
-
-      return orderType;
-    }
-
-    public Builder setOrderType(OrderType orderType) {
+    public Builder orderType(OrderType orderType) {
 
       this.orderType = orderType;
       return this;
     }
 
-    public BigDecimal getTradableAmount() {
-
-      return tradableAmount;
-    }
-
-    public Builder setTradableAmount(BigDecimal tradableAmount) {
+    public Builder tradableAmount(BigDecimal tradableAmount) {
 
       this.tradableAmount = tradableAmount;
       return this;
     }
 
-    public CurrencyPair getCurrencyPair() {
-
-      return currencyPair;
-    }
-
-    public Builder setCurrencyPair(CurrencyPair currencyPair) {
+    public Builder currencyPair(CurrencyPair currencyPair) {
 
       this.currencyPair = currencyPair;
       return this;
     }
 
-    public String getId() {
-
-      return id;
-    }
-
-    public Builder setId(String id) {
+    public Builder id(String id) {
 
       this.id = id;
       return this;
     }
 
-    public Date getTimestamp() {
-
-      return timestamp;
-    }
-
-    public Builder setTimestamp(Date timestamp) {
+    public Builder timestamp(Date timestamp) {
 
       this.timestamp = timestamp;
       return this;
     }
 
-    public BigDecimal getLimitPrice() {
-
-      return limitPrice;
-    }
-
-    public Builder setLimitPrice(BigDecimal limitPrice) {
+    public Builder limitPrice(BigDecimal limitPrice) {
 
       this.limitPrice = limitPrice;
       return this;
@@ -173,7 +137,7 @@ public final class LimitOrder extends Order implements Comparable<LimitOrder> {
 
     public LimitOrder build() {
 
-      return new LimitOrder(this);
+      return new LimitOrder(orderType, tradableAmount, currencyPair, id, timestamp, limitPrice);
     }
 
   }

--- a/xchange-cryptonit/src/main/java/com/xeiam/xchange/cryptonit/v2/CryptonitAdapters.java
+++ b/xchange-cryptonit/src/main/java/com/xeiam/xchange/cryptonit/v2/CryptonitAdapters.java
@@ -17,7 +17,6 @@ import com.xeiam.xchange.cryptonit.v2.dto.marketdata.CryptonitTicker;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -138,7 +137,7 @@ public final class CryptonitAdapters {
     BigDecimal ask = rate.getAsk();
     BigDecimal volume = cryptonitTicker.getVolume().getVolume(currencyPair.baseSymbol);
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withHigh(high).withLow(low).withBid(bid).withAsk(ask).withVolume(volume).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).high(high).low(low).bid(bid).ask(ask).volume(volume).build();
   }
 
   public static Collection<CurrencyPair> adaptCurrencyPairs(List<List<String>> tradingPairs) {

--- a/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/CryptoTradeAdapters.java
+++ b/xchange-cryptotrade/src/main/java/com/xeiam/xchange/cryptotrade/CryptoTradeAdapters.java
@@ -21,7 +21,6 @@ import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -79,7 +78,7 @@ public final class CryptoTradeAdapters {
     BigDecimal high = cryptoTradeTicker.getHigh();
     BigDecimal volume = cryptoTradeTicker.getVolumeTradeCurrency();
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withAsk(ask).withBid(bid).withLast(last).withLow(low).withHigh(high).withVolume(volume).build();
+    return new Ticker.Builder().currencyPair(currencyPair).ask(ask).bid(bid).last(last).low(low).high(high).volume(volume).build();
   }
 
   public static OrderType adaptOrderType(CryptoTradeOrderType cryptoTradeOrderType) {

--- a/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/CryptsyAdapters.java
+++ b/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/CryptsyAdapters.java
@@ -37,7 +37,6 @@ import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -237,7 +236,7 @@ public final class CryptsyAdapters {
     BigDecimal volume = targetMarket.get24hVolume();
     Date timestamp = new Date();
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withVolume(volume).withTimestamp(timestamp).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).high(high).low(low).volume(volume).timestamp(timestamp).build();
   }
 
   public static List<Ticker> adaptPublicTickers(Map<Integer, CryptsyPublicMarketData> marketsReturnData) {
@@ -270,8 +269,8 @@ public final class CryptsyAdapters {
     BigDecimal volume = publicMarketData.getVolume();
     Date timestamp = new Date();
 
-    return TickerBuilder.newInstance().withCurrencyPair(adaptCurrencyPair(publicMarketData)).withLast(last).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withVolume(volume).withTimestamp(
-        timestamp).build();
+    return new Ticker.Builder().currencyPair(adaptCurrencyPair(publicMarketData)).last(last).bid(bid).ask(ask).high(high).low(low).volume(volume).timestamp(
+            timestamp).build();
   }
 
   /**

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitfinex/trade/BitfinexTradeDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitfinex/trade/BitfinexTradeDemo.java
@@ -23,7 +23,7 @@ public class BitfinexTradeDemo {
   private static void raw(Exchange bfx) throws IOException {
 
     BitfinexTradeServiceRaw tradeService = (BitfinexTradeServiceRaw) bfx.getPollingTradeService();
-    LimitOrder limitOrder = new LimitOrder.Builder(OrderType.BID, CurrencyPair.BTC_USD).setLimitPrice(new BigDecimal("481.69")).setTradableAmount(new BigDecimal("0.001")).build();
+    LimitOrder limitOrder = new LimitOrder.Builder(OrderType.BID, CurrencyPair.BTC_USD).limitPrice(new BigDecimal("481.69")).tradableAmount(new BigDecimal("0.001")).build();
     tradeService.placeBitfinexLimitOrder(limitOrder, BitfinexOrderType.LIMIT, false);
   }
 }

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/bittrex/v1/trade/BittrexTradeDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/bittrex/v1/trade/BittrexTradeDemo.java
@@ -30,7 +30,7 @@ public class BittrexTradeDemo {
   private static void generic(PollingTradeService tradeService) throws IOException {
 
     CurrencyPair pair = new CurrencyPair("ZET", "BTC");
-    LimitOrder limitOrder = new LimitOrder.Builder(OrderType.BID, pair).setLimitPrice(new BigDecimal("0.00001000")).setTradableAmount(new BigDecimal("100")).build();
+    LimitOrder limitOrder = new LimitOrder.Builder(OrderType.BID, pair).limitPrice(new BigDecimal("0.00001000")).tradableAmount(new BigDecimal("100")).build();
 
     try {
       String uuid = tradeService.placeLimitOrder(limitOrder);
@@ -64,7 +64,7 @@ public class BittrexTradeDemo {
   private static void raw(BittrexTradeServiceRaw tradeService) throws IOException {
 
     CurrencyPair pair = new CurrencyPair("ZET", "BTC");
-    LimitOrder limitOrder = new LimitOrder.Builder(OrderType.BID, pair).setLimitPrice(new BigDecimal("0.00001000")).setTradableAmount(new BigDecimal("100")).build();
+    LimitOrder limitOrder = new LimitOrder.Builder(OrderType.BID, pair).limitPrice(new BigDecimal("0.00001000")).tradableAmount(new BigDecimal("100")).build();
 
     try {
       String uuid = tradeService.placeBittrexLimitOrder(limitOrder);

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/poloniex/trade/PoloniexTradeDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/poloniex/trade/PoloniexTradeDemo.java
@@ -55,7 +55,7 @@ public class PoloniexTradeDemo {
     long endTime = startTime + 4 * 60 * 60;
     System.out.println(tradeService.getTradeHistory(currencyPair, startTime, endTime));
 
-    LimitOrder order = new LimitOrder.Builder(OrderType.BID, currencyPair).setTradableAmount(new BigDecimal(".01")).setLimitPrice(xmrBuyRate).build();
+    LimitOrder order = new LimitOrder.Builder(OrderType.BID, currencyPair).tradableAmount(new BigDecimal(".01")).limitPrice(xmrBuyRate).build();
     String orderId = tradeService.placeLimitOrder(order);
     System.out.println("Placed order #" + orderId);
 
@@ -85,7 +85,7 @@ public class PoloniexTradeDemo {
     long endTime = new Date().getTime() / 1000;
     System.out.println(Arrays.asList(tradeService.returnTradeHistory(currencyPair, startTime, endTime)));
 
-    LimitOrder order = new LimitOrder.Builder(OrderType.BID, currencyPair).setTradableAmount(new BigDecimal("1")).setLimitPrice(xmrBuyRate).build();
+    LimitOrder order = new LimitOrder.Builder(OrderType.BID, currencyPair).tradableAmount(new BigDecimal("1")).limitPrice(xmrBuyRate).build();
     String orderId = tradeService.buy(order);
     System.out.println("Placed order #" + orderId);
 

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/HitbtcAdapters.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/HitbtcAdapters.java
@@ -80,7 +80,7 @@ public class HitbtcAdapters {
     BigDecimal volume = hitbtcTicker.getVolume();
     Date timestamp = new Date(hitbtcTicker.getTimetamp());
 
-    return Ticker.TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withVolume(volume).withTimestamp(timestamp).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).high(high).low(low).volume(volume).timestamp(timestamp).build();
   }
 
   public static OrderBook adaptOrderBook(HitbtcOrderBook hitbtcOrderBook, CurrencyPair currencyPair) {

--- a/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/ItBitAdapters.java
+++ b/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/ItBitAdapters.java
@@ -169,6 +169,6 @@ public final class ItBitAdapters {
     BigDecimal volume = itBitTicker.getVolume24h();
     Date timestamp = parseDate(itBitTicker.getTimestamp());
 
-    return Ticker.TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withVolume(volume).withTimestamp(timestamp).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).high(high).low(low).volume(volume).timestamp(timestamp).build();
   }
 }

--- a/xchange-justcoin/src/main/java/com/xeiam/xchange/justcoin/JustcoinAdapters.java
+++ b/xchange-justcoin/src/main/java/com/xeiam/xchange/justcoin/JustcoinAdapters.java
@@ -10,7 +10,6 @@ import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -52,8 +51,8 @@ public final class JustcoinAdapters {
 
     for (final JustcoinTicker justcointTicker : justcoinTickers) {
       if (justcointTicker.getId().equals(JustcoinUtils.getApiMarket(currencyPair.baseSymbol, currencyPair.counterSymbol))) {
-        return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(justcointTicker.getLast()).withBid(justcointTicker.getBid()).withAsk(justcointTicker.getAsk()).withHigh(
-            justcointTicker.getHigh()).withLow(justcointTicker.getLow()).withVolume(justcointTicker.getVolume()).build();
+        return new Ticker.Builder().currencyPair(currencyPair).last(justcointTicker.getLast()).bid(justcointTicker.getBid()).ask(justcointTicker.getAsk()).high(
+                justcointTicker.getHigh()).low(justcointTicker.getLow()).volume(justcointTicker.getVolume()).build();
       }
     }
 

--- a/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/KrakenAdapters.java
+++ b/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/KrakenAdapters.java
@@ -16,7 +16,6 @@ import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -96,14 +95,14 @@ public class KrakenAdapters {
 
   public static Ticker adaptTicker(KrakenTicker krakenTicker, CurrencyPair currencyPair) {
 
-    TickerBuilder builder = new TickerBuilder();
-    builder.withAsk(krakenTicker.getAsk().getPrice());
-    builder.withBid(krakenTicker.getBid().getPrice());
-    builder.withLast(krakenTicker.getClose().getPrice());
-    builder.withHigh(krakenTicker.get24HourHigh());
-    builder.withLow(krakenTicker.get24HourLow());
-    builder.withVolume(krakenTicker.get24HourVolume());
-    builder.withCurrencyPair(currencyPair);
+    Ticker.Builder builder = new Ticker.Builder();
+    builder.ask(krakenTicker.getAsk().getPrice());
+    builder.bid(krakenTicker.getBid().getPrice());
+    builder.last(krakenTicker.getClose().getPrice());
+    builder.high(krakenTicker.get24HourHigh());
+    builder.low(krakenTicker.get24HourLow());
+    builder.volume(krakenTicker.get24HourVolume());
+    builder.currencyPair(currencyPair);
     return builder.build();
   }
 

--- a/xchange-lakebtc/src/main/java/com/xeiam/xchange/lakebtc/LakeBTCAdapters.java
+++ b/xchange-lakebtc/src/main/java/com/xeiam/xchange/lakebtc/LakeBTCAdapters.java
@@ -35,7 +35,7 @@ public class LakeBTCAdapters {
     BigDecimal volume = lakeBTCTicker.getVolume();
     Date timestamp = new Date();
 
-    return Ticker.TickerBuilder.newInstance().withCurrencyPair(currencyPair).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withLast(last).withTimestamp(timestamp).withVolume(volume).build();
+    return new Ticker.Builder().currencyPair(currencyPair).bid(bid).ask(ask).high(high).low(low).last(last).timestamp(timestamp).volume(volume).build();
   }
 
   private static List<LimitOrder> transformArrayToLimitOrders(BigDecimal[][] orders, OrderType orderType, CurrencyPair currencyPair) {

--- a/xchange-mintpal/src/main/java/com/xeiam/xchange/mintpal/MintPalAdapters.java
+++ b/xchange-mintpal/src/main/java/com/xeiam/xchange/mintpal/MintPalAdapters.java
@@ -13,7 +13,6 @@ import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -46,8 +45,8 @@ public class MintPalAdapters {
     MathContext mc = new MathContext(8, RoundingMode.HALF_UP);
     BigDecimal baseVolume = mintPalTicker.getVolume24Hour().divide(mintPalTicker.getLastPrice(), mc);
 
-    return TickerBuilder.newInstance().withCurrencyPair(adaptCurrencyPair(mintPalTicker)).withAsk(mintPalTicker.getTopAsk()).withBid(mintPalTicker.getTopBid()).withHigh(mintPalTicker.getHigh24Hour())
-        .withLow(mintPalTicker.getLow24Hour()).withVolume(baseVolume).withLast(mintPalTicker.getLastPrice()).build();
+    return new Ticker.Builder().currencyPair(adaptCurrencyPair(mintPalTicker)).ask(mintPalTicker.getTopAsk()).bid(mintPalTicker.getTopBid()).high(mintPalTicker.getHigh24Hour())
+        .low(mintPalTicker.getLow24Hour()).volume(baseVolume).last(mintPalTicker.getLastPrice()).build();
   }
 
   public static OrderBook adaptOrderBook(final CurrencyPair currencyPair, final List<MintPalPublicOrders> mintPalOrderBook) {

--- a/xchange-okcoin/src/main/java/com/xeiam/xchange/okcoin/OkCoinAdapters.java
+++ b/xchange-okcoin/src/main/java/com/xeiam/xchange/okcoin/OkCoinAdapters.java
@@ -18,7 +18,6 @@ import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -62,8 +61,8 @@ public final class OkCoinAdapters {
 
   public static Ticker adaptTicker(OkCoinTickerResponse tickerResponse, CurrencyPair currencyPair) {
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withHigh(tickerResponse.getTicker().getHigh()).withLow(tickerResponse.getTicker().getLow()).withBid(
-        tickerResponse.getTicker().getBuy()).withAsk(tickerResponse.getTicker().getSell()).withLast(tickerResponse.getTicker().getLast()).withVolume(tickerResponse.getTicker().getVol()).withTimestamp(new Date()).build();
+    return new Ticker.Builder().currencyPair(currencyPair).high(tickerResponse.getTicker().getHigh()).low(tickerResponse.getTicker().getLow()).bid(
+            tickerResponse.getTicker().getBuy()).ask(tickerResponse.getTicker().getSell()).last(tickerResponse.getTicker().getLast()).volume(tickerResponse.getTicker().getVol()).timestamp(new Date()).build();
   }
 
   public static OrderBook adaptOrderBook(OkCoinDepth depth, CurrencyPair currencyPair) {

--- a/xchange-openexchangerates/src/main/java/com/xeiam/xchange/oer/OERAdapters.java
+++ b/xchange-openexchangerates/src/main/java/com/xeiam/xchange/oer/OERAdapters.java
@@ -5,7 +5,6 @@ import java.util.Date;
 
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 
 /**
  * Various adapters for converting from OER DTOs to XChange DTOs
@@ -23,7 +22,7 @@ public final class OERAdapters {
 
     BigDecimal last = BigDecimal.valueOf(exchangeRate);
     Date timestampDate = new Date(timestamp);
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withTimestamp(timestampDate).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).timestamp(timestampDate).build();
   }
 
 }

--- a/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/PoloniexAdapters.java
+++ b/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/PoloniexAdapters.java
@@ -10,7 +10,6 @@ import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -44,7 +43,7 @@ public class PoloniexAdapters {
 
     Date timestamp = new Date();
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withBid(bid).withAsk(ask).withHigh(high).withLow(low).withVolume(volume).withTimestamp(timestamp).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).high(high).low(low).volume(volume).timestamp(timestamp).build();
 
   }
 
@@ -68,7 +67,7 @@ public class PoloniexAdapters {
 
     for (PoloniexLevel level : levels) {
 
-      LimitOrder limitOrder = new LimitOrder.Builder(orderType, currencyPair).setTradableAmount(level.getAmount()).setLimitPrice(level.getLimit()).build();
+      LimitOrder limitOrder = new LimitOrder.Builder(orderType, currencyPair).tradableAmount(level.getAmount()).limitPrice(level.getLimit()).build();
       orders.add(limitOrder);
     }
     return orders;
@@ -131,7 +130,7 @@ public class PoloniexAdapters {
     OrderType type = openOrder.getType().equals("buy") ? OrderType.BID : OrderType.ASK;
     Date timestamp = PoloniexUtils.stringToDate(openOrder.getDate());
     LimitOrder limitOrder =
-        new LimitOrder.Builder(type, currencyPair).setLimitPrice(openOrder.getRate()).setTradableAmount(openOrder.getAmount()).setId(openOrder.getOrderNumber()).setTimestamp(timestamp).build();
+        new LimitOrder.Builder(type, currencyPair).limitPrice(openOrder.getRate()).tradableAmount(openOrder.getAmount()).id(openOrder.getOrderNumber()).timestamp(timestamp).build();
 
     return limitOrder;
   }

--- a/xchange-vaultofsatoshi/src/main/java/com/xeiam/xchange/vaultofsatoshi/VaultOfSatoshiAdapters.java
+++ b/xchange-vaultofsatoshi/src/main/java/com/xeiam/xchange/vaultofsatoshi/VaultOfSatoshiAdapters.java
@@ -11,7 +11,6 @@ import com.xeiam.xchange.dto.Order;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.dto.marketdata.Ticker;
-import com.xeiam.xchange.dto.marketdata.Ticker.TickerBuilder;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
@@ -123,7 +122,7 @@ public final class VaultOfSatoshiAdapters {
     BigDecimal low = vosTicker.getLow();
     BigDecimal volume = vosTicker.getVolume();
 
-    return TickerBuilder.newInstance().withCurrencyPair(currencyPair).withLast(last).withHigh(high).withLow(low).withVolume(volume).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).high(high).low(low).volume(volume).build();
   }
 
   public static LimitOrder createOrder(CurrencyPair currencyPair, List<BigDecimal> priceAndAmount, Order.OrderType orderType) {


### PR DESCRIPTION
Resolve #708 
Normalize Ticker and LimitOrder builders: name methods after Effective Java Builder;
 TickerBuilder: rename to Builder, remove newInstance();
 LimitOrder.Builder: create object using the standard constructor
