### PR TITLE
add add ETP currency and ETP_BTC pair to the Core module

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
@@ -94,6 +94,7 @@ public class Currency implements Comparable<Currency>, Serializable {
   public static final Currency ETB = createCurrency("ETB", "Ethiopian Birr", null);
   public static final Currency ETC = createCurrency("ETC", "Ether Classic", null);
   public static final Currency ETH = createCurrency("ETH", "Ether", null);
+  public static final Currency ETP = createCurrency("ETP", "ETP", null);
   public static final Currency EUR = createCurrency("EUR", "Euro", null);
   public static final Currency FJD = createCurrency("FJD", "Fijian Dollar", null);
   public static final Currency _1ST = createCurrency("1ST", "First Blood", null);

--- a/xchange-core/src/main/java/org/knowm/xchange/currency/CurrencyPair.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/CurrencyPair.java
@@ -314,8 +314,8 @@ public class CurrencyPair implements Comparable<CurrencyPair>, Serializable {
   public static final CurrencyPair XMR_H18 = new CurrencyPair(Currency.XMR, Currency.H18);
   public static final CurrencyPair XLM_H18 = new CurrencyPair(Currency.XLM, Currency.H18);
   public static final CurrencyPair ZEC_H18 = new CurrencyPair(Currency.ZEC, Currency.H18);
-  public static final CurrencyPair ETC_7D =
-      new CurrencyPair(Currency.ETC, Currency.getInstance("7D"));
+  public static final CurrencyPair ETC_7D = new CurrencyPair(Currency.ETC, Currency.getInstance("7D"));
+  public static final CurrencyPair ETP_BTC = new CurrencyPair(Currency.ETP, Currency.BTC);
 
   public final Currency base;
   public final Currency counter;


### PR DESCRIPTION
add add ETP currency and ETP_BTC pair to the Core module.
ETP is my company currency.I use it  a lot when I'm testing  placeLimitOrder,cancelorder,trades.
https://coinmarketcap.com/currencies/metaverse/
so I'd like to add it  to the core module.