### PR TITLE
[cryptopia] Set HistoryParamsFundingType, TradeHistoryParamLimit interfaces to CryptopiaFundingHistoryParams

### DIFF
--- a/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/service/CryptopiaAccountService.java
+++ b/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/service/CryptopiaAccountService.java
@@ -10,14 +10,19 @@ import org.knowm.xchange.dto.account.Balance;
 import org.knowm.xchange.dto.account.FundingRecord;
 import org.knowm.xchange.dto.account.Wallet;
 import org.knowm.xchange.service.account.AccountService;
-import org.knowm.xchange.service.trade.params.DefaultWithdrawFundsParams;
-import org.knowm.xchange.service.trade.params.TradeHistoryParams;
-import org.knowm.xchange.service.trade.params.WithdrawFundsParams;
+import org.knowm.xchange.service.trade.params.*;
 
 public class CryptopiaAccountService extends CryptopiaAccountServiceRaw implements AccountService {
   public CryptopiaAccountService(CryptopiaExchange exchange) {
     super(exchange);
   }
+
+  public enum CryptopiaType {
+    Deposit,
+    Withdraw
+  }
+
+  private static Integer MAX_FUNDING_RESULTS = 100;
 
   @Override
   public AccountInfo getAccountInfo() throws IOException {
@@ -53,34 +58,60 @@ public class CryptopiaAccountService extends CryptopiaAccountServiceRaw implemen
 
   @Override
   public TradeHistoryParams createFundingHistoryParams() {
-    return new CryptopiaFundingHistoryParams(CryptopiaFundingHistoryParams.Type.Deposit, 100);
+    return new CryptopiaFundingHistoryParams(null, 100);
   }
 
   @Override
   public List<FundingRecord> getFundingHistory(TradeHistoryParams params) throws IOException {
-    if (params instanceof CryptopiaFundingHistoryParams) {
-      CryptopiaFundingHistoryParams cryptopiaFundingHistoryParams =
-          (CryptopiaFundingHistoryParams) params;
 
-      return getTransactions(
-          cryptopiaFundingHistoryParams.type.name(), cryptopiaFundingHistoryParams.count);
-    } else {
-      return getTransactions(CryptopiaFundingHistoryParams.Type.Deposit.name(), 100);
+    String cryptopiaType = "";
+    Integer limit = MAX_FUNDING_RESULTS;
+
+    if (params instanceof HistoryParamsFundingType) {
+      final FundingRecord.Type type = ((HistoryParamsFundingType) params).getType();
+      cryptopiaType =
+          type == FundingRecord.Type.DEPOSIT
+              ? CryptopiaType.Deposit.name()
+              : type == FundingRecord.Type.WITHDRAWAL ? CryptopiaType.Withdraw.name() : null;
     }
+
+    if (params instanceof TradeHistoryParamLimit) {
+      limit = ((TradeHistoryParamLimit) params).getLimit();
+    }
+
+    return getTransactions(cryptopiaType, limit);
   }
 
-  public static class CryptopiaFundingHistoryParams implements TradeHistoryParams {
-    public final Type type;
-    public final Integer count;
+  public static class CryptopiaFundingHistoryParams
+      implements TradeHistoryParams, HistoryParamsFundingType, TradeHistoryParamLimit {
 
-    public CryptopiaFundingHistoryParams(Type type, Integer count) {
+    public FundingRecord.Type type;
+
+    private Integer limit;
+
+    public CryptopiaFundingHistoryParams(FundingRecord.Type type, Integer limit) {
       this.type = type;
-      this.count = count;
+      this.limit = limit;
     }
 
-    public enum Type {
-      Deposit,
-      Withdraw
+    @Override
+    public FundingRecord.Type getType() {
+      return type;
+    }
+
+    @Override
+    public void setType(FundingRecord.Type type) {
+      this.type = type;
+    }
+
+    @Override
+    public Integer getLimit() {
+      return limit;
+    }
+
+    @Override
+    public void setLimit(Integer limit) {
+      this.limit = limit;
     }
   }
 }

--- a/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/service/CryptopiaAccountService.java
+++ b/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/service/CryptopiaAccountService.java
@@ -1,8 +1,5 @@
 package org.knowm.xchange.cryptopia.service;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.util.List;
 import org.knowm.xchange.cryptopia.CryptopiaExchange;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.dto.account.AccountInfo;
@@ -12,17 +9,22 @@ import org.knowm.xchange.dto.account.Wallet;
 import org.knowm.xchange.service.account.AccountService;
 import org.knowm.xchange.service.trade.params.*;
 
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.List;
+
 public class CryptopiaAccountService extends CryptopiaAccountServiceRaw implements AccountService {
+
   public CryptopiaAccountService(CryptopiaExchange exchange) {
     super(exchange);
   }
 
-  public enum CryptopiaType {
-    Deposit,
-    Withdraw
-  }
+    private static Integer DEFAULT_RESULTS_LIMIT = 100;
 
-  private static Integer MAX_FUNDING_RESULTS = 100;
+    @Override
+    public TradeHistoryParams createFundingHistoryParams() {
+        return new CryptopiaFundingHistoryParams(null, DEFAULT_RESULTS_LIMIT);
+  }
 
   @Override
   public AccountInfo getAccountInfo() throws IOException {
@@ -57,22 +59,17 @@ public class CryptopiaAccountService extends CryptopiaAccountServiceRaw implemen
   }
 
   @Override
-  public TradeHistoryParams createFundingHistoryParams() {
-    return new CryptopiaFundingHistoryParams(null, 100);
-  }
-
-  @Override
   public List<FundingRecord> getFundingHistory(TradeHistoryParams params) throws IOException {
 
     String cryptopiaType = "";
-    Integer limit = MAX_FUNDING_RESULTS;
+      Integer limit = DEFAULT_RESULTS_LIMIT;
 
     if (params instanceof HistoryParamsFundingType) {
       final FundingRecord.Type type = ((HistoryParamsFundingType) params).getType();
       cryptopiaType =
           type == FundingRecord.Type.DEPOSIT
-              ? CryptopiaType.Deposit.name()
-              : type == FundingRecord.Type.WITHDRAWAL ? CryptopiaType.Withdraw.name() : null;
+                  ? CryptopiaFundingType.Deposit.name()
+                  : type == FundingRecord.Type.WITHDRAWAL ? CryptopiaFundingType.Withdraw.name() : null;
     }
 
     if (params instanceof TradeHistoryParamLimit) {
@@ -81,6 +78,11 @@ public class CryptopiaAccountService extends CryptopiaAccountServiceRaw implemen
 
     return getTransactions(cryptopiaType, limit);
   }
+
+    public enum CryptopiaFundingType {
+        Deposit,
+        Withdraw
+    }
 
   public static class CryptopiaFundingHistoryParams
       implements TradeHistoryParams, HistoryParamsFundingType, TradeHistoryParamLimit {

--- a/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/service/CryptopiaAccountServiceRaw.java
+++ b/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/service/CryptopiaAccountServiceRaw.java
@@ -1,12 +1,5 @@
 package org.knowm.xchange.cryptopia.service;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.knowm.xchange.cryptopia.Cryptopia;
 import org.knowm.xchange.cryptopia.CryptopiaAdapters;
 import org.knowm.xchange.cryptopia.CryptopiaExchange;
@@ -15,6 +8,10 @@ import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.dto.account.Balance;
 import org.knowm.xchange.dto.account.FundingRecord;
 import org.knowm.xchange.exceptions.ExchangeException;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.*;
 
 public class CryptopiaAccountServiceRaw extends CryptopiaBaseService {
 
@@ -90,7 +87,9 @@ public class CryptopiaAccountServiceRaw extends CryptopiaBaseService {
       Date timeStamp = CryptopiaAdapters.convertTimestamp(map.get("Timestamp").toString());
       Currency currency = Currency.getInstance(map.get("Currency").toString());
       FundingRecord.Type fundingType =
-          map.get("Type").toString().equals(CryptopiaAccountService.CryptopiaType.Deposit.name())
+              map.get("Type")
+                      .toString()
+                      .equals(CryptopiaAccountService.CryptopiaFundingType.Deposit.name())
               ? FundingRecord.Type.DEPOSIT
               : FundingRecord.Type.WITHDRAWAL;
 

--- a/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/service/CryptopiaAccountServiceRaw.java
+++ b/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/service/CryptopiaAccountServiceRaw.java
@@ -90,9 +90,7 @@ public class CryptopiaAccountServiceRaw extends CryptopiaBaseService {
       Date timeStamp = CryptopiaAdapters.convertTimestamp(map.get("Timestamp").toString());
       Currency currency = Currency.getInstance(map.get("Currency").toString());
       FundingRecord.Type fundingType =
-          map.get("Type")
-                  .toString()
-                  .equals(CryptopiaAccountService.CryptopiaFundingHistoryParams.Type.Deposit.name())
+          map.get("Type").toString().equals(CryptopiaAccountService.CryptopiaType.Deposit.name())
               ? FundingRecord.Type.DEPOSIT
               : FundingRecord.Type.WITHDRAWAL;
 


### PR DESCRIPTION
Transform CryptopiaFundingHistoryParams into a standard TradeHistory implementation :
- Remove use of specific "Deposit / Withdraw" enum inside the classs ( prefer adapt on getFundingHistory method)
- Rename "count" to "limit"
- Add HistoryParamsFundingType, TradeHistoryParamLimit interfaces (useful for instanceof testing)
- Set the hard writed 100 limit into a static field
- Change the default Type value from Deposit to null ( Deposits and Withdraws ) 