### PR TITLE
Issue #2703. Bitstamp Funding request bug fix

### DIFF
--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountService.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountService.java
@@ -20,7 +20,6 @@ import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.account.AccountService;
 import org.knowm.xchange.service.trade.params.DefaultWithdrawFundsParams;
 import org.knowm.xchange.service.trade.params.RippleWithdrawFundsParams;
-import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamOffset;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
@@ -143,9 +142,6 @@ public class BitstampAccountService extends BitstampAccountServiceRaw implements
     if (params instanceof TradeHistoryParamPaging) {
       limit = Long.valueOf(((TradeHistoryParamPaging) params).getPageLength());
     }
-    if (params instanceof TradeHistoryParamCurrencyPair) {
-      currencyPair = ((TradeHistoryParamCurrencyPair) params).getCurrencyPair();
-    }
     if (params instanceof TradeHistoryParamOffset) {
       offset = ((TradeHistoryParamOffset) params).getOffset();
     }
@@ -153,8 +149,7 @@ public class BitstampAccountService extends BitstampAccountServiceRaw implements
       sort = ((TradeHistoryParamsSorted) params).getOrder();
     }
     BitstampUserTransaction[] txs =
-        getBitstampUserTransactions(
-            limit, currencyPair, offset, sort == null ? null : sort.toString());
+        getBitstampUserTransactions(limit, offset, sort == null ? null : sort.toString());
     return BitstampAdapters.adaptFundingHistory(Arrays.asList(txs));
   }
 }

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountServiceRaw.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountServiceRaw.java
@@ -318,6 +318,17 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
     }
   }
 
+  public BitstampUserTransaction[] getBitstampUserTransactions(
+      Long numberOfTransactions, Long offset, String sort) throws IOException {
+
+    try {
+      return bitstampAuthenticatedV2.getUserTransactions(
+          apiKey, signatureCreator, nonceFactory, numberOfTransactions, offset, sort);
+    } catch (BitstampException e) {
+      throw handleError(e);
+    }
+  }
+
   public BitstampTransferBalanceResponse transferSubAccountBalanceToMain(
       BigDecimal amount, String currency, String subAccount) throws IOException {
     try {


### PR DESCRIPTION
library creates request with double slash in the end: https://dev-publicapi.cryptonit.net/api/v2/user_transactions//

So Bitstamp understands this request like try to get trading pair related transactions but not funding history and throws error: {"status":"error","reason":{"MARKET_UNKNOWN":[]}}"; line: 1, column: 1]

Solution is to use implementation of web service call without currencyPair parameter,