### PR TITLE
[Cex.io] Add `cancel_replace_order` to private implementation

### DIFF
--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/CexIOAuthenticated.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/CexIOAuthenticated.java
@@ -12,6 +12,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import org.knowm.xchange.cexio.dto.ArchivedOrdersRequest;
 import org.knowm.xchange.cexio.dto.CexIORequest;
+import org.knowm.xchange.cexio.dto.CexioCancelReplaceOrderRequest;
 import org.knowm.xchange.cexio.dto.CexioCryptoAddressRequest;
 import org.knowm.xchange.cexio.dto.CexioSingleIdRequest;
 import org.knowm.xchange.cexio.dto.CexioSingleOrderIdRequest;
@@ -23,6 +24,7 @@ import org.knowm.xchange.cexio.dto.account.GHashIOHashrate;
 import org.knowm.xchange.cexio.dto.account.GHashIOWorkers;
 import org.knowm.xchange.cexio.dto.trade.CexIOArchivedOrder;
 import org.knowm.xchange.cexio.dto.trade.CexIOCancelAllOrdersResponse;
+import org.knowm.xchange.cexio.dto.trade.CexIOCancelReplaceOrderResponse;
 import org.knowm.xchange.cexio.dto.trade.CexIOOpenOrder;
 import org.knowm.xchange.cexio.dto.trade.CexIOOpenOrders;
 import org.knowm.xchange.cexio.dto.trade.CexIOOrder;
@@ -65,6 +67,15 @@ public interface CexIOAuthenticated extends CexIO {
       @PathParam("currencyA") String currencyA,
       @PathParam("currencyB") String currencyB,
       CexIORequest request)
