### PR TITLE
Fixed the type operand of 'instanceof'.

### DIFF
--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcAccountService.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcAccountService.java
@@ -79,7 +79,7 @@ public class HitbtcAccountService extends HitbtcAccountServiceRaw implements Acc
 
     List<HitbtcTransaction> transactions;
 
-    if (params instanceof TradeHistoryParams) {
+    if (params instanceof HitbtcFundingHistoryParams) {
       HitbtcFundingHistoryParams hitbtcTradeHistoryParams = (HitbtcFundingHistoryParams) params;
 
       String currency =


### PR DESCRIPTION
The type check in its present form is redundant, and I doubt it has been done intentionally.