### PR TITLE
Bitmex: Add support for linked orders

### DIFF
--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/Bitmex.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/Bitmex.java
@@ -180,7 +180,9 @@ public interface Bitmex {
       @Nullable @FormParam("stopPx") BigDecimal stopPrice,
       @Nullable @FormParam("ordType") String orderType,
       @Nullable @FormParam("clOrdID") String clOrdID,
-      @Nullable @FormParam("execInst") String executionInstructions);
+      @Nullable @FormParam("execInst") String executionInstructions,
+      @Nullable @FormParam("clOrdLinkID") String clOrdLinkID,
+      @Nullable @FormParam("contingencyType") String contingencyType);
 
   @POST
   @Path("order/bulk")
@@ -206,7 +208,9 @@ public interface Bitmex {
       @Nullable @FormParam("ordType") String orderType,
       @Nullable @FormParam("orderID") String orderId,
       @Nullable @FormParam("clOrdID") String clOrdID,
-      @Nullable @FormParam("origClOrdID") String origClOrdID);
+      @Nullable @FormParam("origClOrdID") String origClOrdID,
+      @Nullable @FormParam("clOrdLinkID") String clOrdLinkID,
+      @Nullable @FormParam("contingencyType") String contingencyType);
 
   @PUT
   @Path("order/bulk")
