### PR TITLE
[poloniex] Adding missing fields and tests for AccountService.getFundingHistory

### DIFF
--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAdapters.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAdapters.java
@@ -5,11 +5,7 @@ import static org.knowm.xchange.dto.account.FundingRecord.Type.WITHDRAWAL;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.LoanOrder;
@@ -32,17 +28,8 @@ import org.knowm.xchange.dto.trade.UserTrade;
 import org.knowm.xchange.poloniex.dto.LoanInfo;
 import org.knowm.xchange.poloniex.dto.account.PoloniexBalance;
 import org.knowm.xchange.poloniex.dto.account.PoloniexLoan;
-import org.knowm.xchange.poloniex.dto.marketdata.PoloniexCurrencyInfo;
-import org.knowm.xchange.poloniex.dto.marketdata.PoloniexDepth;
-import org.knowm.xchange.poloniex.dto.marketdata.PoloniexLevel;
-import org.knowm.xchange.poloniex.dto.marketdata.PoloniexMarketData;
-import org.knowm.xchange.poloniex.dto.marketdata.PoloniexPublicTrade;
-import org.knowm.xchange.poloniex.dto.marketdata.PoloniexTicker;
-import org.knowm.xchange.poloniex.dto.trade.PoloniexDeposit;
-import org.knowm.xchange.poloniex.dto.trade.PoloniexDepositsWithdrawalsResponse;
-import org.knowm.xchange.poloniex.dto.trade.PoloniexOpenOrder;
-import org.knowm.xchange.poloniex.dto.trade.PoloniexUserTrade;
-import org.knowm.xchange.poloniex.dto.trade.PoloniexWithdrawal;
+import org.knowm.xchange.poloniex.dto.marketdata.*;
+import org.knowm.xchange.poloniex.dto.trade.*;
 
 /**
  * @author Zach Holmes
@@ -286,7 +273,7 @@ public class PoloniexAdapters {
               d.getTimestamp(),
               Currency.getInstance(d.getCurrency()),
               d.getAmount(),
-              null,
+              String.valueOf(d.getDepositNumber()),
               d.getTxid(),
               DEPOSIT,
               FundingRecord.Status.resolveStatus(d.getStatus()),
@@ -299,6 +286,10 @@ public class PoloniexAdapters {
       final String statusStr = statusParts[0];
       final FundingRecord.Status status = FundingRecord.Status.resolveStatus(statusStr);
       final String externalId = statusParts.length == 1 ? null : statusParts[1];
+
+      // Poloniex returns the fee as an absolute value, that behaviour differs from UserTrades
+      final BigDecimal feeAmount = w.getFee();
+
       fundingRecords.add(
           new FundingRecord(
               w.getAddress(),
@@ -310,7 +301,7 @@ public class PoloniexAdapters {
               WITHDRAWAL,
               status,
               null,
-              null,
+              feeAmount,
               w.getStatus()));
     }
     return fundingRecords;

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/trade/PoloniexDeposit.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/trade/PoloniexDeposit.java
@@ -13,6 +13,8 @@ public class PoloniexDeposit {
   private final String txid;
   private final Date timestamp;
   private final String status;
+  private final long depositNumber;
+  private final String category;
 
   public PoloniexDeposit(
       @JsonProperty("currency") String currency,
@@ -21,7 +23,9 @@ public class PoloniexDeposit {
       @JsonProperty("confirmations") int confirmations,
       @JsonProperty("txid") String txid,
       @JsonProperty("timestamp") long timestamp,
-      @JsonProperty("status") String status) {
+      @JsonProperty("status") String status,
+      @JsonProperty("depositNumber") long depositNumber,
+      @JsonProperty("category") String category) {
     super();
     this.currency = currency;
     this.address = address;
@@ -30,6 +34,8 @@ public class PoloniexDeposit {
     this.txid = txid;
     this.timestamp = new Date(timestamp * 1000);
     this.status = status;
+    this.depositNumber = depositNumber;
+    this.category = category;
   }
 
   public String getCurrency() {
@@ -60,6 +66,14 @@ public class PoloniexDeposit {
     return status;
   }
 
+  public long getDepositNumber() {
+    return depositNumber;
+  }
+
+  public String getCategory() {
+    return category;
+  }
+
   @Override
   public String toString() {
     return "PoloniexDeposit [currency="
@@ -76,6 +90,10 @@ public class PoloniexDeposit {
         + timestamp
         + ", status="
         + status
+        + ", depositNumber="
+        + depositNumber
+        + ", category="
+        + category
         + "]";
   }
 }

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/trade/PoloniexWithdrawal.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/trade/PoloniexWithdrawal.java
@@ -10,26 +10,32 @@ public class PoloniexWithdrawal {
   private final String currency;
   private final String address;
   private final BigDecimal amount;
+  private final BigDecimal fee;
   private final Date timestamp;
   private final String status;
   private final String ipAddress;
+  private final String paymentID;
 
   public PoloniexWithdrawal(
       @JsonProperty("withdrawalNumber") long withdrawalNumber,
       @JsonProperty("currency") String currency,
       @JsonProperty("address") String address,
       @JsonProperty("amount") BigDecimal amount,
+      @JsonProperty("fee") BigDecimal fee,
       @JsonProperty("timestamp") long timestamp,
       @JsonProperty("status") String status,
-      @JsonProperty("ipAddress") String ipAddress) {
+      @JsonProperty("ipAddress") String ipAddress,
+      @JsonProperty("paymentID") String paymentID) {
     super();
     this.withdrawalNumber = withdrawalNumber;
     this.currency = currency;
     this.address = address;
     this.amount = amount;
+    this.fee = fee;
     this.timestamp = new Date(timestamp * 1000);
     this.status = status;
     this.ipAddress = ipAddress;
+    this.paymentID = paymentID;
   }
 
   public long getWithdrawalNumber() {
@@ -48,6 +54,10 @@ public class PoloniexWithdrawal {
     return amount;
   }
 
+  public BigDecimal getFee() {
+    return fee;
+  }
+
   public Date getTimestamp() {
     return timestamp;
   }
@@ -60,6 +70,10 @@ public class PoloniexWithdrawal {
     return ipAddress;
   }
 
+  public String getPaymentID() {
+    return paymentID;
+  }
+
   @Override
   public String toString() {
     return "PoloniexWithdrawal [withdrawalNumber="
@@ -70,12 +84,16 @@ public class PoloniexWithdrawal {
         + address
         + ", amount="
         + amount
+        + ", fee="
+        + fee
         + ", timestamp="
         + timestamp
         + ", status="
         + status
         + ", ipAddress="
         + ipAddress
+        + ", paymentID="
+        + paymentID
         + "]";
   }
 }

--- a/xchange-poloniex/src/test/java/org/knowm/xchange/poloniex/PoloniexAdapterTest.java
+++ b/xchange-poloniex/src/test/java/org/knowm/xchange/poloniex/PoloniexAdapterTest.java
@@ -1,13 +1,25 @@
 package org.knowm.xchange.poloniex;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
+import java.util.Date;
+import java.util.List;
+import org.assertj.core.data.Offset;
 import org.junit.Assert;
 import org.junit.Test;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.dto.account.FundingRecord;
 import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.poloniex.dto.marketdata.PoloniexLoansDataTest;
+import org.knowm.xchange.poloniex.dto.trade.PoloniexDepositsWithdrawalsResponse;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexUserTrade;
 
 public class PoloniexAdapterTest {
@@ -30,5 +42,65 @@ public class PoloniexAdapterTest {
     Assert.assertEquals(new BigDecimal("0.03000000"), result.getCumulativeAmount());
     Assert.assertEquals(null, result.getOriginalAmount());
     Assert.assertEquals("102", result.getId());
+  }
+
+  @Test
+  public void testFundingHistory() throws JsonParseException, JsonMappingException, IOException {
+
+    final InputStream is =
+        PoloniexLoansDataTest.class.getResourceAsStream(
+            "/org/knowm/xchange/poloniex/dto/account/deposits-withdrawals.json");
+
+    final ObjectMapper mapper =
+        new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    final PoloniexDepositsWithdrawalsResponse response =
+        mapper.readValue(is, PoloniexDepositsWithdrawalsResponse.class);
+
+    final List<FundingRecord> fundingRecords = PoloniexAdapters.adaptFundingRecords(response);
+
+    assertThat(fundingRecords).hasSize(2);
+    final FundingRecord deposit =
+        fundingRecords.stream()
+            .filter(record -> record.getType() == FundingRecord.Type.DEPOSIT)
+            .findFirst()
+            .orElseThrow(NullPointerException::new);
+
+    assertThat(deposit.getAddress()).isEqualTo("0xf015a632ac1d13aeca3513c8c76c96334c5861a3");
+    assertThat(deposit.getDate()).isEqualTo(new Date(1556178200000L));
+    assertThat(deposit.getCurrency()).isEqualTo(Currency.ETH);
+    assertThat(deposit.getAmount())
+        .isCloseTo(new BigDecimal("8.995"), Offset.offset(BigDecimal.ZERO));
+    assertThat(deposit.getInternalId()).isEqualTo("152426993");
+    assertThat(deposit.getBlockchainTransactionHash())
+        .isEqualTo("0xa7bc2c38e97c1ed9cee7436da5912ba8c7d721dce9884ca8f6ab3e35da31dd44");
+    assertThat(deposit.getType()).isEqualTo(FundingRecord.Type.DEPOSIT);
+    assertThat(deposit.getStatus()).isEqualTo(FundingRecord.Status.COMPLETE);
+    assertThat(deposit.getBalance()).isNull();
+    assertThat(deposit.getFee()).isNull();
+    assertThat(deposit.getDescription()).isEqualTo("COMPLETE");
+
+    final FundingRecord withdrawal =
+        fundingRecords.stream()
+            .filter(record -> record.getType() == FundingRecord.Type.WITHDRAWAL)
+            .findFirst()
+            .orElseThrow(NullPointerException::new);
+
+    assertThat(withdrawal.getAddress()).isEqualTo("0x4120F5b5A6adA3B543da0535e7a9844689f5016C");
+    assertThat(withdrawal.getDate()).isEqualTo(new Date(1556435569000L));
+    assertThat(withdrawal.getCurrency()).isEqualTo(Currency.ETH);
+    assertThat(withdrawal.getAmount())
+        .isCloseTo(new BigDecimal("2.0"), Offset.offset(BigDecimal.ZERO));
+    assertThat(withdrawal.getInternalId()).isEqualTo("19322067");
+    assertThat(withdrawal.getBlockchainTransactionHash())
+        .isEqualTo("0xf85d3870a4c9a077cd333f59ad49db7f2b21e4a67326961c09d629f6a7bb2e9d");
+    assertThat(withdrawal.getType()).isEqualTo(FundingRecord.Type.WITHDRAWAL);
+    assertThat(withdrawal.getStatus()).isEqualTo(FundingRecord.Status.COMPLETE);
+    assertThat(withdrawal.getBalance()).isNull();
+    assertThat(withdrawal.getFee())
+        .isCloseTo(new BigDecimal("0.01"), Offset.offset(BigDecimal.ZERO));
+    ;
+    assertThat(withdrawal.getDescription())
+        .isEqualTo("COMPLETE: 0xf85d3870a4c9a077cd333f59ad49db7f2b21e4a67326961c09d629f6a7bb2e9d");
   }
 }

--- a/xchange-poloniex/src/test/java/org/knowm/xchange/poloniex/dto/account/PoloniexFundingsDataTest.java
+++ b/xchange-poloniex/src/test/java/org/knowm/xchange/poloniex/dto/account/PoloniexFundingsDataTest.java
@@ -1,0 +1,68 @@
+package org.knowm.xchange.poloniex.dto.account;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.util.Date;
+import org.assertj.core.data.Offset;
+import org.junit.Test;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.poloniex.dto.marketdata.PoloniexLoansDataTest;
+import org.knowm.xchange.poloniex.dto.trade.PoloniexDeposit;
+import org.knowm.xchange.poloniex.dto.trade.PoloniexDepositsWithdrawalsResponse;
+import org.knowm.xchange.poloniex.dto.trade.PoloniexWithdrawal;
+
+public class PoloniexFundingsDataTest {
+
+  @Test
+  public void testUnmarshallDepositsWithdrawalsResponse()
+      throws JsonParseException, JsonMappingException, IOException {
+
+    final InputStream is =
+        PoloniexLoansDataTest.class.getResourceAsStream(
+            "/org/knowm/xchange/poloniex/dto/account/deposits-withdrawals.json");
+
+    final ObjectMapper mapper =
+        new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    final PoloniexDepositsWithdrawalsResponse response =
+        mapper.readValue(is, PoloniexDepositsWithdrawalsResponse.class);
+
+    assertThat(response.getDeposits()).hasSize(1);
+
+    final PoloniexDeposit deposit = response.getDeposits().get(0);
+    assertThat(deposit.getCurrency()).isEqualTo(Currency.ETH.getCurrencyCode());
+    assertThat(deposit.getAddress()).isEqualTo("0xf015a632ac1d13aeca3513c8c76c96334c5861a3");
+    assertThat(deposit.getAmount())
+        .isCloseTo(new BigDecimal("8.995"), Offset.offset(BigDecimal.ZERO));
+    assertThat(deposit.getConfirmations()).isEqualTo(38);
+    assertThat(deposit.getTxid())
+        .isEqualTo("0xa7bc2c38e97c1ed9cee7436da5912ba8c7d721dce9884ca8f6ab3e35da31dd44");
+    assertThat(deposit.getTimestamp()).isEqualTo(new Date(1556178200000L));
+    assertThat(deposit.getStatus()).isEqualTo("COMPLETE");
+    assertThat(deposit.getDepositNumber()).isEqualTo(152426993L);
+    assertThat(deposit.getCategory()).isEqualTo("deposit");
+
+    assertThat(response.getWithdrawals()).hasSize(1);
+
+    final PoloniexWithdrawal withdrawal = response.getWithdrawals().get(0);
+    assertThat(withdrawal.getWithdrawalNumber()).isEqualTo(19322067L);
+    assertThat(withdrawal.getCurrency()).isEqualTo(Currency.ETH.getCurrencyCode());
+    assertThat(withdrawal.getAddress()).isEqualTo("0x4120F5b5A6adA3B543da0535e7a9844689f5016C");
+    assertThat(withdrawal.getAmount())
+        .isCloseTo(new BigDecimal("2.0"), Offset.offset(BigDecimal.ZERO));
+    assertThat(withdrawal.getFee())
+        .isCloseTo(new BigDecimal("0.01"), Offset.offset(BigDecimal.ZERO));
+    assertThat(withdrawal.getTimestamp()).isEqualTo(new Date(1556435569000L));
+    assertThat(withdrawal.getStatus())
+        .isEqualTo("COMPLETE: 0xf85d3870a4c9a077cd333f59ad49db7f2b21e4a67326961c09d629f6a7bb2e9d");
+    assertThat(withdrawal.getIpAddress()).isEqualTo("127.0.0.1");
+    assertThat(withdrawal.getPaymentID()).isEqualTo(null);
+  }
+}

--- a/xchange-poloniex/src/test/resources/org/knowm/xchange/poloniex/dto/account/deposits-withdrawals.json
+++ b/xchange-poloniex/src/test/resources/org/knowm/xchange/poloniex/dto/account/deposits-withdrawals.json
@@ -1,0 +1,31 @@
+{
+  "adjustments": [],
+  "deposits": [
+    {
+      "currency": "ETH",
+      "address": "0xf015a632ac1d13aeca3513c8c76c96334c5861a3",
+      "amount": "8.99500000",
+      "confirmations": 38,
+      "txid": "0xa7bc2c38e97c1ed9cee7436da5912ba8c7d721dce9884ca8f6ab3e35da31dd44",
+      "timestamp": 1556178200,
+      "status": "COMPLETE",
+      "depositNumber": 152426993,
+      "category": "deposit"
+    }
+  ],
+  "withdrawals": [
+    {
+      "withdrawalNumber": 19322067,
+      "currency": "ETH",
+      "address": "0x4120F5b5A6adA3B543da0535e7a9844689f5016C",
+      "amount": "2.00000000",
+      "fee": "0.01000000",
+      "timestamp": 1556435569,
+      "status": "COMPLETE: 0xf85d3870a4c9a077cd333f59ad49db7f2b21e4a67326961c09d629f6a7bb2e9d",
+      "ipAddress": "127.0.0.1",
+      "canCancel": 0,
+      "canResendEmail": 0,
+      "paymentID": null
+    }
+  ]
+}


### PR DESCRIPTION
Withdrawal from Poloniex have Field "fee" which was missing in the DTO.
While fixing that I also added the field "paymentID" in PloniexWithdrawal and the fields "depositNumber" and "category" in PoloniexDeposit