### PR TITLE
Updated CoinMarketCap API to version 2 and added support for convert parameter

### DIFF
--- a/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/CoinMarketCap.java
+++ b/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/CoinMarketCap.java
@@ -1,43 +1,66 @@
 package org.knowm.xchange.coinmarketcap;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Objects;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
+
+import org.knowm.xchange.coinmarketcap.dto.marketdata.CoinMarketCapArrayData;
 import org.knowm.xchange.coinmarketcap.dto.marketdata.CoinMarketCapTicker;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.utils.jackson.CurrencyPairDeserializer;
 
-/** @author allenday https://api.coinmarketcap.com/v1/ticker/ */
-@Path("/v1")
+/** @author allenday https://api.coinmarketcap.com/v2/ticker/ */
+@Path("/v2")
 @Produces(MediaType.APPLICATION_JSON)
 public interface CoinMarketCap {
 
   @GET
   @Path("ticker")
-  List<CoinMarketCapTicker> getTickers() throws IOException;
+  CoinMarketCapArrayData<CoinMarketCapTicker> getTickers(@QueryParam("structure") String structure) throws IOException;
 
   /**
    * @param start return results from rank [start] and above
    * @param limit number of results. 0 = unlimited
-   * @see #getTickers()
+   * @see #getTickers(String structure)
    */
   @GET
   @Path("ticker")
-  List<CoinMarketCapTicker> getTickers(
-      @QueryParam("start") int start, @QueryParam("limit") int limit) throws IOException;
+  CoinMarketCapArrayData<CoinMarketCapTicker> getTickers(
+      @QueryParam("start") int start, @QueryParam("limit") int limit, @QueryParam("structure") String structure) throws IOException;
 
   /**
    * @param limit number of results. 0 = unlimited
-   * @see #getTickers()
+   * @param convert currency to get price converted to
+   * @see #getTickers(String structure)
    */
   @GET
   @Path("ticker")
-  List<CoinMarketCapTicker> getTickers(@QueryParam("limit") int limit) throws IOException;
+  CoinMarketCapArrayData<CoinMarketCapTicker> getTickers(
+          @QueryParam("limit") int limit, @QueryParam("convert") String convert, @QueryParam("structure") String structure) throws IOException;
+
+  /**
+   * @param start return results from rank [start] and above
+   * @param limit number of results. 0 = unlimited
+   * @param convert currency to get price converted to
+   * @see #getTickers(String structure)
+   */
+  @GET
+  @Path("ticker")
+  CoinMarketCapArrayData<CoinMarketCapTicker> getTickers(
+          @QueryParam("start") int start,
+          @QueryParam("limit") int limit,
+          @QueryParam("convert") String convert,
+          @QueryParam("structure") String structure) throws IOException;
+
+  /**
+   * @param limit number of results. 0 = unlimited
+   * @see #getTickers(String structure)
+   */
+  @GET
+  @Path("ticker")
+  CoinMarketCapArrayData<CoinMarketCapTicker> getTickers(
+          @QueryParam("limit") int limit, @QueryParam("structure") String structure) throws IOException;
 
   CoinMarketCapTicker getTicker(CoinMarketCap.Pair pair);
 

--- a/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/dto/marketdata/CoinMarketCapArrayData.java
+++ b/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/dto/marketdata/CoinMarketCapArrayData.java
@@ -1,0 +1,53 @@
+package org.knowm.xchange.coinmarketcap.dto.marketdata;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+@JsonDeserialize(using = CoinMarketCapArrayData.CoinMarketCapTickersDeserializer.class)
+public class CoinMarketCapArrayData<T> {
+
+  private List<T> data;
+
+  private CoinMarketCapArrayData(List<T> data) {
+
+    this.data = data;
+  }
+
+  public List<T> getData() { return data; }
+
+  static class CoinMarketCapTickersDeserializer<T> extends JsonDeserializer<CoinMarketCapArrayData<CoinMarketCapTicker>> {
+
+    @Override
+    public CoinMarketCapArrayData<CoinMarketCapTicker> deserialize(JsonParser jp, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+
+      ObjectCodec oc = jp.getCodec();
+      JsonNode node = oc.readTree(jp);
+
+      if (node.isObject()) {
+        List<CoinMarketCapTicker> tickers = new LinkedList<>();
+        ObjectMapper mapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(CoinMarketCapTicker.class, new CoinMarketCapTicker.CoinMarketCapTickerDeserializer());
+        mapper.registerModule(module);
+        for (JsonNode child : node.get("data")) {
+          tickers.add(mapper.treeToValue(child, CoinMarketCapTicker.class));
+        }
+
+        return new CoinMarketCapArrayData<>(tickers);
+      }
+      return null;
+    }
+  }
+}

--- a/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/dto/marketdata/CoinMarketCapQuote.java
+++ b/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/dto/marketdata/CoinMarketCapQuote.java
@@ -1,0 +1,95 @@
+package org.knowm.xchange.coinmarketcap.dto.marketdata;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+public class CoinMarketCapQuote {
+  private final BigDecimal price;
+  private final BigDecimal volume24h;
+  private final BigDecimal marketCap;
+  private final BigDecimal pctChange1h;
+  private final BigDecimal pctChange24h;
+  private final BigDecimal pctChange7d;
+
+  private CoinMarketCapQuote(
+            final BigDecimal price,
+            final BigDecimal volume24h,
+            final BigDecimal marketCap,
+            final BigDecimal pctChange1h,
+            final BigDecimal pctChange24h,
+            final BigDecimal pctChange7d) {
+
+    this.price = price;
+    this.volume24h = volume24h;
+    this.marketCap = marketCap;
+    this.pctChange1h = pctChange1h;
+    this.pctChange24h = pctChange24h;
+    this.pctChange7d = pctChange7d;
+  }
+
+  public BigDecimal getPrice() { return price; }
+
+  public BigDecimal getVolume24h() {
+        return volume24h;
+    }
+
+  public BigDecimal getMarketCap() {
+        return marketCap;
+    }
+
+  public BigDecimal getPctChange1h() {
+        return pctChange1h;
+    }
+
+  public BigDecimal getPctChange24h() {
+        return pctChange24h;
+    }
+
+  public BigDecimal getPctChange7d() {
+        return pctChange7d;
+    }
+
+  @Override
+  public String toString() {
+
+    return "CoinMarketCapQuote [price=" + price + ", volume24h=" + volume24h + ", marketCap=" + marketCap + "]";
+  }
+
+  static class CoinMarketCapQuoteDeserializer extends JsonDeserializer<CoinMarketCapQuote> {
+
+    @Override
+    public CoinMarketCapQuote deserialize(JsonParser jp, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+
+      ObjectCodec oc = jp.getCodec();
+      JsonNode node = oc.readTree(jp);
+
+      if (node.isObject()) {
+          BigDecimal price = new BigDecimal(node.get("price").asDouble());
+        BigDecimal volume24h = new BigDecimal(node.get("volume_24h").asDouble());
+        BigDecimal marketCap = new BigDecimal(node.get("market_cap").asDouble());
+
+        // TODO use these to create CoinMarketCapHistoricalSpotPrice instances
+        BigDecimal pctChange1h = new BigDecimal(node.get("percent_change_1h").asDouble());
+        BigDecimal pctChange24h = new BigDecimal(node.get("percent_change_24h").asDouble());
+        BigDecimal pctChange7d = new BigDecimal(node.get("percent_change_7d").asDouble());
+
+        return new CoinMarketCapQuote(
+             price,
+             volume24h,
+             marketCap,
+             pctChange1h,
+             pctChange24h,
+             pctChange7d);
+      }
+      return null;
+    }
+  }
+}

--- a/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/service/CoinMarketCapMarketDataService.java
+++ b/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/service/CoinMarketCapMarketDataService.java
@@ -24,6 +24,7 @@ public class CoinMarketCapMarketDataService extends CoinMarketCapMarketDataServi
 
   private Map<String, CoinMarketCapTicker> tickers;
 
+
   /**
    * Constructor
    *
@@ -51,38 +52,17 @@ public class CoinMarketCapMarketDataService extends CoinMarketCapMarketDataServi
       throw new IOException("base and counter currency must not be identical");
 
     CoinMarketCapTicker cmcB = tickers.get(b.getCurrencyCode());
-
-    CurrencyPair pair;
     BigDecimal price;
     BigDecimal volume;
-
-    if (c.getCurrencyCode().compareTo("USD") == 0) {
-      pair = new CurrencyPair(cmcB.getIsoCode(), "USD");
-      price = cmcB.getPriceUSD();
-      volume = cmcB.getVolume24hUSD();
-    } else if (c.getCurrencyCode().compareTo("BTC") == 0) {
-      pair = new CurrencyPair(cmcB.getIsoCode(), "BTC");
-      price = cmcB.getPriceBTC();
-
-      // TODO move to conversion function
-      // volume = new BigDecimal(cmcB.getVolume24hUSD().doubleValue() /
-      // BTC.getPriceUSD().doubleValue());
-      volume = null;
-    } else {
-      CoinMarketCapTicker cmcC = tickers.get(c.getCurrencyCode());
-      pair = new CurrencyPair(cmcB.getIsoCode(), cmcC.getIsoCode());
-
-      // TODO move to conversion function
-      // price = new BigDecimal(cmcB.getPriceBTC().doubleValue() /
-      // cmcC.getPriceBTC().doubleValue());
-      // volume = new BigDecimal((cmcB.getVolume24hUSD().doubleValue() /
-      // BTC.getPriceUSD().doubleValue()) / cmcC.getPriceBTC().doubleValue());
-      price = null;
-      volume = null;
+    try {
+      price = cmcB.getQuotes().get(c.toString()).getPrice();
+      volume = cmcB.getQuotes().get(c.toString()).getVolume24h();
+    } catch (NullPointerException npe) {
+      throw new NotAvailableFromExchangeException();
     }
 
     return new Ticker.Builder()
-        .currencyPair(pair)
+        .currencyPair(currencyPair)
         .timestamp(cmcB.getLastUpdated())
         .last(price)
         .bid(price)
@@ -94,16 +74,16 @@ public class CoinMarketCapMarketDataService extends CoinMarketCapMarketDataServi
         .build();
   }
 
-  public Ticker getTickerFresh(CurrencyPair currencyPair, final Object... args) throws IOException {
+  public Ticker getTickerFresh(CurrencyPair currencyPair) throws IOException {
     tickers = getNewTickers();
-    return getTicker(currencyPair, args);
+    return getTicker(currencyPair);
   }
 
   private Map<String, CoinMarketCapTicker> getNewTickers() throws IOException {
     Map<String, CoinMarketCapTicker> freshTickers = new HashMap<>();
     List<CoinMarketCapTicker> tt = getCoinMarketCapTickers();
     for (CoinMarketCapTicker t : tt) {
-      freshTickers.put(t.getIsoCode(), t);
+      freshTickers.put(t.getSymbol(), t);
     }
     return freshTickers;
   }

--- a/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/service/CoinMarketCapMarketDataServiceRaw.java
+++ b/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/service/CoinMarketCapMarketDataServiceRaw.java
@@ -7,6 +7,7 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.coinmarketcap.CoinMarketCap;
 import org.knowm.xchange.coinmarketcap.dto.marketdata.CoinMarketCapCurrency;
 import org.knowm.xchange.coinmarketcap.dto.marketdata.CoinMarketCapTicker;
+import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
@@ -57,12 +58,28 @@ class CoinMarketCapMarketDataServiceRaw extends BaseExchangeService implements B
    * @param limit count of tickers to be retrieved
    */
   public List<CoinMarketCapTicker> getCoinMarketCapTickers(final int limit) throws IOException {
-    return coinmarketcap.getTickers(limit);
+    return coinmarketcap.getTickers(limit, "array").getData();
+  }
+
+  /**
+   * Retrieves limited amount of tickers from CoinMarketCap
+   *
+   * @param limit count of tickers to be retrieved
+   * @param convert currency to get price converted to
+   */
+  public List<CoinMarketCapTicker> getCoinMarketCapTickers(final int limit, Currency convert) throws IOException {
+    return coinmarketcap.getTickers(limit, convert.toString(), "array").getData();
   }
 
   public List<CoinMarketCapTicker> getCoinMarketCapTickers(int start, int limit)
       throws IOException {
 
-    return coinmarketcap.getTickers(start, limit);
+    return coinmarketcap.getTickers(start, limit, "array").getData();
+  }
+
+  public List<CoinMarketCapTicker> getCoinMarketCapTickers(int start, int limit, Currency convert)
+          throws IOException {
+
+    return coinmarketcap.getTickers(start, limit, convert.toString(), "array").getData();
   }
 }

