### PR TITLE
Add new Coinfloor currencies.

### DIFF
--- a/xchange-coinfloor/src/main/java/com/xeiam/xchange/coinfloor/CoinfloorUtils.java
+++ b/xchange-coinfloor/src/main/java/com/xeiam/xchange/coinfloor/CoinfloorUtils.java
@@ -27,7 +27,7 @@ import com.xeiam.xchange.ExchangeException;
 public class CoinfloorUtils {
 
   public enum CoinfloorCurrency {
-    BTC, GBP
+    BTC, GBP, EUR, USD, PLN
   }
 
   private static final ECNamedCurveParameterSpec spec = ECNamedCurveTable.getParameterSpec("secp224k1");
@@ -119,8 +119,14 @@ public class CoinfloorUtils {
       return null;
     case 63488:
       return CoinfloorCurrency.BTC;
+    case 64000:
+      return CoinfloorCurrency.EUR;
     case 64032:
       return CoinfloorCurrency.GBP;
+    case 64128:
+      return CoinfloorCurrency.USD;
+    case 64936:
+      return CoinfloorCurrency.PLN;
     }
 
     throw new ExchangeException("Currency Code " + currencyCode + " not supported by coinfloor!");
@@ -136,8 +142,14 @@ public class CoinfloorUtils {
     switch (currency) {
     case BTC:
       return 63488;
+    case EUR:
+      return 64000;
     case GBP:
       return 64032;
+    case USD:
+      return 64128;
+    case PLN:
+      return 64936;
     }
 
     throw new ExchangeException("Currency " + currency + " not supported by coinfloor!");
@@ -149,6 +161,9 @@ public class CoinfloorUtils {
     case BTC:
       return 4;
     case GBP:
+    case EUR:
+    case USD:
+    case PLN:
       return 2;
     }
 

--- a/xchange-coinfloor/src/test/java/com/xeiam/xchange/coinfloor/TestCoinfloorUtils.java
+++ b/xchange-coinfloor/src/test/java/com/xeiam/xchange/coinfloor/TestCoinfloorUtils.java
@@ -41,13 +41,24 @@ public class TestCoinfloorUtils {
   public void verifyCurrencyUtils() {
 
     Assert.assertEquals(CoinfloorCurrency.BTC, CoinfloorUtils.getCurrency(63488));
+    Assert.assertEquals(CoinfloorCurrency.EUR, CoinfloorUtils.getCurrency(64000));
     Assert.assertEquals(CoinfloorCurrency.GBP, CoinfloorUtils.getCurrency(64032));
+    Assert.assertEquals(CoinfloorCurrency.USD, CoinfloorUtils.getCurrency(64128));
+    Assert.assertEquals(CoinfloorCurrency.PLN, CoinfloorUtils.getCurrency(64936));
+
     Assert.assertEquals(63488, CoinfloorUtils.toCurrencyCode(CoinfloorCurrency.BTC));
+    Assert.assertEquals(64000, CoinfloorUtils.toCurrencyCode(CoinfloorCurrency.EUR));
     Assert.assertEquals(64032, CoinfloorUtils.toCurrencyCode(CoinfloorCurrency.GBP));
-    Assert.assertEquals(63488, CoinfloorUtils.toCurrencyCode(CoinfloorUtils.getCurrency(63488)));
-    Assert.assertEquals(64032, CoinfloorUtils.toCurrencyCode(CoinfloorUtils.getCurrency(64032)));
-    Assert.assertEquals(CoinfloorCurrency.BTC, CoinfloorUtils.getCurrency(CoinfloorUtils.toCurrencyCode(CoinfloorCurrency.BTC)));
-    Assert.assertEquals(CoinfloorCurrency.GBP, CoinfloorUtils.getCurrency(CoinfloorUtils.toCurrencyCode(CoinfloorCurrency.GBP)));
+    Assert.assertEquals(64128, CoinfloorUtils.toCurrencyCode(CoinfloorCurrency.USD));
+    Assert.assertEquals(64936, CoinfloorUtils.toCurrencyCode(CoinfloorCurrency.PLN));
+
+    for (int n : new int[] { 63488, 64000, 64032, 64128, 64936 }) {
+      Assert.assertEquals(n, CoinfloorUtils.toCurrencyCode(CoinfloorUtils.getCurrency(n)));
+    }
+
+    for (CoinfloorCurrency c : CoinfloorCurrency.values()) {
+      Assert.assertEquals(c, CoinfloorUtils.getCurrency(CoinfloorUtils.toCurrencyCode(c)));
+    }
   }
 
   @Test
@@ -55,9 +66,11 @@ public class TestCoinfloorUtils {
 
     Assert.assertEquals(BigDecimal.valueOf(10000, 4), CoinfloorUtils.scaleToBigDecimal(CoinfloorCurrency.BTC, 10000));
     Assert.assertEquals(BigDecimal.valueOf(100, 2), CoinfloorUtils.scaleToBigDecimal(CoinfloorCurrency.GBP, 100));
+    Assert.assertEquals(BigDecimal.valueOf(10, 2), CoinfloorUtils.scaleToBigDecimal(CoinfloorCurrency.PLN, 10));
     Assert.assertEquals(BigDecimal.valueOf(100, 2), CoinfloorUtils.scalePriceToBigDecimal(CoinfloorCurrency.BTC, CoinfloorCurrency.GBP, 100));
     Assert.assertEquals(10000, CoinfloorUtils.scaleToInt(CoinfloorCurrency.BTC, BigDecimal.valueOf(1)));
     Assert.assertEquals(100, CoinfloorUtils.scaleToInt(CoinfloorCurrency.GBP, BigDecimal.valueOf(1)));
+    Assert.assertEquals(100, CoinfloorUtils.scaleToInt(CoinfloorCurrency.EUR, BigDecimal.valueOf(1)));
     Assert.assertEquals(100, CoinfloorUtils.scalePriceToInt(CoinfloorCurrency.BTC, CoinfloorCurrency.GBP, BigDecimal.valueOf(1)));
   }
 


### PR DESCRIPTION
Coinfloor now supports EUR, USD and PLN. The support
is broken until these are added as it fails to parse
JSON responses referring to the new currencies.

Issue 735.
