### PR TITLE
[Bitmex] added new Altcoin Quarterly Futures Base

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
@@ -275,6 +275,8 @@ public class Currency implements Comparable<Currency>, Serializable {
   public static final Currency M18 = createCurrency("M18", "June 29th", null);
   public static final Currency U18 = createCurrency("U18", "September 28th", null);
   public static final Currency Z18 = createCurrency("Z18", "December 28th", null);
+  public static final Currency H19 = createCurrency("H19", "March 29th", null);
+  public static final Currency M19 = createCurrency("M19", "June 28th", null);
 
   // Cryptos
   public static final Currency BNB = createCurrency("BNB", "Binance Coin", null);


### PR DESCRIPTION
New Bitcoin and Altcoin Quarterly Futures Contracts
December 13, 5:29 AM
On 17th December 2018, the March 2019 quarterly ADA, BCH, EOS, ETH, LTC, TRX, and XRP futures contracts will be listed:

BitMEX Cardano / Bitcoin 29 March 2019 futures contract (ADAH19)
BitMEX Bitcoin Cash / Bitcoin 29 March 2019 futures contract (BCHH19)
BitMEX EOS Token / Bitcoin 29 March 2019 futures contract (EOSH19)
BitMEX Ether / Bitcoin 29 March 2019 futures contract (ETHH19)
BitMEX Litecoin / Bitcoin 29 March 2019 futures contract (LTCH19)
BitMEX Tron / Bitcoin 29 March 2019 futures contract (TRXH19)
BitMEX Ripple / Bitcoin 29 March 2019 futures contract (XRPH19)
On the same date, the June 2019 quarterly BTC futures contract will be listed:

BitMEX BTC / USD 28 June 2019 futures contract (XBTM19)