### PR TITLE
Unmatched Cryptsy pair

### DIFF
--- a/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/CryptsyCurrencyUtils.java
+++ b/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/CryptsyCurrencyUtils.java
@@ -531,6 +531,6 @@ public final class CryptsyCurrencyUtils {
 
     CurrencyPair currencyPairs = marketIds_CurrencyPairs.get(marketId);
 
-    return (currencyPairs == null ? new CurrencyPair("UNKNOWN_UNKNOWN") : currencyPairs);
+    return (currencyPairs == null ? new CurrencyPair("null", "null") : currencyPairs);
   }
 }


### PR DESCRIPTION
Changed from
UNKNOWN_UNKNOWN/USD
to
null/null

More accurately represents the unmatched currency pair