--- a/xchange-coinmarketcap/src/test/java/org/knowm/xchange/coinmarketcap/dto/marketdata/CoinMarketCapMarketDataJsonTest.java
+++ b/xchange-coinmarketcap/src/test/java/org/knowm/xchange/coinmarketcap/dto/marketdata/CoinMarketCapMarketDataJsonTest.java
@@ -3,6 +3,9 @@ package org.knowm.xchange.coinmarketcap.dto.marketdata;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.junit.Test;
 
 /** @author allenday */
@@ -14,28 +17,28 @@ public class CoinMarketCapMarketDataJsonTest {
     // Read in the JSON from the example resources
     InputStream is =
         CoinMarketCapMarketDataJsonTest.class.getResourceAsStream(
-            "/org/knowm/xchange/coinmarketcap/dto/marketdata/example-ticker-data.json");
+            "/org/knowm/xchange/coinmarketcap/dto/marketdata/example-ticker-data-v2.json");
 
     // Use Jackson to parse it
     ObjectMapper mapper = new ObjectMapper();
     // MapLikeType mapType = mapper.getTypeFactory().constructMapLikeType(HashMap.class,
     // String.class, String.class);
 
-    CoinMarketCapTicker[] tickers = mapper.readValue(is, CoinMarketCapTicker[].class);
+    List<CoinMarketCapTicker> tickers = mapper.readValue(is, CoinMarketCapArrayData.class).getData();
 
     CoinMarketCapTicker eth = null;
     CoinMarketCapTicker btc = null;
 
     for (CoinMarketCapTicker t : tickers) {
-      if (t.getIsoCode().compareTo("ETH") == 0) eth = t;
-      if (t.getIsoCode().compareTo("BTC") == 0) btc = t;
+      if (t.getSymbol().compareTo("ETH") == 0) eth = t;
+      if (t.getSymbol().compareTo("BTC") == 0) btc = t;
     }
 
