### PR TITLE
[core] - Reverted changes to currency class and added test to validate toString behaviour

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
@@ -3,7 +3,6 @@ package org.knowm.xchange.currency;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -441,19 +440,10 @@ public class Currency implements Comparable<Currency>, Serializable {
     return attributes.name;
   }
 
-  /** Gets the common code of this currency. */
-  private String getCommonCode() {
-
-	return attributes.commonCode;
-  }
-
   @Override
   public String toString() {
 
-    if (attributes.commonCode == null) {
-      return code;
-    }
-    return attributes.commonCode;
+    return code;
   }
 
   @Override
@@ -484,27 +474,10 @@ public class Currency implements Comparable<Currency>, Serializable {
 
     if (attributes.equals(o.attributes)) return 0;
 
-    Comparator<String> nullSafeStringComparator = Comparator
-            .nullsFirst(String::compareToIgnoreCase);
-
-    Comparator<Integer> nullSafeIntComparator = Comparator
-            .nullsFirst(Integer::compareTo);
-
-    Comparator<Currency> currencyComparator;
-    
-    // If common code exist, prefer it over currency code 
-    if (attributes.commonCode != null && o.attributes.commonCode != null) {
-    		currencyComparator= Comparator
-			.comparing(Currency::getCommonCode, nullSafeStringComparator);
-    } else {
-	currencyComparator= Comparator
-        		.comparing(Currency::getCurrencyCode, nullSafeStringComparator);
-    }
-    
-    return currencyComparator
-    		.thenComparing(Currency::getDisplayName, nullSafeStringComparator)
-    		.thenComparing(Currency::hashCode, nullSafeIntComparator)
-    		.compare(this, o);
+    int comparison = code.compareTo(o.code);
+    if (comparison == 0) comparison = getDisplayName().compareTo(o.getDisplayName());
+    if (comparison == 0) comparison = hashCode() - o.hashCode();
+    return comparison;
   }
 
   private static class CurrencyAttributes implements Serializable {

--- a/xchange-core/src/test/java/org/knowm/xchange/CurrencyTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/CurrencyTest.java
@@ -39,4 +39,10 @@ public class CurrencyTest {
     assertEquals(Currency.XBT, btc);
     assertNotEquals(Currency.LTC, btc);
   }
+
+  @Test
+  public void testToString() {
+    assertEquals("XBT", Currency.XBT.toString());
+    assertEquals("BTC", Currency.BTC.toString());
+  }
 }


### PR DESCRIPTION
See attached testcase , Currencies.XBT.toString() should not return BTC, since various implementations use toString to determine the currency code that gets send to the exchange.