### PR TITLE
#3018 XChange Bitstamp implementation uses not thread safe SimpleDate…

### DIFF
--- a/xchange-bithumb/src/main/java/org/knowm/xchange/bithumb/dto/marketdata/BithumbTransactionHistory.java
+++ b/xchange-bithumb/src/main/java/org/knowm/xchange/bithumb/dto/marketdata/BithumbTransactionHistory.java
@@ -3,14 +3,14 @@ package org.knowm.xchange.bithumb.dto.marketdata;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
+import org.apache.commons.lang3.time.FastDateFormat;
 import org.knowm.xchange.bithumb.BithumbAdapters;
 
 public class BithumbTransactionHistory {
 
-  public static final SimpleDateFormat TRANSACTION_DATE_FORMAT =
-      new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+  public static final FastDateFormat TRANSACTION_DATE_FORMAT =
+      FastDateFormat.getInstance("yyyy-MM-dd HH:mm:ss");
   private final long contNo;
   private final String transactionDate;
   private final BithumbAdapters.OrderType type;

--- a/xchange-bitso/src/main/java/org/knowm/xchange/bitso/BitsoUtils.java
+++ b/xchange-bitso/src/main/java/org/knowm/xchange/bitso/BitsoUtils.java
@@ -1,14 +1,14 @@
 package org.knowm.xchange.bitso;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
+import org.apache.commons.lang3.time.FastDateFormat;
 import org.knowm.xchange.exceptions.ExchangeException;
 
 /** A central place for shared Bitso properties */
 public final class BitsoUtils {
 
-  private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+  private static final FastDateFormat DATE_FORMAT = FastDateFormat.getInstance("yyyy-MM-dd HH:mm:ss");
 
   /** private Constructor */
   private BitsoUtils() {}

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampUtils.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampUtils.java
@@ -1,21 +1,18 @@
 package org.knowm.xchange.bitstamp;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
+import org.apache.commons.lang3.time.FastDateFormat;
 import org.knowm.xchange.exceptions.ExchangeException;
 
 /** A central place for shared Bitstamp properties */
 public final class BitstampUtils {
 
   public static final int MAX_TRANSACTIONS_PER_QUERY = 1000;
-  private static final SimpleDateFormat DATE_FORMAT;
 
-  static {
-    DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-    DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
-  }
+  private static final FastDateFormat DATE_FORMAT =
+          FastDateFormat.getInstance("yyyy-MM-dd HH:mm:ss", TimeZone.getTimeZone("UTC"));
 
   /** private Constructor */
   private BitstampUtils() {}

--- a/xchange-coindeal/src/main/java/org/knowm/xchange/coindeal/dto/trade/CoindealTradeHistory.java
+++ b/xchange-coindeal/src/main/java/org/knowm/xchange/coindeal/dto/trade/CoindealTradeHistory.java
@@ -1,8 +1,6 @@
 package org.knowm.xchange.coindeal.dto.trade;
 
 import com.fasterxml.jackson.annotation.*;
-import java.util.HashMap;
-import java.util.Map;
 
 public class CoindealTradeHistory {
 

--- a/xchange-coindeal/src/test/java/CoindealOrderBookTest.java
+++ b/xchange-coindeal/src/test/java/CoindealOrderBookTest.java
@@ -4,10 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import org.junit.Test;
-import org.knowm.xchange.Exchange;
-import org.knowm.xchange.ExchangeFactory;
-import org.knowm.xchange.ExchangeSpecification;
-import org.knowm.xchange.coindeal.CoindealExchange;
 import org.knowm.xchange.coindeal.dto.marketdata.CoindealOrderBook;
 
 public class CoindealOrderBookTest {

--- a/xchange-coinex/src/main/java/org/knowm/xchange/coinex/dto/CoinexResponse.java
+++ b/xchange-coinex/src/main/java/org/knowm/xchange/coinex/dto/CoinexResponse.java
@@ -2,8 +2,6 @@ package org.knowm.xchange.coinex.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.List;
-
 public class CoinexResponse<T> {
 
     private final int code;

--- a/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/CoinfloorUtils.java
+++ b/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/CoinfloorUtils.java
@@ -1,18 +1,15 @@
 package org.knowm.xchange.coinfloor;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
+import org.apache.commons.lang3.time.FastDateFormat;
 import org.knowm.xchange.exceptions.ExchangeException;
 
 public final class CoinfloorUtils {
 
-  private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-
-  static {
-    DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
-  }
+  private static final FastDateFormat DATE_FORMAT =
+      FastDateFormat.getInstance("yyyy-MM-dd HH:mm:ss", TimeZone.getTimeZone("UTC"));
 
   private CoinfloorUtils() {}
 

--- a/xchange-cryptonit/src/main/java/org/knowm/xchange/cryptonit2/CryptonitUtils.java
+++ b/xchange-cryptonit/src/main/java/org/knowm/xchange/cryptonit2/CryptonitUtils.java
@@ -1,21 +1,17 @@
 package org.knowm.xchange.cryptonit2;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
+import org.apache.commons.lang3.time.FastDateFormat;
 import org.knowm.xchange.exceptions.ExchangeException;
 
 /** A central place for shared Cryptonit properties */
 public final class CryptonitUtils {
 
   public static final int MAX_TRANSACTIONS_PER_QUERY = 1000;
-  private static final SimpleDateFormat DATE_FORMAT;
-
-  static {
-    DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-    DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
-  }
+  private static final FastDateFormat DATE_FORMAT =
+      FastDateFormat.getInstance("yyyy-MM-dd HH:mm:ss", TimeZone.getTimeZone("UTC"));
 
   /** private Constructor */
   private CryptonitUtils() {}

--- a/xchange-gatecoin/src/main/java/org/knowm/xchange/gatecoin/GatecoinUtils.java
+++ b/xchange-gatecoin/src/main/java/org/knowm/xchange/gatecoin/GatecoinUtils.java
@@ -1,14 +1,14 @@
 package org.knowm.xchange.gatecoin;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
+import org.apache.commons.lang3.time.FastDateFormat;
 import org.knowm.xchange.exceptions.ExchangeException;
 
 /** A central place for shared Gatecoin properties */
 public final class GatecoinUtils {
 
-  private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+  private static final FastDateFormat DATE_FORMAT = FastDateFormat.getInstance("yyyy-MM-dd HH:mm:ss");
 
   /** private Constructor */
   private GatecoinUtils() {}

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/util/Util.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/util/Util.java
@@ -1,21 +1,15 @@
 package org.knowm.xchange.independentreserve.util;
 
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
+import org.apache.commons.lang3.time.FastDateFormat;
 
 public class Util {
 
   private static final String TIMEZONE = "UTC";
   private static final String PATTERN = "yyyy-MM-dd'T'HH:mm:ss'Z'";
-  private static final SimpleDateFormat DATE_FORMAT;
-
-  static {
-    DATE_FORMAT = new SimpleDateFormat(PATTERN);
-    DATE_FORMAT.setTimeZone(TimeZone.getTimeZone(TIMEZONE));
-  }
-
-  private Util() {}
+  private static final FastDateFormat DATE_FORMAT =
+      FastDateFormat.getInstance(PATTERN, TimeZone.getTimeZone(TIMEZONE));
 
   /**
    * Format a date String for IR
@@ -24,9 +18,7 @@ public class Util {
    * @return formatted date for Independent Reserve
    */
   public static String formatDate(Date d) {
-    synchronized (DATE_FORMAT) { // SimpleDateFormat is not thread safe, therefore synchronize it
-      return d == null ? null : DATE_FORMAT.format(d);
-    }
+    return d == null ? null : DATE_FORMAT.format(d);
   }
 
   public static Date toDate(String date)

--- a/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/LivecoinAdapters.java
+++ b/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/LivecoinAdapters.java
@@ -4,7 +4,6 @@ import static org.knowm.xchange.currency.Currency.getInstance;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -13,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TimeZone;
 import java.util.stream.Collectors;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -43,15 +41,6 @@ import org.knowm.xchange.utils.DateUtils;
 
 public class LivecoinAdapters {
 
-  private static final SimpleDateFormat dateFormat =
-      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
-
-  static {
-    dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-  }
-
-  private LivecoinAdapters() {}
-
   public static CurrencyPair adaptCurrencyPair(LivecoinRestriction product) {
     String[] data = product.getCurrencyPair().split("\\/");
     return new CurrencyPair(data[0], data[1]);
@@ -69,7 +58,7 @@ public class LivecoinAdapters {
       LivecoinAsksBidsData[] levels, OrderType orderType, CurrencyPair currencyPair) {
 
     if (levels == null || levels.length == 0) {
-      return Collections.EMPTY_LIST;
+      return Collections.emptyList();
     }
     List<LimitOrder> allLevels = new ArrayList<>(levels.length);
     for (LivecoinAsksBidsData ask : levels) {
@@ -135,7 +124,7 @@ public class LivecoinAdapters {
   public static Trades adaptTrades(List<LivecoinTrade> tradesRaw, CurrencyPair currencyPair) {
 
     if (tradesRaw.isEmpty()) {
-      return new Trades(Collections.EMPTY_LIST);
+      return new Trades(Collections.emptyList());
     }
     List<Trade> trades = new ArrayList<>(tradesRaw.size());
 

--- a/xchange-quadrigacx/src/main/java/org/knowm/xchange/quadrigacx/QuadrigaCxUtils.java
+++ b/xchange-quadrigacx/src/main/java/org/knowm/xchange/quadrigacx/QuadrigaCxUtils.java
@@ -1,9 +1,9 @@
 package org.knowm.xchange.quadrigacx;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
+import org.apache.commons.lang3.time.FastDateFormat;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.exceptions.ExchangeException;
 
@@ -12,12 +12,8 @@ public final class QuadrigaCxUtils {
 
   private static final String TIMEZONE = "UTC";
   private static final String PATTERN = "yyyy-MM-dd HH:mm:ss";
-  private static final SimpleDateFormat DATE_FORMAT;
-
-  static {
-    DATE_FORMAT = new SimpleDateFormat(PATTERN);
-    DATE_FORMAT.setTimeZone(TimeZone.getTimeZone(TIMEZONE));
-  }
+  private static final FastDateFormat DATE_FORMAT =
+      FastDateFormat.getInstance(PATTERN, TimeZone.getTimeZone(TIMEZONE));
 
   /** private Constructor */
   private QuadrigaCxUtils() {}
@@ -30,9 +26,7 @@ public final class QuadrigaCxUtils {
    */
   public static Date parseDate(String dateString) {
     try {
-      synchronized (DATE_FORMAT) { // SimpleDateFormat is not thread safe, therefore synchronize it
-        return DATE_FORMAT.parse(dateString);
-      }
+      return DATE_FORMAT.parse(dateString);
     } catch (ParseException e) {
       throw new ExchangeException("Illegal date/time format", e);
     }


### PR DESCRIPTION
Issue #3018 
XChange Bitstamp implementation uses not thread safe SimpleDateFormatter. 
It causes concurrency issue in case using parallel threads. Here is fix for Bitstamp and for some other exchanges as well + some minor syntax fixes (like unused imports)