### PR TITLE
[gateio] Fixed the private trade history fetching

### DIFF
--- a/xchange-gateio/src/main/java/org/knowm/xchange/gateio/GateioAdapters.java
+++ b/xchange-gateio/src/main/java/org/knowm/xchange/gateio/GateioAdapters.java
@@ -208,8 +208,8 @@ public final class GateioAdapters {
         currencyPair,
         gateioTrade.getRate(),
         timestamp,
-        gateioTrade.getId(),
-        gateioTrade.getOrderid(),
+        gateioTrade.getTradeID(),
+        gateioTrade.getOrderNumber(),
         null,
         (Currency) null);
   }

--- a/xchange-gateio/src/main/java/org/knowm/xchange/gateio/dto/trade/GateioTrade.java
+++ b/xchange-gateio/src/main/java/org/knowm/xchange/gateio/dto/trade/GateioTrade.java
@@ -14,14 +14,14 @@ import org.knowm.xchange.gateio.dto.GateioOrderType;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
-@JsonPropertyOrder({"id", "orderid", "pair", "type", "rate", "amount", "time", "time_unix"})
+@JsonPropertyOrder({"tradeID", "orderNumber", "pair", "type", "rate", "amount", "time_unix"})
 public class GateioTrade {
 
-  @JsonProperty("id")
-  private String id;
+  @JsonProperty("tradeID")
+  private String tradeID;
 
-  @JsonProperty("orderid")
-  private String orderid;
+  @JsonProperty("orderNumber")
+  private String orderNumber;
 
   @JsonProperty("pair")
   private String pair;
@@ -35,119 +35,88 @@ public class GateioTrade {
   @JsonProperty("amount")
   private BigDecimal amount;
 
-  @JsonProperty("time")
-  private String time;
-
   @JsonProperty("time_unix")
   private long timeUnix;
 
   @JsonIgnore private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
-  @JsonProperty("id")
-  public String getId() {
-
-    return id;
+  @JsonProperty("tradeID")
+  public String getTradeID() {
+    return tradeID;
   }
 
-  @JsonProperty("id")
-  public void setId(String id) {
-
-    this.id = id;
+  @JsonProperty("tradeID")
+  public void setTradeID(String tradeID) {
+    this.tradeID = tradeID;
   }
 
-  @JsonProperty("orderid")
-  public String getOrderid() {
-
-    return orderid;
+  @JsonProperty("orderNumber")
+  public String getOrderNumber() {
+    return orderNumber;
   }
 
-  @JsonProperty("orderid")
-  public void setOrderid(String orderid) {
-
-    this.orderid = orderid;
+  @JsonProperty("orderNumber")
+  public void setOrderNumber(String orderNumber) {
+    this.orderNumber = orderNumber;
   }
 
   @JsonProperty("pair")
   public String getPair() {
-
     return pair;
   }
 
   @JsonProperty("pair")
   public void setPair(String pair) {
-
     this.pair = pair;
   }
 
   @JsonProperty("type")
   public GateioOrderType getType() {
-
     return type;
   }
 
   @JsonProperty("type")
   public void setType(GateioOrderType type) {
-
     this.type = type;
   }
 
   @JsonProperty("rate")
   public BigDecimal getRate() {
-
     return rate;
   }
 
   @JsonProperty("rate")
   public void setRate(BigDecimal rate) {
-
     this.rate = rate;
   }
 
   @JsonProperty("amount")
   public BigDecimal getAmount() {
-
     return amount;
   }
 
   @JsonProperty("amount")
   public void setAmount(BigDecimal amount) {
-
     this.amount = amount;
-  }
-
-  @JsonProperty("time")
-  public String getTime() {
-
-    return time;
-  }
-
-  @JsonProperty("time")
-  public void setTime(String time) {
-
-    this.time = time;
   }
 
   @JsonProperty("time_unix")
   public long getTimeUnix() {
-
     return timeUnix;
   }
 
   @JsonProperty("time_unix")
   public void setTimeUnix(long timeUnix) {
-
     this.timeUnix = timeUnix;
   }
 
   @JsonAnyGetter
   public Map<String, Object> getAdditionalProperties() {
-
     return this.additionalProperties;
   }
 
   @JsonAnySetter
   public void setAdditionalProperty(String name, Object value) {
-
     this.additionalProperties.put(name, value);
   }
 }


### PR DESCRIPTION
Unfortunatelly the API docs are not up to date.
If you compate the described json structure for the method "Get my last 24h trades API"
https://api.gate.io/api2/1/private/tradeHistory
here is, what i get as example:
`
{"result":"true","trades":[{"tradeID":7996xxxxx,"orderNumber":114427xxxx,"pair":"btc_usdt","type":"buy","rate":"6889.00","amount":"0.0100","total":68.89,"date":"2018-08-07 05:16:35","time_unix":1533590195}],"message":"Success","code":0}
`
this is different to the API doc