### PR TITLE
Fixed bug in BTCChinaAdapters.adaptOrderType()

### DIFF
--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChinaAdapters.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChinaAdapters.java
@@ -409,7 +409,7 @@ public final class BTCChinaAdapters {
 
   public static OrderType adaptOrderType(String type) {
 
-    return type.equals("buy") ? OrderType.BID : OrderType.ASK;
+    return type.equals("bid") ? OrderType.BID : OrderType.ASK;
   }
 
   public static BTCChinaOrderStatus adaptOrderStatus(String status) {


### PR DESCRIPTION
"buy" is not the server response.  It should be "bid".  Otherwise this method always returns OrderType.ASK
