### PR TITLE
[Hitbtc] changed incorrect getOrder method with only string ids as params to QueryOrderParams version

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/DefaultQueryOrderParamCurrencyPair.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/DefaultQueryOrderParamCurrencyPair.java
@@ -7,11 +7,13 @@ public class DefaultQueryOrderParamCurrencyPair extends DefaultQueryOrderParam
 
   private CurrencyPair pair;
 
-  public DefaultQueryOrderParamCurrencyPair() {}
+  public DefaultQueryOrderParamCurrencyPair() {
+    super();
+  }
 
   public DefaultQueryOrderParamCurrencyPair(CurrencyPair pair, String orderId) {
+    super(orderId);
     this.pair = pair;
-    setOrderId(orderId);
   }
 
   @Override

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/DefaultQueryOrderParamCurrencyPair.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/DefaultQueryOrderParamCurrencyPair.java
@@ -1,0 +1,26 @@
+package org.knowm.xchange.service.trade.params.orders;
+
+import org.knowm.xchange.currency.CurrencyPair;
+
+public class DefaultQueryOrderParamCurrencyPair extends DefaultQueryOrderParam
+    implements OrderQueryParamCurrencyPair {
+
+  private CurrencyPair pair;
+
+  public DefaultQueryOrderParamCurrencyPair() {}
+
+  public DefaultQueryOrderParamCurrencyPair(CurrencyPair pair, String orderId) {
+    this.pair = pair;
+    setOrderId(orderId);
+  }
+
+  @Override
+  public CurrencyPair getCurrencyPair() {
+    return pair;
+  }
+
+  @Override
+  public void setCurrencyPair(CurrencyPair currencyPair) {
+    pair = currencyPair;
+  }
+}

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/KucoinAdapters.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/KucoinAdapters.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.OrderStatus;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.account.AccountInfo;
@@ -34,6 +35,7 @@ import org.knowm.xchange.kucoin.dto.marketdata.KucoinTicker;
 import org.knowm.xchange.kucoin.dto.trading.KucoinActiveOrder;
 import org.knowm.xchange.kucoin.dto.trading.KucoinActiveOrders;
 import org.knowm.xchange.kucoin.dto.trading.KucoinDealtOrder;
+import org.knowm.xchange.kucoin.dto.trading.KucoinOrderDetail;
 
 public class KucoinAdapters {
 
@@ -119,6 +121,32 @@ public class KucoinAdapters {
             order.getDealAmount().compareTo(BigDecimal.ZERO) == 0
                 ? OrderStatus.NEW
                 : OrderStatus.PARTIALLY_FILLED)
+        .build();
+  }
+
+  public static Order adaptOrder(KucoinOrderDetail order) {
+    OrderStatus status;
+
+    if (order.getIsActive()) {
+      status =
+          order.getDealAmount().compareTo(BigDecimal.ZERO) == 0
+              ? OrderStatus.NEW
+              : OrderStatus.PARTIALLY_FILLED;
+    } else {
+      status =
+          order.getDealAmount().compareTo(BigDecimal.ZERO) == 0
+              ? OrderStatus.CANCELED
+              : OrderStatus.FILLED;
+    }
+
+    return new LimitOrder.Builder(
+            order.getType(), new CurrencyPair(order.getCoinType(), order.getCoinTypePair()))
+        .id(order.getOrderOid())
+        .originalAmount(order.getDealAmount())
+        .remainingAmount(order.getPendingAmount())
+        .averagePrice(order.getDealPriceAverage())
+        .limitPrice(order.getOrderPrice())
+        .orderStatus(status)
         .build();
   }
 

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/trading/KucoinOrderDetail.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/trading/KucoinOrderDetail.java
@@ -63,4 +63,51 @@ public class KucoinOrderDetail {
   /**
    * INFO: Maybe we need to add dealOrders list here from request, but we don't need it in logic.
    */
+  public String getCoinType() {
+    return coinType;
+  }
+
+  public BigDecimal getDealValueTotal() {
+    return dealValueTotal;
+  }
+
+  public BigDecimal getDealPriceAverage() {
+    return dealPriceAverage;
+  }
+
+  public BigDecimal getFeeTotal() {
+    return feeTotal;
+  }
+
+  public String getUserOid() {
+    return userOid;
+  }
+
+  public BigDecimal getDealAmount() {
+    return dealAmount;
+  }
+
+  public String getCoinTypePair() {
+    return coinTypePair;
+  }
+
+  public BigDecimal getOrderPrice() {
+    return orderPrice;
+  }
+
+  public Order.OrderType getType() {
+    return type;
+  }
+
+  public String getOrderOid() {
+    return orderOid;
+  }
+
+  public BigDecimal getPendingAmount() {
+    return pendingAmount;
+  }
+
+  public Boolean getIsActive() {
+    return isActive;
+  }
 }

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/trading/KucoinOrderQueryParams.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/trading/KucoinOrderQueryParams.java
@@ -1,0 +1,56 @@
+package org.knowm.xchange.kucoin.dto.trading;
+
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.service.trade.params.orders.DefaultQueryOrderParamCurrencyPair;
+
+public class KucoinOrderQueryParams extends DefaultQueryOrderParamCurrencyPair {
+
+  private Order.OrderType orderType;
+  private Integer limit;
+  private Integer page;
+
+  public KucoinOrderQueryParams() {}
+
+  public KucoinOrderQueryParams(
+      CurrencyPair currencyPair, String orderOid, Order.OrderType orderType) {
+    super(currencyPair, orderOid);
+    this.orderType = orderType;
+  }
+
+  public KucoinOrderQueryParams(
+      CurrencyPair currencyPair,
+      String orderOid,
+      Order.OrderType orderType,
+      Integer limit,
+      Integer page) {
+    super(currencyPair, orderOid);
+    this.orderType = orderType;
+    this.limit = limit;
+    this.page = page;
+  }
+
+  public Order.OrderType getOrderType() {
+    return orderType;
+  }
+
+  public void setOrderType(Order.OrderType orderType) {
+    this.orderType = orderType;
+  }
+
+  public Integer getLimit() {
+    return limit;
+  }
+
+  public void setLimit(Integer limit) {
+    this.limit = limit;
+  }
+
+  public Integer getPage() {
+    return page;
+  }
+
+  public void setPage(Integer page) {
+    this.page = page;
+  }
+}


### PR DESCRIPTION
Hitbtc requires currency pair to be passed when getting order, it means that getOrder(String... ids) method can't be used here. Changed this to a QueryOrderParams version. Also added DefaultQueryOrderParamCurrencyPair implementation to the core.