### PR TITLE
Support for streaming full order book from Bitstamp

### DIFF
--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/streaming/BitstampPusherService.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/streaming/BitstampPusherService.java
@@ -82,6 +82,9 @@ public class BitstampPusherService extends BitstampBasePollingService implements
       if (name.equals("order_book")) {
         bindOrderData(instance);
       }
+      else if (name.equals("diff_order_book")) {
+    	bindDiffOrderData(instance);
+      }
       else if (name.equals("live_trades")) {
         bindTradeData(instance);
       }
@@ -173,6 +176,28 @@ public class BitstampPusherService extends BitstampBasePollingService implements
     };
     chan.bind("data", listener);
   }
+  
+  private void bindDiffOrderData(Channel chan) {
+
+	    SubscriptionEventListener listener = new SubscriptionEventListener() {
+
+	      @Override
+	      public void onEvent(String channelName, String eventName, String data) {
+
+	        ExchangeEvent xevt = null;
+	        try {
+	          OrderBook delta = parseOrderBook(data);
+	          xevt = new DefaultExchangeEvent(ExchangeEventType.DEPTH, data, delta);
+	        } catch (IOException e) {
+	          log.error("JSON stream error", e);
+	        }
+	        if (xevt != null) {
+	          addToEventQueue(xevt);
+	        }
+	      }
+	    };
+	    chan.bind("data", listener);
+	  }
 
   private OrderBook parseOrderBook(String rawJson) throws IOException {
 

--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/streaming/BitstampStreamingConfiguration.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/streaming/BitstampStreamingConfiguration.java
@@ -55,6 +55,7 @@ public class BitstampStreamingConfiguration implements ExchangeStreamingConfigur
     channels = new HashSet<String>();
     channels.add("live_trades");
     channels.add("order_book");
+    channels.add("diff_order_book");
     pusherOpts = new PusherOptions();
     pusherOpts.setEncrypted(isEncryptedChannel);
     pusherOpts.setActivityTimeout(4 * timeoutInMs); // Keep-alive interval


### PR DESCRIPTION
First commit only fixes Issue #766. Second commit also adds support for "LIVE FULL ORDER BOOK" (https://www.bitstamp.net/websocket/). But it adds these order book deltas (which are just a OrderBook) as DEPTH events to the event queue.
