### PR TITLE
[Gate.io] Fixed cancelOrder

### DIFF
--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/gateio/trade/GateioTradeDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/gateio/trade/GateioTradeDemo.java
@@ -10,6 +10,8 @@ import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.examples.gateio.GateioDemoUtils;
+import org.knowm.xchange.gateio.Gateio;
+import org.knowm.xchange.gateio.GateioUtils;
 import org.knowm.xchange.gateio.dto.GateioOrderType;
 import org.knowm.xchange.gateio.dto.trade.GateioOpenOrder;
 import org.knowm.xchange.gateio.dto.trade.GateioOpenOrders;
@@ -18,6 +20,7 @@ import org.knowm.xchange.gateio.dto.trade.GateioTrade;
 import org.knowm.xchange.gateio.service.GateioTradeServiceRaw;
 import org.knowm.xchange.service.trade.TradeService;
 import org.knowm.xchange.service.trade.params.DefaultTradeHistoryParamCurrencyPair;
+import org.knowm.xchange.utils.jackson.CurrencyPairDeserializer;
 
 public class GateioTradeDemo {
 
@@ -93,7 +96,7 @@ public class GateioTradeDemo {
       GateioOrderStatus orderStatus = tradeService.getGateioOrderStatus(existingOrderId);
       System.out.println(orderStatus);
 
-      boolean isCancelled = tradeService.cancelOrder(existingOrderId);
+      boolean isCancelled = tradeService.cancelOrder(existingOrderId, CurrencyPairDeserializer.getCurrencyPairFromString(openOrdersList.get(0).getCurrencyPair()));
       System.out.println(isCancelled);
     }
 

--- a/xchange-gateio/src/main/java/org/knowm/xchange/gateio/GateioAuthenticated.java
+++ b/xchange-gateio/src/main/java/org/knowm/xchange/gateio/GateioAuthenticated.java
@@ -54,6 +54,7 @@ public interface GateioAuthenticated extends Gateio {
   @Path("private/cancelorder")
   GateioBaseResponse cancelOrder(
       @FormParam("orderNumber") String orderNumber,
+      @FormParam("currencyPair") String currencyPair,
       @HeaderParam("KEY") String apiKey,
       @HeaderParam("SIGN") ParamsDigest signer,
       @FormParam("nonce") SynchronizedValueFactory<Long> nonce)

--- a/xchange-gateio/src/main/java/org/knowm/xchange/gateio/service/GateioTradeService.java
+++ b/xchange-gateio/src/main/java/org/knowm/xchange/gateio/service/GateioTradeService.java
@@ -15,7 +15,6 @@ import org.knowm.xchange.gateio.GateioAdapters;
 import org.knowm.xchange.gateio.dto.trade.GateioOpenOrders;
 import org.knowm.xchange.gateio.dto.trade.GateioTrade;
 import org.knowm.xchange.service.trade.TradeService;
-import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
 import org.knowm.xchange.service.trade.params.CancelOrderParams;
 import org.knowm.xchange.service.trade.params.DefaultTradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
@@ -74,14 +73,15 @@ public class GateioTradeService extends GateioTradeServiceRaw implements TradeSe
 
   @Override
   public boolean cancelOrder(String orderId) throws IOException {
-
-    return super.cancelOrder(orderId);
+    throw new NotAvailableFromExchangeException();
   }
 
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws IOException {
-    if (orderParams instanceof CancelOrderByIdParams) {
-      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    if (orderParams instanceof GateioCancelOrderParams) {
+      return cancelOrder(
+          ((GateioCancelOrderParams) orderParams).getOrderId(),
+          ((GateioCancelOrderParams) orderParams).getCurrencyPair());
     } else {
       return false;
     }

--- a/xchange-gateio/src/main/java/org/knowm/xchange/gateio/service/GateioTradeServiceRaw.java
+++ b/xchange-gateio/src/main/java/org/knowm/xchange/gateio/service/GateioTradeServiceRaw.java
@@ -13,6 +13,8 @@ import org.knowm.xchange.gateio.dto.trade.GateioOpenOrders;
 import org.knowm.xchange.gateio.dto.trade.GateioOrderStatus;
 import org.knowm.xchange.gateio.dto.trade.GateioPlaceOrderReturn;
 import org.knowm.xchange.gateio.dto.trade.GateioTradeHistoryReturn;
+import org.knowm.xchange.service.trade.params.CancelOrderByCurrencyPair;
+import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
 
 public class GateioTradeServiceRaw extends GateioBaseService {
 
@@ -85,10 +87,15 @@ public class GateioTradeServiceRaw extends GateioBaseService {
     return handleResponse(orderId).getOrderId();
   }
 
-  public boolean cancelOrder(String orderId) throws IOException {
+  public boolean cancelOrder(String orderId, CurrencyPair currencyPair) throws IOException {
 
     GateioBaseResponse cancelOrderResult =
-        bter.cancelOrder(orderId, apiKey, signatureCreator, exchange.getNonceFactory());
+        bter.cancelOrder(
+            orderId,
+            GateioUtils.toPairString(currencyPair),
+            apiKey,
+            signatureCreator,
+            exchange.getNonceFactory());
 
     return handleResponse(cancelOrderResult).isResult();
   }
@@ -147,5 +154,26 @@ public class GateioTradeServiceRaw extends GateioBaseService {
     return String.format(
             "%s_%s", currencyPair.base.getCurrencyCode(), currencyPair.counter.getCurrencyCode())
         .toLowerCase();
+  }
+
+  public static class GateioCancelOrderParams
+      implements CancelOrderByIdParams, CancelOrderByCurrencyPair {
+    public final CurrencyPair currencyPair;
+    public final String orderId;
+
+    public GateioCancelOrderParams(CurrencyPair currencyPair, String orderId) {
+      this.currencyPair = currencyPair;
+      this.orderId = orderId;
+    }
+
+    @Override
+    public String getOrderId() {
+      return orderId;
+    }
+
+    @Override
+    public CurrencyPair getCurrencyPair() {
+      return currencyPair;
+    }
   }
 }


### PR DESCRIPTION
cancelOrder(String orderId) is not supported by the API, cancelOrder(CancelOrderParams orderParams) must be used with GateioCancelOrderParams as the implementation of CancelOrderParams.