### PR TITLE
Supporting new contract XBTZ18

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
@@ -270,6 +270,7 @@ public class Currency implements Comparable<Currency>, Serializable {
   public static final Currency H18 = createCurrency("H18", "March 30th", null);
   public static final Currency M18 = createCurrency("M18", "June 29th", null);
   public static final Currency U18 = createCurrency("U18", "September 28th", null);
+  public static final Currency Z18 = createCurrency("Z18", "December 28th", null);
 
   // Cryptos
   public static final Currency BNB = createCurrency("BNB", "Binance Coin", null);

--- a/xchange-core/src/main/java/org/knowm/xchange/currency/CurrencyPair.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/CurrencyPair.java
@@ -293,6 +293,7 @@ public class CurrencyPair implements Comparable<CurrencyPair>, Serializable {
   public static final CurrencyPair XBT_H18 = new CurrencyPair(Currency.XBT, Currency.H18);
   public static final CurrencyPair XBT_M18 = new CurrencyPair(Currency.XBT, Currency.M18);
   public static final CurrencyPair XBT_U18 = new CurrencyPair(Currency.XBT, Currency.U18);
+  public static final CurrencyPair XBT_Z18 = new CurrencyPair(Currency.XBT, Currency.Z18);
 
   public static final CurrencyPair ADA_H18 = new CurrencyPair(Currency.ADA, Currency.H18);
   public static final CurrencyPair ADA_M18 = new CurrencyPair(Currency.ADA, Currency.M18);


### PR DESCRIPTION
To support new future contract ![XBTZ18](https://www.bitmex.com/app/contract/XBTZ18), also add the new month `Z18`