### PR TITLE
[Livecoin] Exclude currency Bricktox(XBT)

### DIFF
--- a/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/LivecoinAdapters.java
+++ b/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/LivecoinAdapters.java
@@ -278,10 +278,9 @@ public class LivecoinAdapters {
       WalletBuilder builder = wallets.get(curr);
       if (builder == null) {
         builder = new WalletBuilder(curr);
+        wallets.put(curr, builder);
       }
       builder.add(type, value);
-
-      wallets.put(curr, builder);
     }
 
     List<Wallet> res = new ArrayList<>();

--- a/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/LivecoinAdapters.java
+++ b/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/LivecoinAdapters.java
@@ -265,6 +265,14 @@ public class LivecoinAdapters {
       String ccy = balance.get("currency").toString();
       String value = balance.get("value").toString();
 
+      // Livecoin has a currency Bricktox (XBT) which is different from XChange Bitcoin (XBT). See Currency.XBT.
+      // The "get all currencies" call to Livecoin returns all currencies including those with 0 balance.
+      // As a result, XBT overrides BTC, so BTC becomes 0 (in most cases).
+      // Excluding XBT.
+      if (ccy.equals("XBT")) {
+        continue;
+      }
+
       Currency curr = getInstance(ccy);
 
       WalletBuilder builder = wallets.get(curr);

--- a/xchange-livecoin/src/test/java/org/knowm/xchange/livecoin/LivecoinAdaptersTest.java
+++ b/xchange-livecoin/src/test/java/org/knowm/xchange/livecoin/LivecoinAdaptersTest.java
@@ -1,0 +1,54 @@
+package org.knowm.xchange.livecoin;
+
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.dto.account.Balance;
+import org.knowm.xchange.dto.account.Wallet;
+
+public class LivecoinAdaptersTest {
+    @Test
+    public void liveCoinAdapterTest() {
+        List<Map> response = Arrays.asList(
+                responseItem("total", "USD", "16.45759873"),
+                responseItem("trade", "USD", "0.0"),
+                responseItem("available", "USD", "16.45759873"),
+
+                responseItem("total", "BTC", "0.00671945"),
+                responseItem("trade", "BTC", "0.1"),
+                responseItem("available", "BTC", "0.00671945"),
+
+                responseItem("total", "XBT", "0.0"),
+                responseItem("trade", "XBT", "0.0"),
+                responseItem("available", "XBT", "0.0")
+        );
+
+        List<Wallet> wallets = LivecoinAdapters.adaptWallets(response);
+
+        assertTrue(wallets.contains(wallet(Currency.USD, "16.45759873", "0.0", "16.45759873")));
+        assertTrue(wallets.contains(wallet(Currency.BTC, "0.00671945", "0.1", "0.00671945")));
+    }
+
+    private static Map<String, String> responseItem(String type, String currency, String balance) {
+        HashMap<String, String> map = new HashMap<>();
+        map.put("type", type);
+        map.put("currency", currency);
+        map.put("value", balance);
+        return map;
+    }
+
+    private static Wallet wallet(Currency currency, String total, String trade, String available) {
+        return new Wallet(currency.getCurrencyCode(),
+                new Balance.Builder().currency(currency)
+                        .total(new BigDecimal(total))
+                        .available(new BigDecimal(available))
+                        .frozen(new BigDecimal(trade))
+                        .build());
+    }
+}


### PR DESCRIPTION
Livecoin has a currency `Bricktox (XBT)` which is different from `XChange` `Bitcoin (XBT)`.
The `Get All Currencies` call to `Livecoin` returns all currencies including those with 0 balance.
As a result, `XBT`overrides `BTC`, so `BTC` becomes 0 (in most cases). Even if we manage to work around the problem of `Overriding BTC by XBT`, we will still parse `XBT` as `Currency.XBT`, which is `Bitcoin`, which would be different from what `Livecoin` refers to.
This PR contains [LivecoinAdaptersTest](https://github.com/knowm/XChange/pull/2605/files#diff-ecac3431b8f2d8fa6386a4b48b27eddd) which reveals the problem.
This PR is about **excluding XBT** in `Livecoin` client.
Also, this PR contains minor improvement: removed redundant map.put when element is already in the map.