### PR TITLE
Fix Bitflyer last traded price

### DIFF
--- a/xchange-bitflyer/src/main/java/org/knowm/xchange/bitflyer/BitflyerAdapters.java
+++ b/xchange-bitflyer/src/main/java/org/knowm/xchange/bitflyer/BitflyerAdapters.java
@@ -78,6 +78,7 @@ public class BitflyerAdapters {
     BigDecimal bid = ticker.getBestBid();
     BigDecimal ask = ticker.getBestAsk();
     BigDecimal volume = ticker.getVolume();
+    BigDecimal last = ticker.getLtp();
     Date timestamp =
         ticker.getTimestamp() != null ? BitflyerUtils.parseDate(ticker.getTimestamp()) : null;
 
@@ -85,6 +86,7 @@ public class BitflyerAdapters {
         .currencyPair(currencyPair)
         .bid(bid)
         .ask(ask)
+        .last(ask)
         .volume(volume)
         .timestamp(timestamp)
         .build();

--- a/xchange-bitflyer/src/test/java/org/knowm/xchange/bitflyer/service/BitflyerTickerIntegration.java
+++ b/xchange-bitflyer/src/test/java/org/knowm/xchange/bitflyer/service/BitflyerTickerIntegration.java
@@ -23,6 +23,7 @@ public class BitflyerTickerIntegration {
     assertThat(ticker.getCurrencyPair()).isEqualTo(CurrencyPair.BTC_JPY);
     assertThat(ticker.getHigh()).isNull();
     assertThat(ticker.getLow()).isNull();
+    assertThat(ticker.getLast()).isGreaterThan(BigDecimal.ZERO);
     assertThat(ticker.getVolume()).isGreaterThan(BigDecimal.ZERO);
     assertThat(ticker.getBid()).isGreaterThan(BigDecimal.ZERO);
     assertThat(ticker.getAsk()).isGreaterThan(BigDecimal.ZERO);


### PR DESCRIPTION
The last traded price for the Bitflyer ticker is null, even though it is present in the returned ticker data.