### PR TITLE
[openexchangerates] Fixed invalid use of base vs counter

### DIFF
--- a/xchange-openexchangerates/pom.xml
+++ b/xchange-openexchangerates/pom.xml
@@ -29,6 +29,18 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- PowerMockito for unit tests -->
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-reflect</artifactId>
+            <version>1.7.4</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/xchange-openexchangerates/src/main/java/org/knowm/xchange/oer/service/OERMarketDataService.java
+++ b/xchange-openexchangerates/src/main/java/org/knowm/xchange/oer/service/OERMarketDataService.java
@@ -35,7 +35,7 @@ public class OERMarketDataService extends OERMarketDataServiceRaw implements Mar
     // Use reflection to get at data.
     Method method = null;
     try {
-      method = OERRates.class.getMethod("get" + currencyPair.base.getCurrencyCode(), null);
+      method = OERRates.class.getMethod("get" + currencyPair.counter.getCurrencyCode(), null);
     } catch (SecurityException | NoSuchMethodException e) {
       throw new ExchangeException("Problem getting exchange rate!", e);
     }

--- a/xchange-openexchangerates/src/test/java/org/knowm/xchange/oer/service/OERMarketDataServiceRawTest.java
+++ b/xchange-openexchangerates/src/test/java/org/knowm/xchange/oer/service/OERMarketDataServiceRawTest.java
@@ -1,0 +1,33 @@
+package org.knowm.xchange.oer.service;
+
+import java.io.IOException;
+import org.junit.Test;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.oer.OER;
+import org.knowm.xchange.oer.OERExchange;
+import org.knowm.xchange.oer.dto.marketdata.OERRates;
+import org.knowm.xchange.oer.dto.marketdata.OERTickers;
+import org.mockito.Mockito;
+import org.powermock.reflect.Whitebox;
+
+public class OERMarketDataServiceRawTest {
+
+  @Test
+  public void testProxyIsCalledWithCorrectParameters() throws IOException {
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(OERExchange.class.getName());
+    OERMarketDataServiceRaw serviceRaw = new OERMarketDataServiceRaw(exchange);
+    OER oerMock = Mockito.mock(OER.class);
+    OERTickers tickers = new OERTickers(new OERRates(), 0L);
+    tickers.getRates().setAUD(1.23d);
+    Mockito.when(oerMock.getTickers(null, Currency.USD.toString(), Currency.AUD.toString()))
+        .thenReturn(tickers);
+    Whitebox.setInternalState(serviceRaw, "openExchangeRates", oerMock);
+
+    serviceRaw.getOERTicker(CurrencyPair.USD_AUD);
+
+    Mockito.verify(oerMock).getTickers(null, Currency.USD.toString(), Currency.AUD.toString());
+  }
+}

--- a/xchange-openexchangerates/src/test/java/org/knowm/xchange/oer/service/OERMarketDataServiceTest.java
+++ b/xchange-openexchangerates/src/test/java/org/knowm/xchange/oer/service/OERMarketDataServiceTest.java
@@ -1,0 +1,37 @@
+package org.knowm.xchange.oer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import org.junit.Test;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.marketdata.Ticker;
+import org.knowm.xchange.oer.OERExchange;
+import org.knowm.xchange.oer.dto.marketdata.OERRates;
+
+public class OERMarketDataServiceTest {
+
+  @Test
+  public void testTakesCorrectValueFromOERRates() throws IOException {
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(OERExchange.class.getName());
+
+    OERMarketDataService marketDataService =
+        new OERMarketDataService(exchange) {
+          @Override
+          public OERRates getOERTicker(CurrencyPair pair) {
+            assertThat(pair.base).isEqualTo(Currency.USD);
+            OERRates r = new OERRates();
+            r.setAUD(1.23d);
+            return r;
+          }
+        };
+
+    Ticker t = marketDataService.getTicker(CurrencyPair.USD_AUD);
+    assertThat(t.getCurrencyPair()).isEqualTo(CurrencyPair.USD_AUD);
+    assertThat(t.getLast()).isEqualTo(BigDecimal.valueOf(1.23d));
+  }
+}


### PR DESCRIPTION
- Added test for OERMarketDataService and OERMarketDataServiceRaw
- Fixed invalid use of base vs counter