### PR TITLE
[core] - Added support for tradingFeeCurrency to CurrencyPairMetaData

### DIFF
--- a/xchange-bleutrade/src/test/java/org/knowm/xchange/bleutrade/BleutradeTestData.java
+++ b/xchange-bleutrade/src/test/java/org/knowm/xchange/bleutrade/BleutradeTestData.java
@@ -185,8 +185,8 @@ public class BleutradeTestData {
 
   protected static String[] expectedMetaDataStr() {
     return new String[] {
-      "CurrencyPairMetaData [tradingFee=0.0025, minimumAmount=0.10000000, maximumAmount=null, priceScale=8, amountStepSize=null]",
-      "CurrencyPairMetaData [tradingFee=0.0025, minimumAmount=1E-8, maximumAmount=null, priceScale=8, amountStepSize=null]"
+      "CurrencyPairMetaData [tradingFee=0.0025, minimumAmount=0.10000000, maximumAmount=null, priceScale=8, amountStepSize=null, tradingFeeCurrency=null]",
+      "CurrencyPairMetaData [tradingFee=0.0025, minimumAmount=1E-8, maximumAmount=null, priceScale=8, amountStepSize=null, tradingFeeCurrency=null]"
     };
   }
 }

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/meta/CurrencyPairMetaData.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/meta/CurrencyPairMetaData.java
@@ -4,32 +4,30 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Arrays;
+import org.knowm.xchange.currency.Currency;
 
 public class CurrencyPairMetaData implements Serializable {
 
   /** Trading fee (fraction) */
-  @JsonProperty("trading_fee")
   private final BigDecimal tradingFee;
 
   /** Trading fee tiers by volume (fraction). Sorted in ascending order by quantity */
-  @JsonProperty("fee_tiers")
   private final FeeTier[] feeTiers;
 
   /** Minimum trade amount */
-  @JsonProperty("min_amount")
   private final BigDecimal minimumAmount;
 
   /** Maximum trade amount */
-  @JsonProperty("max_amount")
   private final BigDecimal maximumAmount;
 
   /** Decimal places in price */
-  @JsonProperty("price_scale")
   private final Integer priceScale;
 
   /** Amount step size. If set, any amounts must be a multiple of this */
-  @JsonProperty("amount_step_size")
   private final BigDecimal amountStepSize;
+
+  /** Currency that will be used to change for this trade. */
+  private final Currency tradingFeeCurrency;
 
   /**
    * Constructor
@@ -45,7 +43,26 @@ public class CurrencyPairMetaData implements Serializable {
       BigDecimal maximumAmount,
       Integer priceScale,
       FeeTier[] feeTiers) {
-    this(tradingFee, minimumAmount, maximumAmount, priceScale, feeTiers, null);
+    this(tradingFee, minimumAmount, maximumAmount, priceScale, feeTiers, null, null);
+  }
+
+  /**
+   * Constructor
+   *
+   * @param tradingFee Trading fee (fraction)
+   * @param minimumAmount Minimum trade amount
+   * @param maximumAmount Maximum trade amount
+   * @param priceScale Price scale
+   * @param amountStepSize Amounts must be a multiple of this amount if set.
+   */
+  public CurrencyPairMetaData(
+      BigDecimal tradingFee,
+      BigDecimal minimumAmount,
+      BigDecimal maximumAmount,
+      Integer priceScale,
+      FeeTier[] feeTiers,
+      BigDecimal amountStepSize) {
+    this(tradingFee, minimumAmount, maximumAmount, priceScale, feeTiers, amountStepSize, null);
   }
 
   /**
@@ -63,7 +80,8 @@ public class CurrencyPairMetaData implements Serializable {
       @JsonProperty("max_amount") BigDecimal maximumAmount,
       @JsonProperty("price_scale") Integer priceScale,
       @JsonProperty("fee_tiers") FeeTier[] feeTiers,
-      @JsonProperty("amount_step_size") BigDecimal amountStepSize) {
+      @JsonProperty("amount_step_size") BigDecimal amountStepSize,
+      @JsonProperty("trading_fee_currency") Currency tradingFeeCurrency) {
 
     this.tradingFee = tradingFee;
     this.minimumAmount = minimumAmount;
@@ -74,6 +92,7 @@ public class CurrencyPairMetaData implements Serializable {
     }
     this.feeTiers = feeTiers;
     this.amountStepSize = amountStepSize;
+    this.tradingFeeCurrency = tradingFeeCurrency;
   }
 
   public BigDecimal getTradingFee() {
@@ -106,6 +125,10 @@ public class CurrencyPairMetaData implements Serializable {
     return amountStepSize;
   }
 
+  public Currency getTradingFeeCurrency() {
+    return tradingFeeCurrency;
+  }
+
   @Override
   public String toString() {
 
@@ -119,6 +142,8 @@ public class CurrencyPairMetaData implements Serializable {
         + priceScale
         + ", amountStepSize="
         + amountStepSize
+        + ", tradingFeeCurrency="
+        + tradingFeeCurrency
         + "]";
   }
 }

--- a/xchange-core/src/test/java/org/knowm/xchange/dto/meta/ExchangeMetaDataTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/dto/meta/ExchangeMetaDataTest.java
@@ -1,9 +1,16 @@
 package org.knowm.xchange.dto.meta;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
 import org.junit.Test;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
 
 public class ExchangeMetaDataTest {
 
@@ -41,5 +48,23 @@ public class ExchangeMetaDataTest {
   @Test
   public void testGetPollDelayMillisEmpty() {
     assertEquals(null, ExchangeMetaData.getPollDelayMillis(new RateLimit[0]));
+  }
+
+  @Test
+  public void shouldDeserialize() throws IOException {
+    InputStream is =
+        ExchangeMetaDataTest.class.getResourceAsStream(
+            "/org/knowm/xchange/core/meta/exchange-metadata.json");
+
+    ObjectMapper mapper = new ObjectMapper();
+    ExchangeMetaData metaData = mapper.readValue(is, ExchangeMetaData.class);
+
+    assertThat(metaData.getCurrencyPairs().get(CurrencyPair.BTC_USD).getTradingFeeCurrency())
+        .isEqualTo(Currency.USD);
+    assertThat(metaData.getCurrencyPairs().get(CurrencyPair.BTC_USD).getPriceScale()).isEqualTo(2);
+    assertThat(metaData.getCurrencyPairs().get(CurrencyPair.BTC_USD).getMinimumAmount())
+        .isEqualTo(new BigDecimal("0.0001"));
+    assertThat(metaData.getCurrencyPairs().get(CurrencyPair.BTC_USD).getMaximumAmount())
+        .isEqualTo(new BigDecimal("100"));
   }
 }

--- a/xchange-core/src/test/resources/org/knowm/xchange/core/meta/exchange-metadata.json
+++ b/xchange-core/src/test/resources/org/knowm/xchange/core/meta/exchange-metadata.json
@@ -1,0 +1,10 @@
+{
+  "currency_pairs": {
+    "BTC/USD": {
+      "price_scale": 2,
+      "min_amount": 0.0001,
+      "max_amount": 100,
+      "trading_fee_currency": "USD"
+    }
+  }
+}


### PR DESCRIPTION
This is a relatively small PR to address one of the issues raised in https://github.com/knowm/XChange/issues/1544 , it adds a new field `tradingFeeCurrency` to the CurrencyPairMetaData class. 

Future changes can leverage this to better calculate and present fee's to the client even if not returned by the API.

I have not gone through all the exchanges to populate the metadata but am happy to cover some exchanges if this PR gets merged. We could add a default mechanism to always fallback to the counter but that might give users a false sense of quality so i did not do that as part of this PR.