### PR TITLE
Cryptopia: Improve consistency with other implementations of getOrderBook

### DIFF
--- a/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/service/CryptopiaMarketDataService.java
+++ b/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/service/CryptopiaMarketDataService.java
@@ -67,7 +67,12 @@ public class CryptopiaMarketDataService extends CryptopiaMarketDataServiceRaw
   public OrderBook getOrderBook(CurrencyPair currencyPair, Object... args) throws IOException {
     try {
       if (args != null && args.length > 0) {
-        long orderCount = (long) args[0];
+        Long orderCount = null;
+        if (args[0] instanceof Integer) {
+          orderCount = ((Integer) args[0]).longValue();
+        } else if (args[0] instanceof Long) {
+          orderCount = (Long) args[0];
+        }
 
         return CryptopiaAdapters.adaptOrderBook(
             getCryptopiaOrderBook(currencyPair, orderCount), currencyPair);


### PR DESCRIPTION
Other implementation use Integer as first arguments.
This add support for Integer argument.