### PR TITLE
[kraken] Fix UndeclaredThrowableException when fetching tickers

### DIFF
--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/Kraken.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/Kraken.java
@@ -1,12 +1,14 @@
 package org.knowm.xchange.kraken;
 
 import java.io.IOException;
+
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+
 import org.knowm.xchange.kraken.dto.marketdata.results.KrakenAssetPairsResult;
 import org.knowm.xchange.kraken.dto.marketdata.results.KrakenAssetsResult;
 import org.knowm.xchange.kraken.dto.marketdata.results.KrakenDepthResult;
@@ -23,7 +25,7 @@ public interface Kraken {
 
   @GET
   @Path("public/Ticker")
-  KrakenTickerResult getTicker(@QueryParam("pair") String currencyPairs);
+  KrakenTickerResult getTicker(@QueryParam("pair") String currencyPairs) throws IOException;
 
   @GET
   @Path("public/OHLC")


### PR DESCRIPTION
Ensures that `SocketTimeoutException` and similar exceptions are propagated unwrapped.