### PR TITLE
Fixed NULL Error for Authenticated Services

### DIFF
--- a/xchange-btcturk/src/main/java/org/knowm/xchange/btcturk/BTCTurkExchange.java
+++ b/xchange-btcturk/src/main/java/org/knowm/xchange/btcturk/BTCTurkExchange.java
@@ -21,12 +21,9 @@ public class BTCTurkExchange extends BaseExchange implements Exchange {
 
   @Override
   protected void initServices() {
-
     this.marketDataService = new BTCTurkMarketDataService(this);
-    if (exchangeSpecification.getApiKey() != null) {
-      this.accountService = new BTCTurkAccountService(this);
-      this.tradeService = new BTCTurkTradeService(this);
-    }
+    this.accountService = new BTCTurkAccountService(this);
+    this.tradeService = new BTCTurkTradeService(this);
   }
 
   @Override

--- a/xchange-btcturk/src/test/java/org/knowm/xchange/btcturk/service/account/AccountDataFetchIntegrationTest.java
+++ b/xchange-btcturk/src/test/java/org/knowm/xchange/btcturk/service/account/AccountDataFetchIntegrationTest.java
@@ -41,7 +41,7 @@ public class AccountDataFetchIntegrationTest {
   @Test
   public void testBalance() throws IOException, InterruptedException {
 
-    if (accountService != null) {
+    if (!BTCTurkDemoUtilsTest.BTCTURK_APIKEY.isEmpty()) {
       // BTCTurkAccountBalance Test
       BTCTurkAccountBalance accountBalance = btcTurkAccountService.getBTCTurkBalance();
       assertThat(accountBalance).isNotEqualTo(null);
@@ -52,6 +52,6 @@ public class AccountDataFetchIntegrationTest {
       Thread.sleep(1000);
       AccountInfo accountInfo = btcTurkAccountService.getAccountInfo();
       assertThat(accountInfo).isNotEqualTo(null);
-    } else assertThat(accountService).isEqualTo(null);
+    } else assertThat(accountService).isNotEqualTo(null);
   }
 }

--- a/xchange-btcturk/src/test/java/org/knowm/xchange/btcturk/service/trade/TradeDataFetchIntegrationTest.java
+++ b/xchange-btcturk/src/test/java/org/knowm/xchange/btcturk/service/trade/TradeDataFetchIntegrationTest.java
@@ -45,7 +45,7 @@ public class TradeDataFetchIntegrationTest {
   @Test
   public void Tests() throws IOException, InterruptedException {
 
-    if (tradeService != null) {
+    if (!BTCTurkDemoUtilsTest.BTCTURK_APIKEY.isEmpty()) {
       // PlaceOrderAndOpenOrders Test
       Thread.sleep(1000);
       List<BTCTurkOpenOrders> openOrders =
@@ -72,6 +72,6 @@ public class TradeDataFetchIntegrationTest {
       List<BTCTurkUserTransactions> userTransactions =
           btcTurkTradeService.getBTCTurkUserTransactions();
       assertThat(userTransactions.size()).isEqualTo(25);
-    } else assertThat(tradeService).isEqualTo(null);
+    } else assertThat(tradeService).isNotEqualTo(null);
   }
 }


### PR DESCRIPTION
If the api key is defined after running "ExchangeFactory.INSTANCE.createExchange" command, authenticated services were null.