### PR TITLE
[Poloniex] implement market order

### DIFF
--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/GDAXAdapters.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/GDAXAdapters.java
@@ -406,8 +406,7 @@ public class GDAXAdapters {
         .productId(adaptProductID(marketOrder.getCurrencyPair()))
         .type(GDAXPlaceOrder.Type.market)
         .side(adaptSide(marketOrder.getType()))
-        .size(marketOrder.getType().equals(OrderType.BID) ? null : marketOrder.getOriginalAmount())
-        .funds(marketOrder.getType().equals(OrderType.ASK) ? null : marketOrder.getOriginalAmount())
+        .size(marketOrder.getOriginalAmount())
         .build();
   }
 
@@ -429,8 +428,7 @@ public class GDAXAdapters {
           .productId(adaptProductID(stopOrder.getCurrencyPair()))
           .type(GDAXPlaceOrder.Type.market)
           .side(adaptSide(stopOrder.getType()))
-          .size(stopOrder.getType().equals(OrderType.BID) ? null : stopOrder.getOriginalAmount())
-          .funds(stopOrder.getType().equals(OrderType.ASK) ? null : stopOrder.getOriginalAmount())
+          .size(stopOrder.getOriginalAmount())
           .stop(adaptStop(stopOrder.getType()))
           .stopPrice(stopOrder.getStopPrice())
           .build();

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexExchange.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexExchange.java
@@ -23,7 +23,7 @@ public class PoloniexExchange extends BaseExchange implements Exchange {
   protected void initServices() {
     this.marketDataService = new PoloniexMarketDataService(this);
     this.accountService = new PoloniexAccountService(this);
-    this.tradeService = new PoloniexTradeService(this);
+    this.tradeService = new PoloniexTradeService(this,(PoloniexMarketDataService) marketDataService);
   }
 
   @Override


### PR DESCRIPTION
Poloniex does not support market orders directly, but will instantly fill limit orders with very low or high prices. So this is implementation has  the same effect as a market order. Poloniex has maximums for each 'rate' (limit price) but does not provide them. So this method must find the current market price and make the limit order guaranteed to be filled instantly. 