-    assert (eth.getIsoCode().compareTo("ETH") == 0);
-    assert (btc.getIsoCode().compareTo("BTC") == 0);
-    assert (btc.getPriceUSD().doubleValue() == 4423.52);
-    assert (eth.getPriceUSD().doubleValue() == 298.777);
-    assert (eth.getPriceBTC().doubleValue() == 0.067607);
+    assert (eth.getSymbol().compareTo("ETH") == 0);
+    assert (btc.getSymbol().compareTo("BTC") == 0);
+    assert (btc.getQuotes().get("USD").getPrice().doubleValue() == 5947.06);
+    assert (eth.getQuotes().get("USD").getPrice().doubleValue() == 440.86);
+    assert (eth.getQuotes().get("BTC").getPrice().doubleValue() == 0.074130747);
 
     //    Map<String, BigDecimal> exchangeRates = mapper.readValue(is, mapType);
     //

--- a/xchange-coinmarketcap/src/test/java/org/knowm/xchange/coinmarketcap/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-coinmarketcap/src/test/java/org/knowm/xchange/coinmarketcap/service/marketdata/TickerFetchIntegration.java
@@ -1,30 +1,62 @@
 package org.knowm.xchange.coinmarketcap.service.marketdata;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.knowm.xchange.currency.CurrencyPair.NEO_USD;
 
 import java.util.List;
