### PR TITLE
[bitstamp] Fix: order ids have exceeded integer max value. Changed to longs

### DIFF
--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAuthenticated.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAuthenticated.java
@@ -72,7 +72,7 @@ public interface BitstampAuthenticated {
       @FormParam("key") String apiKey,
       @FormParam("signature") ParamsDigest signer,
       @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
-      @FormParam("id") int orderId)
+      @FormParam("id") long orderId)
       throws BitstampException, IOException;
 
   /** @return true if order has been canceled. */

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/trade/BitstampOrder.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/trade/BitstampOrder.java
@@ -11,7 +11,7 @@ import si.mazi.rescu.ExceptionalReturnContentException;
 /** @author Matija Mazi */
 public final class BitstampOrder {
 
-  private int id;
+  private long id;
   private Date datetime;
   /** 0 - buy (bid); 1 - sell (ask) */
   private int type;
@@ -23,7 +23,7 @@ public final class BitstampOrder {
   public BitstampOrder(
       @JsonProperty("status") String status,
       @JsonProperty("reason") Object reason,
-      @JsonProperty("id") int id,
+      @JsonProperty("id") long id,
       @JsonProperty("datetime") String datetime,
       @JsonProperty("type") int type,
       @JsonProperty("price") BigDecimal price,
@@ -48,7 +48,7 @@ public final class BitstampOrder {
     return datetime;
   }
 
-  public int getId() {
+  public long getId() {
 
     return id;
   }

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeService.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeService.java
@@ -53,7 +53,7 @@ public class BitstampTradeService extends BitstampTradeServiceRaw implements Tra
       BitstampOrder[] openOrders = getBitstampOpenOrders(pair);
       for (BitstampOrder bitstampOrder : openOrders) {
         OrderType orderType = bitstampOrder.getType() == 0 ? OrderType.BID : OrderType.ASK;
-        String id = Integer.toString(bitstampOrder.getId());
+        String id = Long.toString(bitstampOrder.getId());
         BigDecimal price = bitstampOrder.getPrice();
         limitOrders.add(
             new LimitOrder(
@@ -79,7 +79,7 @@ public class BitstampTradeService extends BitstampTradeServiceRaw implements Tra
     if (bitstampOrder.getErrorMessage() != null) {
       throw new ExchangeException(bitstampOrder.getErrorMessage());
     }
-    return Integer.toString(bitstampOrder.getId());
+    return Long.toString(bitstampOrder.getId());
   }
 
   @Override
@@ -95,13 +95,13 @@ public class BitstampTradeService extends BitstampTradeServiceRaw implements Tra
     if (bitstampOrder.getErrorMessage() != null) {
       throw new ExchangeException(bitstampOrder.getErrorMessage());
     }
-    return Integer.toString(bitstampOrder.getId());
+    return Long.toString(bitstampOrder.getId());
   }
 
   @Override
   public boolean cancelOrder(String orderId) throws IOException, BitstampException {
 
-    return cancelBitstampOrder(Integer.parseInt(orderId));
+    return cancelBitstampOrder(Long.parseLong(orderId));
   }
 
   @Override

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeServiceRaw.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeServiceRaw.java
@@ -87,7 +87,7 @@ public class BitstampTradeServiceRaw extends BitstampBaseService {
     }
   }
 
-  public boolean cancelBitstampOrder(int orderId) throws IOException {
+  public boolean cancelBitstampOrder(long orderId) throws IOException {
 
     try {
       return bitstampAuthenticated.cancelOrder(apiKey, signatureCreator, nonceFactory, orderId);


### PR DESCRIPTION
Bitstamp orders have exceeded [Integer.MAX_VALUE](https://docs.oracle.com/javase/7/docs/api/constant-values.html#java.lang.Integer.MAX_VALUE) leading to 

``` java
Caused by: org.knowm.xchange.bitstamp.dto.BitstampException: null (HTTP status code: 200)
at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[na:1.8.0_151]
at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[na:1.8.0_151]
at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[na:1.8.0_151]
at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[na:1.8.0_151]
at com.fasterxml.jackson.databind.introspect.AnnotatedConstructor.call(AnnotatedConstructor.java:124) ~[jackson-databind-2.9.2.jar!/:2.9.2]
at com.fasterxml.jackson.databind.deser.std.StdValueInstantiator.createFromObjectWith(StdValueInstantiator.java:274) ~[jackson-databind-2.9.2.jar!/:2.9.2]
at com.fasterxml.jackson.databind.deser.ValueInstantiator.createFromObjectWith(ValueInstantiator.java:228) ~[jackson-databind-2.9.2.jar!/:2.9.2]
at com.fasterxml.jackson.databind.deser.impl.PropertyBasedCreator.build(PropertyBasedCreator.java:189) ~[jackson-databind-2.9.2.jar!/:2.9.2]
at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:487) ~[jackson-databind-2.9.2.jar!/:2.9.2]
at com.fasterxml.jackson.databind.deser.std.ThrowableDeserializer.deserializeFromObject(ThrowableDeserializer.java:65) ~[jackson-databind-2.9.2.jar!/:2.9.2]
at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:159) ~[jackson-databind-2.9.2.jar!/:2.9.2]
at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4001) ~[jackson-databind-2.9.2.jar!/:2.9.2]
at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3030) ~[jackson-databind-2.9.2.jar!/:2.9.2]
at si.mazi.rescu.serialization.jackson.JacksonResponseReader.read(JacksonResponseReader.java:53) ~[rescu-2.0.1.jar!/:na]
at si.mazi.rescu.serialization.jackson.JacksonResponseReader.readException(JacksonResponseReader.java:58) ~[rescu-2.0.1.jar!/:na]
at si.mazi.rescu.ResponseReader.read(ResponseReader.java:82) ~[rescu-2.0.1.jar!/:na]
at si.mazi.rescu.RestInvocationHandler.mapInvocationResult(RestInvocationHandler.java:169) ~[rescu-2.0.1.jar!/:na]
at si.mazi.rescu.RestInvocationHandler.receiveAndMap(RestInvocationHandler.java:157) ~[rescu-2.0.1.jar!/:na]
at si.mazi.rescu.RestInvocationHandler.invoke(RestInvocationHandler.java:120) ~[rescu-2.0.1.jar!/:na]
at com.sun.proxy.$Proxy169.placeMarketOrder(Unknown Source) ~[na:na]
at org.knowm.xchange.bitstamp.service.BitstampTradeServiceRaw.placeBitstampMarketOrder(BitstampTradeServiceRaw.java:54) ~[xchange-bitstamp-4.3.4.jar!/:na]
... 30 common frames omitted
```