### PR TITLE
[bitmex] Fix order book so that the ask side ordering matches other exchanges

### DIFF
--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexAdapters.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexAdapters.java
@@ -1,8 +1,8 @@
 package org.knowm.xchange.bitmex;
 
-import com.google.common.collect.BiMap;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+
 import org.knowm.xchange.bitmex.dto.account.BitmexTicker;
 import org.knowm.xchange.bitmex.dto.marketdata.BitmexDepth;
 import org.knowm.xchange.bitmex.dto.marketdata.BitmexPrivateOrder;
@@ -42,14 +43,16 @@ import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.dto.trade.UserTrade;
 
+import com.google.common.collect.BiMap;
+
 public class BitmexAdapters {
 
   public static OrderBook adaptOrderBook(BitmexDepth bitmexDepth, CurrencyPair currencyPair) {
 
     OrdersContainer asksOrdersContainer =
-        adaptOrders(bitmexDepth.getAsks(), currencyPair, OrderType.ASK);
+        adaptOrders(bitmexDepth.getAsks(), currencyPair, OrderType.ASK, true);
     OrdersContainer bidsOrdersContainer =
-        adaptOrders(bitmexDepth.getBids(), currencyPair, OrderType.BID);
+        adaptOrders(bitmexDepth.getBids(), currencyPair, OrderType.BID, false);
 
     return new OrderBook(
         new Date(Math.max(asksOrdersContainer.getTimestamp(), bidsOrdersContainer.getTimestamp())),
@@ -71,17 +74,18 @@ public class BitmexAdapters {
   }
 
   public static OrdersContainer adaptOrders(
-      List<BitmexPublicOrder> orders, CurrencyPair currencyPair, OrderType orderType) {
+      List<BitmexPublicOrder> orders, CurrencyPair currencyPair, OrderType orderType, boolean reverse) {
 
     // bitmex does not provide timestamps on order book
     long maxTimestamp = System.currentTimeMillis();
-    List<LimitOrder> limitOrders = new ArrayList<>(orders.size());
+    LimitOrder[] limitOrders = new LimitOrder[orders.size()];
 
+    int i = reverse ? orders.size() - 1 : 0;
     for (BitmexPublicOrder order : orders) {
-
-      limitOrders.add(adaptOrder(order, orderType, currencyPair));
+      limitOrders[i] = adaptOrder(order, orderType, currencyPair);
+      i += (reverse ? -1 : 1);
     }
-    return new OrdersContainer(maxTimestamp, limitOrders);
+    return new OrdersContainer(maxTimestamp, Arrays.asList(limitOrders));
   }
 
   public static Trades adaptTrades(List<BitmexPublicTrade> trades, CurrencyPair currencyPair) {


### PR DESCRIPTION
Most exchanges order the bid side in descending order of price, and the ask side in ascending order. Bitmex currently returns ordering both sides in descending order.

This fixes the issue without the cost of a sort.