### PR TITLE
[GDAX] Adds before param to getFills

### DIFF
--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/GDAX.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/GDAX.java
@@ -149,6 +149,20 @@ public interface GDAX {
       @HeaderParam("CB-ACCESS-PASSPHRASE") String passphrase)
       throws GDAXException, IOException;
 
+    /**
+     *
+     * @param apiKey
+     * @param signer
+     * @param nonce
+     * @param passphrase
+     * @param tradeIdAfter Return trades before this tradeId.
+     * @param tradeIdBefore Return trades after this tradeId.
+     * @param orderId
+     * @param productId
+     * @return
+     * @throws GDAXException
+     * @throws IOException
+     */
   @GET
   @Path("fills")
   GDAXFill[] getFills(
@@ -156,7 +170,8 @@ public interface GDAX {
       @HeaderParam("CB-ACCESS-SIGN") ParamsDigest signer,
       @HeaderParam("CB-ACCESS-TIMESTAMP") SynchronizedValueFactory<Long> nonce,
       @HeaderParam("CB-ACCESS-PASSPHRASE") String passphrase,
-      @QueryParam("after") Integer startingOrderId,
+      @QueryParam("after") Integer tradeIdAfter,
+      @QueryParam("before") Integer tradeIdBefore,
       @QueryParam("order_id") String orderId,
       @QueryParam("product_id") String productId)
       throws GDAXException, IOException;

--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXTradeServiceRaw.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXTradeServiceRaw.java
@@ -42,7 +42,8 @@ public class GDAXTradeServiceRaw extends GDAXBaseService {
 
     String orderId = null;
     String productId = null;
-    Integer startingOrderId = null;
+    Integer afterTradeId = null;
+    Integer beforeTradeId = null;
 
     if (tradeHistoryParams instanceof GdaxTradeHistoryParams) {
       GdaxTradeHistoryParams historyParams = (GdaxTradeHistoryParams) tradeHistoryParams;
@@ -51,7 +52,8 @@ public class GDAXTradeServiceRaw extends GDAXBaseService {
       if (currencyPair != null) {
         productId = GDAXAdapters.adaptProductID(currencyPair);
       }
-      startingOrderId = historyParams.paginationOrderId;
+      afterTradeId = historyParams.afterTradeId;
+      beforeTradeId = historyParams.beforeTradeId;
     } else if (tradeHistoryParams instanceof TradeHistoryParamTransactionId) {
       TradeHistoryParamTransactionId tnxIdParams =
           (TradeHistoryParamTransactionId) tradeHistoryParams;
@@ -66,7 +68,7 @@ public class GDAXTradeServiceRaw extends GDAXBaseService {
     }
     try {
       return gdax.getFills(
-          apiKey, digest, nonceFactory, passphrase, startingOrderId, orderId, productId);
+          apiKey, digest, nonceFactory, passphrase, afterTradeId, beforeTradeId, orderId, productId);
     } catch (GDAXException e) {
       throw handleError(e);
     }
@@ -124,17 +126,26 @@ public class GDAXTradeServiceRaw extends GDAXBaseService {
 
     private CurrencyPair currencyPair;
     private String txId;
-    private Integer paginationOrderId;
+    private Integer afterTradeId;
+    private Integer beforeTradeId;
 
-    public Integer getPaginationOrderId() {
-      return paginationOrderId;
+    public Integer getAfterTradeId() {
+      return afterTradeId;
     }
 
-    public void setPaginationOrderId(Integer startingOrderId) {
-      this.paginationOrderId = startingOrderId;
+    public void setAfterTradeId(Integer startingOrderId) {
+      this.afterTradeId = startingOrderId;
     }
 
-    @Override
+      public Integer getBeforeTradeId() {
+          return beforeTradeId;
+      }
+
+      public void setBeforeTradeId(Integer beforeTradeId) {
+          this.beforeTradeId = beforeTradeId;
+      }
+
+      @Override
     public CurrencyPair getCurrencyPair() {
       return currencyPair;
     }


### PR DESCRIPTION
Also renamed the after parameter. The current name
actually incorrectly explains the behaviour. The names
that GDAX assigns to them are also confusing:
* before - returns trades after this trade ID
* after - returns trade before this trade ID

However, consistency with the API seemed the best way to go.