@@ -289,6 +293,12 @@ public interface Bitmex {
     @JsonProperty("execInst")
     private final String executionInstructions;
 
+    @JsonProperty("clOrdLinkID")
+    private final String clOrdLinkID;
+
+    @JsonProperty("contingencyType")
+    private final String contingencyType;
+
     public PlaceOrderCommand(
         String symbol,
         @Nullable String side,
@@ -297,7 +307,9 @@ public interface Bitmex {
         @Nullable BigDecimal stopPrice,
         @Nullable String orderType,
         @Nullable String clOrdID,
-        @Nullable String executionInstructions) {
+        @Nullable String executionInstructions,
+        @Nullable String clOrdLinkID,
+        @Nullable String contingencyType) {
       this.symbol = symbol;
       this.side = side;
       this.orderQuantity = orderQuantity;
@@ -306,6 +318,8 @@ public interface Bitmex {
       this.orderType = orderType;
       this.clOrdID = clOrdID;
       this.executionInstructions = executionInstructions;
+      this.clOrdLinkID = clOrdLinkID;
+      this.contingencyType = contingencyType;
     }
 
     @Override
@@ -331,6 +345,12 @@ public interface Bitmex {
           + '\''
           + ", executionInstructions='"
           + executionInstructions
+          + '\''
+          + ", clOrdLinkID='"
+          + clOrdLinkID
+          + '\''
+          + ", contingencyType='"
+          + contingencyType
           + '\''
           + '}';
     }
@@ -364,6 +384,12 @@ public interface Bitmex {
     @JsonProperty("origClOrdID")
     private final String origClOrdID;
 
+    @JsonProperty("clOrdLinkID")
+    private final String clOrdLinkID;
+
+    @JsonProperty("contingencyType")
+    private final String contingencyType;
+
     public ReplaceOrderCommand(
         int orderQuantity,
         @Nullable BigDecimal price,
@@ -371,7 +397,9 @@ public interface Bitmex {
         @Nullable String orderType,
         @Nullable String orderId,
         @Nullable String clOrdID,
-        @Nullable String origClOrdID) {
+        @Nullable String origClOrdID,
+        @Nullable String clOrdLinkID,
+        @Nullable String contingencyType) {
       this.orderQuantity = orderQuantity;
       this.price = price;
       this.stopPrice = stopPrice;
@@ -379,6 +407,8 @@ public interface Bitmex {
       this.orderId = orderId;
       this.clOrdID = clOrdID;
       this.origClOrdID = origClOrdID;
+      this.clOrdLinkID = clOrdLinkID;
+      this.contingencyType = contingencyType;
     }
 
     @Override
@@ -401,6 +431,12 @@ public interface Bitmex {
           + '\''
           + ", origClOrdID='"
           + origClOrdID
+          + '\''
+          + ", clOrdLinkID='"
+          + clOrdLinkID
+          + '\''
+          + ", contingencyType='"
+          + contingencyType
           + '\''
           + '}';
     }

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexTradeService.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexTradeService.java
@@ -91,6 +91,8 @@ public class BitmexTradeService extends BitmexTradeServiceRaw implements TradeSe
             limitOrder.getLimitPrice(),
             side,
             limitOrder.getId(),
+            null,
+            null,
             null);
     return order.getId();
   }
@@ -111,7 +113,9 @@ public class BitmexTradeService extends BitmexTradeServiceRaw implements TradeSe
             stopOrder.getOriginalAmount(),
             stopOrder.getStopPrice(),
             null,
-            stopOrder.getId());
+            stopOrder.getId(),
+            null,
+            null);
     return order.getId();
   }
 

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexTradeServiceRaw.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexTradeServiceRaw.java
@@ -93,7 +93,9 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
         null,
         "Market",
         null,
-        executionInstructions);
+        executionInstructions,
+        null,
+        null);
   }
 
   public BitmexPrivateOrder placeLimitOrder(
@@ -102,7 +104,9 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
       BigDecimal price,
       BitmexSide side,
       String clOrdID,
-      String executionInstructions) {
+      String executionInstructions,
+      String clOrdLinkID,
+      String contingencyType) {
     return updateRateLimit(
         bitmex.placeOrder(
             apiKey,
@@ -116,7 +120,9 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
             null,
             ORDER_TYPE_LIMIT,
             clOrdID,
-            executionInstructions));
+            executionInstructions,
+            clOrdLinkID,
+            contingencyType));
   }
 
   public List<BitmexPrivateOrder> placeLimitOrderBulk(
@@ -138,7 +144,9 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
       BigDecimal price,
       String orderId,
       String clOrdID,
-      String origClOrdID) {
+      String origClOrdID,
+      String clOrdLinkID,
+      String contingencyType) {
 
     return updateRateLimit(
         bitmex.replaceOrder(
@@ -152,7 +160,9 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
             // if clOrdID is not null we should not send orderID
             clOrdID != null ? null : orderId,
             clOrdID,
-            origClOrdID));
+            origClOrdID,
+            clOrdLinkID,
+            contingencyType));
   }
 
   public BitmexPrivateOrder replaceStopOrder(
@@ -160,7 +170,9 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
       BigDecimal price,
       String orderID,
       String clOrdID,
-      String origClOrdId) {
+      String origClOrdId,
+      String clOrdLinkID,
+      String contingencyType) {
     return updateRateLimit(
         bitmex.replaceOrder(
             apiKey,
@@ -172,7 +184,9 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
             ORDER_TYPE_LIMIT,
             clOrdID != null ? null : orderID,
             clOrdID,
-            origClOrdId));
+            origClOrdId,
+            clOrdLinkID,
+            contingencyType));
   }
 
   public BitmexPrivateOrder placeStopOrder(
@@ -181,7 +195,9 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
       BigDecimal orderQuantity,
       BigDecimal stopPrice,
       String executionInstructions,
-      String clOrdID) {
+      String clOrdID,
+      String clOrdLinkID,
+      String contingencyType) {
     return updateRateLimit(
         bitmex.placeOrder(
             apiKey,
@@ -195,7 +211,9 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
             stopPrice,
             ORDER_TYPE_STOP,
             clOrdID,
-            executionInstructions));
+            executionInstructions,
+            clOrdLinkID,
+            contingencyType));
   }
 
   /**
@@ -205,7 +223,15 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
    *     simpleOrderQty is negative.
    * @param simpleOrderQuantity Order quantity in units of the underlying instrument (i.e. Bitcoin).
    * @param price
-   * @param executionInstructions
+   * @param executionInstructions Optional execution instructions. Valid options:
+   *     ParticipateDoNotInitiate, AllOrNone, MarkPrice, IndexPrice, LastPrice, Close, ReduceOnly,
+   *     Fixed. 'AllOrNone' instruction requires displayQty to be 0. 'MarkPrice', 'IndexPrice' or
+   *     'LastPrice' instruction valid for 'Stop', 'StopLimit', 'MarketIfTouched', and
+   *     'LimitIfTouched' orders.
+   * @param clOrdLinkID Optional Client Order Link ID for contingent orders.
+   * @param contingencyType Optional contingency type for use with clOrdLinkID. Valid options:
+   *     OneCancelsTheOther, OneTriggersTheOther, OneUpdatesTheOtherAbsolute,
+   *     OneUpdatesTheOtherProportional.
    * @return
    */
   public BitmexPrivateOrder placeLimitOrder(
@@ -214,7 +240,9 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
       BigDecimal orderQuantity,
       BigDecimal simpleOrderQuantity,
       BigDecimal price,
-      String executionInstructions) {
+      String executionInstructions,
+      String clOrdLinkID,
+      String contingencyType) {
     return updateRateLimit(
         bitmex.placeOrder(
             apiKey,
@@ -228,7 +256,9 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
             null,
             ORDER_TYPE_LIMIT,
             null,
-            executionInstructions));
+            executionInstructions,
+            clOrdLinkID,
+            contingencyType));
   }
 
   public List<BitmexPrivateOrder> cancelAllOrders() {

--- a/xchange-bitmex/src/test/java/org/knowm/xchange/bitmex/service/BitmexBulkOrderTest.java
+++ b/xchange-bitmex/src/test/java/org/knowm/xchange/bitmex/service/BitmexBulkOrderTest.java
@@ -78,6 +78,8 @@ public class BitmexBulkOrderTest {
             null,
             nosOrdId,
             null,
+            null,
+            null,
             null));
 
     List<BitmexPrivateOrder> bitmexPrivateOrders = tradeService.placeLimitOrderBulk(commands);


### PR DESCRIPTION
This Pull Request adds support for linked orders on Bitmex by adding the parameters `clOrdLinkID` and `contingencyType` to limit, stop and bulk orders.