### PR TITLE
[coindirect] fixed incorrect access of raw constructors + path tweaks

### DIFF
--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/Coindirect.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/Coindirect.java
@@ -19,13 +19,13 @@ public interface Coindirect {
       throws IOException, CoindirectException;
 
   @GET
-  @Path("/api/v1/exchange/historical/trades/{market}/{history}")
+  @Path("api/v1/exchange/historical/trades/{market}/{history}")
   CoindirectTrades getHistoricalExchangeTrades(
       @PathParam("market") String market, @PathParam("history") String history)
       throws IOException, CoindirectException;
 
   @GET
-  @Path("/api/v1/exchange/historical/{market}/{history}/{grouping}")
+  @Path("api/v1/exchange/historical/{market}/{history}/{grouping}")
   CoindirectTicker getHistoricalExchangeData(
       @PathParam("market") String market,
       @PathParam("history") String history,
@@ -33,7 +33,7 @@ public interface Coindirect {
       throws IOException, CoindirectException;
 
   @GET
-  @Path("/api/v1/exchange/market")
+  @Path("api/v1/exchange/market")
   List<CoindirectMarket> listExchangeMarkets(@QueryParam("max") long max)
       throws IOException, CoindirectException;
 }

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/CoindirectAdapters.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/CoindirectAdapters.java
@@ -1,10 +1,14 @@
 package org.knowm.xchange.coindirect;
 
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.knowm.xchange.coindirect.dto.marketdata.CoindirectOrderbook;
 import org.knowm.xchange.coindirect.dto.trade.CoindirectOrder;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
 
@@ -65,6 +69,26 @@ public class CoindirectAdapters {
       default:
         return Order.OrderStatus.UNKNOWN;
     }
+  }
+
+  public static OrderBook adaptOrderBook(
+      CurrencyPair currencyPair, CoindirectOrderbook coindirectOrderbook) {
+    List<LimitOrder> bids =
+        coindirectOrderbook
+            .bids
+            .stream()
+            .map(
+                e -> new LimitOrder(Order.OrderType.BID, e.size, currencyPair, null, null, e.price))
+            .collect(Collectors.toList());
+    List<LimitOrder> asks =
+        coindirectOrderbook
+            .asks
+            .stream()
+            .map(
+                e -> new LimitOrder(Order.OrderType.ASK, e.size, currencyPair, null, null, e.price))
+            .collect(Collectors.toList());
+
+    return new OrderBook(null, asks, bids);
   }
 
   public static Order adaptOrder(CoindirectOrder order) {

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/CoindirectAuthenticated.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/CoindirectAuthenticated.java
@@ -16,13 +16,13 @@ public interface CoindirectAuthenticated extends Coindirect {
   public static final String AUTHORIZATION = "Authorization";
 
   @GET
-  @Path("/api/wallet")
+  @Path("api/wallet")
   List<CoindirectWallet> listWallets(
       @QueryParam("max") long max, @HeaderParam("Authorization") ParamsDigest signer)
       throws IOException, CoindirectException;
 
   @GET
-  @Path("/api/v1/exchange/order")
+  @Path("api/v1/exchange/order")
   List<CoindirectOrder> listExchangeOrders(
       @QueryParam("symbol") String symbol,
       @QueryParam("completed") boolean completed,
@@ -32,19 +32,19 @@ public interface CoindirectAuthenticated extends Coindirect {
       throws IOException, CoindirectException;
 
   @POST
-  @Path("/api/v1/exchange/order")
+  @Path("api/v1/exchange/order")
   @Consumes(MediaType.APPLICATION_JSON)
   CoindirectOrder placeExchangeOrder(
       CoindirectOrderRequest coindirectOrderRequest,
       @HeaderParam("Authorization") ParamsDigest signer);
 
   @DELETE
-  @Path("/api/v1/exchange/order/{uuid}")
+  @Path("api/v1/exchange/order/{uuid}")
   CoindirectOrder cancelExchangeOrder(
       @PathParam("uuid") String uuid, @HeaderParam("Authorization") ParamsDigest signer);
 
   @GET
-  @Path("/api/v1/exchange/order/read/{uuid}")
+  @Path("api/v1/exchange/order/read/{uuid}")
   CoindirectOrder getExchangeOrder(
       @PathParam("uuid") String uuid, @HeaderParam("Authorization") ParamsDigest signer);
 }

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/CoindirectAuthenticated.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/CoindirectAuthenticated.java
@@ -5,6 +5,7 @@ import java.util.List;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import org.knowm.xchange.coindirect.dto.CoindirectException;
+import org.knowm.xchange.coindirect.dto.account.CoindirectAccountChannel;
 import org.knowm.xchange.coindirect.dto.account.CoindirectWallet;
 import org.knowm.xchange.coindirect.dto.trade.CoindirectOrder;
 import org.knowm.xchange.coindirect.dto.trade.CoindirectOrderRequest;
@@ -47,4 +48,9 @@ public interface CoindirectAuthenticated extends Coindirect {
   @Path("api/v1/exchange/order/read/{uuid}")
   CoindirectOrder getExchangeOrder(
       @PathParam("uuid") String uuid, @HeaderParam("Authorization") ParamsDigest signer);
+
+  @GET
+  @Path("api/account/channel")
+  CoindirectAccountChannel getAccountChannel(@HeaderParam("Authorization") ParamsDigest signer)
+      throws IOException, CoindirectException;
 }

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/CoindirectExchange.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/CoindirectExchange.java
@@ -34,7 +34,7 @@ public class CoindirectExchange extends BaseExchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
     ExchangeSpecification spec = new ExchangeSpecification(this.getClass().getCanonicalName());
-    spec.setSslUri("https://api.coindirect.com");
+    spec.setSslUri("https://api.dev.node.limited");
     spec.setHost("www.coindirect.com");
     spec.setPort(80);
     spec.setExchangeName("Coindirect");

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/CoindirectExchange.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/CoindirectExchange.java
@@ -34,7 +34,7 @@ public class CoindirectExchange extends BaseExchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
     ExchangeSpecification spec = new ExchangeSpecification(this.getClass().getCanonicalName());
-    spec.setSslUri("https://api.dev.node.limited");
+    spec.setSslUri("https://api.coindirect.com");
     spec.setHost("www.coindirect.com");
     spec.setPort(80);
     spec.setExchangeName("Coindirect");

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/dto/account/CoindirectAccountChannel.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/dto/account/CoindirectAccountChannel.java
@@ -1,0 +1,11 @@
+package org.knowm.xchange.coindirect.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CoindirectAccountChannel {
+  public final String value;
+
+  public CoindirectAccountChannel(@JsonProperty("value") String value) {
+    this.value = value;
+  }
+}

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectAccountServiceRaw.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectAccountServiceRaw.java
@@ -12,7 +12,7 @@ public class CoindirectAccountServiceRaw extends CoindirectBaseService {
    *
    * @param exchange
    */
-  protected CoindirectAccountServiceRaw(Exchange exchange) {
+  public CoindirectAccountServiceRaw(Exchange exchange) {
     super(exchange);
   }
 

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectAccountServiceRaw.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectAccountServiceRaw.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.coindirect.dto.CoindirectException;
+import org.knowm.xchange.coindirect.dto.account.CoindirectAccountChannel;
 import org.knowm.xchange.coindirect.dto.account.CoindirectWallet;
 
 public class CoindirectAccountServiceRaw extends CoindirectBaseService {
@@ -16,7 +17,12 @@ public class CoindirectAccountServiceRaw extends CoindirectBaseService {
     super(exchange);
   }
 
-  List<CoindirectWallet> listCoindirectWallets(long max) throws IOException, CoindirectException {
+  public List<CoindirectWallet> listCoindirectWallets(long max)
+      throws IOException, CoindirectException {
     return coindirect.listWallets(max, signatureCreator);
+  }
+
+  public CoindirectAccountChannel getAccountChannel() throws IOException, CoindirectException {
+    return coindirect.getAccountChannel(signatureCreator);
   }
 }

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectMarketDataService.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectMarketDataService.java
@@ -14,7 +14,6 @@ import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trade;
 import org.knowm.xchange.dto.marketdata.Trades;
-import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 import org.knowm.xchange.service.marketdata.params.Params;
 
@@ -32,23 +31,7 @@ public class CoindirectMarketDataService extends CoindirectMarketDataServiceRaw
   @Override
   public OrderBook getOrderBook(CurrencyPair currencyPair, Object... args) throws IOException {
     CoindirectOrderbook coindirectOrderbook = getCoindirectOrderbook(currencyPair);
-
-    List<LimitOrder> bids =
-        coindirectOrderbook
-            .bids
-            .stream()
-            .map(
-                e -> new LimitOrder(Order.OrderType.BID, e.size, currencyPair, null, null, e.price))
-            .collect(Collectors.toList());
-    List<LimitOrder> asks =
-        coindirectOrderbook
-            .asks
-            .stream()
-            .map(
-                e -> new LimitOrder(Order.OrderType.ASK, e.size, currencyPair, null, null, e.price))
-            .collect(Collectors.toList());
-
-    return new OrderBook(null, asks, bids);
+    return CoindirectAdapters.adaptOrderBook(currencyPair, coindirectOrderbook);
   }
 
   @Override

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectMarketDataServiceRaw.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectMarketDataServiceRaw.java
@@ -16,7 +16,7 @@ public class CoindirectMarketDataServiceRaw extends CoindirectBaseService {
    *
    * @param exchange
    */
-  protected CoindirectMarketDataServiceRaw(Exchange exchange) {
+  public CoindirectMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
   }
 

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectTradeServiceRaw.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectTradeServiceRaw.java
@@ -3,7 +3,6 @@ package org.knowm.xchange.coindirect.service;
 import java.io.IOException;
 import java.util.List;
 import org.knowm.xchange.Exchange;
-import org.knowm.xchange.coindirect.CoindirectExchange;
 import org.knowm.xchange.coindirect.dto.CoindirectException;
 import org.knowm.xchange.coindirect.dto.trade.CoindirectOrder;
 import org.knowm.xchange.coindirect.dto.trade.CoindirectOrderRequest;

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectTradeServiceRaw.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectTradeServiceRaw.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.coindirect.service;
 import java.io.IOException;
 import java.util.List;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.coindirect.CoindirectExchange;
 import org.knowm.xchange.coindirect.dto.CoindirectException;
 import org.knowm.xchange.coindirect.dto.trade.CoindirectOrder;
 import org.knowm.xchange.coindirect.dto.trade.CoindirectOrderRequest;
@@ -13,7 +14,7 @@ public class CoindirectTradeServiceRaw extends CoindirectBaseService {
    *
    * @param exchange
    */
-  protected CoindirectTradeServiceRaw(Exchange exchange) {
+  public CoindirectTradeServiceRaw(Exchange exchange) {
     super(exchange);
   }
 


### PR DESCRIPTION
Apologies for this, access of *Raw constructors was incorrect, need this for the xchange-stream implementation.