### PR TITLE
Bitstamp: Support for since_timestamp for user_transactions

### DIFF
--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAuthenticatedV2.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAuthenticatedV2.java
@@ -63,7 +63,8 @@ public interface BitstampAuthenticatedV2 {
       @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
       @FormParam("limit") Long numberOfTransactions,
       @FormParam("offset") Long offset,
-      @FormParam("sort") String sort)
+      @FormParam("sort") String sort,
+      @FormParam("since_timestamp") Long sinceTimestamp)
       throws BitstampException, IOException;
 
   @POST
@@ -75,7 +76,8 @@ public interface BitstampAuthenticatedV2 {
       @PathParam("pair") BitstampV2.Pair pair,
       @FormParam("limit") Long numberOfTransactions,
       @FormParam("offset") Long offset,
-      @FormParam("sort") String sort)
+      @FormParam("sort") String sort,
+      @FormParam("since_timestamp") Long sinceTimestamp)
       throws BitstampException, IOException;
 
   @POST

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountService.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountService.java
@@ -24,7 +24,9 @@ import org.knowm.xchange.service.trade.params.TradeHistoryParamOffset;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamsSorted;
+import org.knowm.xchange.service.trade.params.TradeHistoryParamsTimeSpan;
 import org.knowm.xchange.service.trade.params.WithdrawFundsParams;
+import org.knowm.xchange.utils.DateUtils;
 
 /** @author Matija Mazi */
 public class BitstampAccountService extends BitstampAccountServiceRaw implements AccountService {
@@ -155,6 +157,7 @@ public class BitstampAccountService extends BitstampAccountServiceRaw implements
     CurrencyPair currencyPair = null;
     Long offset = null;
     TradeHistoryParamsSorted.Order sort = null;
+    Long sinceTimestamp = null;
     if (params instanceof TradeHistoryParamPaging) {
       limit = Long.valueOf(((TradeHistoryParamPaging) params).getPageLength());
     }
@@ -164,8 +167,12 @@ public class BitstampAccountService extends BitstampAccountServiceRaw implements
     if (params instanceof TradeHistoryParamsSorted) {
       sort = ((TradeHistoryParamsSorted) params).getOrder();
     }
+    if (params instanceof TradeHistoryParamsTimeSpan) {
+      sinceTimestamp =
+          DateUtils.toUnixTimeNullSafe(((TradeHistoryParamsTimeSpan) params).getStartTime());
+    }
     BitstampUserTransaction[] txs =
-        getBitstampUserTransactions(limit, offset, sort == null ? null : sort.toString());
+        getBitstampUserTransactions(limit, offset, sort == null ? null : sort.toString(), sinceTimestamp);
     return BitstampAdapters.adaptFundingHistory(Arrays.asList(txs));
   }
 }

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountServiceRaw.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountServiceRaw.java
@@ -356,7 +356,8 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
   }
 
   public BitstampUserTransaction[] getBitstampUserTransactions(
-      Long numberOfTransactions, CurrencyPair pair, Long offset, String sort) throws IOException {
+      Long numberOfTransactions, CurrencyPair pair, Long offset, String sort, Long sinceTimestamp)
+      throws IOException {
 
     try {
       return bitstampAuthenticatedV2.getUserTransactions(
@@ -366,18 +367,19 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
           new BitstampV2.Pair(pair),
           numberOfTransactions,
           offset,
-          sort);
+          sort,
+          sinceTimestamp);
     } catch (BitstampException e) {
       throw handleError(e);
     }
   }
 
   public BitstampUserTransaction[] getBitstampUserTransactions(
-      Long numberOfTransactions, Long offset, String sort) throws IOException {
+      Long numberOfTransactions, Long offset, String sort, Long sinceTimestamp) throws IOException {
 
     try {
       return bitstampAuthenticatedV2.getUserTransactions(
-          apiKey, signatureCreator, nonceFactory, numberOfTransactions, offset, sort);
+          apiKey, signatureCreator, nonceFactory, numberOfTransactions, offset, sort, sinceTimestamp);
     } catch (BitstampException e) {
       throw handleError(e);
     }

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeHistoryParams.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeHistoryParams.java
@@ -74,6 +74,10 @@ public class BitstampTradeHistoryParams
     return startTime;
   }
 
