### PR TITLE
[Bittrex] Market Order Support

### DIFF
--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/BittrexExchange.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/BittrexExchange.java
@@ -25,7 +25,7 @@ public class BittrexExchange extends BaseExchange implements Exchange {
 
     this.marketDataService = new BittrexMarketDataService(this);
     this.accountService = new BittrexAccountService(this);
-    this.tradeService = new BittrexTradeService(this);
+    this.tradeService = new BittrexTradeService(this, this.marketDataService);
   }
 
   @Override


### PR DESCRIPTION
Bittrex no longer supports market orders. This is a work around
that submits Limit orders that are very likely to be taken up immediately.