### PR TITLE
Update HITBTC placeOrder functionality

### DIFF
--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/HitbtcAuthenticated.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/HitbtcAuthenticated.java
@@ -21,6 +21,8 @@ import org.knowm.xchange.hitbtc.v2.dto.HitbtcInternalTransferResponse;
 import org.knowm.xchange.hitbtc.v2.dto.HitbtcOrder;
 import org.knowm.xchange.hitbtc.v2.dto.HitbtcOwnTrade;
 import org.knowm.xchange.hitbtc.v2.dto.HitbtcTransaction;
+import org.knowm.xchange.hitbtc.v2.service.HitbtcOrderType;
+import org.knowm.xchange.hitbtc.v2.service.HitbtcTimeInForce;
 import si.mazi.rescu.HttpStatusIOException;
 
 /** Version 2 of HitBtc API. See https://api.hitbtc.com/api/2/explore/ */
@@ -82,8 +84,8 @@ public interface HitbtcAuthenticated extends Hitbtc {
       @FormParam("side") String side,
       @FormParam("price") BigDecimal price,
       @FormParam("quantity") BigDecimal quantity,
-      @FormParam("type") String type,
-      @FormParam("timeInForce") String timeInForce)
+      @FormParam("type") HitbtcOrderType type,
+      @FormParam("timeInForce") HitbtcTimeInForce timeInForce)
       throws IOException, HitbtcException;
 
   @PATCH
@@ -144,7 +146,7 @@ public interface HitbtcAuthenticated extends Hitbtc {
    * @param clientOrderId client order id
    * @return list of orders
    * @throws IOException throw in case IO problems
-   * @throws HitbtcException  throw in case internal HITBTC problems
+   * @throws HitbtcException throw in case internal HITBTC problems
    */
   @GET
   @Path("history/order")

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcOrderType.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcOrderType.java
@@ -1,0 +1,19 @@
+package org.knowm.xchange.hitbtc.v2.service;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum HitbtcOrderType {
+  limit,
+  market,
+  stopLimit,
+  stopMarket;
+
+  @JsonCreator
+  public static HitbtcOrderType getOrderType(String s) {
+    try {
+      return HitbtcOrderType.valueOf(s);
+    } catch (Exception e) {
+      throw new RuntimeException("Unknown order type " + s + ".");
+    }
+  }
+}

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcTimeInForce.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcTimeInForce.java
@@ -1,0 +1,18 @@
+package org.knowm.xchange.hitbtc.v2.service;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum HitbtcTimeInForce {
+  GTC,
+  FOK,
+  IOC;
+
+  @JsonCreator
+  public static HitbtcTimeInForce getTimeInForce(String s) {
+    try {
+      return HitbtcTimeInForce.valueOf(s);
+    } catch (Exception e) {
+      throw new RuntimeException("Unknown ordtime in force " + s + ".");
+    }
+  }
+}

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcTradeService.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcTradeService.java
@@ -10,9 +10,7 @@ import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
-import org.knowm.xchange.dto.trade.StopOrder;
 import org.knowm.xchange.dto.trade.UserTrades;
-import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.hitbtc.v2.HitbtcAdapters;
 import org.knowm.xchange.hitbtc.v2.dto.HitbtcOrder;
 import org.knowm.xchange.hitbtc.v2.dto.HitbtcOwnTrade;
@@ -119,5 +117,4 @@ public class HitbtcTradeService extends HitbtcTradeServiceRaw implements TradeSe
 
     return orders;
   }
-
 }

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcTradeServiceRaw.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcTradeServiceRaw.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
@@ -33,22 +34,26 @@ public class HitbtcTradeServiceRaw extends HitbtcBaseService {
             + marketOrder.getCurrencyPair().counter.getCurrencyCode();
     String side = HitbtcAdapters.getSide(marketOrder.getType()).toString();
 
-    return hitbtc.postHitbtcNewOrder(
-        null, symbol, side, null, marketOrder.getOriginalAmount(), "market", "IOC");
+    String clientOrderId = StringUtils.isBlank(marketOrder.getId()) ? null : marketOrder.getId();
+    return hitbtc.postHitbtcNewOrder(clientOrderId, symbol, side, null, marketOrder.getOriginalAmount(), HitbtcOrderType.market, HitbtcTimeInForce.IOC);
   }
 
-  public HitbtcOrder placeLimitOrderRaw(LimitOrder limitOrder) throws IOException {
-
+  public HitbtcOrder placeLimitOrderRaw(LimitOrder limitOrder, HitbtcTimeInForce timeInForce) throws IOException {
     String symbol = HitbtcAdapters.adaptCurrencyPair(limitOrder.getCurrencyPair());
     String side = HitbtcAdapters.getSide(limitOrder.getType()).toString();
+    String clientOrderId = StringUtils.isBlank(limitOrder.getId()) ? null : limitOrder.getId();
     return hitbtc.postHitbtcNewOrder(
-        null,
+        clientOrderId,
         symbol,
         side,
         limitOrder.getLimitPrice(),
         limitOrder.getOriginalAmount(),
-        "limit",
-        "GTC");
+        HitbtcOrderType.limit,
+        timeInForce);
+  }
+
+  public HitbtcOrder placeLimitOrderRaw(LimitOrder limitOrder) throws IOException {
+    return placeLimitOrderRaw(limitOrder, HitbtcTimeInForce.GTC);
   }
 
   public HitbtcOrder updateMarketOrderRaw(


### PR DESCRIPTION
1. clientOrderId now supported
2. custom Time-in-force now supported for limit orders
3. Order type and Time-in-force now placed in the separate enum