### PR TITLE
[Binance] Fix for wrong information for some currencies and currency pairs in meta data

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceExchange.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceExchange.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.knowm.xchange.BaseExchange;
 import org.knowm.xchange.ExchangeSpecification;
-import org.knowm.xchange.binance.dto.marketdata.BinancePrice;
 import org.knowm.xchange.binance.dto.meta.exchangeinfo.BinanceExchangeInfo;
 import org.knowm.xchange.binance.dto.meta.exchangeinfo.Filter;
 import org.knowm.xchange.binance.dto.meta.exchangeinfo.Symbol;
@@ -81,61 +80,57 @@ public class BinanceExchange extends BaseExchange {
       exchangeInfo = marketDataService.getExchangeInfo();
       Symbol[] symbols = exchangeInfo.getSymbols();
 
-      for (BinancePrice price : marketDataService.tickerAllPrices()) {
-        CurrencyPair pair = price.getCurrencyPair();
+      for (Symbol symbol : symbols) {
+        if (!symbol.getStatus().equals("BREAK")) { // Symbols with status "BREAK" are delisted
+          int basePrecision = Integer.parseInt(symbol.getBaseAssetPrecision());
+          int counterPrecision = Integer.parseInt(symbol.getQuotePrecision());
+          int pairPrecision = 8;
+          int amountPrecision = 8;
 
-        for (Symbol symbol : symbols) {
-          if (symbol
-              .getSymbol()
-              .equals(pair.base.getCurrencyCode() + pair.counter.getCurrencyCode())) {
+          BigDecimal minQty = null;
+          BigDecimal maxQty = null;
+          BigDecimal stepSize = null;
 
-            int basePrecision = Integer.parseInt(symbol.getBaseAssetPrecision());
-            int counterPrecision = Integer.parseInt(symbol.getQuotePrecision());
-            int pairPrecision = 8;
-            int amountPrecision = 8;
+          Filter[] filters = symbol.getFilters();
 
-            BigDecimal minQty = null;
-            BigDecimal maxQty = null;
-            BigDecimal stepSize = null;
+          CurrencyPair currentCurrencyPair =
+              new CurrencyPair(symbol.getBaseAsset(), symbol.getQuoteAsset());
 
-            Filter[] filters = symbol.getFilters();
-
-            for (Filter filter : filters) {
-              if (filter.getFilterType().equals("PRICE_FILTER")) {
-                pairPrecision = Math.min(pairPrecision, numberOfDecimals(filter.getTickSize()));
-              } else if (filter.getFilterType().equals("LOT_SIZE")) {
-                amountPrecision = Math.min(amountPrecision, numberOfDecimals(filter.getMinQty()));
-                minQty = new BigDecimal(filter.getMinQty()).stripTrailingZeros();
-                maxQty = new BigDecimal(filter.getMaxQty()).stripTrailingZeros();
-                stepSize = new BigDecimal(filter.getStepSize()).stripTrailingZeros();
-              }
+          for (Filter filter : filters) {
+            if (filter.getFilterType().equals("PRICE_FILTER")) {
+              pairPrecision = Math.min(pairPrecision, numberOfDecimals(filter.getTickSize()));
+            } else if (filter.getFilterType().equals("LOT_SIZE")) {
+              amountPrecision = Math.min(amountPrecision, numberOfDecimals(filter.getMinQty()));
+              minQty = new BigDecimal(filter.getMinQty()).stripTrailingZeros();
+              maxQty = new BigDecimal(filter.getMaxQty()).stripTrailingZeros();
+              stepSize = new BigDecimal(filter.getStepSize()).stripTrailingZeros();
             }
-
-            currencyPairs.put(
-                price.getCurrencyPair(),
-                new CurrencyPairMetaData(
-                    new BigDecimal("0.1"), // Trading fee at Binance is 0.1 %
-                    minQty, // Min amount
-                    maxQty, // Max amount
-                    pairPrecision, // precision
-                    null, /* TODO get fee tiers, although this is not necessary now
-                          because their API returns current fee directly */
-                    stepSize));
-            currencies.put(
-                pair.base,
-                new CurrencyMetaData(
-                    basePrecision,
-                    currencies.containsKey(pair.base)
-                        ? currencies.get(pair.base).getWithdrawalFee()
-                        : null));
-            currencies.put(
-                pair.counter,
-                new CurrencyMetaData(
-                    counterPrecision,
-                    currencies.containsKey(pair.counter)
-                        ? currencies.get(pair.counter).getWithdrawalFee()
-                        : null));
           }
+
+          currencyPairs.put(
+              currentCurrencyPair,
+              new CurrencyPairMetaData(
+                  new BigDecimal("0.1"), // Trading fee at Binance is 0.1 %
+                  minQty, // Min amount
+                  maxQty, // Max amount
+                  pairPrecision, // precision
+                  null, /* TODO get fee tiers, although this is not necessary now
+                        because their API returns current fee directly */
+                  stepSize));
+          currencies.put(
+              new Currency(symbol.getBaseAsset()),
+              new CurrencyMetaData(
+                  basePrecision,
+                  currencies.containsKey(currentCurrencyPair.base)
+                      ? currencies.get(currentCurrencyPair.base).getWithdrawalFee()
+                      : null));
+          currencies.put(
+              new Currency(symbol.getQuoteAsset()),
+              new CurrencyMetaData(
+                  counterPrecision,
+                  currencies.containsKey(currentCurrencyPair.counter)
+                      ? currencies.get(currentCurrencyPair.counter).getWithdrawalFee()
+                      : null));
         }
       }
     } catch (Exception e) {

--- a/xchange-binance/src/test/java/org/knowm/xchange/test/binance/AccountServiceIntegration.java
+++ b/xchange-binance/src/test/java/org/knowm/xchange/test/binance/AccountServiceIntegration.java
@@ -41,18 +41,32 @@ public class AccountServiceIntegration {
     Map<CurrencyPair, CurrencyPairMetaData> currencyPairs =
         exchange.getExchangeMetaData().getCurrencyPairs();
     Map<Currency, CurrencyMetaData> currencies = exchange.getExchangeMetaData().getCurrencies();
+    CurrencyPair currPair;
+    Currency curr;
 
-    CurrencyPair currPair =
+    currPair =
         currencyPairs.keySet().stream()
             .filter(cp -> "ETH/BTC".equals(cp.toString()))
             .collect(StreamUtils.singletonCollector());
     Assert.assertNotNull(currPair);
 
-    Currency cur =
-        currencies.keySet().stream()
-            .filter(c -> Currency.BTC == c)
+    currPair =
+        currencyPairs.keySet().stream()
+            .filter(cp -> "IOTX/ETH".equals(cp.toString()))
             .collect(StreamUtils.singletonCollector());
-    Assert.assertNotNull(cur);
+    Assert.assertNotNull(currPair);
+
+    curr =
+        currencies.keySet().stream()
+            .filter(c -> Currency.BTC.equals(c))
+            .collect(StreamUtils.singletonCollector());
+    Assert.assertNotNull(curr);
+
+    curr =
+        currencies.keySet().stream()
+            .filter(c -> c.equals(new Currency("IOTX")))
+            .collect(StreamUtils.singletonCollector());
+    Assert.assertNotNull(curr);
   }
 
   @Test


### PR DESCRIPTION
As described in #3073, the meta data for certain currencies and currency pairs such as IOTX/BTC is not correctly stored and retrieved for Binance. 

The root cause of this problem is in the initialization routine for Binance.  

Within the `remoteInit()` method in `BinanceExchange.java` we find the following code:
```Symbol[] symbols = exchangeInfo.getSymbols();

for (BinancePrice price : marketDataService.tickerAllPrices()) {
  CurrencyPair pair = price.getCurrencyPair();

  for (Symbol symbol : symbols) {
    if (symbol
        .getSymbol()
        .equals(pair.base.getCurrencyCode() + pair.counter.getCurrencyCode())) {
```

Interestingly, this routine combines two for-loops while only one is necessary since you want to iterate just once over the currency pairs. Additionally, we see two ways of receiving the information: Once the information about the symbols is received via the designated way (`exchangeInfo.getSymbols()` maps to `GET /api/v1/exchangeInfo`) including all the details. In the second way the currency pairs are received via the price information (`marketDataService.tickerAllPrices(marketDataService.tickerAllPrices()` maps to `GET api/v1/ticker/allPrices`). 

If we look at the responses from Binance we can guess already why this problem exists. The designated way gets a response that clearly shows which currencies are used in the currency pair IOTXETH, i.e. IOTX and ETH
```
symbol | "IOTXETH"
status | "TRADING"
baseAsset | "IOTX"
baseAssetPrecision | 8
quoteAsset | "ETH"
quotePrecision | 8
orderTypes | […]
icebergAllowed | true
isSpotTradingAllowed | true
isMarginTradingAllowed | false
```
while in the second way the response contains only the string “IOTXETH”, which is later not split correctly into its currencies.
```
symbol	"IOTXETH"
price	"0.00005001"
```

If we dig deeper, we find the reason for this behaviour. Getting the prices triggers the routine `getCurrencyPairFromString(String currencyPairString)` from the `CurrencyPairDeserializer` class that tries to guess the right way to split the string. While this function is really cool it cannot be expected to guess every currency pair correctly. One currency pair, where it fails, is “IOTXETH”, where it splits the string into “IOT” and “XETH”. 

There are two ways to fix the problem. First, one could try to fix the `CurrencyPairDeserializer` for all currency pairs where the function is working incorrectly. However, this function is already really great at doing its job and I believe it will not be possible to get this function right for every current and future currency pair. Secondly, we might change the for-loop in the Binance class and dispense the price function to receive symbols altogether. This seems way better since we get the full and accurate information already with the `exchangeInfo.getSymbols()` so that we should not abuse the price function to do something it is not designed for. I assume that the author used the price function to only get the currency pairs that are currently traded on Binance. However, we can get this information also from the exchange symbols themselves, which have attached a status. We would filter out all symbols with the status “BREAK” since these symbols have been delisted by Binance. We would keep all symbols with other status values since trading might only be stopped for a temporary period. Thus, our fixed function looks like:
```
for (Symbol symbol : symbols) {
  if (!symbol.getStatus().equals("BREAK")) { // Symbols with status "BREAK" are delisted
```

In order to keep the correct behaviour in future implementations, we also add two test cases that previously would have failed but now show the correct behaviour:
```
currPair =
    currencyPairs.keySet().stream()
        .filter(cp -> "IOTX/ETH".equals(cp.toString()))
        .collect(StreamUtils.singletonCollector());
Assert.assertNotNull(currPair);

curr =
    currencies.keySet().stream()
        .filter(c -> c.equals(new Currency("IOTX")))
        .collect(StreamUtils.singletonCollector());
Assert.assertNotNull(curr);
```


