### PR TITLE
[Bitfinex] Retrieve (historic) Candles from Bitfinex

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
 		<module>xchange-cryptopia</module>
 		<module>xchange-coinsuper</module>
 		<module>xchange-dsx</module>
+		<module>xchange-dragonex</module>
 		<module>xchange-exmo</module>
 		<module>xchange-exx</module>
 		<module>xchange-examples</module>

--- a/xchange-coinbasepro/src/main/resources/coinbasepro.json
+++ b/xchange-coinbasepro/src/main/resources/coinbasepro.json
@@ -59,6 +59,21 @@
       "min_amount": 0.01,
       "max_amount": 10000.00,
       "price_scale": 2
+    },
+    "BTC/USDC": {
+      "min_amount": 0.001,
+      "max_amount": 70,
+      "price_scale": 0.01
+    },
+    "ETH/USDC": {
+      "min_amount": 0.001,
+      "max_amount": 700,
+      "price_scale": 0.01
+    },
+    "BAT/USDC": {
+      "min_amount": 1,
+      "max_amount": 300000,
+      "price_scale": 0.000001
     }
   },
   "currencies": {
@@ -87,6 +102,10 @@
       "withdrawal_fee": 0.0
     },
     "GBP": {
+      "scale": 2,
+      "withdrawal_fee": 0.0
+    },
+    "USDC": {
       "scale": 2,
       "withdrawal_fee": 0.0
     }

--- a/xchange-coinbasepro/src/test/java/org/knowm/xchange/coinbasepro/CoinbaseProExchangeIntegration.java
+++ b/xchange-coinbasepro/src/test/java/org/knowm/xchange/coinbasepro/CoinbaseProExchangeIntegration.java
@@ -9,8 +9,10 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeFactory;
 import org.knowm.xchange.coinbasepro.dto.CoinbaseProTrades;
 import org.knowm.xchange.coinbasepro.service.CoinbaseProMarketDataServiceRaw;
+import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.Trades;
+import org.knowm.xchange.dto.meta.ExchangeMetaData;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 
 public class CoinbaseProExchangeIntegration {
@@ -60,5 +62,16 @@ public class CoinbaseProExchangeIntegration {
 
     Trades trades3 = marketDataService.getTrades(currencyPair, new Long(0), new Long(1005));
     assertEquals("Unexpected trades list length (100)", 1004, trades3.getTrades().size());
+  }
+
+  @Test
+  public void testExchangeMetaData() {
+    final Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseProExchange.class.getName());
+
+    ExchangeMetaData exchangeMetaData = exchange.getExchangeMetaData();
+
+    Assert.assertNotNull(exchangeMetaData);
+    Assert.assertNotNull(exchangeMetaData.getCurrencies());
+    Assert.assertNotNull("USDC is not defined", exchangeMetaData.getCurrencies().get(new Currency("USDC")));
   }
 }

--- a/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/Coinbene.java
+++ b/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/Coinbene.java
@@ -7,6 +7,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import org.knowm.xchange.coinbene.dto.marketdata.CoinbeneOrderBook;
+import org.knowm.xchange.coinbene.dto.marketdata.CoinbeneSymbol;
 import org.knowm.xchange.coinbene.dto.marketdata.CoinbeneTicker;
 import org.knowm.xchange.coinbene.dto.marketdata.CoinbeneTrades;
 
@@ -45,4 +46,9 @@ public interface Coinbene {
   @Path("market/trades")
   CoinbeneTrades trades(@QueryParam("symbol") String symbol, @QueryParam("size") Integer size)
       throws IOException, CoinbeneException;
+
+  /** Retrieves trade symbols */
+  @GET
+  @Path("market/symbol")
+  CoinbeneSymbol.Container symbol() throws IOException, CoinbeneException;
 }

--- a/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/CoinbeneExchange.java
+++ b/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/CoinbeneExchange.java
@@ -9,9 +9,13 @@ import org.knowm.xchange.coinbene.service.CoinbeneMarketDataService;
 import org.knowm.xchange.coinbene.service.CoinbeneTradeService;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.utils.nonce.CurrentTimeNonceFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 public class CoinbeneExchange extends BaseExchange implements Exchange {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CoinbeneExchange.class);
 
   private SynchronizedValueFactory<Long> nonceFactory = new CurrentTimeNonceFactory();
 
@@ -26,8 +30,7 @@ public class CoinbeneExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass().getCanonicalName());
     exchangeSpecification.setSslUri("https://api.coinbene.com/");
     exchangeSpecification.setHost("coinbene.com");
     exchangeSpecification.setPort(80);
@@ -39,10 +42,12 @@ public class CoinbeneExchange extends BaseExchange implements Exchange {
 
   @Override
   public SynchronizedValueFactory<Long> getNonceFactory() {
-
     return nonceFactory;
   }
 
   @Override
-  public void remoteInit() throws IOException, ExchangeException {}
+  public void remoteInit() throws IOException, ExchangeException {
+
+      exchangeMetaData = ((CoinbeneMarketDataService) marketDataService).getMetadata();
+  }
 }

--- a/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/dto/CoinbeneAdapters.java
+++ b/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/dto/CoinbeneAdapters.java
@@ -1,12 +1,15 @@
 package org.knowm.xchange.coinbene.dto;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.knowm.xchange.coinbene.dto.account.CoinbeneCoinBalances;
 import org.knowm.xchange.coinbene.dto.marketdata.CoinbeneOrder;
 import org.knowm.xchange.coinbene.dto.marketdata.CoinbeneOrderBook;
+import org.knowm.xchange.coinbene.dto.marketdata.CoinbeneSymbol;
 import org.knowm.xchange.coinbene.dto.marketdata.CoinbeneTicker;
 import org.knowm.xchange.coinbene.dto.marketdata.CoinbeneTrade;
 import org.knowm.xchange.coinbene.dto.trading.CoinbeneLimitOrder;
@@ -20,6 +23,8 @@ import org.knowm.xchange.dto.account.Wallet;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trade;
+import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
+import org.knowm.xchange.dto.meta.ExchangeMetaData;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
 
@@ -133,5 +138,15 @@ public class CoinbeneAdapters {
         .cumulativeAmount(order.getFilledQuantity())
         .originalAmount(order.getOrderQuantity())
         .build();
+  }
+
+  public static ExchangeMetaData adaptMetadata(List<CoinbeneSymbol> markets) {
+    Map<CurrencyPair, CurrencyPairMetaData> pairMeta = new HashMap<>();
+    for (CoinbeneSymbol ticker : markets) {
+      pairMeta.put(
+          new CurrencyPair(ticker.getBaseAsset(), ticker.getQuoteAsset()),
+          new CurrencyPairMetaData(null, ticker.getMinQuantity(), null, null, null));
+    }
+    return new ExchangeMetaData(pairMeta, null, null, null, null);
   }
 }

--- a/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/dto/marketdata/CoinbeneSymbol.java
+++ b/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/dto/marketdata/CoinbeneSymbol.java
@@ -1,0 +1,82 @@
+package org.knowm.xchange.coinbene.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.util.List;
+import org.knowm.xchange.coinbene.dto.CoinbeneResponse;
+
+public class CoinbeneSymbol {
+
+  private String ticker; // "CONIUSDT";
+  private String baseAsset; // "CONI";
+  private String quoteAsset; // "USDT";
+  private BigDecimal takerFee; // "0.0010";
+  private BigDecimal makerFee; // "0.0010";
+  private int tickSize; // "5";
+  private int lotStepSize; // "2";
+  private BigDecimal minQuantity; // "1.00000000"
+
+  public CoinbeneSymbol(
+      @JsonProperty("ticker") String ticker,
+      @JsonProperty("baseAsset") String baseAsset,
+      @JsonProperty("quoteAsset") String quoteAsset,
+      @JsonProperty("takerFee") BigDecimal takerFee,
+      @JsonProperty("makerFee") BigDecimal makerFee,
+      @JsonProperty("tickSize") int tickSize,
+      @JsonProperty("lotStepSize") int lotStepSize,
+      @JsonProperty("minQuantity") BigDecimal minQuantity) {
+    this.ticker = ticker;
+    this.baseAsset = baseAsset;
+    this.quoteAsset = quoteAsset;
+    this.takerFee = takerFee;
+    this.makerFee = makerFee;
+    this.tickSize = tickSize;
+    this.lotStepSize = lotStepSize;
+    this.minQuantity = minQuantity;
+  }
+
+  public String getTicker() {
+    return ticker;
+  }
+
+  public String getBaseAsset() {
+    return baseAsset;
+  }
+
+  public String getQuoteAsset() {
+    return quoteAsset;
+  }
+
+  public BigDecimal getTakerFee() {
+    return takerFee;
+  }
+
+  public BigDecimal getMakerFee() {
+    return makerFee;
+  }
+
+  public int getTickSize() {
+    return tickSize;
+  }
+
+  public int getLotStepSize() {
+    return lotStepSize;
+  }
+
+  public BigDecimal getMinQuantity() {
+    return minQuantity;
+  }
+
+  public static class Container extends CoinbeneResponse {
+
+    private final List<CoinbeneSymbol> symbol;
+
+    public Container(@JsonProperty("symbol") List<CoinbeneSymbol> symbol) {
+      this.symbol = symbol;
+    }
+
+    public List<CoinbeneSymbol> getSymbol() {
+      return symbol;
+    }
+  }
+}

