### PR TITLE
[Bittrex-Kraken] various fixes

### DIFF
--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/BittrexAdapters.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/BittrexAdapters.java
@@ -20,7 +20,6 @@ import org.knowm.xchange.bittrex.dto.trade.BittrexOrderBase;
 import org.knowm.xchange.bittrex.dto.trade.BittrexUserTrade;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
-import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.OrderStatus;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.account.Balance;
@@ -244,8 +243,8 @@ public final class BittrexAdapters {
       wallets.add(
           new Balance(
               Currency.getInstance(balance.getCurrency().toUpperCase()),
-              balance.getBalance(),
-              balance.getAvailable(),
+              Optional.ofNullable(balance.getBalance()).orElse(BigDecimal.ZERO),
+              Optional.ofNullable(balance.getAvailable()).orElse(BigDecimal.ZERO),
               calculateFrozenBalance(balance),
               BigDecimal.ZERO,
               BigDecimal.ZERO,
@@ -259,8 +258,8 @@ public final class BittrexAdapters {
   public static Balance adaptBalance(BittrexBalance balance) {
     return new Balance(
         Currency.getInstance(balance.getCurrency().toUpperCase()),
-        balance.getBalance(),
-        balance.getAvailable(),
+        Optional.ofNullable(balance.getBalance()).orElse(BigDecimal.ZERO),
+        Optional.ofNullable(balance.getAvailable()).orElse(BigDecimal.ZERO),
         calculateFrozenBalance(balance),
         BigDecimal.ZERO,
         BigDecimal.ZERO,

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/dto/trade/BittrexOpenOrder.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/dto/trade/BittrexOpenOrder.java
@@ -1,9 +1,8 @@
 package org.knowm.xchange.bittrex.dto.trade;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
 import java.util.Date;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class BittrexOpenOrder extends BittrexOrderBase {
 
@@ -27,9 +26,23 @@ public class BittrexOpenOrder extends BittrexOrderBase {
       @JsonProperty("IsConditional") Boolean isConditional,
       @JsonProperty("Condition") String condition,
       @JsonProperty("ConditionTarget") Object conditionTarget) {
-    super(orderUuid, exchange, orderType, quantity, quantityRemaining, limit, commissionPaid,
-        price, pricePerUnit, opened, closed, cancelInitiated, immediateOrCancel, isConditional,
-        condition, conditionTarget);
+    super(
+        orderUuid,
+        exchange,
+        orderType,
+        quantity,
+        quantityRemaining,
+        limit,
+        commissionPaid,
+        price,
+        pricePerUnit,
+        opened,
+        closed,
+        cancelInitiated,
+        immediateOrCancel,
+        isConditional,
+        condition,
+        conditionTarget);
     this.uuid = uuid;
   }
 

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/dto/trade/BittrexOrder.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/dto/trade/BittrexOrder.java
@@ -1,9 +1,8 @@
 package org.knowm.xchange.bittrex.dto.trade;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
 import java.util.Date;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class BittrexOrder extends BittrexOrderBase {
 
@@ -39,7 +38,23 @@ public class BittrexOrder extends BittrexOrderBase {
       @JsonProperty("IsConditional") Boolean isConditional,
       @JsonProperty("Condition") String condition,
       @JsonProperty("ConditionTarget") String conditionTarget) {
-    super(orderUuid, exchange, type, quantity, quantityRemaining, limit, commissionPaid, price, pricePerUnit, opened, closed, cancelInitiated, immediateOrCancel, isConditional, condition, conditionTarget);
+    super(
+        orderUuid,
+        exchange,
+        type,
+        quantity,
+        quantityRemaining,
+        limit,
+        commissionPaid,
+        price,
+        pricePerUnit,
+        opened,
+        closed,
+        cancelInitiated,
+        immediateOrCancel,
+        isConditional,
+        condition,
+        conditionTarget);
     this.accountId = accountId;
     this.reserved = reserved;
     this.reserveRemaining = reserveRemaining;
@@ -79,8 +94,19 @@ public class BittrexOrder extends BittrexOrderBase {
 
   @Override
   protected String additionalToString() {
-    return "accountId=" + accountId + ", reserved=" + reserved + ", reserveRemaining=" + reserveRemaining
-        + ", commissionReserved=" + commissionReserved + ", commissionReserveRemaining=" + commissionReserveRemaining
-        + ", isOpen=" + isOpen + ", sentinel=" + sentinel;
+    return "accountId="
+        + accountId
+        + ", reserved="
+        + reserved
+        + ", reserveRemaining="
+        + reserveRemaining
+        + ", commissionReserved="
+        + commissionReserved
+        + ", commissionReserveRemaining="
+        + commissionReserveRemaining
+        + ", isOpen="
+        + isOpen
+        + ", sentinel="
+        + sentinel;
   }
 }

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/dto/trade/BittrexOrderBase.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/dto/trade/BittrexOrderBase.java
@@ -155,7 +155,8 @@ public abstract class BittrexOrderBase {
         + getCondition()
         + ", conditionTarget="
         + getConditionTarget()
-        + ", " + additionalToString()
+        + ", "
+        + additionalToString()
         + "]";
   }
 

--- a/xchange-bittrex/src/test/java/org/knowm/xchange/bittrex/BittrexAdaptersTest.java
+++ b/xchange-bittrex/src/test/java/org/knowm/xchange/bittrex/BittrexAdaptersTest.java
@@ -3,21 +3,21 @@ package org.knowm.xchange.bittrex;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
-
+import org.junit.Assert;
 import org.junit.Test;
 import org.knowm.xchange.bittrex.dto.BittrexBaseResponse;
+import org.knowm.xchange.bittrex.dto.account.BittrexBalance;
 import org.knowm.xchange.bittrex.dto.trade.BittrexOpenOrder;
 import org.knowm.xchange.bittrex.dto.trade.BittrexOrder;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.trade.LimitOrder;
-
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class BittrexAdaptersTest {
 
@@ -309,5 +309,19 @@ public class BittrexAdaptersTest {
     assertThat(order.getCurrencyPair()).isEqualTo(CurrencyPair.LTC_BTC);
     assertThat(order.getStatus()).isEqualTo(Order.OrderStatus.NEW);
     assertThat(LimitOrder.class.isAssignableFrom(order.getClass()));
+  }
+
+  @Test
+  public void testCalculateFrozenBalance() {
+    BittrexBalance balance = new BittrexBalance(null, null, null, null, null, false, null);
+    Assert.assertEquals(BigDecimal.ZERO, BittrexAdapters.calculateFrozenBalance(balance));
+
+    balance =
+        new BittrexBalance(
+            BigDecimal.ONE, new BigDecimal("100"), null, null, BigDecimal.TEN, false, null);
+    Assert.assertEquals(new BigDecimal("89"), BittrexAdapters.calculateFrozenBalance(balance));
+
+    balance = new BittrexBalance(null, new BigDecimal("100"), null, null, null, false, null);
+    Assert.assertEquals(new BigDecimal("100"), BittrexAdapters.calculateFrozenBalance(balance));
   }
 }

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenBaseService.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenBaseService.java
@@ -2,7 +2,9 @@ package org.knowm.xchange.kraken.service;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -125,22 +127,12 @@ public class KrakenBaseService extends BaseExchangeService implements BaseServic
   }
 
   protected String delimitAssetPairs(CurrencyPair[] currencyPairs) throws IOException {
-
-    String assetPairsString = null;
-    if (currencyPairs != null && currencyPairs.length > 0) {
-      StringBuilder delimitStringBuilder = null;
-      for (CurrencyPair currencyPair : currencyPairs) {
-        String krakenAssetPair = KrakenUtils.createKrakenCurrencyPair(currencyPair);
-        if (delimitStringBuilder == null) {
-          delimitStringBuilder = new StringBuilder(krakenAssetPair);
-        } else {
-          delimitStringBuilder.append(",").append(krakenAssetPair);
-        }
-      }
-      assetPairsString = delimitStringBuilder.toString();
-    }
-
-    return assetPairsString;
+    return currencyPairs != null && currencyPairs.length > 0
+        ? Arrays.stream(currencyPairs)
+            .map(KrakenUtils::createKrakenCurrencyPair)
+            .filter(Objects::nonNull)
+            .collect(Collectors.joining(","))
+        : null;
   }
 
   protected String delimitSet(Set<IOrderFlags> items) {


### PR DESCRIPTION
Bittrex: fixed BigDecimal calculation with now possible null values, due to Bittrex 02/27/2019 backend update
Kraken: fixed null pointer exception cases on not supported currency pairs