### PR TITLE
[binance] Add step size to metadata

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceExchange.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceExchange.java
@@ -96,6 +96,7 @@ public class BinanceExchange extends BaseExchange {
 
             BigDecimal minQty = null;
             BigDecimal maxQty = null;
+            BigDecimal stepSize = null;
 
             Filter[] filters = symbol.getFilters();
 
@@ -106,6 +107,7 @@ public class BinanceExchange extends BaseExchange {
                 amountPrecision = Math.min(amountPrecision, numberOfDecimals(filter.getMinQty()));
                 minQty = new BigDecimal(filter.getMinQty()).stripTrailingZeros();
                 maxQty = new BigDecimal(filter.getMaxQty()).stripTrailingZeros();
+                stepSize = new BigDecimal(filter.getStepSize()).stripTrailingZeros();
               }
             }
 
@@ -116,8 +118,9 @@ public class BinanceExchange extends BaseExchange {
                     minQty, // Min amount
                     maxQty, // Max amount
                     pairPrecision, // precision
-                    null /* TODO get fee tiers, although this is not necessary now
-                         because their API returns current fee directly */));
+                    null, /* TODO get fee tiers, although this is not necessary now
+                         because their API returns current fee directly */
+                    stepSize));
             currencies.put(
                 pair.base,
                 new CurrencyMetaData(

--- a/xchange-bleutrade/src/test/java/org/knowm/xchange/bleutrade/BleutradeTestData.java
+++ b/xchange-bleutrade/src/test/java/org/knowm/xchange/bleutrade/BleutradeTestData.java
@@ -4,6 +4,7 @@ import static org.knowm.xchange.bleutrade.BleutradeUtils.toDate;
 
 import java.math.BigDecimal;
 import java.util.Date;
+
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
@@ -185,8 +186,8 @@ public class BleutradeTestData {
 
   protected static String[] expectedMetaDataStr() {
     return new String[] {
-      "CurrencyPairMetaData [tradingFee=0.0025, minimumAmount=0.10000000, maximumAmount=null, priceScale=8]",
-      "CurrencyPairMetaData [tradingFee=0.0025, minimumAmount=1E-8, maximumAmount=null, priceScale=8]"
+      "CurrencyPairMetaData [tradingFee=0.0025, minimumAmount=0.10000000, maximumAmount=null, priceScale=8, amountStepSize=null]",
+      "CurrencyPairMetaData [tradingFee=0.0025, minimumAmount=1E-8, maximumAmount=null, priceScale=8, amountStepSize=null]"
     };
   }
 }

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/meta/CurrencyPairMetaData.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/meta/CurrencyPairMetaData.java
@@ -23,8 +23,13 @@ public class CurrencyPairMetaData implements Serializable {
   @JsonProperty("max_amount")
   private final BigDecimal maximumAmount;
 
+  /** Decimal places in price */
   @JsonProperty("price_scale")
   private final Integer priceScale;
+
+  /** Amount step size. If set, any amounts must be a multiple of this */
+  @JsonProperty("amount_step_size")
+  private final BigDecimal amountStepSize;
 
   /**
    * Constructor
@@ -35,11 +40,30 @@ public class CurrencyPairMetaData implements Serializable {
    * @param priceScale Price scale
    */
   public CurrencyPairMetaData(
+      BigDecimal tradingFee,
+      BigDecimal minimumAmount,
+      BigDecimal maximumAmount,
+      Integer priceScale,
+      FeeTier[] feeTiers) {
+    this(tradingFee, minimumAmount, maximumAmount, priceScale, feeTiers, null);
+  }
+
+  /**
+   * Constructor
+   *
+   * @param tradingFee Trading fee (fraction)
+   * @param minimumAmount Minimum trade amount
+   * @param maximumAmount Maximum trade amount
+   * @param priceScale Price scale
+   * @param amountStepSize Amounts must be a multiple of this amount if set.
+   */
+  public CurrencyPairMetaData(
       @JsonProperty("trading_fee") BigDecimal tradingFee,
       @JsonProperty("min_amount") BigDecimal minimumAmount,
       @JsonProperty("max_amount") BigDecimal maximumAmount,
       @JsonProperty("price_scale") Integer priceScale,
-      @JsonProperty("fee_tiers") FeeTier[] feeTiers) {
+      @JsonProperty("fee_tiers") FeeTier[] feeTiers,
+      @JsonProperty("amount_step_size") BigDecimal amountStepSize) {
 
     this.tradingFee = tradingFee;
     this.minimumAmount = minimumAmount;
@@ -49,6 +73,7 @@ public class CurrencyPairMetaData implements Serializable {
       Arrays.sort(feeTiers);
     }
     this.feeTiers = feeTiers;
+    this.amountStepSize = amountStepSize;
   }
 
   public BigDecimal getTradingFee() {
@@ -76,6 +101,11 @@ public class CurrencyPairMetaData implements Serializable {
     return feeTiers;
   }
 
+  public BigDecimal getAmountStepSize() {
+
+    return amountStepSize;
+  }
+
   @Override
   public String toString() {
 
@@ -87,6 +117,8 @@ public class CurrencyPairMetaData implements Serializable {
         + maximumAmount
         + ", priceScale="
         + priceScale
+        + ", amountStepSize="
+        + amountStepSize
         + "]";
   }
 }


### PR DESCRIPTION
Add the amount step size to `CurrencyPairMetadata`. On Binance, for each currency pair, all trade amounts have to be a multiple of the specified amount otherwise you get a `LOT_SIZE` filter error on placing an order.

I'm assuming Binance can't be the only exchange with this sort of behaviour, so have added it to the core API.