### PR TITLE
Btcchina Streaming: fix trade sign

### DIFF
--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChinaAdapters.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/BTCChinaAdapters.java
@@ -411,7 +411,7 @@ public final class BTCChinaAdapters {
 
   public static OrderType adaptOrderType(String type) {
 
-    return type.equals("bid") ? OrderType.BID : OrderType.ASK;
+    return type.equals("buy") ? OrderType.BID : OrderType.ASK;
   }
 
   public static BTCChinaOrderStatus adaptOrderStatus(String status) {


### PR DESCRIPTION
The trade sign was wrong in the streaming adapter of Btcchina, resulting in every Trade being a "sell".

Only affects the streaming implementation
