### PR TITLE
[bitmex] Add REJECTED order status to adapter.

### DIFF
--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexAdapters.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexAdapters.java
@@ -356,6 +356,8 @@ public class BitmexAdapters {
         return OrderStatus.CANCELED;
       case EXPIRED:
         return OrderStatus.EXPIRED;
+      case REJECTED:
+        return OrderStatus.REJECTED;
       default:
         return null;
     }
@@ -371,6 +373,8 @@ public class BitmexAdapters {
         return OrderStatus.FILLED;
       case Canceled:
         return OrderStatus.CANCELED;
+      case Rejected:
+        return OrderStatus.REJECTED;
       default:
         return null;
     }

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/dto/marketdata/BitmexPrivateOrder.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/dto/marketdata/BitmexPrivateOrder.java
@@ -270,6 +270,7 @@ public class BitmexPrivateOrder {
     New,
     Partially_filled,
     Filled,
-    Canceled
+    Canceled,
+    Rejected
   }
 }

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/dto/trade/BitmexOrderStatus.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/dto/trade/BitmexOrderStatus.java
@@ -18,7 +18,8 @@ public enum BitmexOrderStatus {
   OPEN,
   CLOSED,
   CANCELED,
-  EXPIRED;
+  EXPIRED,
+  REJECTED;
 
   private static final Map<String, BitmexOrderStatus> fromString = new HashMap<>();
 

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexTradeServiceRaw.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexTradeServiceRaw.java
@@ -107,12 +107,12 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
   }
 
   public BitmexPrivateOrder replaceLimitOrder(
-          String symbol,
-          BigDecimal orderQuantity,
-          BigDecimal price,
-          String orderId,
-          String clOrdID,
-          String origClOrdID) {
+      String symbol,
+      BigDecimal orderQuantity,
+      BigDecimal price,
+      String orderId,
+      String clOrdID,
+      String origClOrdID) {
 
     return bitmex.replaceOrder(
         apiKey,
@@ -129,11 +129,11 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
   }
 
   public BitmexPrivateOrder replaceStopOrder(
-          BigDecimal orderQuantity,
-          BigDecimal price,
-          String orderID,
-          String clOrdID,
-          String origClOrdId) {
+      BigDecimal orderQuantity,
+      BigDecimal price,
+      String orderID,
+      String clOrdID,
+      String origClOrdId) {
     return bitmex.replaceOrder(
         apiKey,
         exchange.getNonceFactory(),


### PR DESCRIPTION
Querying order history fails if it contains rejected orders.