### PR TITLE
[CoinMarketCap] Fix initialization (API key was not initalized)

### DIFF
--- a/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/pro/v1/CmcExchange.java
+++ b/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/pro/v1/CmcExchange.java
@@ -14,10 +14,6 @@ public class CmcExchange extends BaseExchange implements Exchange {
 
   private SynchronizedValueFactory<Long> nonceFactory = new CurrentTimeNonceFactory();
 
-  public CmcExchange() {
-    initServices();
-  }
-
   @Override
   protected void initServices() {
     if (this.marketDataService == null) {
@@ -43,11 +39,6 @@ public class CmcExchange extends BaseExchange implements Exchange {
     if (this.exchangeSpecification == null)
       this.exchangeSpecification = getDefaultExchangeSpecification();
     return exchangeSpecification;
-  }
-
-  @Override
-  public void applySpecification(ExchangeSpecification exchangeSpecification) {
-    this.exchangeSpecification = exchangeSpecification;
   }
 
   @Override

--- a/xchange-coinmarketcap/src/main/resources/CoinMarketCap.json
+++ b/xchange-coinmarketcap/src/main/resources/CoinMarketCap.json
@@ -1,0 +1,4 @@
+{
+  "currency_pairs": {},
+  "currencies": {}
+}


### PR DESCRIPTION
This is a follow-up fix to #2900 which was already implemented and merged in the PR #2944. 

## Problem before:
The implementation in #2944 worked perfecty for me in the Xchange unit tests, but failed with "missing api-key" errors when used in my own project.

After investigating the difference I found that the order of initialization was the problem:
The `marketDataService` (and therefore the CmcBaseService) gets created within in the `initServices()` method, which was called directly from the constructor as can be seen here: [CmcExchange.java#L18](https://github.com/jakubkalicki/XChange/blob/da615747aecd1462e8a9358285779fc8ed5751b8/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/pro/v1/CmcExchange.java#L18)

As the `applySpecification(..)` method (where the ExchangeSpecification and the API key gets injected) gets called [at a later point in time](https://github.com/knowm/XChange/blob/cca4ac0389cd76bb95715501ae81d9aa08853b11/xchange-core/src/main/java/org/knowm/xchange/ExchangeFactory.java#L128) the `marketDataService` (and in consequence the `CmcBaseService`) was created at a point in time, when  `exchange.getExchangeSpecification().getApiKey()` still returned `null`:
[CmcBaseService.java#L17](https://github.com/knowm/XChange/blob/9901cf400b30682d769b6c9862fbf65fd60d1436/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/pro/v1/service/CmcBaseService.java#L17).

## Why did it work in the unit tests
In the unit tests the api-secret gets read from [a property file using the `AuthUtils.setApiAndSecretKey()` helper](https://github.com/timmolter/XChange/blob/9e3a65468f02be14935c9895e51868966c14c481/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/pro/v1/CmcExchange.java#L32). Of course this works also before `applySpecification(..)` gets called (as the property file exist already before).

## What this changes:
I just removed the explicit call to `initServices()` and also the overridden implementation of `applySpecification(..)` as the super-implementation in `BaseExchange.java` already takes care of calling `initServices()`.

As in BaseExchange.java also the exchange metadata JSON is read (which was not present at all until now) I also added the `CoinMarketCap.json` to prevent parsing errors. But please note that it's still almost empty, so the exchange still won't return anything useful on `getExchangeMetaData()` (but this was the same situation before).
