### PR TITLE
Fix filled.get(counter)==NULL when adapting a cancelled order.

### DIFF
--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/dto/trade/CexIOArchivedOrder.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/dto/trade/CexIOArchivedOrder.java
@@ -204,9 +204,7 @@ public class CexIOArchivedOrder {
       String counter = map.get("symbol2");
       String base = map.get("symbol1");
 
-      int scale = 8; // todo: check if this is correct for all
-      BigDecimal price =
-          filled.get(counter).divide(filled.get(base), scale, BigDecimal.ROUND_HALF_UP);
+      BigDecimal price = new BigDecimal(map.get("price"));
 
       BigDecimal amount = new BigDecimal(map.get("amount"));
       if (amount.compareTo(BigDecimal.ZERO) == 0)


### PR DESCRIPTION
Remove base/counter price calculation, use API-supplied price instead.