### PR TITLE
[dragonex] added new 'depth' method to fetch the order book

### DIFF
--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/Dragonex.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/Dragonex.java
@@ -10,6 +10,7 @@ import javax.ws.rs.core.MediaType;
 import org.knowm.xchange.dragonex.dto.DragonResult;
 import org.knowm.xchange.dragonex.dto.DragonexException;
 import org.knowm.xchange.dragonex.dto.marketdata.Coin;
+import org.knowm.xchange.dragonex.dto.marketdata.Depth;
 import org.knowm.xchange.dragonex.dto.marketdata.Order;
 import org.knowm.xchange.dragonex.dto.marketdata.Symbol;
 import org.knowm.xchange.dragonex.dto.marketdata.Ticker;
@@ -43,6 +44,13 @@ public interface Dragonex {
   @GET
   @Path("market/sell/")
   DragonResult<List<Order>> marketSellOrders(@QueryParam("symbol_id") long symbolId)
+      throws DragonexException, IOException;
+
+  /** Query orders quotes */
+  @GET
+  @Path("market/depth/")
+  DragonResult<Depth> marketDepth(
+      @QueryParam("symbol_id") long symbolId, @QueryParam("count") int count)
       throws DragonexException, IOException;
 
   /** Query real time quotes */

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/marketdata/Depth.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/dto/marketdata/Depth.java
@@ -1,0 +1,31 @@
+package org.knowm.xchange.dragonex.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class Depth {
+
+  private final List<Order> buys;
+  private final List<Order> sells;
+
+  public Depth(@JsonProperty("buys") List<Order> buys, @JsonProperty("sells") List<Order> sells) {
+    this.buys = buys;
+    this.sells = sells;
+  }
+
+  public List<Order> getBuys() {
+    return buys;
+  }
+
+  public List<Order> getSells() {
+    return sells;
+  }
+
+  @Override
+  public String toString() {
+    return "Depth ["
+        + (buys != null ? "buys=" + buys + ", " : "")
+        + (sells != null ? "sells=" + sells : "")
+        + "]";
+  }
+}

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonexMarketDataService.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonexMarketDataService.java
@@ -7,6 +7,7 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dragonex.dto.marketdata.Depth;
 import org.knowm.xchange.dragonex.dto.marketdata.Order;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.marketdata.OrderBook;
@@ -42,14 +43,11 @@ public class DragonexMarketDataService extends DragonexMarketDataServiceRaw
     long symbolId = exchange.symbolId(pair);
     BiFunction<OrderType, Order, LimitOrder> f =
         (t, o) -> new LimitOrder(t, o.volume, pair, null, null, o.price);
+    Depth d = super.marketDepth(symbolId, 50); // currently the max count of orders: 50
     List<LimitOrder> bids =
-        super.marketBuyOrders(symbolId).stream()
-            .map(o -> f.apply(OrderType.BID, o))
-            .collect(Collectors.toList());
+        d.getBuys().stream().map(o -> f.apply(OrderType.BID, o)).collect(Collectors.toList());
     List<LimitOrder> asks =
-        super.marketSellOrders(symbolId).stream()
-            .map(o -> f.apply(OrderType.ASK, o))
-            .collect(Collectors.toList());
+        d.getSells().stream().map(o -> f.apply(OrderType.ASK, o)).collect(Collectors.toList());
     return new OrderBook(null, asks, bids);
   }
 }

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonexMarketDataServiceRaw.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/service/DragonexMarketDataServiceRaw.java
@@ -6,6 +6,7 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.dragonex.dto.DragonResult;
 import org.knowm.xchange.dragonex.dto.DragonexException;
 import org.knowm.xchange.dragonex.dto.marketdata.Coin;
+import org.knowm.xchange.dragonex.dto.marketdata.Depth;
 import org.knowm.xchange.dragonex.dto.marketdata.Order;
 import org.knowm.xchange.dragonex.dto.marketdata.Symbol;
 import org.knowm.xchange.dragonex.dto.marketdata.Ticker;
@@ -35,6 +36,11 @@ public class DragonexMarketDataServiceRaw extends DragonexBaseService {
     DragonResult<List<Order>> marketSellOrders =
         exchange.dragonexPublic().marketSellOrders(symbolId);
     return marketSellOrders.getResult();
+  }
+
+  public Depth marketDepth(long symbolId, int count) throws DragonexException, IOException {
+    DragonResult<Depth> marketDepth = exchange.dragonexPublic().marketDepth(symbolId, count);
+    return marketDepth.getResult();
   }
 
   List<Ticker> ticker(long symbolId) throws DragonexException, IOException {


### PR DESCRIPTION
- added new 'depth' method to fetch the order book
- additionally added the "count" parameter, so we can fetch 50 orders (default is 10)