### PR TITLE
[Bitmex] Add missing amount correction 

### DIFF
--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexAdapters.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexAdapters.java
@@ -457,7 +457,7 @@ public class BitmexAdapters {
             walletTransaction.getAddress(),
             dateFunding,
             Currency.getInstance(currency),
-            walletTransaction.getAmount(),
+            walletTransaction.getAmount().divide(BigDecimal.valueOf(100_000_000L)),
             walletTransaction.getTransactID(),
             walletTransaction.getTx(),
             walletTransaction.getTransactType().equals("Deposit") ? FundingRecord.Type.DEPOSIT : FundingRecord.Type.WITHDRAWAL,


### PR DESCRIPTION
Divide by 100 000 000 to get BTC instead of satoshis amount