### PR TITLE
[bx.in] Add required by exchange instrument parameter at order cancel

### DIFF
--- a/xchange-bx/src/main/java/org/knowm/xchange/bx/service/BxTradeService.java
+++ b/xchange-bx/src/main/java/org/knowm/xchange/bx/service/BxTradeService.java
@@ -8,7 +8,7 @@ import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.trade.*;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.service.trade.TradeService;
-import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
+import org.knowm.xchange.service.trade.params.CancelOrderByPairAndIdParams;
 import org.knowm.xchange.service.trade.params.CancelOrderParams;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
@@ -46,13 +46,19 @@ public class BxTradeService extends BxTradeServiceRaw implements TradeService {
 
   @Override
   public boolean cancelOrder(String orderId) throws IOException {
-    return cancelBxOrder(orderId);
+    throw new NotAvailableFromExchangeException();
   }
 
   @Override
   public boolean cancelOrder(CancelOrderParams cancelOrderParams) throws IOException {
-    return cancelOrderParams instanceof CancelOrderByIdParams
-        && cancelBxOrder(((CancelOrderByIdParams) cancelOrderParams).getOrderId());
+    if (!(cancelOrderParams instanceof CancelOrderByPairAndIdParams)) {
+      throw new IllegalArgumentException();
+    }
+    CancelOrderByPairAndIdParams cancelOrderByPairAndIdParams = (CancelOrderByPairAndIdParams) cancelOrderParams;
+    return cancelBxOrder(
+            cancelOrderByPairAndIdParams.getOrderId(),
+            cancelOrderByPairAndIdParams.getCurrencyPair()
+    );
   }
 
   @Override

--- a/xchange-bx/src/main/java/org/knowm/xchange/bx/service/BxTradeServiceRaw.java
+++ b/xchange-bx/src/main/java/org/knowm/xchange/bx/service/BxTradeServiceRaw.java
@@ -11,6 +11,7 @@ import org.knowm.xchange.bx.dto.trade.results.BxCancelOrderResult;
 import org.knowm.xchange.bx.dto.trade.results.BxCreateOrderResult;
 import org.knowm.xchange.bx.dto.trade.results.BxOrdersResult;
 import org.knowm.xchange.bx.dto.trade.results.BxTradeHistoryResult;
+import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.exceptions.ExchangeException;
@@ -22,10 +23,11 @@ public class BxTradeServiceRaw extends BxBaseService {
     super(exchange);
   }
 
-  public boolean cancelBxOrder(String orderId) throws IOException {
+  public boolean cancelBxOrder(String orderId, CurrencyPair currencyPair) throws IOException {
+    String pairId = BxUtils.createBxCurrencyPair(currencyPair);
     BxCancelOrderResult result =
         bx.cancelOrder(
-            null,
+            pairId,
             orderId,
             exchange.getExchangeSpecification().getApiKey(),
             exchange.getNonceFactory(),

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/CancelOrderByPairAndIdParams.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/CancelOrderByPairAndIdParams.java
@@ -1,0 +1,7 @@
+package org.knowm.xchange.service.trade.params;
+
+import org.knowm.xchange.currency.CurrencyPair;
+
+public interface CancelOrderByPairAndIdParams extends CancelOrderByIdParams {
+  CurrencyPair getCurrencyPair();
+}


### PR DESCRIPTION
Add new `org.knowm.xchange.service.trade.params.CancelOrderByPairAndIdParams`
  cancel parameter type to cancel order using instrument and order id;
Use CancelOrderByPairAndIdParams for bx.in.