### PR TITLE
[bitfinex] fixed leading space when extracting tx hash

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexAdapters.java
@@ -666,7 +666,7 @@ public final class BitfinexAdapters {
 
         // Address will only be present for crypto payments. It will be null for all fiat payments
         if (address != null) {
-          cleanedDescription = cleanedDescription.replace(address.toLowerCase(), "");
+          cleanedDescription = cleanedDescription.replace(address.toLowerCase(), "").trim();
         }
 
         // check its just some hex characters, and if so lets assume its the txn hash


### PR DESCRIPTION
In some cases there is a leading space on Bitfinex transactions, this simple patch just removes them.