### PR TITLE
[btcmarkets] - Changed withdrawFunds to return null 

### DIFF
--- a/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/BTCMarketsAccountService.java
+++ b/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/BTCMarketsAccountService.java
@@ -29,10 +29,16 @@ public class BTCMarketsAccountService extends BTCMarketsAccountServiceRaw
   public String withdrawFunds(WithdrawFundsParams params) throws IOException {
     if (params instanceof DefaultWithdrawFundsParams) {
       DefaultWithdrawFundsParams defaultWithdrawFundsParams = (DefaultWithdrawFundsParams) params;
-      return withdrawCrypto(
+      withdrawCrypto(
           defaultWithdrawFundsParams.getAddress(),
           defaultWithdrawFundsParams.getAmount(),
           defaultWithdrawFundsParams.getCurrency());
+      // The BTCMarkets API doesn't return a useful value such as an id but the fixed value 'Pending
+      // Authorization'
+      // See https://github.com/BTCMarkets/API/issues/137
+      // and
+      // https://github.com/BTCMarkets/API/wiki/Fund-Transfer-API
+      return null;
     }
     throw new IllegalStateException("Cannot process " + params);
   }

--- a/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/service/BTCMarketsAccountServiceTest.java
+++ b/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/service/BTCMarketsAccountServiceTest.java
@@ -74,7 +74,7 @@ public class BTCMarketsAccountServiceTest extends BTCMarketsTestSupport {
   }
 
   @Test
-  public void withdrawFundsShouldRetrnTheStatus() throws IOException {
+  public void withdrawFundsShouldReturnNull() throws IOException {
 
     String status = "the-status"; // maybe the id would be more useful?
     BTCMarketsWithdrawCryptoResponse response =
@@ -94,7 +94,7 @@ public class BTCMarketsAccountServiceTest extends BTCMarketsTestSupport {
     // when
     String result = accountService.withdrawFunds(Currency.BTC, BigDecimal.TEN, "any address");
 
-    assertThat(result).isEqualTo(status);
+    assertThat(result).isNull();
   }
 
   @Test(expected = NotYetImplementedForExchangeException.class)


### PR DESCRIPTION
As per the btcmarkets API page, the withdraw funds page returns a fixed string 'Pending Authorization'.

```
{"success":true,"errorCode":null,"errorMessage":null,"status":"Pending Authorization"}
```

This does not conform to the API's return type which expects the method to return a transaction ID that might be used later on.

The lack of a usable return value has been raised with BTCMarkets in the following issue https://github.com/BTCMarkets/API/issues/137 but this has not been addressed.