--- a/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/service/CoinbeneMarketDataService.java
+++ b/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/service/CoinbeneMarketDataService.java
@@ -5,11 +5,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.coinbene.dto.CoinbeneAdapters;
+import org.knowm.xchange.coinbene.dto.marketdata.CoinbeneSymbol;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trade;
 import org.knowm.xchange.dto.marketdata.Trades;
+import org.knowm.xchange.dto.meta.ExchangeMetaData;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 
 public class CoinbeneMarketDataService extends CoinbeneMarketDataServiceRaw
@@ -60,5 +62,11 @@ public class CoinbeneMarketDataService extends CoinbeneMarketDataServiceRaw
             .map(trade -> CoinbeneAdapters.adaptTrade(trade, currencyPair))
             .collect(Collectors.toList());
     return new Trades(trades, Trades.TradeSortType.SortByTimestamp);
+  }
+
+  public ExchangeMetaData getMetadata() throws IOException {
+
+    List<CoinbeneSymbol> symbol = getSymbol().getSymbol();
+    return CoinbeneAdapters.adaptMetadata(symbol);
   }
 }

--- a/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/service/CoinbeneMarketDataServiceRaw.java
+++ b/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/service/CoinbeneMarketDataServiceRaw.java
@@ -5,6 +5,7 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.coinbene.CoinbeneException;
 import org.knowm.xchange.coinbene.dto.CoinbeneAdapters;
 import org.knowm.xchange.coinbene.dto.marketdata.CoinbeneOrderBook;
+import org.knowm.xchange.coinbene.dto.marketdata.CoinbeneSymbol;
 import org.knowm.xchange.coinbene.dto.marketdata.CoinbeneTicker;
 import org.knowm.xchange.coinbene.dto.marketdata.CoinbeneTrades;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -34,6 +35,14 @@ public class CoinbeneMarketDataServiceRaw extends CoinbeneBaseService {
     try {
       return checkSuccess(
           coinbene.orderBook(CoinbeneAdapters.adaptCurrencyPair(currencyPair), size));
+    } catch (CoinbeneException e) {
+      throw new ExchangeException(e.getMessage(), e);
+    }
+  }
+
+  public CoinbeneSymbol.Container getSymbol() throws IOException {
+    try {
+      return checkSuccess(coinbene.symbol());
     } catch (CoinbeneException e) {
       throw new ExchangeException(e.getMessage(), e);
     }

--- a/xchange-coinbene/src/test/java/org/knowm/xchange/coinbene/service/marketdata/CoinbeneMarketDataServiceIntegration.java
+++ b/xchange-coinbene/src/test/java/org/knowm/xchange/coinbene/service/marketdata/CoinbeneMarketDataServiceIntegration.java
@@ -3,10 +3,12 @@ package org.knowm.xchange.coinbene.service.marketdata;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.knowm.xchange.currency.CurrencyPair.BTC_USDT;
 
+import java.util.List;
 import org.junit.Test;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeFactory;
 import org.knowm.xchange.coinbene.CoinbeneExchange;
+import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trades;
@@ -56,5 +58,14 @@ public class CoinbeneMarketDataServiceIntegration {
     Trades tradesLimit20 = COINBENE.getMarketDataService().getTrades(BTC_USDT, 20);
     assertThat(tradesLimit20.getTrades().size()).isEqualTo(20);
     tradesLimit20.getTrades().forEach(t -> assertThat(t.getCurrencyPair()).isEqualTo(BTC_USDT));
+  }
+
+  @Test
+  public void testGetSymbol() {
+
+    List<CurrencyPair> symbols = COINBENE.getExchangeSymbols();
+    assertThat(symbols).isNotNull();
+    assertThat(symbols.contains(CurrencyPair.ETH_BTC)).isEqualTo(true);
+
   }
 }

--- a/xchange-dragonex/api-specification.txt
+++ b/xchange-dragonex/api-specification.txt
@@ -1,0 +1,6 @@
+Dragonex Exchange API specification
+================================
+
+Documentation
+-------------
+https://github.com/Dragonexio/OpenApi/tree/master/docs

