### PR TITLE
OkCoin: Fix parameter renaming for market orders

### DIFF
--- a/xchange-okcoin/src/main/java/com/xeiam/xchange/okcoin/OkCoinDigest.java
+++ b/xchange-okcoin/src/main/java/com/xeiam/xchange/okcoin/OkCoinDigest.java
@@ -71,7 +71,7 @@ public class OkCoinDigest implements ParamsDigest {
         nameValueMap.remove("amount");
       }
       else if (nameValueMap.get("type").equals("sell_market")) {
-        nameValueMap.remove("rate");
+        nameValueMap.remove("price");
       }
     }
     final List<Map.Entry<String, String>> nameValueList = new ArrayList<Map.Entry<String, String>>(nameValueMap.entrySet());


### PR DESCRIPTION
Market sell order failed after OkCoin renamed `rate` field to `price`.
