### PR TITLE
[Bitmex] Refactoring and optimisation

### DIFF
--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/Bitmex.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/Bitmex.java
@@ -25,7 +25,7 @@ public interface Bitmex {
       @HeaderParam("api-key") String apiKey,
       @HeaderParam("api-expires") SynchronizedValueFactory<Long> nonce,
       @HeaderParam("api-signature") ParamsDigest paramsDigest)
-      throws IOException;
+      throws IOException, BitmexException;
 
   @GET
   @Path("user/wallet")
@@ -34,7 +34,7 @@ public interface Bitmex {
       @HeaderParam("api-expires") SynchronizedValueFactory<Long> nonce,
       @HeaderParam("api-signature") ParamsDigest paramsDigest /*,
            @Nullable @QueryParam("currency") String currency*/)
-      throws IOException;
+      throws IOException, BitmexException;
 
   // Get a history of all of your wallet transactions (deposits, withdrawals, PNL)
   @GET
@@ -44,7 +44,7 @@ public interface Bitmex {
       @HeaderParam("api-expires") SynchronizedValueFactory<Long> nonce,
       @HeaderParam("api-signature") ParamsDigest paramsDigest,
       @Nullable @QueryParam("currency") String currency)
-      throws IOException;
+      throws IOException, BitmexException;
 
   // Get a summary of all of your wallet transactions (deposits, withdrawals, PNL)
   @GET
@@ -54,7 +54,7 @@ public interface Bitmex {
       @HeaderParam("api-expires") SynchronizedValueFactory<Long> nonce,
       @HeaderParam("api-signature") ParamsDigest paramsDigest,
       @Nullable @QueryParam("currency") String currency)
-      throws IOException;
+      throws IOException, BitmexException;
 
   @GET
   @Path("user/margin")
@@ -63,7 +63,7 @@ public interface Bitmex {
       @HeaderParam("api-expires") SynchronizedValueFactory<Long> nonce,
       @HeaderParam("api-signature") ParamsDigest paramsDigest,
       @Nullable @QueryParam("currency") String currency)
-      throws IOException;
+      throws IOException, BitmexException;
 
   @GET
   @Path("user/margin?currency=all")
@@ -71,7 +71,7 @@ public interface Bitmex {
       @HeaderParam("api-key") String apiKey,
       @HeaderParam("api-expires") SynchronizedValueFactory<Long> nonce,
       @HeaderParam("api-signature") ParamsDigest paramsDigest)
-      throws IOException;
+      throws IOException, BitmexException;
 
   @GET
   @Path("trade")
@@ -80,7 +80,7 @@ public interface Bitmex {
       @QueryParam("reverse") Boolean reverse,
       @Nullable @QueryParam("count") Integer count,
       @Nullable @QueryParam("start") Integer start)
-      throws IOException;
+      throws IOException, BitmexException;
 
   @GET
   @Path("trade/bucketed")
@@ -90,13 +90,13 @@ public interface Bitmex {
       @QueryParam("symbol") String symbol,
       @QueryParam("count") Long count,
       @QueryParam("reverse") Boolean reverse)
-      throws IOException;
+      throws IOException, BitmexException;
 
   @GET
   @Path("orderBook/L2")
   BitmexPublicOrderList getDepth(
       @QueryParam("symbol") String currencyPair, @QueryParam("depth") Double depth)
-      throws IOException;
+      throws IOException, BitmexException;
 
   @GET
   @Path("position")
@@ -104,7 +104,7 @@ public interface Bitmex {
       @HeaderParam("api-key") String apiKey,
       @HeaderParam("api-expires") SynchronizedValueFactory<Long> nonce,
       @HeaderParam("api-signature") ParamsDigest paramsDigest)
-      throws IOException;
+      throws IOException, BitmexException;
 
   @GET
   @Path("position")
@@ -114,7 +114,7 @@ public interface Bitmex {
       @HeaderParam("api-signature") ParamsDigest paramsDigest,
       @Nullable @QueryParam("symbol") String symbol,
       @Nullable @QueryParam("filter") String filter)
-      throws IOException;
+      throws IOException, BitmexException;
 
   @GET
   @Path("instrument")
