### PR TITLE
[coindirect] fixed incorrect access of raw constructors + path tweaks

### DIFF
--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/Coindirect.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/Coindirect.java
@@ -19,13 +19,13 @@ public interface Coindirect {
       throws IOException, CoindirectException;
 
   @GET
-  @Path("/api/v1/exchange/historical/trades/{market}/{history}")
+  @Path("api/v1/exchange/historical/trades/{market}/{history}")
   CoindirectTrades getHistoricalExchangeTrades(
       @PathParam("market") String market, @PathParam("history") String history)
       throws IOException, CoindirectException;
 
   @GET
-  @Path("/api/v1/exchange/historical/{market}/{history}/{grouping}")
+  @Path("api/v1/exchange/historical/{market}/{history}/{grouping}")
   CoindirectTicker getHistoricalExchangeData(
       @PathParam("market") String market,
       @PathParam("history") String history,
@@ -33,7 +33,7 @@ public interface Coindirect {
       throws IOException, CoindirectException;
 
   @GET
-  @Path("/api/v1/exchange/market")
+  @Path("api/v1/exchange/market")
   List<CoindirectMarket> listExchangeMarkets(@QueryParam("max") long max)
       throws IOException, CoindirectException;
 }

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/CoindirectAuthenticated.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/CoindirectAuthenticated.java
@@ -16,13 +16,13 @@ public interface CoindirectAuthenticated extends Coindirect {
   public static final String AUTHORIZATION = "Authorization";
 
   @GET
-  @Path("/api/wallet")
+  @Path("api/wallet")
   List<CoindirectWallet> listWallets(
       @QueryParam("max") long max, @HeaderParam("Authorization") ParamsDigest signer)
       throws IOException, CoindirectException;
 
   @GET
-  @Path("/api/v1/exchange/order")
+  @Path("api/v1/exchange/order")
   List<CoindirectOrder> listExchangeOrders(
       @QueryParam("symbol") String symbol,
       @QueryParam("completed") boolean completed,
@@ -32,19 +32,19 @@ public interface CoindirectAuthenticated extends Coindirect {
       throws IOException, CoindirectException;
 
   @POST
-  @Path("/api/v1/exchange/order")
+  @Path("api/v1/exchange/order")
   @Consumes(MediaType.APPLICATION_JSON)
   CoindirectOrder placeExchangeOrder(
       CoindirectOrderRequest coindirectOrderRequest,
       @HeaderParam("Authorization") ParamsDigest signer);
 
   @DELETE
-  @Path("/api/v1/exchange/order/{uuid}")
+  @Path("api/v1/exchange/order/{uuid}")
   CoindirectOrder cancelExchangeOrder(
       @PathParam("uuid") String uuid, @HeaderParam("Authorization") ParamsDigest signer);
 
   @GET
-  @Path("/api/v1/exchange/order/read/{uuid}")
+  @Path("api/v1/exchange/order/read/{uuid}")
   CoindirectOrder getExchangeOrder(
       @PathParam("uuid") String uuid, @HeaderParam("Authorization") ParamsDigest signer);
 }

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectAccountServiceRaw.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectAccountServiceRaw.java
@@ -12,7 +12,7 @@ public class CoindirectAccountServiceRaw extends CoindirectBaseService {
    *
    * @param exchange
    */
-  protected CoindirectAccountServiceRaw(Exchange exchange) {
+  public CoindirectAccountServiceRaw(Exchange exchange) {
     super(exchange);
   }
 

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectMarketDataServiceRaw.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectMarketDataServiceRaw.java
@@ -16,7 +16,7 @@ public class CoindirectMarketDataServiceRaw extends CoindirectBaseService {
    *
    * @param exchange
    */
-  protected CoindirectMarketDataServiceRaw(Exchange exchange) {
+  public CoindirectMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
   }
 

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectTradeServiceRaw.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectTradeServiceRaw.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.coindirect.service;
 import java.io.IOException;
 import java.util.List;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.coindirect.CoindirectExchange;
 import org.knowm.xchange.coindirect.dto.CoindirectException;
 import org.knowm.xchange.coindirect.dto.trade.CoindirectOrder;
 import org.knowm.xchange.coindirect.dto.trade.CoindirectOrderRequest;
@@ -13,7 +14,7 @@ public class CoindirectTradeServiceRaw extends CoindirectBaseService {
    *
    * @param exchange
    */
-  protected CoindirectTradeServiceRaw(Exchange exchange) {
+  public CoindirectTradeServiceRaw(Exchange exchange) {
     super(exchange);
   }
 


### PR DESCRIPTION
Apologies for this, access of *Raw constructors was incorrect, need this for the xchange-stream implementation.