### PR TITLE
ItBit: balance should contain open orders as well

### DIFF
--- a/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/ItBitAdapters.java
+++ b/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/ItBitAdapters.java
@@ -114,7 +114,7 @@ public final class ItBitAdapters {
       for (int j = 0; j < balances.length; j++) {
         ItBitAccountBalance itBitAccountBalance = balances[j];
 
-        Wallet wallet = new Wallet(itBitAccountBalance.getCurrency(), itBitAccountBalance.getAvailableBalance(), itBitAccountInfoReturn.getName());
+        Wallet wallet = new Wallet(itBitAccountBalance.getCurrency(), itBitAccountBalance.getTotalBalance(), itBitAccountInfoReturn.getName());
         wallets.add(wallet);
       }
     }


### PR DESCRIPTION
To make it more uniform with other implementation, itBit wallet should return the total balance including open orders.
