### PR TITLE
[Bitfinex] Add cancel all. Cleanup and refactoring

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexAdapters.java
@@ -3,7 +3,6 @@ package org.knowm.xchange.bitfinex.v1;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexAdapters.java
@@ -23,10 +23,12 @@ import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexSymbolDetail;
 import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexTicker;
 import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexTrade;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexAccountInfosResponse;
+import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrderFlags;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrderStatusResponse;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexTradeResponse;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.OrderStatus;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.account.Balance;
@@ -101,13 +103,28 @@ public final class BitfinexAdapters {
     return currency;
   }
 
-  public static List<CurrencyPair> adaptCurrencyPairs(Collection<String> bitfinexSymbol) {
-
-    List<CurrencyPair> currencyPairs = new ArrayList<>();
-    for (String symbol : bitfinexSymbol) {
-      currencyPairs.add(adaptCurrencyPair(symbol));
+  public static BitfinexOrderType adaptOrderFlagsToType(Set<Order.IOrderFlags> flags) {
+    if (flags.contains(BitfinexOrderFlags.MARGIN)) {
+      if (flags.contains(BitfinexOrderFlags.FILL_OR_KILL)) {
+        return BitfinexOrderType.MARGIN_FILL_OR_KILL;
+      } else if (flags.contains(BitfinexOrderFlags.TRAILING_STOP)) {
+        return BitfinexOrderType.MARGIN_TRAILING_STOP;
+      } else if (flags.contains(BitfinexOrderFlags.STOP)) {
+        return BitfinexOrderType.MARGIN_STOP;
+      } else {
+        return BitfinexOrderType.MARGIN_LIMIT;
+      }
+    } else {
+      if (flags.contains(BitfinexOrderFlags.FILL_OR_KILL)) {
+        return BitfinexOrderType.FILL_OR_KILL;
+      } else if (flags.contains(BitfinexOrderFlags.TRAILING_STOP)) {
+        return BitfinexOrderType.TRAILING_STOP;
+      } else if (flags.contains(BitfinexOrderFlags.STOP)) {
+        return BitfinexOrderType.STOP;
+      } else {
+        return BitfinexOrderType.LIMIT;
+      }
     }
-    return currencyPairs;
   }
 
   public static CurrencyPair adaptCurrencyPair(String bitfinexSymbol) {

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexNewOrderRequest.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexNewOrderRequest.java
@@ -24,10 +24,10 @@ public class BitfinexNewOrderRequest {
   protected String type;
 
   @JsonProperty("amount")
-  protected BigDecimal amount;
+  protected String amount;
 
   @JsonProperty("price")
-  protected BigDecimal price;
+  protected String price;
 
   @JsonProperty("is_hidden")
   protected boolean is_hidden = false;
@@ -57,8 +57,12 @@ public class BitfinexNewOrderRequest {
     this.request = "/v1/order/new";
     this.nonce = nonce;
     this.symbol = symbol;
-    this.amount = amount;
-    this.price = price;
+    if (amount != null) {
+      this.amount = amount.toPlainString();
+    }
+    if (price != null) {
+      this.price = price.toPlainString();
+    }
     this.exchange = exchange;
     this.side = side;
     this.type = type;
@@ -125,12 +129,17 @@ public class BitfinexNewOrderRequest {
   }
 
   public String getAmount() {
+    if (amount == null) {
+      return null;
+    }
 
-    return amount.toPlainString();
+    return amount;
   }
 
   public String getPrice() {
-
-    return price.toPlainString();
+    if (price == null) {
+      return null;
+    }
+    return price;
   }
 }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexMarketDataServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexMarketDataServiceRaw.java
@@ -103,14 +103,22 @@ public class BitfinexMarketDataServiceRaw extends BitfinexBaseService {
 
   public List<CurrencyPair> getExchangeSymbols() throws IOException {
 
-    List<CurrencyPair> currencyPairs = new ArrayList<>();
-    for (String symbol : bitfinex.getSymbols()) {
-      currencyPairs.add(BitfinexAdapters.adaptCurrencyPair(symbol));
+    try {
+      List<CurrencyPair> currencyPairs = new ArrayList<>();
+      for (String symbol : bitfinex.getSymbols()) {
+        currencyPairs.add(BitfinexAdapters.adaptCurrencyPair(symbol));
+      }
+      return currencyPairs;
+    } catch (BitfinexException e) {
+      throw handleException(e);
     }
-    return currencyPairs;
   }
 
   public List<BitfinexSymbolDetail> getSymbolDetails() throws IOException {
-    return bitfinex.getSymbolsDetails();
+    try {
+      return bitfinex.getSymbolsDetails();
+    } catch (BitfinexException e) {
+      throw handleException(e);
+    }
   }
 }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexTradeService.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexTradeService.java
@@ -20,6 +20,7 @@ import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.service.trade.TradeService;
+import org.knowm.xchange.service.trade.params.CancelAllOrders;
 import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
 import org.knowm.xchange.service.trade.params.CancelOrderParams;
 import org.knowm.xchange.service.trade.params.DefaultTradeHistoryParamsTimeSpan;
@@ -80,29 +81,8 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Tra
   @Override
   public String placeLimitOrder(LimitOrder limitOrder) throws IOException {
 
-    BitfinexOrderStatusResponse newOrder;
-    if (limitOrder.hasFlag(BitfinexOrderFlags.MARGIN)) {
-      if (limitOrder.hasFlag(BitfinexOrderFlags.FILL_OR_KILL)) {
-        newOrder = placeBitfinexLimitOrder(limitOrder, BitfinexOrderType.MARGIN_FILL_OR_KILL);
-      } else if (limitOrder.hasFlag(BitfinexOrderFlags.TRAILING_STOP)) {
-        newOrder = placeBitfinexLimitOrder(limitOrder, BitfinexOrderType.MARGIN_TRAILING_STOP);
-      } else if (limitOrder.hasFlag(BitfinexOrderFlags.STOP)) {
-        newOrder = placeBitfinexLimitOrder(limitOrder, BitfinexOrderType.MARGIN_STOP);
-      } else {
-        newOrder = placeBitfinexLimitOrder(limitOrder, BitfinexOrderType.MARGIN_LIMIT);
-      }
-    } else {
-      if (limitOrder.hasFlag(BitfinexOrderFlags.FILL_OR_KILL)) {
-        newOrder = placeBitfinexLimitOrder(limitOrder, BitfinexOrderType.FILL_OR_KILL);
-      } else if (limitOrder.hasFlag(BitfinexOrderFlags.TRAILING_STOP)) {
-        newOrder = placeBitfinexLimitOrder(limitOrder, BitfinexOrderType.TRAILING_STOP);
-      } else if (limitOrder.hasFlag(BitfinexOrderFlags.STOP)) {
-        newOrder = placeBitfinexLimitOrder(limitOrder, BitfinexOrderType.STOP);
-      } else {
-        newOrder = placeBitfinexLimitOrder(limitOrder, BitfinexOrderType.LIMIT);
-      }
-    }
-
+    BitfinexOrderType type = BitfinexAdapters.adaptOrderFlagsToType(limitOrder.getOrderFlags());
+    BitfinexOrderStatusResponse newOrder = placeBitfinexLimitOrder(limitOrder, type);
     return String.valueOf(newOrder.getId());
   }
 
@@ -116,9 +96,13 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Tra
   public boolean cancelOrder(CancelOrderParams orderParams) throws IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
       return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
-    } else {
-      return false;
     }
+    if (orderParams instanceof CancelAllOrders) {
+      return cancelAllBitfinexOrders();
+    }
+
+    throw new IllegalArgumentException(
+        String.format("Unknown parameter type: %s", orderParams.getClass()));
   }
 
   /**

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexTradeServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexTradeServiceRaw.java
@@ -213,12 +213,7 @@ public class BitfinexTradeServiceRaw extends BitfinexBaseService {
       }
 
     } else { // order amend
-      boolean useRemaining;
-      if (limitOrder.hasFlag(BitfinexOrderFlags.USE_REMAINING)) {
-        useRemaining = true;
-      } else {
-        useRemaining = false;
-      }
+      boolean useRemaining = limitOrder.hasFlag(BitfinexOrderFlags.USE_REMAINING);
 
       BitfinexReplaceOrderRequest request =
           new BitfinexReplaceOrderRequest(


### PR DESCRIPTION
Add cancel all;
Parse exceptions raised for exchange symbols and symbols details requests;
Use BigDecimal instead of String for order amount and price;
Move order flags conversion into adapter class.
Remove unused `adaptCurrencyPairs`.