### PR TITLE
[Gemini] Market Order

### DIFF
--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/GeminiExchange.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/GeminiExchange.java
@@ -23,7 +23,7 @@ public class GeminiExchange extends BaseExchange {
     concludeHostParams(exchangeSpecification);
     this.marketDataService = new GeminiMarketDataService(this);
     this.accountService = new GeminiAccountService(this);
-    this.tradeService = new GeminiTradeService(this);
+    this.tradeService = new GeminiTradeService(this, this.marketDataService);
   }
 
   @Override


### PR DESCRIPTION
Gemini does not support market orders directly. This is a work around that places effective market orders by placing out priced limit orders that are very likely to be taken up immediately.