+  /**
+   * This will fetch historic user trades with a timestamp greater than or equal to startTime.
+   * @param startTime a start time with seconds precision. Milliseconds will be truncated.
+   */
   @Override
   public void setStartTime(Date startTime) {
     this.startTime = startTime;

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeHistoryParams.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeHistoryParams.java
@@ -1,20 +1,24 @@
 package org.knowm.xchange.bitstamp.service;
 
+import java.util.Date;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamOffset;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamsSorted;
+import org.knowm.xchange.service.trade.params.TradeHistoryParamsTimeSpan;
 
 public class BitstampTradeHistoryParams
     implements TradeHistoryParamCurrencyPair,
         TradeHistoryParamsSorted,
         TradeHistoryParamOffset,
-        TradeHistoryParamPaging {
+        TradeHistoryParamPaging,
+        TradeHistoryParamsTimeSpan {
   private CurrencyPair currencyPair;
   private Order order;
   private Integer offset;
   private Integer pageLength;
+  private Date startTime;
 
   public BitstampTradeHistoryParams(CurrencyPair currencyPair, Integer pageLength) {
     this.currencyPair = currencyPair;
@@ -63,6 +67,26 @@ public class BitstampTradeHistoryParams
   @Override
   public Integer getPageNumber() {
     return (offset == null || pageLength == null) ? null : offset / pageLength;
+  }
+
+  @Override
+  public Date getStartTime() {
+    return startTime;
+  }
+
+  @Override
+  public void setStartTime(Date startTime) {
+    this.startTime = startTime;
+  }
+
+  @Override
+  public Date getEndTime() {
+    return null;
+  }
+
+  @Override
+  public void setEndTime(Date endTime) {
+    throw new UnsupportedOperationException("Bitstamp doesn't support end time");
   }
 
   @Override

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeService.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeService.java
@@ -30,8 +30,10 @@ import org.knowm.xchange.service.trade.params.TradeHistoryParamOffset;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamsSorted;
+import org.knowm.xchange.service.trade.params.TradeHistoryParamsTimeSpan;
 import org.knowm.xchange.service.trade.params.orders.DefaultOpenOrdersParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
+import org.knowm.xchange.utils.DateUtils;
 
 /** @author Matija Mazi */
 public class BitstampTradeService extends BitstampTradeServiceRaw implements TradeService {
@@ -120,6 +122,7 @@ public class BitstampTradeService extends BitstampTradeServiceRaw implements Tra
     CurrencyPair currencyPair = null;
     Long offset = null;
     TradeHistoryParamsSorted.Order sort = null;
+    Long sinceTimestamp = null;
     if (params instanceof TradeHistoryParamPaging) {
       limit = Long.valueOf(((TradeHistoryParamPaging) params).getPageLength());
     }
@@ -132,9 +135,13 @@ public class BitstampTradeService extends BitstampTradeServiceRaw implements Tra
     if (params instanceof TradeHistoryParamsSorted) {
       sort = ((TradeHistoryParamsSorted) params).getOrder();
     }
+    if (params instanceof TradeHistoryParamsTimeSpan) {
+      sinceTimestamp =
+          DateUtils.toUnixTimeNullSafe(((TradeHistoryParamsTimeSpan) params).getStartTime());
+    }
     BitstampUserTransaction[] txs =
         getBitstampUserTransactions(
-            limit, currencyPair, offset, sort == null ? null : sort.toString());
+            limit, currencyPair, offset, sort == null ? null : sort.toString(), sinceTimestamp);
     return BitstampAdapters.adaptTradeHistory(txs);
   }
 

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeServiceRaw.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeServiceRaw.java
@@ -116,6 +116,7 @@ public class BitstampTradeServiceRaw extends BitstampBaseService {
           new BitstampV2.Pair(pair),
           numberOfTransactions,
           null,
+          null,
           null);
     } catch (BitstampException e) {
       throw handleError(e);
@@ -124,12 +125,12 @@ public class BitstampTradeServiceRaw extends BitstampBaseService {
 
   public BitstampUserTransaction[] getBitstampUserTransactions(Long numberOfTransactions)
       throws IOException {
-    return getBitstampUserTransactions(numberOfTransactions, null, null);
+    return getBitstampUserTransactions(numberOfTransactions, null, null, null);
   }
 
   public BitstampUserTransaction[] getBitstampUserTransactions(
-      Long numberOfTransactions, CurrencyPair pair, Long offset, String sort) throws IOException {
-
+      Long numberOfTransactions, CurrencyPair pair, Long offset, String sort, Long sinceTimestamp)
+      throws IOException {
     try {
       return bitstampAuthenticatedV2.getUserTransactions(
           apiKey,
@@ -138,17 +139,24 @@ public class BitstampTradeServiceRaw extends BitstampBaseService {
           new BitstampV2.Pair(pair),
           numberOfTransactions,
           offset,
-          sort);
+          sort,
+          sinceTimestamp);
     } catch (BitstampException e) {
       throw handleError(e);
     }
   }
 
   public BitstampUserTransaction[] getBitstampUserTransactions(
-      Long numberOfTransactions, Long offset, String sort) throws IOException {
+      Long numberOfTransactions, Long offset, String sort, Long sinceTimestamp) throws IOException {
     try {
       return bitstampAuthenticatedV2.getUserTransactions(
-          apiKey, signatureCreator, nonceFactory, numberOfTransactions, offset, sort);
+          apiKey,
+          signatureCreator,
+          nonceFactory,
+          numberOfTransactions,
+          offset,
+          sort,
+          sinceTimestamp);
     } catch (BitstampException e) {
       throw handleError(e);
     }


### PR DESCRIPTION
This will make it possible to fetch historic trades based on unix timestamp. Setting a startTime on a TradeHistoryParamsTimeSpan will fetch all UserTrades since that time, inclusive. The resolution is seconds and any milliseconds will be truncated from the timestamp before sending the request.