### PR TITLE
[bitstamp] bug fix of null open ticker values

### DIFF
--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAdapters.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAdapters.java
@@ -164,6 +164,7 @@ public final class BitstampAdapters {
    */
   public static Ticker adaptTicker(BitstampTicker bitstampTicker, CurrencyPair currencyPair) {
 
+    BigDecimal open = bitstampTicker.getOpen();
     BigDecimal last = bitstampTicker.getLast();
     BigDecimal bid = bitstampTicker.getBid();
     BigDecimal ask = bitstampTicker.getAsk();
@@ -175,6 +176,7 @@ public final class BitstampAdapters {
 
     return new Ticker.Builder()
         .currencyPair(currencyPair)
+        .open(open)
         .last(last)
         .bid(bid)
         .ask(ask)

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/marketdata/BitstampTicker.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/marketdata/BitstampTicker.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 /** @author Matija Mazi */
 public final class BitstampTicker {
 
+  private final BigDecimal open;
   private final BigDecimal last;
   private final BigDecimal high;
   private final BigDecimal low;
@@ -18,6 +19,7 @@ public final class BitstampTicker {
   /**
    * Constructor
    *
+   * @param open
    * @param last
    * @param high
    * @param low
@@ -27,6 +29,7 @@ public final class BitstampTicker {
    * @param ask
    */
   public BitstampTicker(
+      @JsonProperty("open") BigDecimal open,
       @JsonProperty("last") BigDecimal last,
       @JsonProperty("high") BigDecimal high,
       @JsonProperty("low") BigDecimal low,
@@ -36,6 +39,7 @@ public final class BitstampTicker {
       @JsonProperty("ask") BigDecimal ask,
       @JsonProperty("timestamp") long timestamp) {
 
+    this.open = open;
     this.last = last;
     this.high = high;
     this.low = low;
@@ -44,6 +48,10 @@ public final class BitstampTicker {
     this.bid = bid;
     this.ask = ask;
     this.timestamp = timestamp;
+  }
+
+  public BigDecimal getOpen() {
+    return open;
   }
 
   public BigDecimal getLast() {
@@ -89,7 +97,9 @@ public final class BitstampTicker {
   @Override
   public String toString() {
 
-    return "BitstampTicker [last="
+    return "BitstampTicker [open="
+        + open
+        + ", last="
         + last
         + ", high="
         + high


### PR DESCRIPTION
The Bitstamp Ticker, both generic and raw, were not returning the `open` price. This patch adds open into the Bitstamp dto and adapter.

Previous ticker output:
```
Ticker [currencyPair=BTC/USD, open=null, last=9270.00, bid=9270.00, ask=9271.30, high=9328.09, low=8974.62,avg=9145.57, volume=11788.29697217, quoteVolume=null, timestamp=1525877122000, bidSize=null, askSize=null]
BitstampTicker [last=9270.00, high=9328.09, low=8974.62, vwap=9145.57, volume=11788.29697217, bid=9270.00, ask=9271.30, timestamp=1525877122]
```

Updated ticker output:
```
Ticker [currencyPair=BTC/USD, open=9181.52, last=9276.56, bid=9276.57, ask=9279.00, high=9328.09, low=8974.62,avg=9145.61, volume=11782.53647669, quoteVolume=null, timestamp=1525877215000, bidSize=null, askSize=null]
BitstampTicker [open=9181.52, last=9276.56, high=9328.09, low=8974.62, vwap=9145.61, volume=11782.53647669, bid=9276.57, ask=9279.00, timestamp=1525877215]
```