### PR TITLE
Adds API method to cancel order by any property, especially for HitBTC.

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/TradeService.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/TradeService.java
@@ -124,6 +124,25 @@ public interface TradeService extends BaseService {
   }
 
   /**
+   * cancels order matching the given one (conveniance method, typical just delegate to
+   * cancelOrder(CancelOrderByIdParams), but for some exchanges cancel might not work by id, but by
+   * other properties of the order)
+   *
+   * @param order
+   * @return true if order was successfully cancelled, false otherwise.
+   * @throws ExchangeException - Indication that the exchange reported some kind of error with the
+   *     request or response
+   * @throws NotAvailableFromExchangeException - Indication that the exchange does not support the
+   *     requested function or data
+   * @throws NotYetImplementedForExchangeException - Indication that the exchange supports the
+   *     requested function or data, but it has not yet been implemented
+   * @throws IOException - Indication that a networking error occurred while fetching JSON data
+   */
+  default boolean cancelOrder(Order order) throws IOException {
+    return cancelOrder(new DefaultCancelOrderParamId(order.getId()));
+  }
+
+  /**
    * cancels order with matching orderId (conveniance method, typical just delegate to
    * cancelOrder(CancelOrderByIdParams))
    *

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcTradeService.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcTradeService.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
@@ -11,11 +12,13 @@ import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.dto.trade.UserTrades;
+import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
+import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.hitbtc.v2.HitbtcAdapters;
+import org.knowm.xchange.hitbtc.v2.dto.HitbtcLimitOrder;
 import org.knowm.xchange.hitbtc.v2.dto.HitbtcOrder;
 import org.knowm.xchange.hitbtc.v2.dto.HitbtcOwnTrade;
 import org.knowm.xchange.service.trade.TradeService;
-import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
 import org.knowm.xchange.service.trade.params.CancelOrderParams;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamLimit;
@@ -52,14 +55,22 @@ public class HitbtcTradeService extends HitbtcTradeServiceRaw implements TradeSe
   }
 
   @Override
-  public boolean cancelOrder(CancelOrderParams orderParams) throws IOException {
-    if (orderParams instanceof CancelOrderByIdParams) {
-      String clientOrderId = ((CancelOrderByIdParams) orderParams).getOrderId();
+  public boolean cancelOrder(Order order) throws IOException {
+    if (order instanceof HitbtcLimitOrder) {
+      // Cancel by client order id
+      HitbtcLimitOrder hitbtcOrder = (HitbtcLimitOrder) order;
+      String clientOrderId = hitbtcOrder.getClientOrderId();
       HitbtcOrder cancelOrderRaw = cancelOrderRaw(clientOrderId);
       return "canceled".equals(cancelOrderRaw.status);
-    } else {
-      return false;
     }
+    // For other kinds of orders, cancel is not implemented
+    throw new NotYetImplementedForExchangeException();
+  }
+
+  @Override
+  public boolean cancelOrder(CancelOrderParams orderParams) throws IOException {
+    // We can only cancel by client order id, not by the commonly used parameters
+    throw new NotAvailableFromExchangeException();
   }
 
   /** Required parameters: {@link TradeHistoryParamPaging} {@link TradeHistoryParamCurrencyPair} */


### PR DESCRIPTION
HitBTC cannot cancel orders by id, so the new API method is implemented differently for HitBTC, but cancels orders by id for other exchanges. (Discussed at PR #2774)