### PR TITLE
[Bitfinex] Retrieve (historic) Candles from Bitfinex

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/Bitfinex.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/Bitfinex.java
@@ -8,6 +8,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import org.knowm.xchange.bitfinex.common.dto.BitfinexException;
+import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexCandle;
 import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexPublicFundingTrade;
 import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexPublicTrade;
 import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexTicker;
@@ -34,6 +35,17 @@ public interface Bitfinex {
   @GET
   @Path("/trades/{symbol}/hist")
   BitfinexPublicTrade[] getPublicTrades(
+      @PathParam("symbol") String fundingSymbol,
+      @QueryParam("limit") int limit,
+      @QueryParam("start") long startTimestamp,
+      @QueryParam("end") long endTimestamp,
+      @QueryParam("sort") int sort)
+      throws IOException, BitfinexException;
+
+  @GET
+  @Path("/candles/trade:{interval}:{symbol}/hist")
+  BitfinexCandle[] getCandles(
+      @PathParam("interval") String interval,
       @PathParam("symbol") String fundingSymbol,
       @QueryParam("limit") int limit,
       @QueryParam("start") long startTimestamp,

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexCandle.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexCandle.java
@@ -4,18 +4,24 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import java.math.BigDecimal;
 
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
-public class BitfinexPublicTrade {
+public class BitfinexCandle {
 
-	private long timestamp;
-	private BigDecimal open;
-	private BigDecimal close;
-	private BigDecimal high;
-	private BigDecimal low;
-	private BigDecimal volume;
+  private long timestamp;
+  private BigDecimal open;
+  private BigDecimal close;
+  private BigDecimal high;
+  private BigDecimal low;
+  private BigDecimal volume;
 
-	public BitfinexCandle() {}
+  public BitfinexCandle() {}
 
-	public BitfinexCandle(long timestamp, BigDecimal open, BigDecimal close, BigDecimal high, BigDecimal low, BigDecimal volume) {
+  public BitfinexCandle(
+      long timestamp,
+      BigDecimal open,
+      BigDecimal close,
+      BigDecimal high,
+      BigDecimal low,
+      BigDecimal volume) {
 
     this.timestamp = timestamp;
     this.open = open;
@@ -23,55 +29,54 @@ public class BitfinexPublicTrade {
     this.high = high;
     this.low = low;
     this.volume = volume;
-    
   }
 
-	public long getTimestamp() {
+  public long getTimestamp() {
 
-		return timestamp;
-	}
+    return timestamp;
+  }
 
-	public BigDecimal getOpen() {
+  public BigDecimal getOpen() {
 
-		return open;
-	}
+    return open;
+  }
 
-	public BigDecimal getClose() {
+  public BigDecimal getClose() {
 
-		return close;
-	}
+    return close;
+  }
 
-	public BigDecimal getHigh() {
+  public BigDecimal getHigh() {
 
-		return high;
-	}
+    return high;
+  }
 
-	public BigDecimal getLow() {
+  public BigDecimal getLow() {
 
-		return low;
-	}
+    return low;
+  }
 
-	public BigDecimal getVolume() {
+  public BigDecimal getVolume() {
 
-		return volume;
-	}
+    return volume;
+  }
 
-	@Override
-	public String toString() {
-		StringBuilder builder = new StringBuilder();
-		builder.append("BitfinexCandle [timestamp=");
-		builder.append(timestamp);
-		builder.append(", open=");
-		builder.append(open);
-		builder.append(", close=");
-		builder.append(close);
-		builder.append(", high=");
-		builder.append(high);
-		builder.append(", low=");
-		builder.append(low);
-		builder.append(", volume=");
-		builder.append(volume);
-		builder.append("]");
-		return builder.toString();
-	}
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("BitfinexCandle [timestamp=");
+    builder.append(timestamp);
+    builder.append(", open=");
+    builder.append(open);
+    builder.append(", close=");
+    builder.append(close);
+    builder.append(", high=");
+    builder.append(high);
+    builder.append(", low=");
+    builder.append(low);
+    builder.append(", volume=");
+    builder.append(volume);
+    builder.append("]");
+    return builder.toString();
+  }
 }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexCandle.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexCandle.java
@@ -1,0 +1,77 @@
+package org.knowm.xchange.bitfinex.v2.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.math.BigDecimal;
+
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+public class BitfinexPublicTrade {
+
+	private long timestamp;
+	private BigDecimal open;
+	private BigDecimal close;
+	private BigDecimal high;
+	private BigDecimal low;
+	private BigDecimal volume;
+
+	public BitfinexCandle() {}
+
+	public BitfinexCandle(long timestamp, BigDecimal open, BigDecimal close, BigDecimal high, BigDecimal low, BigDecimal volume) {
+
+    this.timestamp = timestamp;
+    this.open = open;
+    this.close = close;
+    this.high = high;
+    this.low = low;
+    this.volume = volume;
+    
+  }
+
+	public long getTimestamp() {
+
+		return timestamp;
+	}
+
+	public BigDecimal getOpen() {
+
+		return open;
+	}
+
+	public BigDecimal getClose() {
+
+		return close;
+	}
+
+	public BigDecimal getHigh() {
+
+		return high;
+	}
+
+	public BigDecimal getLow() {
+
+		return low;
+	}
+
+	public BigDecimal getVolume() {
+
+		return volume;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("BitfinexCandle [timestamp=");
+		builder.append(timestamp);
+		builder.append(", open=");
+		builder.append(open);
+		builder.append(", close=");
+		builder.append(close);
+		builder.append(", high=");
+		builder.append(high);
+		builder.append(", low=");
+		builder.append(low);
+		builder.append(", volume=");
+		builder.append(volume);
+		builder.append("]");
+		return builder.toString();
+	}
+}

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/CandleInterval.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/CandleInterval.java
@@ -1,0 +1,40 @@
+package org.knowm.xchange.bitfinex.v2.dto.marketdata;
+
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+// Available values: '1m', '5m', '15m', '30m', '1h', '3h', '6h', '12h', '1D', '7D', '14D', '1M'
+public enum CandleInterval {
+  m1("1m", MINUTES.toMillis(1)),
+  m5("5m", MINUTES.toMillis(5)),
+  m15("15m", MINUTES.toMillis(15)),
+  m30("30m", MINUTES.toMillis(30)),
+
+  h1("1h", HOURS.toMillis(1)),
+  h3("3h", HOURS.toMillis(3)),
+  h6("6h", HOURS.toMillis(6)),
+  h12("12h", HOURS.toMillis(12)),
+
+  d1("1D", DAYS.toMillis(1)),
+  d7("7D", DAYS.toMillis(7)),
+  d14("14D", DAYS.toMillis(7)),
+
+  M1("1M", DAYS.toMillis(30));
+
+  private final String code;
+  private final Long millis;
+
+  private CandleInterval(String code, Long millis) {
+    this.millis = millis;
+    this.code = code;
+  }
+
+  public Long getMillis() {
+    return millis;
+  }
+
+  public String getCode() {
+    return code;
+  }
+}

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/service/BitfinexMarketDataServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/service/BitfinexMarketDataServiceRaw.java
@@ -6,9 +6,11 @@ import java.util.List;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitfinex.common.dto.BitfinexException;
 import org.knowm.xchange.bitfinex.v2.BitfinexAdapters;
+import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexCandle;
 import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexPublicFundingTrade;
 import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexPublicTrade;
 import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexTicker;
+import org.knowm.xchange.bitfinex.v2.dto.marketdata.CandleInterval;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import si.mazi.rescu.HttpStatusIOException;
@@ -46,6 +48,27 @@ public class BitfinexMarketDataServiceRaw extends BitfinexBaseService {
       return bitfinex.getPublicTrades(
           "t" + currencyPair.base.toString() + currencyPair.counter.toString(),
           limitTrades,
+          startTimestamp,
+          endTimestamp,
+          sort);
+    } catch (HttpStatusIOException e) {
+      throw handleException(new BitfinexException(e.getHttpBody()));
+    }
+  }
+
+  public BitfinexCandle[] getBitfinexCandles(
+      CandleInterval candleInterval,
+      CurrencyPair currencyPair,
+      int limitCandles,
+      long startTimestamp,
+      long endTimestamp,
+      int sort)
+      throws IOException {
+    try {
+      return bitfinex.getCandles(
+          candleInterval.getCode(),
+          "t" + currencyPair.base.toString() + currencyPair.counter.toString(),
+          limitCandles,
           startTimestamp,
           endTimestamp,
           sort);

--- a/xchange-coinbasepro/src/test/java/org/knowm/xchange/coinbasepro/CoinbaseProExchangeIntegration.java
+++ b/xchange-coinbasepro/src/test/java/org/knowm/xchange/coinbasepro/CoinbaseProExchangeIntegration.java
@@ -66,12 +66,14 @@ public class CoinbaseProExchangeIntegration {
 
   @Test
   public void testExchangeMetaData() {
-    final Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseProExchange.class.getName());
+    final Exchange exchange =
+        ExchangeFactory.INSTANCE.createExchange(CoinbaseProExchange.class.getName());
 
     ExchangeMetaData exchangeMetaData = exchange.getExchangeMetaData();
 
     Assert.assertNotNull(exchangeMetaData);
     Assert.assertNotNull(exchangeMetaData.getCurrencies());
-    Assert.assertNotNull("USDC is not defined", exchangeMetaData.getCurrencies().get(new Currency("USDC")));
+    Assert.assertNotNull(
+        "USDC is not defined", exchangeMetaData.getCurrencies().get(new Currency("USDC")));
   }
 }

--- a/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/CoinbeneExchange.java
+++ b/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/CoinbeneExchange.java
@@ -30,7 +30,8 @@ public class CoinbeneExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification =
+        new ExchangeSpecification(this.getClass().getCanonicalName());
     exchangeSpecification.setSslUri("https://api.coinbene.com/");
     exchangeSpecification.setHost("coinbene.com");
     exchangeSpecification.setPort(80);
@@ -48,6 +49,6 @@ public class CoinbeneExchange extends BaseExchange implements Exchange {
   @Override
   public void remoteInit() throws IOException, ExchangeException {
 
-      exchangeMetaData = ((CoinbeneMarketDataService) marketDataService).getMetadata();
+    exchangeMetaData = ((CoinbeneMarketDataService) marketDataService).getMetadata();
   }
 }

--- a/xchange-coinbene/src/test/java/org/knowm/xchange/coinbene/service/marketdata/CoinbeneMarketDataServiceIntegration.java
+++ b/xchange-coinbene/src/test/java/org/knowm/xchange/coinbene/service/marketdata/CoinbeneMarketDataServiceIntegration.java
@@ -66,6 +66,5 @@ public class CoinbeneMarketDataServiceIntegration {
     List<CurrencyPair> symbols = COINBENE.getExchangeSymbols();
     assertThat(symbols).isNotNull();
     assertThat(symbols.contains(CurrencyPair.ETH_BTC)).isEqualTo(true);
-
   }
 }


### PR DESCRIPTION
By now it was not possible to get candles as this service URI was not implemented yet. I have created a BitfinexCandle class and added the data retrieval to the MarketDataRaw service.

This ist the relevant documentation part:
https://docs.bitfinex.com/v2/reference#rest-public-candles