### PR TITLE
[Liqui] Unplugged Liqui getAccountInfo

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/exceptions/NotAvailableFromExchangeException.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/exceptions/NotAvailableFromExchangeException.java
@@ -14,7 +14,7 @@ public class NotAvailableFromExchangeException extends UnsupportedOperationExcep
    *
    * @param message Message
    */
-  private NotAvailableFromExchangeException(String message) {
+  public NotAvailableFromExchangeException(String message) {
 
     super(message);
   }

--- a/xchange-liqui/src/main/java/org/knowm/xchange/liqui/service/LiquiAccountService.java
+++ b/xchange-liqui/src/main/java/org/knowm/xchange/liqui/service/LiquiAccountService.java
@@ -8,7 +8,6 @@ import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.dto.account.AccountInfo;
 import org.knowm.xchange.dto.account.FundingRecord;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
-import org.knowm.xchange.liqui.LiquiAdapters;
 import org.knowm.xchange.service.account.AccountService;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.WithdrawFundsParams;
@@ -21,7 +20,8 @@ public class LiquiAccountService extends LiquiAccountServiceRaw implements Accou
 
   @Override
   public AccountInfo getAccountInfo() throws IOException {
-    return LiquiAdapters.adaptAccountInfo(getAccountInfoRaw());
+    throw new NotAvailableFromExchangeException(
+        "Liqui balances cannot be retrieved in one call. Please build them by merging active orders amounts and LiquiAccountServiceRaw.getAccountInfoRaw amounts.");
   }
 
   @Override


### PR DESCRIPTION
The balances cannot be retrieved in one API call. It is better to return nothing instead of returning wrong balances.