### PR TITLE
[Liqui.io] Fix CurrencyPair not fetched on TradeService

### DIFF
--- a/xchange-liqui/src/main/java/org/knowm/xchange/liqui/service/LiquiTradeService.java
+++ b/xchange-liqui/src/main/java/org/knowm/xchange/liqui/service/LiquiTradeService.java
@@ -78,15 +78,28 @@ public class LiquiTradeService extends LiquiTradeServiceRaw implements TradeServ
 
   @Override
   public UserTrades getTradeHistory(final TradeHistoryParams params) throws IOException {
+
+    CurrencyPair currencyPair = null;
+    Long startTime = null;
+    Long endTime = null;
+    Integer limit = null;
+
+    if (params instanceof TradeHistoryParamCurrencyPair) {
+      currencyPair = ((TradeHistoryParamCurrencyPair) params).getCurrencyPair();
+    }
+
+    if (params instanceof TradeHistoryParamsTimeSpan) {
+      startTime = ((TradeHistoryParamsTimeSpan) params).getStartTime().getTime();
+      endTime = ((TradeHistoryParamsTimeSpan) params).getEndTime().getTime();
+    }
+
+    if (params instanceof TradeHistoryParamLimit) {
+      limit = ((TradeHistoryParamLimit) params).getLimit();
+    }
+
     if (params instanceof LiquiTradeHistoryParams) {
-      if (((LiquiTradeHistoryParams) params).getCurrencyPair() != null) {
-        return LiquiAdapters.adaptTradesHistory(getTradeHistory());
-      } else {
-        return LiquiAdapters.adaptTradesHistory(
-            getTradeHistory(
-                ((LiquiTradeHistoryParams) params).getCurrencyPair(),
-                ((LiquiTradeHistoryParams) params).getLimit()));
-      }
+      return LiquiAdapters.adaptTradesHistory(
+          getTradeHistory(currencyPair, null, null, limit, startTime, endTime));
     }
 
     throw new LiquiException("Unable to get trade history with the provided params: " + params);
@@ -113,21 +126,11 @@ public class LiquiTradeService extends LiquiTradeServiceRaw implements TradeServ
   }
 
   public static class LiquiTradeHistoryParams
-      implements TradeHistoryParams, TradeHistoryParamCurrencyPair, TradeHistoryParamLimit {
-
-    private CurrencyPair currencyPair = null;
+      implements TradeHistoryParams, TradeHistoryParamLimit {
 
     private int limit = 1000;
 
     public LiquiTradeHistoryParams() {}
-
-    public CurrencyPair getCurrencyPair() {
-      return currencyPair;
-    }
-
-    public void setCurrencyPair(final CurrencyPair currencyPair) {
-      this.currencyPair = currencyPair;
-    }
 
     @Override
     public Integer getLimit() {

--- a/xchange-liqui/src/main/java/org/knowm/xchange/liqui/service/LiquiTradeServiceRaw.java
+++ b/xchange-liqui/src/main/java/org/knowm/xchange/liqui/service/LiquiTradeServiceRaw.java
@@ -75,65 +75,13 @@ public class LiquiTradeServiceRaw extends LiquiBaseService {
             orderId));
   }
 
-  public Map<Long, LiquiUserTrade> getTradeHistory() {
-    return checkResult(
-            liquiAuthenticated.tradeHistory(
-                exchange.getExchangeSpecification().getApiKey(),
-                signatureCreator,
-                exchange.getNonceFactory(),
-                "tradeHistory",
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null))
-        .getHistory();
-  }
-
-  public Map<Long, LiquiUserTrade> getTradeHistory(final CurrencyPair pair) {
-    return checkResult(
-            liquiAuthenticated.tradeHistory(
-                exchange.getExchangeSpecification().getApiKey(),
-                signatureCreator,
-                exchange.getNonceFactory(),
-                "tradeHistory",
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                new Liqui.Pairs(pair)))
-        .getHistory();
-  }
-
-  public Map<Long, LiquiUserTrade> getTradeHistory(
-      final CurrencyPair pair, final int amountOftrades) {
-    return checkResult(
-            liquiAuthenticated.tradeHistory(
-                exchange.getExchangeSpecification().getApiKey(),
-                signatureCreator,
-                exchange.getNonceFactory(),
-                "tradeHistory",
-                null,
-                amountOftrades,
-                null,
-                null,
-                null,
-                null,
-                new Liqui.Pairs(pair)))
-        .getHistory();
-  }
-
   public Map<Long, LiquiUserTrade> getTradeHistory(
       final CurrencyPair pair,
-      final long fromTrade,
-      final long toTrade,
-      final int amountOftrades,
-      final long startTime,
-      final long endTime) {
+      final Long fromTrade,
+      final Long toTrade,
+      final Integer amountOftrades,
+      final Long startTime,
+      final Long endTime) {
     return checkResult(
             liquiAuthenticated.tradeHistory(
                 exchange.getExchangeSpecification().getApiKey(),
@@ -146,7 +94,7 @@ public class LiquiTradeServiceRaw extends LiquiBaseService {
                 null,
                 startTime,
                 endTime,
-                new Liqui.Pairs(pair)))
+                pair != null ? new Liqui.Pairs(pair) : null))
         .getHistory();
   }
 }


### PR DESCRIPTION
- Use a respectful default class of trade history params (LiquiTradeHistoryParams) with no currency pair ( avoid loop by default )
- Fix an error on LiquiTradeServiceRaw getTradeHistory method ( don't get the CurrencyPair in case of CurrencyPair )
- Remove unused multiples getTradeHistory methods in LiquiTradeServiceRaw ( should not be used somewhere else than LiquiTradeService )