### PR TITLE
[Kraken] Fix for "invalid amount" error mapping to "FundsExceeded"

### DIFF
--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenBaseService.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenBaseService.java
@@ -77,8 +77,7 @@ public class KrakenBaseService extends BaseExchangeService implements BaseServic
       } else if ("EGeneral:Temporary lockout".equals(error)) {
         throw new FrequencyLimitExceededException(error);
 
-      } else if ("EOrder:Insufficient funds".equals(error)
-          || "EFunding:Invalid amount".equals(error)) {
+      } else if ("EOrder:Insufficient funds".equals(error)) {
         throw new FundsExceededException(error);
       }
       if ("EAPI:Rate limit exceeded".equals(error)) {


### PR DESCRIPTION
The Kraken error "invalid amount" was mapped to "FundsExceeded" - which is not correct. Invalid amount refers to the precision of the price. 