### PR TITLE
Fix for GDAX broken market orders.

### DIFF
--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/GDAXAdapters.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/GDAXAdapters.java
@@ -406,8 +406,7 @@ public class GDAXAdapters {
         .productId(adaptProductID(marketOrder.getCurrencyPair()))
         .type(GDAXPlaceOrder.Type.market)
         .side(adaptSide(marketOrder.getType()))
-        .size(marketOrder.getType().equals(OrderType.BID) ? null : marketOrder.getOriginalAmount())
-        .funds(marketOrder.getType().equals(OrderType.ASK) ? null : marketOrder.getOriginalAmount())
+        .size(marketOrder.getOriginalAmount())
         .build();
   }
 
@@ -429,8 +428,7 @@ public class GDAXAdapters {
           .productId(adaptProductID(stopOrder.getCurrencyPair()))
           .type(GDAXPlaceOrder.Type.market)
           .side(adaptSide(stopOrder.getType()))
-          .size(stopOrder.getType().equals(OrderType.BID) ? null : stopOrder.getOriginalAmount())
-          .funds(stopOrder.getType().equals(OrderType.ASK) ? null : stopOrder.getOriginalAmount())
+          .size(stopOrder.getOriginalAmount())
           .stop(adaptStop(stopOrder.getType()))
           .stopPrice(stopOrder.getStopPrice())
           .build();


### PR DESCRIPTION
This fix is for everyone that is using GDAX and placing market orders. It was broken by this commit...

https://github.com/knowm/XChange/commit/54c53fd6e0d5f52b93562f82bcc408e4c2b26ae1#commitcomment-28933480

The problem is that the XChange interface doesn't specify "fund size" market orders. It specifically provides "order size" market orders. The above commit makes GDAX different than all of the rest of the exchanges. 