### PR TITLE
[livecoin] orderbooks parsing fix

### DIFF
--- a/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/LivecoinAdapters.java
+++ b/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/LivecoinAdapters.java
@@ -34,11 +34,11 @@ import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.UserTrade;
 import org.knowm.xchange.livecoin.dto.account.LivecoinBalance;
 import org.knowm.xchange.livecoin.dto.marketdata.LivecoinAllOrderBooks;
+import org.knowm.xchange.livecoin.dto.marketdata.LivecoinOrder;
 import org.knowm.xchange.livecoin.dto.marketdata.LivecoinOrderBook;
 import org.knowm.xchange.livecoin.dto.marketdata.LivecoinRestriction;
 import org.knowm.xchange.livecoin.dto.marketdata.LivecoinTicker;
 import org.knowm.xchange.livecoin.dto.marketdata.LivecoinTrade;
-import org.knowm.xchange.livecoin.service.LivecoinAsksBidsData;
 import org.knowm.xchange.utils.DateUtils;
 
 public class LivecoinAdapters {
@@ -66,13 +66,13 @@ public class LivecoinAdapters {
   }
 
   private static List<LimitOrder> toLimitOrderList(
-      LivecoinAsksBidsData[] levels, OrderType orderType, CurrencyPair currencyPair) {
+      List<LivecoinOrder> levels, OrderType orderType, CurrencyPair currencyPair) {
 
-    if (levels == null || levels.length == 0) {
+    if (levels == null || levels.isEmpty()) {
       return Collections.EMPTY_LIST;
     }
-    List<LimitOrder> allLevels = new ArrayList<>(levels.length);
-    for (LivecoinAsksBidsData ask : levels) {
+    List<LimitOrder> allLevels = new ArrayList<>(levels.size());
+    for (LivecoinOrder ask : levels) {
       if (ask != null) {
         allLevels.add(
             new LimitOrder(orderType, ask.getQuantity(), currencyPair, "0", null, ask.getRate()));

--- a/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/LivecoinErrorAdapter.java
+++ b/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/LivecoinErrorAdapter.java
@@ -18,14 +18,14 @@ public class LivecoinErrorAdapter {
   public static ExchangeException adapt(LivecoinException e) {
     String message = e.getErrorMessage();
     if (StringUtils.isEmpty(message)) {
-      return new ExchangeException("Operation failed without any error message");
+      return new ExchangeException("Operation failed without any error message", e);
     }
     if (UNKNOWN_CURRENCY_MESSAGE.matcher(message).matches()) {
-      return new CurrencyPairNotValidException(message);
+      return new CurrencyPairNotValidException(message, e);
     }
     if (TRADE_SUSPENDED_MESSAGE.matcher(message).matches()) {
-      return new MarketSuspendedException(message);
+      return new MarketSuspendedException(message, e);
     }
-    return new ExchangeException(message);
+    return new ExchangeException(message, e);
   }
 }

--- a/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/dto/marketdata/LivecoinOrder.java
+++ b/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/dto/marketdata/LivecoinOrder.java
@@ -1,26 +1,20 @@
-package org.knowm.xchange.livecoin.service;
+package org.knowm.xchange.livecoin.dto.marketdata;
 
 import java.math.BigDecimal;
 
-public class LivecoinAsksBidsData {
+public class LivecoinOrder {
   private final BigDecimal quantity;
   private final BigDecimal rate;
 
-  /**
-   * @param rate
-   * @param quantity
-   */
-  public LivecoinAsksBidsData(BigDecimal quantity, BigDecimal rate) {
+  public LivecoinOrder(BigDecimal quantity, BigDecimal rate) {
     this.quantity = quantity;
     this.rate = rate;
   }
 
-  /** @return The quantity */
   public BigDecimal getQuantity() {
     return quantity;
   }
 
-  /** @return The rate */
   public BigDecimal getRate() {
     return rate;
   }

--- a/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/dto/marketdata/LivecoinOrderBook.java
+++ b/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/dto/marketdata/LivecoinOrderBook.java
@@ -1,73 +1,42 @@
 package org.knowm.xchange.livecoin.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.math.BigDecimal;
-import java.util.Arrays;
-import org.knowm.xchange.livecoin.service.LivecoinAsksBidsData;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.List;
 
 public class LivecoinOrderBook {
 
   private final Long timestamp;
-  private final LivecoinAsksBidsData[] asks;
-  private final LivecoinAsksBidsData[] bids;
+  private final List<LivecoinOrder> asks;
+  private final List<LivecoinOrder> bids;
 
   public LivecoinOrderBook(
       @JsonProperty("timestamp") Long timestamp,
-      @JsonProperty("asks") Object[][] asks,
-      @JsonProperty("bids") Object[][] bids) {
+      @JsonProperty("asks") @JsonDeserialize(using = LivecoinOrdersDeserializer.class)
+          List<LivecoinOrder> asks,
+      @JsonProperty("bids") @JsonDeserialize(using = LivecoinOrdersDeserializer.class)
+          List<LivecoinOrder> bids) {
     super();
 
     this.timestamp = timestamp;
-
-    if (bids != null && bids.length > 0) {
-      this.bids = new LivecoinAsksBidsData[bids.length];
-      for (int i = 0; i < bids.length; i++) {
-        this.bids[i] = convertToOrderBookEntry(bids[i]);
-      }
-    } else {
-      this.bids = null;
-    }
-
-    if (asks != null && asks.length > 0) {
-      this.asks = new LivecoinAsksBidsData[asks.length];
-      for (int i = 0; i < asks.length; i++) {
-        this.asks[i] = convertToOrderBookEntry(asks[i]);
-      }
-    } else {
-      this.asks = null;
-    }
-  }
-
-  private static LivecoinAsksBidsData convertToOrderBookEntry(Object[] dataObject) {
-    if (dataObject != null && dataObject.length == 2) {
-      BigDecimal volume = new BigDecimal((String) dataObject[0]);
-      BigDecimal price = new BigDecimal((String) dataObject[1]);
-
-      return new LivecoinAsksBidsData(price, volume);
-    }
-    return null;
+    this.asks = asks;
+    this.bids = bids;
   }
 
   public Long getTimestamp() {
     return timestamp;
   }
 
-  public LivecoinAsksBidsData[] getAsks() {
+  public List<LivecoinOrder> getAsks() {
     return asks;
   }
 
-  public LivecoinAsksBidsData[] getBids() {
+  public List<LivecoinOrder> getBids() {
     return bids;
   }
 
   @Override
   public String toString() {
-    return "LivecoinOrderBook [timestamp="
-        + timestamp
-        + ", asks="
-        + Arrays.toString(asks)
-        + ", bids="
-        + Arrays.toString(bids)
-        + "]";
+    return "LivecoinOrderBook [timestamp=" + timestamp + ", asks=" + asks + ", bids=" + bids + "]";
   }
 }

--- a/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/dto/marketdata/LivecoinOrdersDeserializer.java
+++ b/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/dto/marketdata/LivecoinOrdersDeserializer.java
@@ -1,0 +1,47 @@
+package org.knowm.xchange.livecoin.dto.marketdata;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class LivecoinOrdersDeserializer extends JsonDeserializer<List<LivecoinOrder>> {
+
+  @Override
+  public List<LivecoinOrder> deserialize(JsonParser jsonParser, DeserializationContext ctxt)
+      throws IOException, JsonProcessingException {
+    JsonNode array = jsonParser.readValueAsTree();
+    if (array.isNull()) {
+      return Collections.EMPTY_LIST;
+    }
+    if (!array.isArray()) {
+      throw new JsonParseException(array.traverse(), "Expected array");
+    }
+    List<LivecoinOrder> result = new ArrayList<>(array.size());
+    for (int i = 0; i < array.size(); ++i) {
+      JsonNode order = array.get(i);
+      if (!order.isArray() || order.size() < 2) {
+        throw new JsonParseException(order.traverse(), "Expected array of at least two elements");
+      }
+      BigDecimal quantity = toBigDecimal(order.get(0));
+      BigDecimal rate = toBigDecimal(order.get(1));
+      result.add(new LivecoinOrder(quantity, rate));
+    }
+    return result;
+  }
+
+  private BigDecimal toBigDecimal(JsonNode elem) throws JsonProcessingException {
+    try {
+      return new BigDecimal(elem.asText());
+    } catch (NumberFormatException e) {
+      throw new JsonParseException(elem.traverse(), "Expected decimal", e);
+    }
+  }
+}

--- a/xchange-livecoin/src/test/java/org/knowm/xchange/livecoin/service/MarketDataIntegration.java
+++ b/xchange-livecoin/src/test/java/org/knowm/xchange/livecoin/service/MarketDataIntegration.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.livecoin.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
+import java.util.List;
 import java.util.Map;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -12,6 +13,7 @@ import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.exceptions.CurrencyPairNotValidException;
 import org.knowm.xchange.livecoin.LivecoinExchange;
+import org.knowm.xchange.livecoin.dto.marketdata.LivecoinOrder;
 import org.knowm.xchange.livecoin.dto.marketdata.LivecoinOrderBook;
 
 public class MarketDataIntegration {
@@ -48,9 +50,9 @@ public class MarketDataIntegration {
         .isNotNull()
         .containsKeys(CurrencyPair.BTC_USD, CurrencyPair.ETH_BTC);
     LivecoinOrderBook btcUsdOrderBook = orderBooksByPair.get(CurrencyPair.BTC_USD);
-    LivecoinAsksBidsData[] btcUsdAsks = btcUsdOrderBook.getAsks();
+    List<LivecoinOrder> btcUsdAsks = btcUsdOrderBook.getAsks();
     assertThat(btcUsdAsks).isNotEmpty();
-    LivecoinAsksBidsData firstBtcUsdAsk = btcUsdAsks[0];
+    LivecoinOrder firstBtcUsdAsk = btcUsdAsks.get(0);
     assertThat(firstBtcUsdAsk.getQuantity()).isNotNull().isPositive();
   }
 


### PR DESCRIPTION
Livecoin added a third value to their order book entries which broke the current parsing mechanism - it was returning empty order books.

```
{
    "timestamp": 1553777858097,
    "asks": [
        [
            "0.03430012",
            "0.01498781",
            1553777852095
        ],
        [
            "0.03430013",
            "0.00478876",
            1553777849476
        ],
```

I've implemented parsing of these type of arrays in a more proper way