--- a/xchange-dragonex/pom.xml
+++ b/xchange-dragonex/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.knowm.xchange</groupId>
+        <artifactId>xchange-parent</artifactId>
+        <version>4.3.13-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>xchange-dragonex</artifactId>
+    <name>XChange Dragonex</name>
+    <description>XChange implementation for the Dragonex Exchange</description>
+
+    <url>http://knowm.org/open-source/xchange/</url>
+    <inceptionYear>2018</inceptionYear>
+
+    <organization>
+        <name>Knowm Inc.</name>
+        <url>http://knowm.org/open-source/xchange/</url>
+    </organization>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.knowm.xchange</groupId>
+            <artifactId>xchange-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/Dragonex.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/Dragonex.java
@@ -1,0 +1,53 @@
+package org.knowm.xchange.dragonex;
+
+import java.io.IOException;
+import java.util.List;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import org.knowm.xchange.dragonex.dto.DragonResult;
+import org.knowm.xchange.dragonex.dto.DragonexException;
+import org.knowm.xchange.dragonex.dto.marketdata.Coin;
+import org.knowm.xchange.dragonex.dto.marketdata.Order;
+import org.knowm.xchange.dragonex.dto.marketdata.Symbol;
+import org.knowm.xchange.dragonex.dto.marketdata.Ticker;
+
+@Path("api/v1")
+@Produces(MediaType.APPLICATION_JSON)
+public interface Dragonex {
+
+  /** Query all coins in DragonEx Platform */
+  @GET
+  @Path("coin/all/")
+  DragonResult<List<Coin>> coinAll() throws DragonexException, IOException;
+
+  /** Query all exchange pairs */
+  @GET
+  @Path("symbol/all/")
+  DragonResult<List<Symbol>> symbolAll() throws DragonexException, IOException;
+
+  /** Query K line @TODO */
+  /*@GET
+  @Path("market/kline/")
+  DragonResult<KLine> kLine() throws DragonexException, IOException;*/
+
+  /** Query buy orders quotes */
+  @GET
+  @Path("market/buy/")
+  DragonResult<List<Order>> marketBuyOrders(@QueryParam("symbol_id") long symbolId)
+      throws DragonexException, IOException;
+
+  /** Query sell orders quotes */
+  @GET
+  @Path("market/sell/")
+  DragonResult<List<Order>> marketSellOrders(@QueryParam("symbol_id") long symbolId)
+      throws DragonexException, IOException;
+
+  /** Query real time quotes */
+  @GET
+  @Path("market/real/")
+  DragonResult<List<Ticker>> ticker(@QueryParam("symbol_id") long symbolId)
+      throws DragonexException, IOException;
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/DragonexAdapters.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/DragonexAdapters.java
@@ -1,0 +1,3 @@
+package org.knowm.xchange.dragonex;
+
+public class DragonexAdapters {}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/DragonexAuthenticated.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/DragonexAuthenticated.java
@@ -1,0 +1,123 @@
+package org.knowm.xchange.dragonex;
+
+import java.io.IOException;
+import java.util.List;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+import org.knowm.xchange.dragonex.dto.DragonResult;
+import org.knowm.xchange.dragonex.dto.DragonexException;
+import org.knowm.xchange.dragonex.dto.Token;
+import org.knowm.xchange.dragonex.dto.TokenStatus;
+import org.knowm.xchange.dragonex.dto.account.Balance;
+import org.knowm.xchange.dragonex.dto.trade.DealHistory;
+import org.knowm.xchange.dragonex.dto.trade.DealHistoryRequest;
+import org.knowm.xchange.dragonex.dto.trade.OrderHistory;
+import org.knowm.xchange.dragonex.dto.trade.OrderHistoryRequest;
+import org.knowm.xchange.dragonex.dto.trade.OrderPlacement;
+import org.knowm.xchange.dragonex.dto.trade.OrderReference;
+import org.knowm.xchange.dragonex.dto.trade.UserOrder;
+import si.mazi.rescu.ParamsDigest;
+
+/** https://github.com/Dragonexio/OpenApi/blob/master/docs/English/1.interface_document_v1.md */
+@Path("api/v1")
+@Consumes(MediaType.APPLICATION_JSON)
+public interface DragonexAuthenticated {
+
+  /** Create new token */
+  @POST
+  @Path("token/new/")
+  DragonResult<Token> tokenNew(
+      @HeaderParam("date") String date,
+      @HeaderParam("auth") ParamsDigest auth,
+      @HeaderParam("content-sha1") ParamsDigest contentSHA1)
+      throws DragonexException, IOException;
+
+  /** Token status */
+  @POST
+  @Path("token/status/")
+  DragonResult<TokenStatus> tokenStatus(
+      @HeaderParam("date") String date,
+      @HeaderParam("token") String token,
+      @HeaderParam("auth") ParamsDigest auth,
+      @HeaderParam("content-sha1") ParamsDigest contentSHA1)
+      throws DragonexException, IOException;
+
+  /** Query all coins you own */
+  @POST
+  @Path("user/own/")
+  DragonResult<List<Balance>> userCoins(
+      @HeaderParam("date") String date,
+      @HeaderParam("token") String token,
+      @HeaderParam("auth") ParamsDigest auth,
+      @HeaderParam("content-sha1") ParamsDigest contentSHA1)
+      throws DragonexException, IOException;
+
+  /** Add new buy order */
+  @POST
+  @Path("order/buy/")
+  DragonResult<UserOrder> orderBuy(
+      @HeaderParam("date") String date,
+      @HeaderParam("token") String token,
+      @HeaderParam("auth") ParamsDigest auth,
+      @HeaderParam("Content-Sha1") ParamsDigest contentSHA1,
+      OrderPlacement orderPlacement)
+      throws DragonexException, IOException;
+
+  /** Add new sell order */
+  @POST
+  @Path("order/sell/")
+  DragonResult<UserOrder> orderSell(
+      @HeaderParam("date") String date,
+      @HeaderParam("token") String token,
+      @HeaderParam("auth") ParamsDigest auth,
+      @HeaderParam("Content-Sha1") ParamsDigest contentSHA1,
+      OrderPlacement orderPlacement)
+      throws DragonexException, IOException;
+
+  /** Cancel Order */
+  @POST
+  @Path("order/cancel/")
+  DragonResult<UserOrder> orderCancel(
+      @HeaderParam("date") String date,
+      @HeaderParam("token") String token,
+      @HeaderParam("auth") ParamsDigest auth,
+      @HeaderParam("Content-Sha1") ParamsDigest contentSHA1,
+      OrderReference ref)
+      throws DragonexException, IOException;
+
+  /** Request details of user’s delegation records */
+  @POST
+  @Path("order/detail/")
+  DragonResult<UserOrder> orderDetail(
+      @HeaderParam("date") String date,
+      @HeaderParam("token") String token,
+      @HeaderParam("auth") ParamsDigest auth,
+      @HeaderParam("Content-Sha1") ParamsDigest contentSHA1,
+      OrderReference ref)
+      throws DragonexException, IOException;
+
+  /** Request user’s delegation records */
+  @POST
+  @Path("order/history/")
+  DragonResult<OrderHistory> orderHistory(
+      @HeaderParam("date") String date,
+      @HeaderParam("token") String token,
+      @HeaderParam("auth") ParamsDigest auth,
+      @HeaderParam("Content-Sha1") ParamsDigest contentSHA1,
+      OrderHistoryRequest orderHistory)
+      throws DragonexException, IOException;
+
+  /** Request user’s records of successful trade */
+  @POST
+  @Path("deal/history/")
+  DragonResult<DealHistory> dealHistory(
+      @HeaderParam("date") String date,
+      @HeaderParam("token") String token,
+      @HeaderParam("auth") ParamsDigest auth,
+      @HeaderParam("Content-Sha1") ParamsDigest contentSHA1,
+      DealHistoryRequest orderHistory)
+      throws DragonexException, IOException;
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/DragonexErrorAdapter.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/DragonexErrorAdapter.java
@@ -1,0 +1,33 @@
+package org.knowm.xchange.dragonex;
+
+import org.apache.commons.lang3.StringUtils;
+import org.knowm.xchange.dragonex.dto.DragonexException;
+import org.knowm.xchange.exceptions.CurrencyPairNotValidException;
+import org.knowm.xchange.exceptions.ExchangeException;
+import org.knowm.xchange.exceptions.ExchangeSecurityException;
+
+/** @author walec51 */
+public class DragonexErrorAdapter {
+
+  private static final String INVALID_CURRENCY_MESSAGE_START = "Invalid currency pair";
+
+  public static ExchangeException adapt(DragonexException e) {
+    switch (e.getHttpStatusCode()) {
+      case 403:
+        return new ExchangeSecurityException(e);
+      default:
+        return adaptBasedOnErrorMessage(e);
+    }
+  }
+
+  private static ExchangeException adaptBasedOnErrorMessage(DragonexException e) {
+    String message = e.getError();
+    if (StringUtils.isEmpty(message)) {
+      return new ExchangeException("Operation failed without any error message");
+    }
+    if (message.startsWith(INVALID_CURRENCY_MESSAGE_START)) {
+      return new CurrencyPairNotValidException(message);
+    }
+    return new ExchangeException(message, e);
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/DragonexExchange.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/DragonexExchange.java
@@ -1,0 +1,131 @@
+package org.knowm.xchange.dragonex;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.knowm.xchange.BaseExchange;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dragonex.dto.DragonexException;
+import org.knowm.xchange.dragonex.dto.Token;
+import org.knowm.xchange.dragonex.dto.marketdata.Coin;
+import org.knowm.xchange.dragonex.dto.marketdata.Symbol;
+import org.knowm.xchange.dragonex.service.DragonDigest;
+import org.knowm.xchange.dragonex.service.DragonexAccountService;
+import org.knowm.xchange.dragonex.service.DragonexAccountServiceRaw;
+import org.knowm.xchange.dragonex.service.DragonexMarketDataService;
+import org.knowm.xchange.dragonex.service.DragonexTradeService;
+import org.knowm.xchange.exceptions.ExchangeException;
+import si.mazi.rescu.ClientConfig;
+import si.mazi.rescu.ParamsDigest;
+import si.mazi.rescu.RestProxyFactory;
+import si.mazi.rescu.SynchronizedValueFactory;
+
+public class DragonexExchange extends BaseExchange implements Exchange {
+
+  private Dragonex dragonexPublic;
+  private DragonexAuthenticated dragonexAuthenticated;
+  private ParamsDigest signatureCreator;
+  private final AtomicReference<Token> currentToken = new AtomicReference<>();
+  private final Map<Long, String> coins = new HashMap<>();
+  private Map<Long, CurrencyPair> symbols = new HashMap<>();
+  private Map<CurrencyPair, Long> pairs = new HashMap<>();
+
+  @Override
+  protected void initServices() {
+    this.marketDataService = new DragonexMarketDataService(this);
+    this.accountService = new DragonexAccountService(this);
+    this.tradeService = new DragonexTradeService(this);
+
+    ClientConfig rescuConfig =
+        ((DragonexMarketDataService) this.marketDataService).getClientConfig();
+    ExchangeSpecification spec = this.getExchangeSpecification();
+    this.dragonexPublic =
+        RestProxyFactory.createProxy(Dragonex.class, spec.getSslUri(), rescuConfig);
+
+    if (spec.getApiKey() != null && spec.getSecretKey() != null) {
+      this.dragonexAuthenticated =
+          RestProxyFactory.createProxy(DragonexAuthenticated.class, spec.getSslUri(), rescuConfig);
+      this.signatureCreator = new DragonDigest(spec.getApiKey(), spec.getSecretKey());
+    }
+
+    Token token = (Token) spec.getExchangeSpecificParametersItem("dragonex.token");
+    currentToken.set(token);
+  }
+
+  public CurrencyPair pair(long symbolId) {
+    return symbols.get(symbolId);
+  }
+
+  public long symbolId(CurrencyPair pair) {
+    Long symbolId = pairs.get(pair);
+    if (symbolId == null) {
+      throw new ExchangeException("Not supported pair " + pair + " by Dragonex.");
+    }
+    return symbolId;
+  }
+
+  public Token getOrCreateToken() throws DragonexException, IOException {
+    Token token = currentToken.get();
+    if (token != null && token.valid()) {
+      return token;
+    }
+    synchronized (currentToken) {
+      token = currentToken.get();
+      if (token != null && token.valid()) {
+        return token;
+      }
+      token = ((DragonexAccountServiceRaw) accountService).tokenNew();
+      currentToken.set(token);
+    }
+    return token;
+  }
+
+  public Dragonex dragonexPublic() {
+    return dragonexPublic;
+  }
+
+  public DragonexAuthenticated dragonexAuthenticated() {
+    return dragonexAuthenticated;
+  }
+
+  public ParamsDigest signatureCreator() {
+    return signatureCreator;
+  }
+
+  @Override
+  public ExchangeSpecification getDefaultExchangeSpecification() {
+    ExchangeSpecification spec = new ExchangeSpecification(this.getClass().getCanonicalName());
+    spec.setSslUri("https://openapi.dragonex.io/");
+    spec.setHost("openapi.dragonex.io");
+    spec.setPort(80);
+    spec.setExchangeName("Dragonex");
+    spec.setExchangeDescription("Dragonex is a bitcoin and altcoin exchange.");
+    return spec;
+  }
+
+  @Override
+  public SynchronizedValueFactory<Long> getNonceFactory() {
+    throw new ExchangeException("Dragonex does not require a nonce factory.");
+  }
+
+  @Override
+  public void remoteInit() throws IOException, ExchangeException {
+    try {
+      List<Coin> coinAll = ((DragonexMarketDataService) marketDataService).coinAll();
+      coinAll.forEach(c -> coins.put(c.coinId, c.code));
+      List<Symbol> symbolAll = ((DragonexMarketDataService) marketDataService).symbolAll();
+      symbolAll.forEach(
+          c -> {
+            CurrencyPair pair = new CurrencyPair(c.symbol.toUpperCase().replace('_', '/'));
+            symbols.put(c.symbolId, pair);
+            pairs.put(pair, c.symbolId);
+          });
+    } catch (Throwable e) {
+      throw new RuntimeException("Could not initialize the Dragonex service.", e);
+    }
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/DragonexUtils.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/DragonexUtils.java
@@ -1,0 +1,16 @@
+package org.knowm.xchange.dragonex;
+
+import java.util.Date;
+import org.knowm.xchange.exceptions.ExchangeException;
+
+public class DragonexUtils {
+  public static Date nanos2Date(String nanos) {
+    // timestamp is provided in nano seconds!
+    try {
+      long millis = Long.valueOf(nanos.substring(0, nanos.length() - 6));
+      return new Date(millis);
+    } catch (Throwable e) {
+      throw new ExchangeException("Invalid timestamp provided by dragonex: " + nanos);
+    }
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/DragonResult.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/DragonResult.java
@@ -1,0 +1,41 @@
+package org.knowm.xchange.dragonex.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class DragonResult<T> {
+
+  public final boolean ok;
+  public final int code;
+  public final String msg;
+  private final T data;
+
+  public DragonResult(
+      @JsonProperty("ok") boolean ok,
+      @JsonProperty("code") int code,
+      @JsonProperty("msg") String msg,
+      @JsonProperty("data") T data) {
+    this.ok = ok;
+    this.code = code;
+    this.msg = msg;
+    this.data = data;
+  }
+
+  public T getResult() {
+    if (!ok) {
+      throw new DragonexException(msg + ", code: " + code);
+    }
+    return data;
+  }
+
+  @Override
+  public String toString() {
+    return "DragonResult [ok="
+        + ok
+        + ", code="
+        + code
+        + ", "
+        + (msg != null ? "msg=" + msg + ", " : "")
+        + (data != null ? "data=" + data : "")
+        + "]";
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/DragonexException.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/DragonexException.java
@@ -1,0 +1,31 @@
+package org.knowm.xchange.dragonex.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import si.mazi.rescu.HttpStatusExceptionSupport;
+
+@SuppressWarnings("serial")
+public class DragonexException extends HttpStatusExceptionSupport {
+
+  @JsonProperty("error")
+  private String error;
+
+  public DragonexException() {}
+
+  public DragonexException(String error) {
+    this.error = error;
+    setHttpStatusCode(200);
+  }
+
+  public String getError() {
+    return error;
+  }
+
+  public void setError(String error) {
+    this.error = error;
+  }
+
+  @Override
+  public String getMessage() {
+    return error;
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/LoanInfo.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/LoanInfo.java
@@ -1,0 +1,33 @@
+package org.knowm.xchange.dragonex.dto;
+
+import java.util.List;
+import org.knowm.xchange.dto.LoanOrder;
+
+/** DTO representing loan information */
+public final class LoanInfo {
+
+  /** Provided loans */
+  private final List<LoanOrder> providedLoans;
+
+  /** Used loans */
+  private final List<LoanOrder> usedLoans;
+
+  /**
+   * Constructs an {@link LoanInfo}.
+   *
+   * @param providedLoans provided loans.
+   * @param usedLoans used loans.
+   */
+  public LoanInfo(List<LoanOrder> providedLoans, List<LoanOrder> usedLoans) {
+    this.providedLoans = providedLoans;
+    this.usedLoans = usedLoans;
+  }
+
+  public List<LoanOrder> getProvidedLoans() {
+    return providedLoans;
+  }
+
+  public List<LoanOrder> getUsedLoans() {
+    return usedLoans;
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/Token.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/Token.java
@@ -1,0 +1,27 @@
+package org.knowm.xchange.dragonex.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.concurrent.TimeUnit;
+
+public class Token {
+
+  /** unix time in seconds */
+  public final long expireTime;
+
+  public final String token;
+
+  public Token(@JsonProperty("expire_time") long expireTime, @JsonProperty("token") String token) {
+    this.expireTime = expireTime;
+    this.token = token;
+  }
+
+  @Override
+  public String toString() {
+    return "Token [expireTime=" + expireTime + ", " + (token != null ? "token=" + token : "") + "]";
+  }
+
+  /** assume the token is expired 1 minute before the actual expiry */
+  public boolean valid() {
+    return expireTime * 1000 - System.currentTimeMillis() > TimeUnit.MINUTES.toMillis(1);
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/TokenStatus.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/TokenStatus.java
@@ -1,0 +1,18 @@
+package org.knowm.xchange.dragonex.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TokenStatus {
+
+  /** user id in DragonEx platform */
+  public final long uid;
+
+  public TokenStatus(@JsonProperty("uid") long uid) {
+    this.uid = uid;
+  }
+
+  @Override
+  public String toString() {
+    return "TokenStatus [uid=" + uid + "]";
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/account/Balance.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/account/Balance.java
@@ -1,0 +1,35 @@
+package org.knowm.xchange.dragonex.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+
+public class Balance {
+
+  public final String code;
+  public final long coinId;
+  public final BigDecimal frozen;
+  public final BigDecimal volume;
+
+  public Balance(
+      @JsonProperty("code") String code,
+      @JsonProperty("coin_id") long coinId,
+      @JsonProperty("frozen") BigDecimal frozen,
+      @JsonProperty("volume") BigDecimal volume) {
+    this.code = code;
+    this.coinId = coinId;
+    this.frozen = frozen;
+    this.volume = volume;
+  }
+
+  @Override
+  public String toString() {
+    return "Balance ["
+        + (code != null ? "code=" + code + ", " : "")
+        + "coinId="
+        + coinId
+        + ", "
+        + (frozen != null ? "frozen=" + frozen + ", " : "")
+        + (volume != null ? "volume=" + volume : "")
+        + "]";
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/marketdata/Coin.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/marketdata/Coin.java
@@ -1,0 +1,19 @@
+package org.knowm.xchange.dragonex.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Coin {
+
+  public final String code;
+  public final long coinId;
+
+  public Coin(@JsonProperty("code") String code, @JsonProperty("coin_id") long coinId) {
+    this.code = code;
+    this.coinId = coinId;
+  }
+
+  @Override
+  public String toString() {
+    return "Coin [" + (code != null ? "code=" + code + ", " : "") + "coinId=" + coinId + "]";
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/marketdata/KLine.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/marketdata/KLine.java
@@ -1,0 +1,50 @@
+package org.knowm.xchange.dragonex.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class KLine {
+
+  private final List<String> columns;
+  private final List<KLineData> lists;
+
+  public KLine(
+      @JsonProperty("columns") List<String> columns, @JsonProperty("lists") List<KLineData> lists) {
+    this.columns = columns;
+    this.lists = lists;
+  }
+
+  public static class KLineData {
+    private final String amount; // exchange amount
+    private final String closePrice; // closing price
+    private final String maxPrice; // highest price
+    private final String minPrice; // lowest price
+    private final String openPrice; // opening price
+    private final String preClosePrice; // previous closing price
+    private final long timestamp; // second-level timestamp
+    private final String usdtAmount; // corresponding USDT exchange amount
+    private final String volume; // exchange volume
+
+    public KLineData(
+        @JsonProperty("amount") String amount,
+        @JsonProperty("close_price") String closePrice,
+        @JsonProperty("max_price") String maxPrice,
+        @JsonProperty("min_price") String minPrice,
+        @JsonProperty("open_price") String openPrice,
+        @JsonProperty("pre_close_price") String preClosePrice,
+        @JsonProperty("timestamp") long timestamp,
+        @JsonProperty("usdt_amount") String usdtAmount,
+        @JsonProperty("volume") String volume) {
+
+      this.amount = amount;
+      this.closePrice = closePrice;
+      this.maxPrice = maxPrice;
+      this.minPrice = minPrice;
+      this.openPrice = openPrice;
+      this.preClosePrice = preClosePrice;
+      this.timestamp = timestamp;
+      this.usdtAmount = usdtAmount;
+      this.volume = volume;
+    }
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/marketdata/Order.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/marketdata/Order.java
@@ -1,0 +1,23 @@
+package org.knowm.xchange.dragonex.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+
+public class Order {
+
+  public final BigDecimal price;
+  public final BigDecimal volume;
+
+  public Order(@JsonProperty("price") BigDecimal price, @JsonProperty("volume") BigDecimal volume) {
+    this.price = price;
+    this.volume = volume;
+  }
+
+  @Override
+  public String toString() {
+    return "Order ["
+        + (price != null ? "price=" + price + ", " : "")
+        + (volume != null ? "volume=" + volume : "")
+        + "]";
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/marketdata/Symbol.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/marketdata/Symbol.java
@@ -1,0 +1,23 @@
+package org.knowm.xchange.dragonex.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Symbol {
+
+  public final String symbol;
+  public final long symbolId;
+
+  public Symbol(@JsonProperty("symbol") String symbol, @JsonProperty("symbol_id") long symbolId) {
+    this.symbol = symbol;
+    this.symbolId = symbolId;
+  }
+
+  @Override
+  public String toString() {
+    return "Coin ["
+        + (symbol != null ? "symbol=" + symbol + ", " : "")
+        + "symbolId="
+        + symbolId
+        + "]";
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/marketdata/Ticker.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/marketdata/Ticker.java
@@ -1,0 +1,72 @@
+package org.knowm.xchange.dragonex.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+
+public class Ticker {
+
+  public final BigDecimal closePrice;
+  public final BigDecimal currentVolume;
+  public final BigDecimal maxPrice;
+  public final BigDecimal minPrice;
+  public final BigDecimal openPrice;
+  public final BigDecimal priceBase;
+  public final BigDecimal priceChange;
+  public final BigDecimal priceChangeRate;
+  public final long timestamp;
+  public final BigDecimal totalAmount;
+  public final BigDecimal totalVolume;
+  public final BigDecimal usdtAmount;
+  public final long symbolId;
+
+  public Ticker(
+      @JsonProperty("close_price") BigDecimal closePrice,
+      @JsonProperty("current_volume") BigDecimal currentVolume,
+      @JsonProperty("max_price") BigDecimal maxPrice,
+      @JsonProperty("min_price") BigDecimal minPrice,
+      @JsonProperty("open_price") BigDecimal openPrice,
+      @JsonProperty("price_base") BigDecimal priceBase,
+      @JsonProperty("price_change") BigDecimal priceChange,
+      @JsonProperty("price_change_rate") BigDecimal priceChangeRate,
+      @JsonProperty("timestamp") long timestamp,
+      @JsonProperty("total_amount") BigDecimal totalAmount,
+      @JsonProperty("total_volume") BigDecimal totalVolume,
+      @JsonProperty("usdt_amount") BigDecimal usdtAmount,
+      @JsonProperty("symbol_id") long symbolId) {
+    this.closePrice = closePrice;
+    this.currentVolume = currentVolume;
+    this.maxPrice = maxPrice;
+    this.minPrice = minPrice;
+    this.openPrice = openPrice;
+    this.priceBase = priceBase;
+    this.priceChange = priceChange;
+    this.priceChangeRate = priceChangeRate;
+    this.timestamp = timestamp;
+    this.totalAmount = totalAmount;
+    this.totalVolume = totalVolume;
+    this.usdtAmount = usdtAmount;
+    this.symbolId = symbolId;
+  }
+
+  @Override
+  public String toString() {
+    return "Ticker ["
+        + (closePrice != null ? "closePrice=" + closePrice + ", " : "")
+        + (currentVolume != null ? "currentVolume=" + currentVolume + ", " : "")
+        + (maxPrice != null ? "maxPrice=" + maxPrice + ", " : "")
+        + (minPrice != null ? "minPrice=" + minPrice + ", " : "")
+        + (openPrice != null ? "openPrice=" + openPrice + ", " : "")
+        + (priceBase != null ? "priceBase=" + priceBase + ", " : "")
+        + (priceChange != null ? "priceChange=" + priceChange + ", " : "")
+        + (priceChangeRate != null ? "priceChangeRate=" + priceChangeRate + ", " : "")
+        + "timestamp="
+        + timestamp
+        + ", "
+        + (totalAmount != null ? "totalAmount=" + totalAmount + ", " : "")
+        + (totalVolume != null ? "totalVolume=" + totalVolume + ", " : "")
+        + (usdtAmount != null ? "usdtAmount=" + usdtAmount + ", " : "")
+        + "symbolId="
+        + symbolId
+        + "]";
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/trade/Deal.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/trade/Deal.java
@@ -1,0 +1,55 @@
+package org.knowm.xchange.dragonex.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.util.Date;
+import org.knowm.xchange.dragonex.DragonexUtils;
+
+/**
+ * {"charge": "0.0066", "deal_type": 1, "order_id": "1540349135948523001", "order_type": 2, "price":
+ * "6557.2000", "symbol_id": 101, "timestamp": 1540349180147282172, "trade_id":
+ * "15403491801472794729", "volume": "0.0010"}
+ */
+public class Deal {
+  /** commission of current trade */
+  public final BigDecimal charge;
+  /** deal type: 1-buy, 2-sell */
+  public final int dealType;
+
+  public final String orderId;
+  /** order type: 1-buy, 2-sell */
+  public final int orderType;
+
+  public final BigDecimal price;
+  public final int symbolId;
+  /** timestamp is provided in nano seconds */
+  public final String timestamp;
+
+  public final String tradeId;
+  public final BigDecimal volume;
+
+  public Deal(
+      @JsonProperty("charge") BigDecimal charge,
+      @JsonProperty("deal_type") int dealType,
+      @JsonProperty("order_id") String orderId,
+      @JsonProperty("order_type") int orderType,
+      @JsonProperty("price") BigDecimal price,
+      @JsonProperty("symbol_id") int symbolId,
+      @JsonProperty("timestamp") String timestamp,
+      @JsonProperty("trade_id") String tradeId,
+      @JsonProperty("volume") BigDecimal volume) {
+    this.charge = charge;
+    this.dealType = dealType;
+    this.orderId = orderId;
+    this.orderType = orderType;
+    this.price = price;
+    this.symbolId = symbolId;
+    this.timestamp = timestamp;
+    this.tradeId = tradeId;
+    this.volume = volume;
+  }
+
+  public Date getTimestamp() {
+    return DragonexUtils.nanos2Date(timestamp);
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/trade/DealHistory.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/trade/DealHistory.java
@@ -1,0 +1,22 @@
+package org.knowm.xchange.dragonex.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class DealHistory {
+
+  private final List<Deal> list;
+
+  public DealHistory(@JsonProperty("list") List<Deal> list) {
+    this.list = list;
+  }
+
+  public List<Deal> getList() {
+    return list;
+  }
+
+  @Override
+  public String toString() {
+    return "DealHistory [" + (list != null ? "list=" + list : "") + "]";
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/trade/DealHistoryRequest.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/trade/DealHistoryRequest.java
@@ -1,0 +1,35 @@
+package org.knowm.xchange.dragonex.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(Include.NON_NULL)
+public class DealHistoryRequest {
+
+  @JsonProperty("symbol_id")
+  public final long symbolId;
+  /**
+   * search direction: 1-consult forwardly from start time, 2-consult backwardly from start time.
+   * default 2
+   */
+  @JsonProperty("direction")
+  public final Integer direction;
+  /** transmit nothing or 0 from current time, or transmit Unix timestamp (ns) */
+  @JsonProperty("start")
+  public final Long start;
+  /** counts of records, in default 10 */
+  @JsonProperty("count")
+  public final Integer count;
+
+  public DealHistoryRequest(long symbolId, Integer direction, Long start, Integer count) {
+    this.symbolId = symbolId;
+    this.direction = direction;
+    this.start = start;
+    this.count = count;
+  }
+
+  public DealHistoryRequest(long symbolId) {
+    this(symbolId, null, null, 1000);
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/trade/DragonexCancelOrderParams.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/trade/DragonexCancelOrderParams.java
@@ -1,0 +1,29 @@
+package org.knowm.xchange.dragonex.dto.trade;
+
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.service.trade.params.CancelOrderByCurrencyPair;
+import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
+
+public class DragonexCancelOrderParams implements CancelOrderByCurrencyPair, CancelOrderByIdParams {
+
+  private CurrencyPair currencyPair;
+  private String orderId;
+
+  @Override
+  public CurrencyPair getCurrencyPair() {
+    return currencyPair;
+  }
+
+  @Override
+  public String getOrderId() {
+    return orderId;
+  }
+
+  public void setCurrencyPair(CurrencyPair currencyPair) {
+    this.currencyPair = currencyPair;
+  }
+
+  public void setOrderId(String orderId) {
+    this.orderId = orderId;
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/trade/OrderHistory.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/trade/OrderHistory.java
@@ -1,0 +1,25 @@
+package org.knowm.xchange.dragonex.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class OrderHistory {
+
+  private final List<UserOrder> list;
+  public final long count;
+
+  public OrderHistory(
+      @JsonProperty("list") List<UserOrder> list, @JsonProperty("count") long count) {
+    this.list = list;
+    this.count = count;
+  }
+
+  public List<UserOrder> getList() {
+    return list;
+  }
+
+  @Override
+  public String toString() {
+    return "OrderHistory [" + (list != null ? "list=" + list + ", " : "") + "count=" + count + "]";
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/trade/OrderHistoryRequest.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/trade/OrderHistoryRequest.java
@@ -1,0 +1,40 @@
+package org.knowm.xchange.dragonex.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(Include.NON_NULL)
+public class OrderHistoryRequest {
+
+  @JsonProperty("symbol_id")
+  public final long symbolId;
+  /**
+   * search direction: 1-consult forwardly from start time, 2-consult backwardly from start time.
+   * default 2
+   */
+  @JsonProperty("direction")
+  public final Integer direction;
+  /** transmit nothing or 0 from current time, or transmit Unix timestamp (ns) */
+  @JsonProperty("start")
+  public final Long start;
+  /** counts of records, in default 10 */
+  @JsonProperty("count")
+  public final Integer count;
+  /** order status: 0-all states, 1-pending trade, 2-successful trade, 3-canceled, 4-failed */
+  @JsonProperty("status")
+  public final int status;
+
+  public OrderHistoryRequest(
+      long symbolId, Integer direction, Long start, Integer count, int status) {
+    this.symbolId = symbolId;
+    this.direction = direction;
+    this.start = start;
+    this.count = count;
+    this.status = status;
+  }
+
+  public OrderHistoryRequest(long symbolId, int status) {
+    this(symbolId, null, null, null, status);
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/trade/OrderPlacement.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/trade/OrderPlacement.java
@@ -1,0 +1,32 @@
+package org.knowm.xchange.dragonex.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+
+public class OrderPlacement {
+
+  @JsonProperty("symbol_id")
+  public final long symbolId;
+
+  @JsonProperty("price")
+  public final String price;
+
+  @JsonProperty("volume")
+  public final String volume;
+
+  public OrderPlacement(long symbolId, BigDecimal price, BigDecimal volume) {
+    this.symbolId = symbolId;
+    this.price = price.toString();
+    this.volume = volume.toString();
+  }
+
+  @Override
+  public String toString() {
+    return "OrderPlacement [symbolId="
+        + symbolId
+        + ", "
+        + (price != null ? "price=" + price + ", " : "")
+        + (volume != null ? "volume=" + volume : "")
+        + "]";
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/trade/OrderReference.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/trade/OrderReference.java
@@ -1,0 +1,22 @@
+package org.knowm.xchange.dragonex.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class OrderReference {
+
+  @JsonProperty("symbol_id")
+  public final long symbolId;
+  /** order id you want to cancel */
+  @JsonProperty("order_id")
+  public final long orderId;
+
+  public OrderReference(long symbolId, long orderId) {
+    this.symbolId = symbolId;
+    this.orderId = orderId;
+  }
+
+  @Override
+  public String toString() {
+    return "OrderReference [symbolId=" + symbolId + ", orderId=" + orderId + "]";
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/trade/UserOrder.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/trade/UserOrder.java
@@ -1,0 +1,63 @@
+package org.knowm.xchange.dragonex.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.util.Date;
+import org.knowm.xchange.dragonex.DragonexUtils;
+
+public class UserOrder {
+
+  public final long orderId;
+  /** order type: 1-Buy, 2-Sell */
+  public final int orderType;
+
+  public final long symbolId;
+  public final BigDecimal price;
+  /** order status: 1-pending trade, 2-successful trade, 3-canceled, 4-failed */
+  public final int status;
+  /** timestamp is provided in nano seconds */
+  private final String timestamp;
+  /** volume of successful trade */
+  public final BigDecimal tradeVolume;
+  /** volume of order */
+  public final BigDecimal volume;
+
+  public UserOrder(
+      @JsonProperty("order_id") long orderId,
+      @JsonProperty("order_type") int orderType,
+      @JsonProperty("price") BigDecimal price,
+      @JsonProperty("status") int status,
+      @JsonProperty("symbol_id") long symbolId,
+      @JsonProperty("timestamp") String timestamp,
+      @JsonProperty("trade_volume") BigDecimal tradeVolume,
+      @JsonProperty("volume") BigDecimal volume) {
+    this.orderId = orderId;
+    this.orderType = orderType;
+    this.price = price;
+    this.status = status;
+    this.symbolId = symbolId;
+    this.timestamp = timestamp;
+    this.tradeVolume = tradeVolume;
+    this.volume = volume;
+  }
+
+  @Override
+  public String toString() {
+    return "UserOrder [orderId="
+        + orderId
+        + ", "
+        + (price != null ? "price=" + price + ", " : "")
+        + "status="
+        + status
+        + ", timestamp="
+        + timestamp
+        + ", "
+        + (tradeVolume != null ? "tradeVolume=" + tradeVolume + ", " : "")
+        + (volume != null ? "volume=" + volume : "")
+        + "]";
+  }
+
+  public Date getTimestamp() {
+    return DragonexUtils.nanos2Date(timestamp);
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonDigest.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonDigest.java
@@ -1,0 +1,68 @@
+package org.knowm.xchange.dragonex.service;
+
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.Formatter;
+import javax.crypto.Mac;
+import javax.ws.rs.core.MediaType;
+import org.knowm.xchange.service.BaseParamsDigest;
+import si.mazi.rescu.RestInvocation;
+
+/** https://github.com/Dragonexio/OpenApi/blob/master/docs/English/0.way_of_invocation.md */
+public class DragonDigest extends BaseParamsDigest {
+
+  private final String api;
+
+  public DragonDigest(String api, String secret) {
+    super(secret, HMAC_SHA_1);
+    this.api = api;
+  }
+
+  @Override
+  public String digestParams(RestInvocation restInvocation) {
+
+    String date = restInvocation.getHttpHeadersFromParams().get("date");
+    String sha1 = sha1(restInvocation.getRequestBody());
+    String s =
+        restInvocation.getHttpMethod()
+            + "\n"
+            + sha1
+            + "\n"
+            + MediaType.APPLICATION_JSON
+            + "\n"
+            + date
+            + "\n"
+            + "/"
+            + restInvocation.getPath();
+
+    Mac mac = getMac();
+    mac.update(s.getBytes());
+    return api + ":" + Base64.getEncoder().encodeToString(mac.doFinal());
+  }
+
+  public static String sha1(String str) {
+    if (str == null) {
+      return "";
+    }
+    String sha1 = "";
+    try {
+      MessageDigest crypt = MessageDigest.getInstance("SHA-1");
+      crypt.reset();
+      crypt.update(str.getBytes("UTF-8"));
+      sha1 = byteToHex(crypt.digest());
+    } catch (Throwable e) {
+      throw new RuntimeException(e);
+    }
+    return sha1;
+  }
+
+  private static String byteToHex(final byte[] hash) {
+    Formatter formatter = new Formatter();
+    for (byte b : hash) {
+      formatter.format("%02x", b);
+    }
+    String result = formatter.toString();
+    formatter.close();
+    return result;
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonexAccountService.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonexAccountService.java
@@ -1,0 +1,35 @@
+package org.knowm.xchange.dragonex.service;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.dragonex.dto.account.Balance;
+import org.knowm.xchange.dto.account.AccountInfo;
+import org.knowm.xchange.dto.account.Wallet;
+import org.knowm.xchange.service.account.AccountService;
+
+public class DragonexAccountService extends DragonexAccountServiceRaw implements AccountService {
+
+  public DragonexAccountService(Exchange exchange) {
+    super(exchange);
+  }
+
+  @Override
+  public AccountInfo getAccountInfo() throws IOException {
+    List<Balance> userCoins = userCoins(exchange.getOrCreateToken().token);
+    List<org.knowm.xchange.dto.account.Balance> balances =
+        userCoins
+            .stream()
+            .map(
+                b ->
+                    new org.knowm.xchange.dto.account.Balance(
+                        Currency.getInstance(b.code.toUpperCase()),
+                        b.volume,
+                        b.volume.subtract(b.frozen),
+                        b.frozen))
+            .collect(Collectors.toList());
+    return new AccountInfo(new Wallet(balances));
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonexAccountServiceRaw.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonexAccountServiceRaw.java
@@ -1,0 +1,41 @@
+package org.knowm.xchange.dragonex.service;
+
+import java.io.IOException;
+import java.util.List;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.dragonex.dto.DragonResult;
+import org.knowm.xchange.dragonex.dto.DragonexException;
+import org.knowm.xchange.dragonex.dto.Token;
+import org.knowm.xchange.dragonex.dto.TokenStatus;
+import org.knowm.xchange.dragonex.dto.account.Balance;
+
+public class DragonexAccountServiceRaw extends DragonexBaseService {
+
+  public DragonexAccountServiceRaw(Exchange exchange) {
+    super(exchange);
+  }
+
+  public Token tokenNew() throws DragonexException, IOException {
+    DragonResult<Token> tokenNew =
+        exchange
+            .dragonexAuthenticated()
+            .tokenNew(utcNow(), exchange.signatureCreator(), ContentSHA1);
+    return tokenNew.getResult();
+  }
+
+  public TokenStatus tokenStatus(String token) throws DragonexException, IOException {
+    DragonResult<TokenStatus> tokenStatus =
+        exchange
+            .dragonexAuthenticated()
+            .tokenStatus(utcNow(), token, exchange.signatureCreator(), ContentSHA1);
+    return tokenStatus.getResult();
+  }
+
+  public List<Balance> userCoins(String token) throws DragonexException, IOException {
+    DragonResult<List<Balance>> userCoins =
+        exchange
+            .dragonexAuthenticated()
+            .userCoins(utcNow(), token, exchange.signatureCreator(), ContentSHA1);
+    return userCoins.getResult();
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonexBaseService.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonexBaseService.java
@@ -1,0 +1,34 @@
+package org.knowm.xchange.dragonex.service;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.TimeZone;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.dragonex.DragonexExchange;
+import org.knowm.xchange.service.BaseExchangeService;
+import org.knowm.xchange.service.BaseService;
+import si.mazi.rescu.ParamsDigest;
+
+public class DragonexBaseService extends BaseExchangeService<DragonexExchange>
+    implements BaseService {
+
+  /** https://github.com/Dragonexio/OpenApi/blob/master/docs/English/0.way_of_invocation.md */
+  protected static final ParamsDigest ContentSHA1 =
+      restInvocation -> DragonDigest.sha1(restInvocation.getRequestBody());
+
+  /** current date in utc as http header */
+  protected static String utcNow() {
+
+    Calendar calendar = Calendar.getInstance();
+    SimpleDateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
+    dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+    return dateFormat.format(calendar.getTime());
+    // return java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME.format(
+    //    ZonedDateTime.now(ZoneOffset.UTC));
+  }
+
+  public DragonexBaseService(Exchange exchange) {
+    super((DragonexExchange) exchange);
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonexMarketDataService.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonexMarketDataService.java
@@ -1,0 +1,57 @@
+package org.knowm.xchange.dragonex.service;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dragonex.dto.marketdata.Order;
+import org.knowm.xchange.dto.Order.OrderType;
+import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.marketdata.Ticker;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.service.marketdata.MarketDataService;
+
+public class DragonexMarketDataService extends DragonexMarketDataServiceRaw
+    implements MarketDataService {
+
+  public DragonexMarketDataService(Exchange exchange) {
+    super(exchange);
+  }
+
+  @Override
+  public Ticker getTicker(CurrencyPair pair, Object... args) throws IOException {
+    org.knowm.xchange.dragonex.dto.marketdata.Ticker t =
+        super.ticker(exchange.symbolId(pair)).get(0);
+    return new Ticker.Builder()
+        .currencyPair(pair)
+        .volume(t.totalVolume)
+        .quoteVolume(t.totalAmount)
+        .high(t.maxPrice)
+        .low(t.minPrice)
+        .open(t.openPrice)
+        .last(t.closePrice)
+        .timestamp(new Date(t.timestamp * 1000))
+        .build();
+  }
+
+  @Override
+  public OrderBook getOrderBook(CurrencyPair pair, Object... args) throws IOException {
+    long symbolId = exchange.symbolId(pair);
+    BiFunction<OrderType, Order, LimitOrder> f =
+        (t, o) -> new LimitOrder(t, o.volume, pair, null, null, o.price);
+    List<LimitOrder> bids =
+        super.marketBuyOrders(symbolId)
+            .stream()
+            .map(o -> f.apply(OrderType.BID, o))
+            .collect(Collectors.toList());
+    List<LimitOrder> asks =
+        super.marketSellOrders(symbolId)
+            .stream()
+            .map(o -> f.apply(OrderType.ASK, o))
+            .collect(Collectors.toList());
+    return new OrderBook(null, asks, bids);
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonexMarketDataServiceRaw.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonexMarketDataServiceRaw.java
@@ -1,0 +1,44 @@
+package org.knowm.xchange.dragonex.service;
+
+import java.io.IOException;
+import java.util.List;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.dragonex.dto.DragonResult;
+import org.knowm.xchange.dragonex.dto.DragonexException;
+import org.knowm.xchange.dragonex.dto.marketdata.Coin;
+import org.knowm.xchange.dragonex.dto.marketdata.Order;
+import org.knowm.xchange.dragonex.dto.marketdata.Symbol;
+import org.knowm.xchange.dragonex.dto.marketdata.Ticker;
+
+public class DragonexMarketDataServiceRaw extends DragonexBaseService {
+
+  public DragonexMarketDataServiceRaw(Exchange exchange) {
+    super(exchange);
+  }
+
+  public List<Coin> coinAll() throws DragonexException, IOException {
+    DragonResult<List<Coin>> coinAll = exchange.dragonexPublic().coinAll();
+    return coinAll.getResult();
+  }
+
+  public List<Symbol> symbolAll() throws DragonexException, IOException {
+    DragonResult<List<Symbol>> symbolAll = exchange.dragonexPublic().symbolAll();
+    return symbolAll.getResult();
+  }
+
+  public List<Order> marketBuyOrders(long symbolId) throws DragonexException, IOException {
+    DragonResult<List<Order>> marketBuyOrders = exchange.dragonexPublic().marketBuyOrders(symbolId);
+    return marketBuyOrders.getResult();
+  }
+
+  public List<Order> marketSellOrders(long symbolId) throws DragonexException, IOException {
+    DragonResult<List<Order>> marketSellOrders =
+        exchange.dragonexPublic().marketSellOrders(symbolId);
+    return marketSellOrders.getResult();
+  }
+
+  List<Ticker> ticker(long symbolId) throws DragonexException, IOException {
+    DragonResult<List<Ticker>> ticker = exchange.dragonexPublic().ticker(symbolId);
+    return ticker.getResult();
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonexTradeService.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonexTradeService.java
@@ -1,0 +1,165 @@
+package org.knowm.xchange.dragonex.service;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dragonex.dto.trade.DealHistory;
+import org.knowm.xchange.dragonex.dto.trade.DealHistoryRequest;
+import org.knowm.xchange.dragonex.dto.trade.OrderHistory;
+import org.knowm.xchange.dragonex.dto.trade.OrderHistoryRequest;
+import org.knowm.xchange.dragonex.dto.trade.OrderPlacement;
+import org.knowm.xchange.dragonex.dto.trade.OrderReference;
+import org.knowm.xchange.dragonex.dto.trade.UserOrder;
+import org.knowm.xchange.dto.Order.OrderType;
+import org.knowm.xchange.dto.marketdata.Trades.TradeSortType;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.dto.trade.OpenOrders;
+import org.knowm.xchange.dto.trade.UserTrade;
+import org.knowm.xchange.dto.trade.UserTrades;
+import org.knowm.xchange.exceptions.ExchangeException;
+import org.knowm.xchange.service.trade.TradeService;
+import org.knowm.xchange.service.trade.params.CancelOrderByCurrencyPair;
+import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
+import org.knowm.xchange.service.trade.params.CancelOrderParams;
+import org.knowm.xchange.service.trade.params.DefaultTradeHistoryParamCurrencyPair;
+import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
+import org.knowm.xchange.service.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.trade.params.TradeHistoryParamsSorted;
+import org.knowm.xchange.service.trade.params.TradeHistoryParamsSorted.Order;
+import org.knowm.xchange.service.trade.params.orders.DefaultOpenOrdersParamCurrencyPair;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamCurrencyPair;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
+
+public class DragonexTradeService extends DragonexTradeServiceRaw implements TradeService {
+
+  public DragonexTradeService(Exchange exchange) {
+    super(exchange);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders() throws IOException {
+    throw new ExchangeException("You need to provide the currency pair.");
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws IOException {
+    if (!(params instanceof OpenOrdersParamCurrencyPair)) {
+      throw new ExchangeException("You need to provide the currency pair.");
+    }
+    OpenOrdersParamCurrencyPair pairParams = (OpenOrdersParamCurrencyPair) params;
+    if (pairParams.getCurrencyPair() == null) {
+      throw new ExchangeException("You need to provide the currency pair.");
+    }
+    long symbolId = exchange.symbolId(pairParams.getCurrencyPair());
+    OrderHistoryRequest req =
+        new OrderHistoryRequest(symbolId, null, null, 1000, 1 /* pending status*/);
+    OrderHistory orderHistory = super.orderHistory(exchange.getOrCreateToken().token, req);
+
+    List<LimitOrder> openOrders =
+        orderHistory
+            .getList()
+            .stream()
+            .map(
+                o ->
+                    new LimitOrder(
+                        o.orderType == 1 ? OrderType.BID : OrderType.ASK,
+                        o.volume,
+                        exchange.pair(o.symbolId),
+                        Long.toString(o.orderId),
+                        o.getTimestamp(),
+                        o.price))
+            .collect(Collectors.toList());
+    return new OpenOrders(openOrders);
+  }
+
+  @Override
+  public String placeLimitOrder(LimitOrder limitOrder) throws IOException {
+    OrderPlacement orderPlacement =
+        new OrderPlacement(
+            exchange.symbolId(limitOrder.getCurrencyPair()),
+            limitOrder.getLimitPrice(),
+            limitOrder.getOriginalAmount());
+    UserOrder newOrder =
+        limitOrder.getType() == OrderType.BID
+            ? super.orderBuy(exchange.getOrCreateToken().token, orderPlacement)
+            : super.orderSell(exchange.getOrCreateToken().token, orderPlacement);
+    return Long.toString(newOrder.orderId);
+  }
+
+  @Override
+  public boolean cancelOrder(CancelOrderParams params) throws IOException {
+
+    if (!(params instanceof CancelOrderByCurrencyPair)) {
+      throw new ExchangeException("You need to provide the currency pair.");
+    }
+    if (!(params instanceof CancelOrderByIdParams)) {
+      throw new ExchangeException("You need to provide the order id.");
+    }
+
+    CurrencyPair pair = ((CancelOrderByCurrencyPair) params).getCurrencyPair();
+    if (pair == null) {
+      throw new ExchangeException("You need to provide the currency pair.");
+    }
+    long orderId;
+    try {
+      orderId = Long.valueOf(((CancelOrderByIdParams) params).getOrderId());
+    } catch (Throwable e) {
+      throw new ExchangeException("You need to provide the order id as a number.", e);
+    }
+    OrderReference ref = new OrderReference(exchange.symbolId(pair), orderId);
+    UserOrder order = super.orderCancel(exchange.getOrCreateToken().token, ref);
+    return order.status == 3;
+  }
+
+  @Override
+  public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
+    if (!(params instanceof TradeHistoryParamCurrencyPair)) {
+      throw new ExchangeException("You need to provide the currency pair.");
+    }
+    TradeHistoryParamCurrencyPair pairParams = (TradeHistoryParamCurrencyPair) params;
+    CurrencyPair pair = pairParams.getCurrencyPair();
+    if (pair == null) {
+      throw new ExchangeException("You need to provide the currency pair.");
+    }
+    long symbolId = exchange.symbolId(pair);
+    Integer direction = null;
+    if (params instanceof TradeHistoryParamsSorted) {
+      TradeHistoryParamsSorted sort = (TradeHistoryParamsSorted) params;
+      direction = sort.getOrder() == Order.asc ? 1 : 2;
+    }
+    DealHistoryRequest req = new DealHistoryRequest(symbolId, direction, null, 1000);
+    DealHistory dealHistory = super.dealHistory(exchange.getOrCreateToken().token, req);
+    List<UserTrade> trades =
+        dealHistory
+            .getList()
+            .stream()
+            .map(
+                d -> {
+                  CurrencyPair p = exchange.pair(d.symbolId);
+                  return new UserTrade(
+                      d.orderType == 1 ? OrderType.BID : OrderType.ASK,
+                      d.volume,
+                      p,
+                      d.price,
+                      d.getTimestamp(),
+                      d.tradeId,
+                      d.orderId,
+                      d.charge,
+                      p.counter);
+                })
+            .collect(Collectors.toList());
+    return new UserTrades(trades, TradeSortType.SortByTimestamp);
+  }
+
+  @Override
+  public TradeHistoryParams createTradeHistoryParams() {
+    return new DefaultTradeHistoryParamCurrencyPair();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return new DefaultOpenOrdersParamCurrencyPair();
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonexTradeServiceRaw.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonexTradeServiceRaw.java
@@ -1,0 +1,74 @@
+package org.knowm.xchange.dragonex.service;
+
+import java.io.IOException;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.dragonex.dto.DragonResult;
+import org.knowm.xchange.dragonex.dto.DragonexException;
+import org.knowm.xchange.dragonex.dto.trade.DealHistory;
+import org.knowm.xchange.dragonex.dto.trade.DealHistoryRequest;
+import org.knowm.xchange.dragonex.dto.trade.OrderHistory;
+import org.knowm.xchange.dragonex.dto.trade.OrderHistoryRequest;
+import org.knowm.xchange.dragonex.dto.trade.OrderPlacement;
+import org.knowm.xchange.dragonex.dto.trade.OrderReference;
+import org.knowm.xchange.dragonex.dto.trade.UserOrder;
+
+public class DragonexTradeServiceRaw extends DragonexBaseService {
+
+  public DragonexTradeServiceRaw(Exchange exchange) {
+    super(exchange);
+  }
+
+  public UserOrder orderBuy(String token, OrderPlacement orderPlacement)
+      throws DragonexException, IOException {
+    DragonResult<UserOrder> orderBuy =
+        exchange
+            .dragonexAuthenticated()
+            .orderBuy(utcNow(), token, exchange.signatureCreator(), ContentSHA1, orderPlacement);
+    return orderBuy.getResult();
+  }
+
+  public UserOrder orderSell(String token, OrderPlacement orderPlacement)
+      throws DragonexException, IOException {
+    DragonResult<UserOrder> orderSell =
+        exchange
+            .dragonexAuthenticated()
+            .orderSell(utcNow(), token, exchange.signatureCreator(), ContentSHA1, orderPlacement);
+    return orderSell.getResult();
+  }
+
+  public UserOrder orderCancel(String token, OrderReference ref)
+      throws DragonexException, IOException {
+    DragonResult<UserOrder> order =
+        exchange
+            .dragonexAuthenticated()
+            .orderCancel(utcNow(), token, exchange.signatureCreator(), ContentSHA1, ref);
+    return order.getResult();
+  }
+
+  public UserOrder orderDetail(String token, OrderReference ref)
+      throws DragonexException, IOException {
+    DragonResult<UserOrder> order =
+        exchange
+            .dragonexAuthenticated()
+            .orderDetail(utcNow(), token, exchange.signatureCreator(), ContentSHA1, ref);
+    return order.getResult();
+  }
+
+  public OrderHistory orderHistory(String token, OrderHistoryRequest req)
+      throws DragonexException, IOException {
+    DragonResult<OrderHistory> orderHistory =
+        exchange
+            .dragonexAuthenticated()
+            .orderHistory(utcNow(), token, exchange.signatureCreator(), ContentSHA1, req);
+    return orderHistory.getResult();
+  }
+
+  public DealHistory dealHistory(String token, DealHistoryRequest req)
+      throws DragonexException, IOException {
+    DragonResult<DealHistory> dealHistory =
+        exchange
+            .dragonexAuthenticated()
+            .dealHistory(utcNow(), token, exchange.signatureCreator(), ContentSHA1, req);
+    return dealHistory.getResult();
+  }
+}

--- a/xchange-dragonex/src/main/resources/dragonex.json
+++ b/xchange-dragonex/src/main/resources/dragonex.json
@@ -1,0 +1,8 @@
+ {
+  "currency_pairs": {},
+  "currencies": {},
+  "public_rate_limits": [],
+  "private_rate_limits": [],
+  "share_rate_limits": true
+}
+

--- a/xchange-dragonex/src/test/resources/logback.xml
+++ b/xchange-dragonex/src/test/resources/logback.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="30 seconds" >
+
+    <!-- include resource="org/springframework/boot/logging/logback/base.xml"/-->
+    <logger name="net.areiter.trader" level="ALL"/>
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="si.mazi.rescu.HttpTemplate" level="ALL"/>
+    <logger name="io.socket" level="WARN"/>
+    
+        
+    
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+     ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    
+    <root level="WARN">
+      <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
By now it was not possible to get candles as this service URI was not implemented yet. I have created a BitfinexCandle class and added the data retrieval to the MarketDataRaw service.

This ist the relevant documentation part:
https://docs.bitfinex.com/v2/reference#rest-public-candles