### PR TITLE
[bitfinex] Fix NPE when fetching open stop-limit orders

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexAdapters.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -58,6 +59,8 @@ import org.slf4j.LoggerFactory;
 public final class BitfinexAdapters {
 
   public static final Logger log = LoggerFactory.getLogger(BitfinexAdapters.class);
+
+  private static final AtomicBoolean warnedStopLimit = new AtomicBoolean();
 
   private BitfinexAdapters() {}
 
@@ -423,41 +426,67 @@ public final class BitfinexAdapters {
           Arrays.stream(BitfinexOrderType.values())
               .filter(v -> v.getValue().equals(order.getType()))
               .findFirst();
-      switch (bitfinexOrderType.orElse(null)) {
-        case FILL_OR_KILL:
-          limitOrder = limitOrderCreator.get();
-          limitOrder.addOrderFlag(BitfinexOrderFlags.FILL_OR_KILL);
-          break;
-        case MARGIN_FILL_OR_KILL:
-          limitOrder = limitOrderCreator.get();
-          limitOrder.addOrderFlag(BitfinexOrderFlags.FILL_OR_KILL);
-          limitOrder.addOrderFlag(BitfinexOrderFlags.MARGIN);
-          break;
-        case MARGIN_LIMIT:
-          limitOrder = limitOrderCreator.get();
-          limitOrder.addOrderFlag(BitfinexOrderFlags.MARGIN);
-          break;
-        case MARGIN_STOP:
-          stopOrder = stopOrderCreator.get();
-          stopOrder.addOrderFlag(BitfinexOrderFlags.STOP);
-          stopOrder.addOrderFlag(BitfinexOrderFlags.MARGIN);
-          break;
-        case MARGIN_TRAILING_STOP:
-          limitOrder = limitOrderCreator.get();
-          limitOrder.addOrderFlag(BitfinexOrderFlags.TRAILING_STOP);
-          limitOrder.addOrderFlag(BitfinexOrderFlags.MARGIN);
-          break;
-        case STOP:
-          stopOrder = stopOrderCreator.get();
-          stopOrder.addOrderFlag(BitfinexOrderFlags.STOP);
-          break;
-        case TRAILING_STOP:
-          limitOrder = limitOrderCreator.get();
-          limitOrder.addOrderFlag(BitfinexOrderFlags.TRAILING_STOP);
-          break;
-        default:
-          limitOrder = limitOrderCreator.get();
-          break;
+
+      if (bitfinexOrderType.isPresent()) {
+        switch (bitfinexOrderType.get()) {
+          case FILL_OR_KILL:
+            limitOrder = limitOrderCreator.get();
+            limitOrder.addOrderFlag(BitfinexOrderFlags.FILL_OR_KILL);
+            break;
+          case MARGIN_FILL_OR_KILL:
+            limitOrder = limitOrderCreator.get();
+            limitOrder.addOrderFlag(BitfinexOrderFlags.FILL_OR_KILL);
+            limitOrder.addOrderFlag(BitfinexOrderFlags.MARGIN);
+            break;
+          case MARGIN_LIMIT:
+            limitOrder = limitOrderCreator.get();
+            limitOrder.addOrderFlag(BitfinexOrderFlags.MARGIN);
+            break;
+          case MARGIN_STOP:
+            stopOrder = stopOrderCreator.get();
+            stopOrder.addOrderFlag(BitfinexOrderFlags.STOP);
+            stopOrder.addOrderFlag(BitfinexOrderFlags.MARGIN);
+            break;
+          case MARGIN_STOP_LIMIT:
+            stopLimitWarning();
+            stopOrder = stopOrderCreator.get();
+            stopOrder.addOrderFlag(BitfinexOrderFlags.STOP);
+            stopOrder.addOrderFlag(BitfinexOrderFlags.MARGIN);
+            break;
+          case MARGIN_TRAILING_STOP:
+            limitOrder = limitOrderCreator.get();
+            limitOrder.addOrderFlag(BitfinexOrderFlags.TRAILING_STOP);
+            limitOrder.addOrderFlag(BitfinexOrderFlags.MARGIN);
+            break;
+          case STOP:
+            stopOrder = stopOrderCreator.get();
+            stopOrder.addOrderFlag(BitfinexOrderFlags.STOP);
+            break;
+          case STOP_LIMIT:
+            stopLimitWarning();
+            stopOrder = stopOrderCreator.get();
+            stopOrder.addOrderFlag(BitfinexOrderFlags.STOP);
+            break;
+          case TRAILING_STOP:
+            limitOrder = limitOrderCreator.get();
+            limitOrder.addOrderFlag(BitfinexOrderFlags.TRAILING_STOP);
+            break;
+          case LIMIT:
+            limitOrder = limitOrderCreator.get();
+            break;
+          case MARGIN_MARKET:
+          case MARKET:
+            log.warn("Unexpected market order on book. Defaulting to limit order");
+            limitOrder = limitOrderCreator.get();
+            break;
+          default:
+            log.warn("Unhandled Bitfinex order type [{}]. Defaulting to limit order", order.getType());
+            limitOrder = limitOrderCreator.get();
+            break;
+        }
+      } else {
+        log.warn("Unknown Bitfinex order type [{}]. Defaulting to limit order", order.getType());
+        limitOrder = limitOrderCreator.get();
       }
 
       if (limitOrder != null) {
@@ -468,6 +497,14 @@ public final class BitfinexAdapters {
     }
 
     return new OpenOrders(limitOrders, hiddenOrders);
+  }
+
+  private static void stopLimitWarning() {
+    if (warnedStopLimit.compareAndSet(false, true)) {
+      log.warn("Found a stop-limit order. Bitfinex v1 API does not return limit prices for stop-limit "
+          + "orders so these are returned as stop-at-market orders. This warning will only appear "
+          + "once.");
+    }
   }
 
   public static UserTrades adaptTradeHistory(BitfinexTradeResponse[] trades, String symbol) {
@@ -543,9 +580,9 @@ public final class BitfinexAdapters {
    * Flipped order of arguments to avoid type-erasure clash with {@link #adaptMetaData(List,
    * ExchangeMetaData)}
    *
-   * @param exchangeMetaData
-   * @param symbolDetails
-   * @return
+   * @param exchangeMetaData The exchange metadata provided from bitfinex.json.
+   * @param symbolDetails The symbol data fetced from Bitfinex.
+   * @return The combined result.
    */
   public static ExchangeMetaData adaptMetaData(
       ExchangeMetaData exchangeMetaData,
@@ -699,8 +736,8 @@ public final class BitfinexAdapters {
     /**
      * Constructor
      *
-     * @param timestamp
-     * @param limitOrders
+     * @param timestamp The timestamp for the data fetched.
+     * @param limitOrders The orders.
      */
     public OrdersContainer(long timestamp, List<LimitOrder> limitOrders) {
 

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexOrderType.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexOrderType.java
@@ -4,11 +4,13 @@ public enum BitfinexOrderType {
   MARKET("exchange market"),
   LIMIT("exchange limit"),
   STOP("exchange stop"),
+  STOP_LIMIT("exchange stop limit"),
   TRAILING_STOP("exchange trailing-stop"),
   FILL_OR_KILL("exchange fill-or-kill"),
   MARGIN_MARKET("market"),
   MARGIN_LIMIT("limit"),
   MARGIN_STOP("stop"),
+  MARGIN_STOP_LIMIT("stop limit"),
   MARGIN_TRAILING_STOP("trailing-stop"),
   MARGIN_FILL_OR_KILL("fill-or-kill");
 


### PR DESCRIPTION
Also report unhandled order types in the future and warn where the data returned won't be accurate.

This code really needs to be moved to the v2 API which fully supports all order types.