### PR TITLE
[btcmarkets] - Changed type of BTCMarketsPlaceOrderResponse.id from Int to Long matching API return values

### DIFF
--- a/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/dto/trade/BTCMarketsPlaceOrderResponse.java
+++ b/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/dto/trade/BTCMarketsPlaceOrderResponse.java
@@ -6,20 +6,20 @@ import org.knowm.xchange.btcmarkets.dto.BTCMarketsBaseResponse;
 public class BTCMarketsPlaceOrderResponse extends BTCMarketsBaseResponse {
 
   private final String clientRequestId;
-  private final Integer id;
+  private final Long id;
 
   public BTCMarketsPlaceOrderResponse(
       @JsonProperty("success") Boolean success,
       @JsonProperty("errorMessage") String errorMessage,
       @JsonProperty("errorCode") Integer errorCode,
       @JsonProperty("clientRequestId") String clientRequestId,
-      @JsonProperty("id") Integer id) {
+      @JsonProperty("id") Long id) {
     super(success, errorMessage, errorCode);
     this.clientRequestId = clientRequestId;
     this.id = id;
   }
 
-  public Integer getId() {
+  public Long getId() {
     return id;
   }
 

--- a/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/service/BTCMarketsTradeServiceTest.java
+++ b/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/service/BTCMarketsTradeServiceTest.java
@@ -74,7 +74,7 @@ public class BTCMarketsTradeServiceTest extends BTCMarketsTestSupport {
             "generatedReqId");
 
     BTCMarketsPlaceOrderResponse orderResponse =
-        new BTCMarketsPlaceOrderResponse(true, null, 0, "11111", 12345);
+        new BTCMarketsPlaceOrderResponse(true, null, 0, "11111", 12345L);
 
     BTCMarketsAuthenticated btcm = mock(BTCMarketsAuthenticated.class);
     PowerMockito.when(
@@ -117,7 +117,7 @@ public class BTCMarketsTradeServiceTest extends BTCMarketsTestSupport {
             "generatedReqId");
 
     BTCMarketsPlaceOrderResponse orderResponse =
-        new BTCMarketsPlaceOrderResponse(true, null, 0, "11111", 12345);
+        new BTCMarketsPlaceOrderResponse(true, null, 0, "11111", 12345L);
 
     BTCMarketsAuthenticated btcm = mock(BTCMarketsAuthenticated.class);
     PowerMockito.when(


### PR DESCRIPTION
Increasing the size of the Id field on the placeOrder return, matching the current API returned values.