@@ -149,7 +149,8 @@ public interface Bitmex {
       @Nullable @QueryParam("start") Integer start,
       @Nullable @QueryParam("reverse") Boolean reverse,
       @Nullable @QueryParam("startTime") Date startTime,
-      @Nullable @QueryParam("endTime") Date endTime);
+      @Nullable @QueryParam("endTime") Date endTime)
+      throws IOException, BitmexException;
 
   /**
    * @param apiKey
@@ -174,7 +175,7 @@ public interface Bitmex {
       @HeaderParam("api-signature") ParamsDigest paramsDigest,
       @FormParam("symbol") String symbol,
       @FormParam("side") String side,
-      @FormParam("orderQty") Integer orderQuantity,
+      @FormParam("orderQty") BigDecimal orderQuantity,
       @FormParam("simpleOrderQty") BigDecimal simpleOrderQuantity,
       @FormParam("price") BigDecimal price,
       @Nullable @FormParam("stopPx") BigDecimal stopPrice,
@@ -182,17 +183,17 @@ public interface Bitmex {
       @Nullable @FormParam("clOrdID") String clOrdID,
       @Nullable @FormParam("execInst") String executionInstructions,
       @Nullable @FormParam("clOrdLinkID") String clOrdLinkID,
-      @Nullable @FormParam("contingencyType") String contingencyType);
+      @Nullable @FormParam("contingencyType") String contingencyType)
+      throws IOException, BitmexException;
 
   @POST
   @Path("order/bulk")
-  //  @Consumes("application/json")
-  //  @Produces("application/json")
   BitmexPrivateOrderList placeOrderBulk(
       @HeaderParam("api-key") String apiKey,
       @HeaderParam("api-expires") SynchronizedValueFactory<Long> nonce,
       @HeaderParam("api-signature") ParamsDigest paramsDigest,
-      @FormParam("orders") String orderCommands);
+      @FormParam("orders") String orderCommands)
+      throws IOException, BitmexException;
 
   @PUT
   @Path("order")
@@ -202,7 +203,7 @@ public interface Bitmex {
       @HeaderParam("api-key") String apiKey,
       @HeaderParam("api-expires") SynchronizedValueFactory<Long> nonce,
       @HeaderParam("api-signature") ParamsDigest paramsDigest,
-      @FormParam("orderQty") int orderQuantity,
+      @Nullable @FormParam("orderQty") BigDecimal orderQuantity,
       @Nullable @FormParam("price") BigDecimal price,
       @Nullable @FormParam("stopPx") BigDecimal stopPrice,
       @Nullable @FormParam("ordType") String orderType,
@@ -210,7 +211,8 @@ public interface Bitmex {
       @Nullable @FormParam("clOrdID") String clOrdID,
       @Nullable @FormParam("origClOrdID") String origClOrdID,
       @Nullable @FormParam("clOrdLinkID") String clOrdLinkID,
-      @Nullable @FormParam("contingencyType") String contingencyType);
+      @Nullable @FormParam("contingencyType") String contingencyType)
+      throws IOException, BitmexException;
 
   @PUT
   @Path("order/bulk")
@@ -229,7 +231,8 @@ public interface Bitmex {
       @HeaderParam("api-expires") SynchronizedValueFactory<Long> nonce,
       @HeaderParam("api-signature") ParamsDigest paramsDigest,
       @Nullable @FormParam("orderID") String orderID,
-      @Nullable @FormParam("clOrdID") String clOrdID);
+      @Nullable @FormParam("clOrdID") String clOrdID)
+      throws IOException, BitmexException;
 
   @DELETE
   @Path("order/all")
@@ -239,7 +242,8 @@ public interface Bitmex {
       @HeaderParam("api-signature") ParamsDigest paramsDigest,
       @Nullable @FormParam("symbol") String symbol,
       @Nullable @FormParam("filter") String filter,
-      @Nullable @FormParam("text") String text);
+      @Nullable @FormParam("text") String text)
+      throws IOException, BitmexException;
 
   @GET
   @Path("user/depositAddress")
@@ -247,7 +251,8 @@ public interface Bitmex {
       @HeaderParam("api-key") String apiKey,
       @HeaderParam("api-expires") SynchronizedValueFactory<Long> nonce,
       @HeaderParam("api-signature") ParamsDigest paramsDigest,
-      @QueryParam("currency") String currency);
+      @QueryParam("currency") String currency)
+      throws IOException, BitmexException;
 
   @POST
   @Path("user/requestWithdrawal")
@@ -257,7 +262,8 @@ public interface Bitmex {
       @HeaderParam("api-signature") ParamsDigest paramsDigest,
       @FormParam("currency") String currency,
       @FormParam("amount") BigDecimal amount,
-      @FormParam("address") String address);
+      @FormParam("address") String address)
+      throws IOException, BitmexException;
 
   @POST
   @Path("position/leverage")
@@ -266,7 +272,8 @@ public interface Bitmex {
       @HeaderParam("api-expires") SynchronizedValueFactory<Long> nonce,
       @HeaderParam("api-signature") ParamsDigest paramsDigest,
       @FormParam("symbol") String symbol,
-      @FormParam("leverage") BigDecimal leverage);
+      @FormParam("leverage") BigDecimal leverage)
+      throws IOException, BitmexException;
 
   public static class PlaceOrderCommand {
     @JsonProperty("symbol")

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexAdapters.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexAdapters.java
@@ -22,6 +22,7 @@ import org.knowm.xchange.bitmex.dto.trade.BitmexTrade;
 import org.knowm.xchange.bitmex.dto.trade.BitmexUserTrade;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.OrderStatus;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.account.Balance;
@@ -99,6 +100,25 @@ public class BitmexAdapters {
     BigDecimal volume = order.getVolume();
 
     return new LimitOrder(orderType, volume, currencyPair, "", null, order.getPrice());
+  }
+
+  public static LimitOrder adaptOrder(BitmexPrivateOrder rawOrder) {
+    Order.OrderType type =
+        rawOrder.getSide() == BitmexSide.BUY ? Order.OrderType.BID : Order.OrderType.ASK;
+
+    CurrencyPair pair = adaptCurrencyPair(rawOrder.getSymbol());
+
+    return new LimitOrder(
+        type,
+        rawOrder.getVolume(),
+        pair,
+        rawOrder.getId(),
+        rawOrder.getTimestamp(),
+        rawOrder.getPrice(),
+        rawOrder.getAvgPx(),
+        rawOrder.getCumQty(),
+        null,
+        BitmexAdapters.adaptOrderStatus(rawOrder.getOrderStatus()));
   }
 
   public static Ticker adaptTicker(BitmexTicker bitmexTicker, CurrencyPair currencyPair) {
@@ -191,7 +211,6 @@ public class BitmexAdapters {
 
     BigDecimal originalAmount = bitmexOrder.getVolume();
     BigDecimal filledAmount = bitmexOrder.getVolumeExecuted();
-    BigDecimal remainingAmount = originalAmount.min(filledAmount);
     CurrencyPair pair = adaptCurrencyPair(orderDescription.getAssetPair());
     Date timestamp = new Date((long) (bitmexOrder.getOpenTimestamp() * 1000L));
 
@@ -379,6 +398,10 @@ public class BitmexAdapters {
   public static CurrencyPair adaptCurrencyPair(CurrencyPair currencyPair) {
 
     return currencyPair;
+  }
+
+  public static String adaptCurrencyPairToSymbol(CurrencyPair currencyPair) {
+    return currencyPair.base.getCurrencyCode() + currencyPair.counter.getCurrencyCode();
   }
 
   public static class OrdersContainer {

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexException.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexException.java
@@ -4,19 +4,28 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class BitmexException extends RuntimeException {
 
-  @JsonProperty("message")
-  private String message;
+  static class Error {
+    @JsonProperty("message")
+    private String message;
 
-  @JsonProperty("name")
-  private String name;
+    @JsonProperty("name")
+    private String name;
 
-  public BitmexException(
-      @JsonProperty("message") String message, @JsonProperty("name") String name) {
-    this.message = message;
-    this.name = name;
+    public Error(@JsonProperty("message") String message, @JsonProperty("name") String name) {
+      this.message = message;
+      this.name = name;
+    }
   }
 
+  @JsonProperty("error")
+  private Error error;
+
+  public BitmexException(@JsonProperty("error") Error error) {
+    this.error = error;
+  }
+
+  @Override
   public String getMessage() {
-    return message == null ? name : message;
+    return error.message == null ? error.name : error.message;
   }
 }

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexTradeServiceRaw.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexTradeServiceRaw.java
@@ -80,14 +80,15 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
   }
 
   public BitmexPrivateOrder placeMarketOrder(
-      String symbol, BitmexSide side, BigDecimal orderQuantity, String executionInstructions) {
+      String symbol, BitmexSide side, BigDecimal orderQuantity, String executionInstructions)
+      throws IOException {
     return bitmex.placeOrder(
         apiKey,
         exchange.getNonceFactory(),
         signatureCreator,
         symbol,
         side == null ? null : side.getCapitalized(),
-        orderQuantity.intValue(),
+        orderQuantity,
         null,
         null,
         null,
@@ -104,7 +105,8 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
       BigDecimal price,
       BitmexSide side,
       String clOrdID,
-      String executionInstructions) {
+      String executionInstructions)
+      throws IOException {
     return placeLimitOrder(
         symbol, orderQuantity, price, side, clOrdID, executionInstructions, null, null);
   }
@@ -117,7 +119,8 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
       String clOrdID,
       String executionInstructions,
       String clOrdLinkID,
-      String contingencyType) {
+      String contingencyType)
+      throws IOException {
     return updateRateLimit(
         bitmex.placeOrder(
             apiKey,
@@ -125,7 +128,7 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
             signatureCreator,
             symbol,
             side == null ? null : side.getCapitalized(),
-            orderQuantity.intValue(),
+            orderQuantity,
             null,
             price,
             null,
@@ -136,8 +139,8 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
             contingencyType));
   }
 
-  public List<BitmexPrivateOrder> placeLimitOrderBulk(
-      Collection<Bitmex.PlaceOrderCommand> commands) {
+  public List<BitmexPrivateOrder> placeLimitOrderBulk(Collection<Bitmex.PlaceOrderCommand> commands)
+      throws IOException {
     String s = ObjectMapperHelper.toCompactJSON(commands);
     return updateRateLimit(
         bitmex.placeOrderBulk(apiKey, exchange.getNonceFactory(), signatureCreator, s));
@@ -150,21 +153,21 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
   }
 
   public BitmexPrivateOrder replaceLimitOrder(
-      String symbol,
       BigDecimal orderQuantity,
       BigDecimal price,
       String orderId,
       String clOrdID,
       String origClOrdID,
       String clOrdLinkID,
-      String contingencyType) {
+      String contingencyType)
+      throws IOException {
 
     return updateRateLimit(
         bitmex.replaceOrder(
             apiKey,
             exchange.getNonceFactory(),
             signatureCreator,
-            orderQuantity.intValue(),
+            orderQuantity,
             price,
             null,
             ORDER_TYPE_LIMIT,
@@ -183,13 +186,14 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
       String clOrdID,
       String origClOrdId,
       String clOrdLinkID,
-      String contingencyType) {
+      String contingencyType)
+      throws IOException {
     return updateRateLimit(
         bitmex.replaceOrder(
             apiKey,
             exchange.getNonceFactory(),
             signatureCreator,
-            orderQuantity.intValue(),
+            orderQuantity,
             null,
             price,
             ORDER_TYPE_LIMIT,
@@ -208,7 +212,8 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
       String executionInstructions,
       String clOrdID,
       String clOrdLinkID,
-      String contingencyType) {
+      String contingencyType)
+      throws IOException {
     return updateRateLimit(
         bitmex.placeOrder(
             apiKey,
@@ -216,7 +221,7 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
             signatureCreator,
             symbol,
             side == null ? null : side.getCapitalized(),
-            orderQuantity.intValue(),
+            orderQuantity,
             null,
             null,
             stopPrice,
@@ -253,7 +258,8 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
       BigDecimal price,
       String executionInstructions,
       String clOrdLinkID,
-      String contingencyType) {
+      String contingencyType)
+      throws IOException {
     return updateRateLimit(
         bitmex.placeOrder(
             apiKey,
@@ -261,7 +267,7 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
             signatureCreator,
             symbol,
             side == null ? null : side.getCapitalized(),
-            orderQuantity != null ? orderQuantity.intValue() : null,
+            orderQuantity,
             simpleOrderQuantity,
             price,
             null,
@@ -272,21 +278,23 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
             contingencyType));
   }
 
-  public List<BitmexPrivateOrder> cancelAllOrders() {
+  public List<BitmexPrivateOrder> cancelAllOrders() throws IOException {
     return cancelAllOrders(null, null, null);
   }
 
-  public List<BitmexPrivateOrder> cancelAllOrders(String symbol, String filter, String text) {
+  public List<BitmexPrivateOrder> cancelAllOrders(String symbol, String filter, String text)
+      throws IOException {
     return updateRateLimit(
         bitmex.cancelAllOrders(
             apiKey, exchange.getNonceFactory(), signatureCreator, symbol, filter, text));
   }
 
-  public List<BitmexPrivateOrder> cancelBitmexOrder(String orderID) {
+  public List<BitmexPrivateOrder> cancelBitmexOrder(String orderID) throws IOException {
     return cancelBitmexOrder(orderID, null);
   }
 
-  public List<BitmexPrivateOrder> cancelBitmexOrder(String orderID, String clOrdID) {
+  public List<BitmexPrivateOrder> cancelBitmexOrder(String orderID, String clOrdID)
+      throws IOException {
     List<BitmexPrivateOrder> orders =
         updateRateLimit(
             bitmex.cancelOrder(
@@ -298,7 +306,8 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
     return orders;
   }
 
-  public BitmexPosition updateLeveragePosition(String symbol, BigDecimal leverage) {
+  public BitmexPosition updateLeveragePosition(String symbol, BigDecimal leverage)
+      throws IOException {
     BitmexPosition order =
         updateRateLimit(
             bitmex.updateLeveragePosition(

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/CancelAllOrders.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/CancelAllOrders.java
@@ -1,0 +1,3 @@
+package org.knowm.xchange.service.trade.params;
+
+public interface CancelAllOrders extends CancelOrderParams {}


### PR DESCRIPTION
Add `org.knowm.xchange.service.trade.params.CancelAllOrders` parameter type to use to cancel all orders;
Use CancelAllOrders parameter type to cancel all limit orders;
Optimize opened orders receiving - instead of receiving all order and filter, request exchange to return the opened orders only;
Fix quantity silent trimming to int at order placing by making `orderQuantity` as BigDecimal;
Fix the wrong format of BitmexException;