+
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeFactory;
 import org.knowm.xchange.coinmarketcap.CoinMarketCapExchange;
+import org.knowm.xchange.coinmarketcap.dto.marketdata.CoinMarketCapTicker;
+import org.knowm.xchange.coinmarketcap.service.CoinMarketCapMarketDataService;
+import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 
 /** @author allenday */
 public class TickerFetchIntegration {
+  private static Exchange exchange;
+
+  @BeforeClass
+  public static void initExchange() {
+    exchange =
+            ExchangeFactory.INSTANCE.createExchange(CoinMarketCapExchange.class.getName());
+  }
 
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(CoinMarketCapExchange.class.getName());
     MarketDataService marketDataService = exchange.getMarketDataService();
 
     CurrencyPair NEO_BTC = new CurrencyPair("NEO", "BTC");
-    Ticker ticker0 = marketDataService.getTicker(NEO_BTC);
+    Ticker ticker0 = marketDataService.getTicker(NEO_USD);
     // System.out.println(ticker.toString());
     assertThat(ticker0).isNotNull();
+
+    Boolean found = false;
+    List<CurrencyPair> pairs = exchange.getExchangeSymbols();
+    for (CurrencyPair p : pairs) {
+      if (p.compareTo(NEO_BTC) == 0) {
+        found = true;
+      }
+    }
+    assert (found);
+  }
+
+  @Test
+  public void tickerConvertParamTest() throws Exception {
+
+    CoinMarketCapMarketDataService marketDataService =
+            (CoinMarketCapMarketDataService)exchange.getMarketDataService();
+
+    CurrencyPair NEO_BTC = new CurrencyPair("NEO", "BTC");
+    List<CoinMarketCapTicker> tickers = marketDataService.getCoinMarketCapTickers(0, new Currency("EUR"));
+    // System.out.println(ticker.toString());
+    assertThat(tickers).isNotNull();
 
     Boolean found = false;
     List<CurrencyPair> pairs = exchange.getExchangeSymbols();

--- a/xchange-coinmarketcap/src/test/resources/org/knowm/xchange/coinmarketcap/dto/marketdata/example-ticker-data-v2.json
+++ b/xchange-coinmarketcap/src/test/resources/org/knowm/xchange/coinmarketcap/dto/marketdata/example-ticker-data-v2.json
@@ -1,0 +1,299 @@
+{
+  "data": {
+    "1": {
+      "id": 1,
+      "name": "Bitcoin",
+      "symbol": "BTC",
+      "website_slug": "bitcoin",
+      "rank": 1,
+      "circulating_supply": 17112925.0,
+      "total_supply": 17112925.0,
+      "max_supply": 21000000.0,
+      "quotes": {
+        "USD": {
+          "price": 5947.06,
+          "volume_24h": 3709430000.0,
+          "market_cap": 101771591751.0,
+          "percent_change_1h": 0.06,
+          "percent_change_24h": -2.91,
+          "percent_change_7d": -9.11
+        },
+        "BTC": {
+          "price": 1.0,
+          "volume_24h": 623741.8152835182,
+          "market_cap": 17112925.0,
+          "percent_change_1h": 0,
+          "percent_change_24h": 0,
+          "percent_change_7d": 0
+        }
+      },
+      "last_updated": 1529852374
+    },
+    "1027": {
+      "id": 1027,
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "website_slug": "ethereum",
+      "rank": 2,
+      "circulating_supply": 100276174.0,
+      "total_supply": 100276174.0,
+      "max_supply": null,
+      "quotes": {
+        "USD": {
+          "price": 440.86,
+          "volume_24h": 2019650000.0,
+          "market_cap": 44207753931.0,
+          "percent_change_1h": -0.6,
+          "percent_change_24h": -6.39,
+          "percent_change_7d": -12.26
+        },
+        "BTC": {
+          "price": 0.074130747,
+          "volume_24h": 339604.7795044947,
+          "market_cap": 7433548.0,
+          "percent_change_1h": -0.66,
+          "percent_change_24h": -3.58,
+          "percent_change_7d": -3.46
+        }
+      },
+      "last_updated": 1529852361
+    },
+    "52": {
+      "id": 52,
+      "name": "Ripple",
+      "symbol": "XRP",
+      "website_slug": "ripple",
+      "rank": 3,
+      "circulating_supply": 39245304677.0,
+      "total_supply": 99991944394.0,
+      "max_supply": 100000000000.0,
+      "quotes": {
+        "USD": {
+          "price": 0.463202,
+          "volume_24h": 292248000.0,
+          "market_cap": 18178503617.0,
+          "percent_change_1h": -0.66,
+          "percent_change_24h": -4.82,
+          "percent_change_7d": -12.79
+        },
+        "BTC": {
+          "price": 7.78876e-05,
+          "volume_24h": 49141.5926525039,
+          "market_cap": 3056721.0,
+          "percent_change_1h": -0.72,
+          "percent_change_24h": -1.96,
+          "percent_change_7d": -4.05
+        }
+      },
+      "last_updated": 1529852342
+    },
+    "1831": {
+      "id": 1831,
+      "name": "Bitcoin Cash",
+      "symbol": "BCH",
+      "website_slug": "bitcoin-cash",
+      "rank": 4,
+      "circulating_supply": 17201025.0,
+      "total_supply": 17201025.0,
+      "max_supply": 21000000.0,
+      "quotes": {
+        "USD": {
+          "price": 704.56,
+          "volume_24h": 456889000.0,
+          "market_cap": 12119154174.0,
+          "percent_change_1h": 0.69,
+          "percent_change_24h": -6.58,
+          "percent_change_7d": -17.53
+        },
+        "BTC": {
+          "price": 0.1184719845,
+          "volume_24h": 76826.0283232387,
+          "market_cap": 2037840.0,
+          "percent_change_1h": 0.63,
+          "percent_change_24h": -3.78,
+          "percent_change_7d": -9.26
+        }
+      },
+      "last_updated": 1529852362
+    },
+    "1765": {
+      "id": 1765,
+      "name": "EOS",
+      "symbol": "EOS",
+      "website_slug": "eos",
+      "rank": 5,
+      "circulating_supply": 896149492.0,
+      "total_supply": 900000000.0,
+      "max_supply": 1000000000.0,
+      "quotes": {
+        "USD": {
+          "price": 7.33356,
+          "volume_24h": 936579000.0,
+          "market_cap": 6571966070.0,
+          "percent_change_1h": -0.56,
+          "percent_change_24h": -11.64,
+          "percent_change_7d": -30.67
+        },
+        "BTC": {
+          "price": 0.0012331404,
+          "volume_24h": 157486.0519315426,
+          "market_cap": 1105078.0,
+          "percent_change_1h": -0.62,
+          "percent_change_24h": -8.99,
+          "percent_change_7d": -23.72
+        }
+      },
+      "last_updated": 1529852361
+    },
+    "2": {
+      "id": 2,
+      "name": "Litecoin",
+      "symbol": "LTC",
+      "website_slug": "litecoin",
+      "rank": 6,
+      "circulating_supply": 57118545.0,
+      "total_supply": 57118545.0,
+      "max_supply": 84000000.0,
+      "quotes": {
+        "USD": {
+          "price": 77.0822,
+          "volume_24h": 419986000.0,
+          "market_cap": 4402823103.0,
+          "percent_change_1h": -1.0,
+          "percent_change_24h": -6.89,
+          "percent_change_7d": -20.45
+        },
+        "BTC": {
+          "price": 0.0129613961,
+          "volume_24h": 70620.7773252666,
+          "market_cap": 740336.0,
+          "percent_change_1h": -1.06,
+          "percent_change_24h": -4.1,
+          "percent_change_7d": -12.48
+        }
+      },
+      "last_updated": 1529852342
+    },
+    "512": {
+      "id": 512,
+      "name": "Stellar",
+      "symbol": "XLM",
+      "website_slug": "stellar",
+      "rank": 7,
+      "circulating_supply": 18759619711.0,
+      "total_supply": 104045664101.0,
+      "max_supply": null,
+      "quotes": {
+        "USD": {
+          "price": 0.186982,
+          "volume_24h": 41608300.0,
+          "market_cap": 3507711213.0,
+          "percent_change_1h": -0.11,
+          "percent_change_24h": -6.5,
+          "percent_change_7d": -19.57
+        },
+        "BTC": {
+          "price": 3.14411e-05,
+          "volume_24h": 6996.448665391,
+          "market_cap": 589823.0,
+          "percent_change_1h": -0.17,
+          "percent_change_24h": -3.69,
+          "percent_change_7d": -11.51
+        }
+      },
+      "last_updated": 1529852345
+    },
+    "2010": {
+      "id": 2010,
+      "name": "Cardano",
+      "symbol": "ADA",
+      "website_slug": "cardano",
+      "rank": 8,
+      "circulating_supply": 25927070538.0,
+      "total_supply": 31112483745.0,
+      "max_supply": 45000000000.0,
+      "quotes": {
+        "USD": {
+          "price": 0.125574,
+          "volume_24h": 54041800.0,
+          "market_cap": 3255765956.0,
+          "percent_change_1h": -0.3,
+          "percent_change_24h": -7.86,
+          "percent_change_7d": -22.91
+        },
+        "BTC": {
+          "price": 2.11153e-05,
+          "volume_24h": 9087.1455811779,
+          "market_cap": 547458.0,
+          "percent_change_1h": -0.36,
+          "percent_change_24h": -5.1,
+          "percent_change_7d": -15.18
+        }
+      },
+      "last_updated": 1529852367
+    },
+    "1958": {
+      "id": 1958,
+      "name": "TRON",
+      "symbol": "TRX",
+      "website_slug": "tron",
+      "rank": 9,
+      "circulating_supply": 65748111645.0,
+      "total_supply": 100000000000.0,
+      "max_supply": null,
+      "quotes": {
+        "USD": {
+          "price": 0.0408227,
+          "volume_24h": 178189000.0,
+          "market_cap": 2684015437.0,
+          "percent_change_1h": -0.06,
+          "percent_change_24h": -6.32,
+          "percent_change_7d": -5.23
+        },
+        "BTC": {
+          "price": 6.8643e-06,
+          "volume_24h": 29962.5361102797,
+          "market_cap": 451318.0,
+          "percent_change_1h": -0.12,
+          "percent_change_24h": -3.51,
+          "percent_change_7d": 4.27
+        }
+      },
+      "last_updated": 1529852366
+    },
+    "825": {
+      "id": 825,
+      "name": "Tether",
+      "symbol": "USDT",
+      "website_slug": "tether",
+      "rank": 10,
+      "circulating_supply": 2607140346.0,
+      "total_supply": 2830109502.0,
+      "max_supply": null,
+      "quotes": {
+        "USD": {
+          "price": 1.00358,
+          "volume_24h": 3202080000.0,
+          "market_cap": 2616473908.0,
+          "percent_change_1h": 0.21,
+          "percent_change_24h": 0.12,
+          "percent_change_7d": 0.04
+        },
+        "BTC": {
+          "price": 0.0001687523,
+          "volume_24h": 538430.7540196333,
+          "market_cap": 439961.0,
+          "percent_change_1h": 0.15,
+          "percent_change_24h": 3.12,
+          "percent_change_7d": 10.07
+        }
+      },
+      "last_updated": 1529852348
+    }
+  },
+  "metadata": {
+    "timestamp": 1529852116,
+    "num_cryptocurrencies": 1586,
+    "error": null
+  }
+}


### PR DESCRIPTION
This modification/update was the result of the need for the 'convert' parameter in `/ticker`. While checking out the code, I realized that I had to update the API, too. So here it is. 

All CoinMarketCap tests pass and I have added a test JSON file for the new version.

Some code might not be optimal (but should be functional) because I haven't ever used jax-rs stuff or Jackson more extensively.