### PR TITLE
[binance] Don't set time-in-force for stop orders with no limit price.

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeService.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.binance.BinanceAdapters;
 import org.knowm.xchange.binance.BinanceErrorAdapter;
@@ -134,7 +135,7 @@ public class BinanceTradeService extends BinanceTradeServiceRaw implements Trade
   @Override
   public String placeStopOrder(StopOrder so) throws IOException {
 
-    TimeInForce tif = TimeInForce.GTC;
+    TimeInForce tif = null;
     Set<IOrderFlags> orderFlags = so.getOrderFlags();
     Iterator<IOrderFlags> orderFlagsIterator = orderFlags.iterator();
 
@@ -143,6 +144,14 @@ public class BinanceTradeService extends BinanceTradeServiceRaw implements Trade
       if (orderFlag instanceof TimeInForce) {
         tif = (TimeInForce) orderFlag;
       }
+    }
+
+    // Time-in-force should not be provided for market orders but is required for
+    // limit orders, so we only default it for limit orders. If the caller
+    // specifies one for a market order, we don't remove it, since Binance might allow
+    // it at some point.
+    if (so.getLimitPrice() != null && tif == null) {
+      tif = TimeInForce.GTC;
     }
 
     OrderType orderType;


### PR DESCRIPTION
The Binance API guide states that it should be omitted. This is moot since I haven't found any pairs where such orders are actually allowed, but at least this means if Binance adds the support for such orders, XChange will be ready.