### PR TITLE
[Bx.in] Remove extra request to history for each ticker request

### DIFF
--- a/xchange-bx/src/main/java/org/knowm/xchange/bx/BxAdapters.java
+++ b/xchange-bx/src/main/java/org/knowm/xchange/bx/BxAdapters.java
@@ -56,13 +56,9 @@ public class BxAdapters {
   public static Ticker adaptTicker(BxTicker bxTicker, SynchronizedValueFactory<Long> nonce) {
     Ticker.Builder builder = new Ticker.Builder();
     builder.currencyPair(BxUtils.translateBxCurrencyPair(bxTicker.getPairingId()));
-    builder.open(bxTicker.getOpen());
     builder.last(bxTicker.getLastPrice());
     builder.bid(bxTicker.getOrderBook().getBids().getHighBid());
     builder.ask(bxTicker.getOrderBook().getAsks().getHighBid());
-    builder.high(bxTicker.getHigh());
-    builder.low(bxTicker.getLow());
-    builder.vwap(bxTicker.getAvg());
     builder.volume(bxTicker.getVolume24hours());
     builder.timestamp(new Date(nonce.createValue()));
     return builder.build();

--- a/xchange-bx/src/main/java/org/knowm/xchange/bx/dto/marketdata/BxTicker.java
+++ b/xchange-bx/src/main/java/org/knowm/xchange/bx/dto/marketdata/BxTicker.java
@@ -12,11 +12,6 @@ public class BxTicker {
   private final BigDecimal lastPrice;
   private final BigDecimal volume24hours;
   private final BxOrderBook orderBook;
-  private BigDecimal open = null;
-  private BigDecimal high = null;
-  private BigDecimal low = null;
-  private BigDecimal avg = null;
-  private BigDecimal volume = null;
 
   public BxTicker(
       @JsonProperty("pairing_id") String pairingId,
@@ -61,46 +56,6 @@ public class BxTicker {
 
   public BxOrderBook getOrderBook() {
     return orderBook;
-  }
-
-  public BigDecimal getOpen() {
-    return open;
-  }
-
-  public BigDecimal getHigh() {
-    return high;
-  }
-
-  public BigDecimal getLow() {
-    return low;
-  }
-
-  public BigDecimal getAvg() {
-    return avg;
-  }
-
-  public BigDecimal getVolume() {
-    return volume;
-  }
-
-  public void setOpen(BigDecimal open) {
-    this.open = open;
-  }
-
-  public void setHigh(BigDecimal high) {
-    this.high = high;
-  }
-
-  public void setLow(BigDecimal low) {
-    this.low = low;
-  }
-
-  public void setAvg(BigDecimal avg) {
-    this.avg = avg;
-  }
-
-  public void setVolume(BigDecimal volume) {
-    this.volume = volume;
   }
 
   @Override

--- a/xchange-bx/src/main/java/org/knowm/xchange/bx/service/BxMarketDataServiceRaw.java
+++ b/xchange-bx/src/main/java/org/knowm/xchange/bx/service/BxMarketDataServiceRaw.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bx.BxUtils;
 import org.knowm.xchange.bx.dto.marketdata.BxAssetPair;
-import org.knowm.xchange.bx.dto.marketdata.BxHistoryTrade;
 import org.knowm.xchange.bx.dto.marketdata.BxTicker;
 import org.knowm.xchange.currency.CurrencyPair;
 
@@ -20,25 +19,8 @@ public class BxMarketDataServiceRaw extends BxBaseService {
   }
 
   public BxTicker getBxTicker(CurrencyPair currencyPair) throws IOException {
-    String keyRequest = BxUtils.createBxCurrencyPair(currencyPair);
+    String pairKey = BxUtils.createBxCurrencyPair(currencyPair);
     Map<String, BxTicker> tickerMap = checkResult(bx.getTicker());
-    BxTicker result = null;
-    for (String key : tickerMap.keySet()) {
-      if (key.equals(keyRequest)) {
-        result = tickerMap.get(key);
-        break;
-      }
-    }
-    if (result != null) {
-      BxHistoryTrade historyTrade =
-          checkResult(
-              bx.getHistoryTrade(keyRequest, BxUtils.createUTCDate(exchange.getNonceFactory())));
-      result.setOpen(historyTrade.getOpen());
-      result.setHigh(historyTrade.getHigh());
-      result.setLow(historyTrade.getLow());
-      result.setAvg(historyTrade.getAvg());
-      result.setVolume(historyTrade.getVolume());
-    }
-    return result;
+    return tickerMap.get(pairKey);
   }
 }

--- a/xchange-bx/src/test/java/org/knowm/xchange/bx/BxPublicApiIntegration.java
+++ b/xchange-bx/src/test/java/org/knowm/xchange/bx/BxPublicApiIntegration.java
@@ -1,10 +1,5 @@
 package org.knowm.xchange.bx;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 import org.junit.Test;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeFactory;
@@ -12,15 +7,26 @@ import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class BxPublicApiIntegration {
 
   @Test
   public void getTickerTest() throws IOException {
     Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BxExchange.class.getName());
     MarketDataService marketDataService = exchange.getMarketDataService();
-    Ticker ticker = marketDataService.getTicker(new CurrencyPair("THB", "BTC"));
-    System.out.println(ticker.toString());
-    assertThat(ticker).isNotNull();
+    CurrencyPair pair = new CurrencyPair("THB", "BTC");
+    Ticker ticker = marketDataService.getTicker(pair);
+    System.out.println(ticker);
+    assertThat(ticker.getCurrencyPair()).isEqualTo(pair);
+    assertThat(ticker.getLast()).isPositive();
+    assertThat(ticker.getBid()).isPositive();
+    assertThat(ticker.getAsk()).isPositive();
+    assertThat(ticker.getVolume()).isPositive();
   }
 
   @Test


### PR DESCRIPTION
Remove extra request to /api/tradehistory/ to get open, high, low, avg,  volume from the exchange. This data was nice to have, but additional request removal helps to reduce traffic between exchange.