### PR TITLE
Clear Kraken assets and assetPairs during a remote init. 

### DIFF
--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenExchange.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenExchange.java
@@ -47,10 +47,10 @@ public class KrakenExchange extends BaseExchange implements Exchange {
 
   @Override
   public void remoteInit() throws IOException {
-
     KrakenAssetPairs assetPairs =
         ((KrakenMarketDataServiceRaw) marketDataService).getKrakenAssetPairs();
     KrakenAssets assets = ((KrakenMarketDataServiceRaw) marketDataService).getKrakenAssets();
+    KrakenUtils.clearAssets();
     // other endpoints?
     // hard-coded meta data from json file not available at an endpoint?
     exchangeMetaData =

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenUtils.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenUtils.java
@@ -100,4 +100,11 @@ public class KrakenUtils {
     }
     return currencyOut.getCommonlyUsedCurrency();
   }
+
+  public static void clearAssets() {
+    assetPairMap.clear();
+    assetPairMapReverse.clear();
+    assetsMap.clear();
+    assetsMapReverse.clear();
+  }
 }


### PR DESCRIPTION
Allows new assets to be dynamically loaded when creating a new KrakenExchange instance or performing a remoteInit. Currently assets can only be loaded once during initial kraken exchange initialization. 