### PR TITLE
[Liqui] Fixed retrieved order amounts

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
@@ -273,7 +273,7 @@ public class LimitOrder extends Order implements Comparable<LimitOrder> {
     public LimitOrder build() {
 
       LimitOrder order;
-      if (remainingAmount != null) {
+      if (remainingAmount != null && originalAmount != null) {
         order =
             new LimitOrder(
                 orderType,

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.dto.trade;
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.Set;
+
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 
@@ -16,7 +17,9 @@ import org.knowm.xchange.dto.Order;
  */
 public class LimitOrder extends Order implements Comparable<LimitOrder> {
 
-  /** The limit price */
+  /**
+   * The limit price
+   */
   protected final BigDecimal limitPrice;
 
   /**
@@ -25,9 +28,9 @@ public class LimitOrder extends Order implements Comparable<LimitOrder> {
    * @param currencyPair The identifier (e.g. BTC/USD)
    * @param id An id (usually provided by the exchange)
    * @param timestamp a Date object representing the order's timestamp according to the exchange's
-   *     server, null if not provided
+   * server, null if not provided
    * @param limitPrice In a BID this is the highest acceptable price, in an ASK this is the lowest
-   *     acceptable price
+   * acceptable price
    */
   public LimitOrder(
       OrderType type,
@@ -48,9 +51,9 @@ public class LimitOrder extends Order implements Comparable<LimitOrder> {
    * @param currencyPair The identifier (e.g. BTC/USD)
    * @param id An id (usually provided by the exchange)
    * @param timestamp a Date object representing the order's timestamp according to the exchange's
-   *     server, null if not provided
+   * server, null if not provided
    * @param limitPrice In a BID this is the highest acceptable price, in an ASK this is the lowest
-   *     acceptable price
+   * acceptable price
    */
   public LimitOrder(
       OrderType type,
@@ -80,9 +83,9 @@ public class LimitOrder extends Order implements Comparable<LimitOrder> {
    * @param currencyPair The identifier (e.g. BTC/USD)
    * @param id An id (usually provided by the exchange)
    * @param timestamp a Date object representing the order's timestamp according to the exchange's
-   *     server, null if not provided
+   * server, null if not provided
    * @param limitPrice In a BID this is the highest acceptable price, in an ASK this is the lowest
-   *     acceptable price
+   * acceptable price
    * @param averagePrice the weighted average price of any fills belonging to the order
    * @param cumulativeAmount the amount that has been filled
    * @param status the status of the order at the exchange or broker
@@ -112,7 +115,9 @@ public class LimitOrder extends Order implements Comparable<LimitOrder> {
     this.limitPrice = limitPrice;
   }
 
-  /** @return The limit price */
+  /**
+   * @return The limit price
+   */
   public BigDecimal getLimitPrice() {
 
     return limitPrice;
@@ -272,34 +277,20 @@ public class LimitOrder extends Order implements Comparable<LimitOrder> {
 
     public LimitOrder build() {
 
-      LimitOrder order;
-      if (remainingAmount != null && originalAmount != null) {
-        order =
-            new LimitOrder(
-                orderType,
-                originalAmount,
-                currencyPair,
-                id,
-                timestamp,
-                limitPrice,
-                averagePrice,
-                originalAmount.subtract(remainingAmount),
-                fee,
-                status);
-      } else {
-        order =
-            new LimitOrder(
-                orderType,
-                originalAmount,
-                currencyPair,
-                id,
-                timestamp,
-                limitPrice,
-                averagePrice,
-                cumulativeAmount,
-                fee,
-                status);
-      }
+      LimitOrder order =
+          new LimitOrder(
+              orderType,
+              originalAmount,
+              currencyPair,
+              id,
+              timestamp,
+              limitPrice,
+              averagePrice,
+              originalAmount == null || remainingAmount == null
+                  ? cumulativeAmount
+                  : originalAmount.subtract(remainingAmount),
+              fee,
+              status);
       order.setOrderFlags(flags);
       return order;
     }

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
@@ -186,6 +186,7 @@ public class LimitOrder extends Order implements Comparable<LimitOrder> {
           (Builder)
               new Builder(order.getType(), order.getCurrencyPair())
                   .originalAmount(order.getOriginalAmount())
+                  .cumulativeAmount(order.getCumulativeAmount())
                   .timestamp(order.getTimestamp())
                   .id(order.getId())
                   .flags(order.getOrderFlags())

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/DefaultOpenOrdersParam.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/DefaultOpenOrdersParam.java
@@ -4,11 +4,10 @@ import org.knowm.xchange.dto.trade.LimitOrder;
 
 public class DefaultOpenOrdersParam implements OpenOrdersParams {
 
-  public DefaultOpenOrdersParam() {
-  }
+  public DefaultOpenOrdersParam() {}
 
   @Override
   public boolean accept(LimitOrder order) {
-	return order != null;
+    return order != null;
   }
 }

--- a/xchange-liqui/src/main/java/org/knowm/xchange/liqui/LiquiAdapters.java
+++ b/xchange-liqui/src/main/java/org/knowm/xchange/liqui/LiquiAdapters.java
@@ -184,7 +184,8 @@ public class LiquiAdapters {
     final Order.OrderStatus status = adaptOrderStatus(orderInfo.getStatus());
 
     return new LimitOrder.Builder(type, orderInfo.getPair())
-        .originalAmount(originalAmount.orElse(orderInfo.getAmount()))
+        .originalAmount(originalAmount.orElse(null))
+        .remainingAmount(orderInfo.getAmount())
         .timestamp(timestamp)
         .limitPrice(orderInfo.getRate())
         .cumulativeAmount(cumulativeAmount.orElse(null))

--- a/xchange-liqui/src/main/java/org/knowm/xchange/liqui/LiquiAdapters.java
+++ b/xchange-liqui/src/main/java/org/knowm/xchange/liqui/LiquiAdapters.java
@@ -184,8 +184,7 @@ public class LiquiAdapters {
     final Order.OrderStatus status = adaptOrderStatus(orderInfo.getStatus());
 
     return new LimitOrder.Builder(type, orderInfo.getPair())
-        .originalAmount(originalAmount.orElse(null))
-        .remainingAmount(orderInfo.getAmount())
+        .originalAmount(originalAmount.orElse(orderInfo.getAmount()))
         .timestamp(timestamp)
         .limitPrice(orderInfo.getRate())
         .cumulativeAmount(cumulativeAmount.orElse(null))

--- a/xchange-liqui/src/main/java/org/knowm/xchange/liqui/LiquiAdapters.java
+++ b/xchange-liqui/src/main/java/org/knowm/xchange/liqui/LiquiAdapters.java
@@ -6,6 +6,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -123,26 +124,7 @@ public class LiquiAdapters {
 
   public static LimitOrder adaptActiveOrder(final LiquiOrderInfo orderInfo, final long id) {
 
-    final OrderType type = adaptOrderType(orderInfo.getType());
-
-    final BigDecimal originalAmount = orderInfo.getStartAmount();
-    final BigDecimal filledAmount = orderInfo.getStartAmount().subtract(orderInfo.getAmount());
-    final CurrencyPair pair = orderInfo.getPair();
-    final Date timestamp = new Date(orderInfo.getTimestampCreated() * 1000L);
-
-    final Order.OrderStatus status = adaptOrderStatus(orderInfo.getStatus());
-
-    return new LimitOrder(
-        type,
-        originalAmount,
-        pair,
-        String.valueOf(id),
-        timestamp,
-        orderInfo.getRate(),
-        orderInfo.getRate(),
-        filledAmount,
-        null,
-        status);
+    return LimitOrder.Builder.from(adaptLiquiOrderInfo(orderInfo)).id(String.valueOf(id)).build();
   }
 
   public static Order.OrderStatus adaptOrderStatus(final String status) {
@@ -187,15 +169,27 @@ public class LiquiAdapters {
         null);
   }
 
-  public static Order adaptOrderInfo(final LiquiOrderInfo info) {
-    final OrderType orderType = adaptOrderType(info.getType());
-    final CurrencyPair pair = info.getPair();
-    final BigDecimal amount = info.getStartAmount().subtract(info.getAmount());
-    final BigDecimal startAmount = info.getStartAmount();
-    final BigDecimal rate = info.getRate();
-    final Date timestamp = new Date(info.getTimestampCreated() * 1000L);
+  public static Order adaptOrderInfo(final LiquiOrderInfo orderInfo) {
 
-    return new LimitOrder(orderType, startAmount, amount, pair, "", timestamp, rate);
+    return adaptLiquiOrderInfo(orderInfo);
+  }
+
+  public static Order adaptLiquiOrderInfo(final LiquiOrderInfo orderInfo) {
+
+    final OrderType type = adaptOrderType(orderInfo.getType());
+    final Optional<BigDecimal> originalAmount = Optional.ofNullable(orderInfo.getStartAmount());
+    final Optional<BigDecimal> cumulativeAmount =
+        originalAmount.map(startAmount -> startAmount.subtract(orderInfo.getAmount()));
+    final Date timestamp = new Date(orderInfo.getTimestampCreated() * 1000L);
+    final Order.OrderStatus status = adaptOrderStatus(orderInfo.getStatus());
+
+    return new LimitOrder.Builder(type, orderInfo.getPair())
+        .originalAmount(originalAmount.orElse(orderInfo.getAmount()))
+        .timestamp(timestamp)
+        .limitPrice(orderInfo.getRate())
+        .cumulativeAmount(cumulativeAmount.orElse(null))
+        .orderStatus(status)
+        .build();
   }
 
   public static ExchangeMetaData adaptToExchangeMetaData(final Map<String, LiquiPairInfo> infos) {

--- a/xchange-liqui/src/main/java/org/knowm/xchange/liqui/dto/trade/LiquiOrderInfo.java
+++ b/xchange-liqui/src/main/java/org/knowm/xchange/liqui/dto/trade/LiquiOrderInfo.java
@@ -27,7 +27,7 @@ public class LiquiOrderInfo {
     final String[] split = pair.split("_");
     this.pair = new CurrencyPair(split[0], split[1]);
     this.type = type;
-    this.startAmount = new BigDecimal(startAmount != null ? startAmount : "0");
+    this.startAmount = startAmount != null ? new BigDecimal(startAmount) : null;
     this.amount = new BigDecimal(amount);
     this.rate = new BigDecimal(rate);
     this.timestampCreated = timestampCreated;


### PR DESCRIPTION
Fix for https://github.com/knowm/XChange/issues/2727:
[Liqui] Fixed retrieved order amounts 
[core] Added cumulativeAmount in LimitOrder "from" builder
