### PR TITLE
[core] support null values for currency pair

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/OpenOrdersParamCurrencyPair.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/OpenOrdersParamCurrencyPair.java
@@ -13,8 +13,7 @@ public interface OpenOrdersParamCurrencyPair extends OpenOrdersParams {
   @Override
   default boolean accept(Order order) {
     return order != null
-        && getCurrencyPair() != null
-        && getCurrencyPair().equals(order.getCurrencyPair());
+        && (getCurrencyPair() == null || getCurrencyPair().equals(order.getCurrencyPair()));
   }
 
   CurrencyPair getCurrencyPair();


### PR DESCRIPTION
support null values for currency pair inside OpenOrdersParamCurrencyPair class