### PR TITLE
Make HitBTC client order id main id, since this id is used by the API.

### DIFF
--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/dto/HitbtcLimitOrder.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/dto/HitbtcLimitOrder.java
@@ -1,23 +1,24 @@
 package org.knowm.xchange.hitbtc.v2.dto;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Date;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.trade.LimitOrder;
 
 public class HitbtcLimitOrder extends LimitOrder {
-  public final String clientOrderId;
+  public final BigInteger hitbtcOrderId;
 
   public HitbtcLimitOrder(
       OrderType type,
       BigDecimal originalAmount,
       CurrencyPair currencyPair,
-      String id,
+      BigInteger id,
       Date timestamp,
       BigDecimal limitPrice,
       String clientOrderId) {
-    super(type, originalAmount, currencyPair, id, timestamp, limitPrice);
-    this.clientOrderId = clientOrderId;
+    super(type, originalAmount, currencyPair, clientOrderId, timestamp, limitPrice);
+    this.hitbtcOrderId = id;
   }
 
   public HitbtcLimitOrder(
@@ -25,19 +26,20 @@ public class HitbtcLimitOrder extends LimitOrder {
       BigDecimal originalAmount,
       BigDecimal cumulativeAmount,
       CurrencyPair currencyPair,
-      String id,
+      BigInteger id,
       Date timestamp,
       BigDecimal limitPrice,
       String clientOrderId) {
-    super(type, originalAmount, cumulativeAmount, currencyPair, id, timestamp, limitPrice);
-    this.clientOrderId = clientOrderId;
+    super(
+        type, originalAmount, cumulativeAmount, currencyPair, clientOrderId, timestamp, limitPrice);
+    this.hitbtcOrderId = id;
   }
 
   public HitbtcLimitOrder(
       OrderType type,
       BigDecimal originalAmount,
       CurrencyPair currencyPair,
-      String id,
+      BigInteger id,
       Date timestamp,
       BigDecimal limitPrice,
       BigDecimal averagePrice,
@@ -49,17 +51,17 @@ public class HitbtcLimitOrder extends LimitOrder {
         type,
         originalAmount,
         currencyPair,
-        id,
+        clientOrderId,
         timestamp,
         limitPrice,
         averagePrice,
         cumulativeAmount,
         fee,
         status);
-    this.clientOrderId = clientOrderId;
+    this.hitbtcOrderId = id;
   }
 
-  public String getClientOrderId() {
-    return clientOrderId;
+  public BigInteger getHitbtcOrderId() {
+    return hitbtcOrderId;
   }
 }

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/dto/HitbtcMarketOrder.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/dto/HitbtcMarketOrder.java
@@ -1,18 +1,19 @@
 package org.knowm.xchange.hitbtc.v2.dto;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Date;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.trade.MarketOrder;
 
 public class HitbtcMarketOrder extends MarketOrder {
-  public final String clientOrderId;
+  public final BigInteger hitbtcOrderId;
 
   public HitbtcMarketOrder(
       OrderType type,
       BigDecimal originalAmount,
       CurrencyPair currencyPair,
-      String id,
+      BigInteger id,
       Date timestamp,
       BigDecimal averagePrice,
       BigDecimal cumulativeAmount,
@@ -23,24 +24,24 @@ public class HitbtcMarketOrder extends MarketOrder {
         type,
         originalAmount,
         currencyPair,
-        id,
+        clientOrderId,
         timestamp,
         averagePrice,
         cumulativeAmount,
         fee,
         status);
-    this.clientOrderId = clientOrderId;
+    this.hitbtcOrderId = id;
   }
 
   public HitbtcMarketOrder(
       OrderType type,
       BigDecimal originalAmount,
       CurrencyPair currencyPair,
-      String id,
+      BigInteger id,
       Date timestamp,
       String clientOrderId) {
-    super(type, originalAmount, currencyPair, id, timestamp);
-    this.clientOrderId = clientOrderId;
+    super(type, originalAmount, currencyPair, clientOrderId, timestamp);
+    this.hitbtcOrderId = id;
   }
 
   public HitbtcMarketOrder(
@@ -49,17 +50,17 @@ public class HitbtcMarketOrder extends MarketOrder {
       CurrencyPair currencyPair,
       Date timestamp,
       String clientOrderId) {
-    super(type, originalAmount, currencyPair, timestamp);
-    this.clientOrderId = clientOrderId;
+    super(type, originalAmount, currencyPair, clientOrderId, timestamp);
+    this.hitbtcOrderId = null;
   }
 
   public HitbtcMarketOrder(
       OrderType type, BigDecimal originalAmount, CurrencyPair currencyPair, String clientOrderId) {
-    super(type, originalAmount, currencyPair);
-    this.clientOrderId = clientOrderId;
+    super(type, originalAmount, currencyPair, clientOrderId, null);
+    this.hitbtcOrderId = null;
   }
 
-  public String getClientOrderId() {
-    return clientOrderId;
+  public BigInteger getHitbtcOrderId() {
+    return hitbtcOrderId;
   }
 }

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/dto/HitbtcOrder.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/dto/HitbtcOrder.java
@@ -2,11 +2,12 @@ package org.knowm.xchange.hitbtc.v2.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Date;
 
 public class HitbtcOrder {
 
-  public final String id;
+  public final BigInteger id;
   public final String clientOrderId;
   public final String symbol;
   public final String side;
@@ -21,7 +22,7 @@ public class HitbtcOrder {
   private final Date updatedAt;
 
   public HitbtcOrder(
-      @JsonProperty("id") String id,
+      @JsonProperty("id") BigInteger id,
       @JsonProperty("clientOrderId") String clientOrderId,
       @JsonProperty("symbol") String symbol,
       @JsonProperty("side") String side,

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcTradeService.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcTradeService.java
@@ -43,12 +43,12 @@ public class HitbtcTradeService extends HitbtcTradeServiceRaw implements TradeSe
 
   @Override
   public String placeMarketOrder(MarketOrder marketOrder) throws IOException {
-    return placeMarketOrderRaw(marketOrder).id;
+    return placeMarketOrderRaw(marketOrder).clientOrderId;
   }
 
   @Override
   public String placeLimitOrder(LimitOrder limitOrder) throws IOException {
-    return placeLimitOrderRaw(limitOrder).id;
+    return placeLimitOrderRaw(limitOrder).clientOrderId;
   }
 
   @Override

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcTradeServiceRaw.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcTradeServiceRaw.java
@@ -11,8 +11,6 @@ import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
 import org.knowm.xchange.hitbtc.v2.HitbtcAdapters;
 import org.knowm.xchange.hitbtc.v2.dto.HitbtcBalance;
-import org.knowm.xchange.hitbtc.v2.dto.HitbtcLimitOrder;
-import org.knowm.xchange.hitbtc.v2.dto.HitbtcMarketOrder;
 import org.knowm.xchange.hitbtc.v2.dto.HitbtcOrder;
 import org.knowm.xchange.hitbtc.v2.dto.HitbtcOwnTrade;
 import org.knowm.xchange.hitbtc.v2.dto.HitbtcSort;
@@ -32,10 +30,7 @@ public class HitbtcTradeServiceRaw extends HitbtcBaseService {
     String symbol = HitbtcAdapters.adaptCurrencyPair(marketOrder.getCurrencyPair());
     String side = HitbtcAdapters.getSide(marketOrder.getType()).toString();
 
-    String clientOrderId = null;
-    if (marketOrder instanceof HitbtcMarketOrder) {
-      clientOrderId = ((HitbtcMarketOrder) marketOrder).getClientOrderId();
-    }
+    String clientOrderId = marketOrder.getId();
 
     return hitbtc.postHitbtcNewOrder(
         clientOrderId,
@@ -52,11 +47,7 @@ public class HitbtcTradeServiceRaw extends HitbtcBaseService {
     String symbol = HitbtcAdapters.adaptCurrencyPair(limitOrder.getCurrencyPair());
     String side = HitbtcAdapters.getSide(limitOrder.getType()).toString();
 
-    String clientOrderId = null;
-    if (limitOrder instanceof HitbtcLimitOrder) {
-      HitbtcLimitOrder order = (HitbtcLimitOrder) limitOrder;
-      clientOrderId = order.getClientOrderId();
-    }
+    String clientOrderId = limitOrder.getId();
 
     return hitbtc.postHitbtcNewOrder(
         clientOrderId,


### PR DESCRIPTION
HitBTC uses the client order id for all API request. Therefore, after requesting an order it was impossible to do any other API requests with it, since not the client order id but the exchange id was returned. I updated the API such that now the id of an order can actually be used in the API requests that require an order id.