+      throws IOException;
+
+  @POST
+  @Path("cancel_replace_order/{currencyA}/{currencyB}/")
+  CexIOCancelReplaceOrderResponse cancelReplaceOrder(
+      @HeaderParam("signature") ParamsDigest signer,
+      @PathParam("currencyA") String currencyA,
+      @PathParam("currencyB") String currencyB,
+      CexioCancelReplaceOrderRequest request)
       throws IOException;
 
   @POST

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/dto/CexioCancelReplaceOrderRequest.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/dto/CexioCancelReplaceOrderRequest.java
@@ -1,0 +1,27 @@
+package org.knowm.xchange.cexio.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+
+public class CexioCancelReplaceOrderRequest extends CexIORequest {
+
+  @JsonProperty("order_id")
+  public final String orderId;
+
+  @JsonProperty("type")
+  public final String type;
+
+  @JsonProperty("amount")
+  public final BigDecimal amount;
+
+  @JsonProperty("price")
+  public final BigDecimal price;
+
+  public CexioCancelReplaceOrderRequest(
+      String orderId, String type, BigDecimal amount, BigDecimal price) {
+    this.orderId = orderId;
+    this.type = type;
+    this.amount = amount;
+    this.price = price;
+  }
+}

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/dto/trade/CexIOCancelReplaceOrderResponse.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/dto/trade/CexIOCancelReplaceOrderResponse.java
@@ -1,0 +1,66 @@
+package org.knowm.xchange.cexio.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.math.BigDecimal;
+import java.util.Date;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CexIOCancelReplaceOrderResponse {
+
+  private Boolean complete;
+  private BigDecimal price;
+  private BigDecimal amount;
+  private Date time;
+  private String type;
+  private String id;
+  private BigDecimal pending;
+
+  private String error;
+
+  public Boolean getComplete() {
+    return complete;
+  }
+
+  public BigDecimal getPrice() {
+    return price;
+  }
+
+  public BigDecimal getAmount() {
+    return amount;
+  }
+
+  public Date getTime() {
+    return time;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public BigDecimal getPending() {
+    return pending;
+  }
+
+  public String getError() {
+    return error;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuffer buffer = new StringBuffer("{");
+    buffer.append("id='").append(id).append('\'');
+    buffer.append(", complete=").append(complete);
+    buffer.append(", price=").append(price);
+    buffer.append(", amount=").append(amount);
+    buffer.append(", time=").append(time);
+    buffer.append(", type='").append(type).append('\'');
+    buffer.append(", pending=").append(pending);
+    buffer.append(", error=").append(error);
+    buffer.append('}');
+    return buffer.toString();
+  }
+}

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOTradeServiceRaw.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOTradeServiceRaw.java
@@ -23,6 +23,7 @@ import org.knowm.xchange.cexio.dto.trade.CexIOOpenOrder;
 import org.knowm.xchange.cexio.dto.trade.CexIOOpenOrders;
 import org.knowm.xchange.cexio.dto.trade.CexIOOrder;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
@@ -100,15 +101,31 @@ public class CexIOTradeServiceRaw extends CexIOBaseService {
   }
 
   public CexIOCancelReplaceOrderResponse cancelReplaceCexIOOrder(
-      CurrencyPair currencyPair, String type, String orderId, BigDecimal amount, BigDecimal price)
+      CurrencyPair currencyPair,
+      Order.OrderType type,
+      String orderId,
+      BigDecimal amount,
+      BigDecimal price)
       throws ExchangeException, IOException {
+
+    String orderType;
+    switch (type) {
+      case BID:
+        orderType = "buy";
+        break;
+      case ASK:
+        orderType = "sell";
+        break;
+      default:
+        throw new IllegalArgumentException(String.format("Unexpected order type '%s'", type));
+    }
 
     CexIOCancelReplaceOrderResponse response =
         cexIOAuthenticated.cancelReplaceOrder(
             signatureCreator,
             currencyPair.base.getCurrencyCode(),
             currencyPair.counter.getCurrencyCode(),
-            new CexioCancelReplaceOrderRequest(orderId, type, amount, price));
+            new CexioCancelReplaceOrderRequest(orderId, orderType, amount, price));
 
     if (response.getError() != null) {
       throw new ExchangeException(response.getError());

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOTradeServiceRaw.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOTradeServiceRaw.java
@@ -4,6 +4,7 @@ import static org.knowm.xchange.dto.Order.OrderType.BID;
 import static org.knowm.xchange.utils.DateUtils.toUnixTimeNullSafe;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -11,11 +12,13 @@ import java.util.Map;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.cexio.dto.ArchivedOrdersRequest;
 import org.knowm.xchange.cexio.dto.CexIORequest;
+import org.knowm.xchange.cexio.dto.CexioCancelReplaceOrderRequest;
 import org.knowm.xchange.cexio.dto.CexioSingleIdRequest;
 import org.knowm.xchange.cexio.dto.CexioSingleOrderIdRequest;
 import org.knowm.xchange.cexio.dto.PlaceOrderRequest;
 import org.knowm.xchange.cexio.dto.trade.CexIOArchivedOrder;
 import org.knowm.xchange.cexio.dto.trade.CexIOCancelAllOrdersResponse;
+import org.knowm.xchange.cexio.dto.trade.CexIOCancelReplaceOrderResponse;
 import org.knowm.xchange.cexio.dto.trade.CexIOOpenOrder;
 import org.knowm.xchange.cexio.dto.trade.CexIOOpenOrders;
 import org.knowm.xchange.cexio.dto.trade.CexIOOrder;
@@ -94,6 +97,24 @@ public class CexIOTradeServiceRaw extends CexIOBaseService {
         currencyPair.base.getCurrencyCode(),
         currencyPair.counter.getCurrencyCode(),
         new CexIORequest());
+  }
+
+  public CexIOCancelReplaceOrderResponse cancelReplaceCexIOOrder(
+      CurrencyPair currencyPair, String type, String orderId, BigDecimal amount, BigDecimal price)
+      throws ExchangeException, IOException {
+
+    CexIOCancelReplaceOrderResponse response =
+        cexIOAuthenticated.cancelReplaceOrder(
+            signatureCreator,
+            currencyPair.base.getCurrencyCode(),
+            currencyPair.counter.getCurrencyCode(),
+            new CexioCancelReplaceOrderRequest(orderId, type, amount, price));
+
+    if (response.getError() != null) {
+      throw new ExchangeException(response.getError());
+    }
+
+    return response;
   }
 
   public List<CexIOArchivedOrder> archivedOrders(TradeHistoryParams tradeHistoryParams)


### PR DESCRIPTION
Implement cex.io specific function, that allows to cancel and place an order with a single command.