### PR TITLE
Add ZenCash currency pairs

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
@@ -261,6 +261,7 @@ public class Currency implements Comparable<Currency>, Serializable {
   public static final Currency YER = createCurrency("YER", "Yemeni Rial", null);
   public static final Currency ZAR = createCurrency("ZAR", "South African Rand", null);
   public static final Currency ZEC = createCurrency("ZEC", "Zcash", null);
+  public static final Currency ZEN = createCurrency("ZEN", "ZenCash", null);
   public static final Currency ZMK = createCurrency("ZMK", "Zambian Kwacha", null);
   public static final Currency ZRC = createCurrency("ZRC", "ziftrCOIN", null);
   public static final Currency ZWL = createCurrency("ZWL", "Zimbabwean Dollar", null);

--- a/xchange-core/src/main/java/org/knowm/xchange/currency/CurrencyPair.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/CurrencyPair.java
@@ -265,6 +265,9 @@ public class CurrencyPair implements Comparable<CurrencyPair>, Serializable {
   public static final CurrencyPair ZEC_USD = new CurrencyPair(Currency.ZEC, Currency.USD);
   public static final CurrencyPair ZEC_BTC = new CurrencyPair(Currency.ZEC, Currency.BTC);
 
+  public static final CurrencyPair ZEN_USD = new CurrencyPair(Currency.ZEN, Currency.USD);
+  public static final CurrencyPair ZEN_BTC = new CurrencyPair(Currency.ZEN, Currency.BTC);
+
   public static final CurrencyPair GNO_ETH = new CurrencyPair(Currency.GNO, Currency.ETH);
   public static final CurrencyPair GNO_BTC = new CurrencyPair(Currency.GNO, Currency.BTC);
 


### PR DESCRIPTION
ZenCash is becoming increasingly popular and is available on an already impressive and growing number of exchanges. We want to use this XChange package in our own projects, and this PR gives us that option.