### PR TITLE
Poloniex trade history fee amount fix

### DIFF
--- a/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/PoloniexAdapters.java
+++ b/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/PoloniexAdapters.java
@@ -144,7 +144,10 @@ public class PoloniexAdapters {
     Date date = PoloniexUtils.stringToDate(userTrade.getDate());
     String tradeId = String.valueOf(userTrade.getTradeID());
     String orderId = String.valueOf(userTrade.getOrderNumber());
+    
+    // Poloniex returns fee as a multiplier, e.g. a 0.2% fee is 0.002
+    BigDecimal feeAmount = amount.multiply(price).multiply(userTrade.getFee());
 
-    return new UserTrade(orderType, amount, currencyPair, price, date, tradeId, orderId, userTrade.getFee(), currencyPair.counterSymbol);
+    return new UserTrade(orderType, amount, currencyPair, price, date, tradeId, orderId, feeAmount, currencyPair.counterSymbol);
   }
 }


### PR DESCRIPTION
Exchange returns fee information as a multiplier (currently 0.002 for a 0.2% fee) not the absolute charged amount.
