### PR TITLE
[Bitfinex] Remove deprecated workaround for DSH and QTM

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexAdapters.java
@@ -91,14 +91,7 @@ public final class BitfinexAdapters {
   }
 
   public static String adaptBitfinexCurrency(String bitfinexSymbol) {
-    String currency = bitfinexSymbol.toUpperCase();
-    if (currency.equals("DSH")) {
-      currency = "DASH";
-    }
-    if (currency.equals("QTM")) {
-      currency = "QTUM";
-    }
-    return currency;
+    return bitfinexSymbol.toUpperCase();
   }
 
   public static List<CurrencyPair> adaptCurrencyPairs(Collection<String> bitfinexSymbol) {

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexUtils.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexUtils.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bitfinex.v1;
 
 import org.knowm.xchange.bitfinex.common.dto.BitfinexException;
+import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 
 /** A central place for shared Bitfinex properties */
@@ -9,21 +10,22 @@ public final class BitfinexUtils {
   /** private Constructor */
   private BitfinexUtils() {}
 
-  public static String adaptXchangeCurrency(String xchangeSymbol) {
-    String currency = xchangeSymbol.toLowerCase();
-    if (currency.equals("dash")) {
-      currency = "dsh";
+  public static String adaptXchangeCurrency(Currency xchangeSymbol) {
+
+    if (xchangeSymbol == null) {
+      return null;
     }
-    if (currency.equals("qtum")) {
-      currency = "qtm";
-    }
-    return currency;
+
+    return xchangeSymbol.toString().toLowerCase();
   }
 
   public static String toPairString(CurrencyPair currencyPair) {
 
-    return adaptXchangeCurrency(currencyPair.base.toString())
-        + adaptXchangeCurrency(currencyPair.counter.toString());
+    if (currencyPair == null) {
+      return null;
+    }
+
+    return adaptXchangeCurrency(currencyPair.base) + adaptXchangeCurrency(currencyPair.counter);
   }
 
   /**

--- a/xchange-bitfinex/src/main/resources/bitfinex.json
+++ b/xchange-bitfinex/src/main/resources/bitfinex.json
@@ -40,12 +40,12 @@
       "min_amount": 0.20000000,
       "trading_fee": 0.002
     },
-    "DASH/USD": {
+    "DSH/USD": {
       "price_scale": 2,
       "min_amount": 0.04000000,
       "trading_fee": 0.002
     },
-    "DASH/BTC": {
+    "DSH/BTC": {
       "price_scale": 6,
       "min_amount": 0.04000000,
       "trading_fee": 0.002
@@ -229,7 +229,7 @@
       "scale": 8,
       "withdrawal_fee": 0.01
     },
-    "DASH": {
+    "DSH": {
       "scale": 8,
       "withdrawal_fee": 0.01
     },


### PR DESCRIPTION
Remove deprecated workaround with pair renaming: DASH <=> DSH, QTUM <=> QTM.