### PR TITLE
[Okex]  API v3

### DIFF
--- a/xchange-okcoin/pom.xml
+++ b/xchange-okcoin/pom.xml
@@ -28,6 +28,12 @@
             <artifactId>xchange-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        
+        <dependency>
+            <groupId>com.okcoin.commons</groupId>
+            <artifactId>okex-java-sdk-api</artifactId>
+            <version>1.0.0</version>
+        </dependency>
 
     </dependencies>
 

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/dto/account/OkCoinRecords.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/dto/account/OkCoinRecords.java
@@ -94,7 +94,8 @@ public class OkCoinRecords {
   public enum RechargeStatus {
     FAILURE(-1, "Failure"),
     WAIT_CONFIRMATION(0, "Wait Confirmation"),
-    COMPLETE(1, "Complete"),
+    CONFIRMATION_ACCOUNT(1, "Confirmation Account;"),
+    RECHARGE_SUCCESS(2, "Complete")
     ;
 
     private static final Map<Integer, RechargeStatus> fromInt =

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinAccountService.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinAccountService.java
@@ -29,6 +29,8 @@ import org.knowm.xchange.service.trade.params.WithdrawFundsParams;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.account.param.Withdraw;
+import com.okcoin.commons.okex.open.api.bean.account.result.WithdrawFee;
 
 public class OkCoinAccountService extends OkCoinAccountServiceRaw implements AccountService {
 
@@ -60,23 +62,7 @@ public class OkCoinAccountService extends OkCoinAccountServiceRaw implements Acc
     String currencySymbol =
         OkCoinAdapters.adaptSymbol(currency);
 
-    BigDecimal staticFee =
-        this.exchange.getExchangeMetaData().getCurrencies().get(currency).getWithdrawalFee();
-
-    if (staticFee == null) {
-      throw new IllegalArgumentException("Unsupported withdraw currency " + currency);
-    }
-
-    NumberFormat format = new DecimalFormat("0.####"); // lowest fee is 0.0005
-    String fee = format.format(staticFee);
-
-    // Default withdraw target is external address. Use withdraw function in OkCoinAccountServiceRaw
-    // for internal withdraw
-    OKCoinWithdraw result = withdraw(currencySymbol, address, amount, "address", fee);
-
-    if (result != null) return result.getWithdrawId();
-
-    return "";
+    return this.withdraw(currencySymbol, address, amount, "address").getWithdrawId();
   }
 
   @Override
@@ -94,6 +80,13 @@ public class OkCoinAccountService extends OkCoinAccountServiceRaw implements Acc
     JSONObject object = result.getJSONObject(0);
     String address = object.getString("address");
     return address;
+  }
+  
+  public BigDecimal getWithdrawalFee(Currency currency) {
+	  return this.accountAPIService
+			  .getWithdrawFee(OkCoinAdapters.adaptSymbol(currency))
+			  .get(0)
+			  .getMin_fee();
   }
 
   @Override

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinAccountService.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinAccountService.java
@@ -21,6 +21,7 @@ import org.knowm.xchange.service.account.AccountService;
 import org.knowm.xchange.service.trade.params.DefaultTradeHistoryParamPaging;
 import org.knowm.xchange.service.trade.params.DefaultWithdrawFundsParams;
 import org.knowm.xchange.service.trade.params.HistoryParamsFundingType;
+import org.knowm.xchange.service.trade.params.RippleWithdrawFundsParams;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrency;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
@@ -53,21 +54,28 @@ public class OkCoinAccountService extends OkCoinAccountServiceRaw implements Acc
   @Override
   public String withdrawFunds(Currency currency, BigDecimal amount, String address)
       throws IOException {
-    boolean useIntl =
-        this.exchange
-            .getExchangeSpecification()
-            .getExchangeSpecificParametersItem("Use_Intl")
-            .equals(true);
-
-    String currencySymbol =
-        OkCoinAdapters.adaptSymbol(currency);
-
-    return this.withdraw(currencySymbol, address, amount, "address").getWithdrawId();
+    
+    return this.withdraw(
+    		OkCoinAdapters.adaptSymbol(currency), 
+    		address, 
+    		amount, 
+    		"address").getWithdrawId();
   }
 
   @Override
   public String withdrawFunds(WithdrawFundsParams params) throws IOException {
-    if (params instanceof DefaultWithdrawFundsParams) {
+    
+	if (params instanceof RippleWithdrawFundsParams) {
+      RippleWithdrawFundsParams defaultParams = (RippleWithdrawFundsParams) params;
+      return withdraw(
+        OkCoinAdapters.adaptSymbol(defaultParams.getCurrency()),
+        defaultParams.getAddress(),
+        defaultParams.getAmount(),
+        "address",
+        null,
+        defaultParams.getTag()).getWithdrawId();
+      
+    } else if (params instanceof DefaultWithdrawFundsParams) {
       DefaultWithdrawFundsParams defaultParams = (DefaultWithdrawFundsParams) params;
       return withdrawFunds(defaultParams.currency, defaultParams.amount, defaultParams.address);
     }

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinAccountService.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinAccountService.java
@@ -26,6 +26,10 @@ import org.knowm.xchange.service.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.WithdrawFundsParams;
 
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+
 public class OkCoinAccountService extends OkCoinAccountServiceRaw implements AccountService {
 
   /**
@@ -54,8 +58,7 @@ public class OkCoinAccountService extends OkCoinAccountServiceRaw implements Acc
             .equals(true);
 
     String currencySymbol =
-        OkCoinAdapters.adaptSymbol(
-            new CurrencyPair(currency, useIntl ? Currency.USD : Currency.CNY));
+        OkCoinAdapters.adaptSymbol(currency);
 
     BigDecimal staticFee =
         this.exchange.getExchangeMetaData().getCurrencies().get(currency).getWithdrawalFee();
@@ -87,7 +90,10 @@ public class OkCoinAccountService extends OkCoinAccountServiceRaw implements Acc
 
   @Override
   public String requestDepositAddress(Currency currency, String... args) throws IOException {
-    throw new NotAvailableFromExchangeException();
+    JSONArray result = this.accountAPIService.getDepositAddress(OkCoinAdapters.adaptSymbol(currency));
+    JSONObject object = result.getJSONObject(0);
+    String address = object.getString("address");
+    return address;
   }
 
   @Override

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinAccountServiceRaw.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinAccountServiceRaw.java
@@ -117,34 +117,40 @@ public class OkCoinAccountServiceRaw extends OKCoinBaseTradeService {
       String currencySymbol, String withdrawAddress, BigDecimal amount, String target)
       throws IOException {
 	  
-	BigDecimal fee;
-	if (target.equals("address")) { // External address
-	  fee = getWithdrawalFee(currencySymbol);
-    
-    } else if (target.equals("okex")
-        || target.equals("okcn")
-        || target.equals("okcom")) { // Internal address
-      fee = BigDecimal.ZERO;
-    } else {
-      throw new IllegalArgumentException("Unsupported withdraw target");
-    }
-    return withdraw(currencySymbol, withdrawAddress, amount, target, fee);
+    return withdraw(currencySymbol, withdrawAddress, amount, target, null, null);
   }
   
   public OKCoinWithdraw withdraw(
-      String currencySymbol, String withdrawAddress, BigDecimal amount, String target, BigDecimal fee)
+      String currencySymbol, String withdrawAddress, BigDecimal amount, String target, BigDecimal fee, String tag)
       throws IOException {
 
     if (tradepwd == null) {
       throw new ExchangeException(
           "You need to provide the 'trade/admin password' using exchange.getExchangeSpecification().setExchangeSpecificParametersItem(\"tradepwd\", \"SECRET\");");
     }
+    
+    if (fee == null) {
+    	if (target.equals("address")) { // External address
+    	  fee = getWithdrawalFee(currencySymbol);
+        
+        } else if (target.equals("okex")
+            || target.equals("okcn")
+            || target.equals("okcom")) { // Internal address
+          fee = BigDecimal.ZERO;
+        } else {
+          throw new IllegalArgumentException("Unsupported withdraw target");
+        }
+    }
+    
     Withdraw withdraw = new Withdraw();
     withdraw.setTo_address(withdrawAddress);
     withdraw.setAmount(amount);
     withdraw.setCurrency(currencySymbol);
     withdraw.setFee(fee);
     withdraw.setTrade_pwd(tradepwd);
+    if (tag != null) { 
+    	withdraw.setTag(tag);
+    }
     // Default withdraw target is external address. Use withdraw function in OkCoinAccountServiceRaw
     // for internal withdraw
     int destination;

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinMarketDataService.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinMarketDataService.java
@@ -6,6 +6,7 @@ import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trades;
+import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.okcoin.OkCoinAdapters;
 import org.knowm.xchange.okcoin.dto.marketdata.OkCoinTrade;
 import org.knowm.xchange.service.marketdata.MarketDataService;
@@ -30,7 +31,16 @@ public class OkCoinMarketDataService extends OkCoinMarketDataServiceRaw
 
   @Override
   public OrderBook getOrderBook(CurrencyPair currencyPair, Object... args) throws IOException {
-    return OkCoinAdapters.adaptOrderBook(getDepth(currencyPair), currencyPair);
+	Integer size = null; // For default size
+	
+	if (args != null && args.length == 1) {
+      if (!(args[0] instanceof Integer)) {
+        throw new ExchangeException("Argument 0 must be an Integer!");
+      }
+      size = (Integer) args[0];
+    }
+	
+    return OkCoinAdapters.adaptOrderBook(getDepth(currencyPair, size), currencyPair);
   }
 
   @Override

--- a/xchange-okcoin/src/okex-java-sdk-api/.gitignore
+++ b/xchange-okcoin/src/okex-java-sdk-api/.gitignore
@@ -1,0 +1,20 @@
+# Created by .ignore support plugin (hsz.mobi)
+/.idea
+logs
+transaction-logs
+target/
+.mvn/
+**/.DS_Store
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+.classpath
+.project
+.settings
+
+#logs
+/logs/
+/transaction-logs/

--- a/xchange-okcoin/src/okex-java-sdk-api/README.md
+++ b/xchange-okcoin/src/okex-java-sdk-api/README.md
@@ -1,0 +1,79 @@
+OKCoin OKEX V3 Open Api使用说明
+--------------
+### 1.使用技术：okhttp3 + retrofit2
+### 2.依赖maven，内部使用 (用户可上传nexus使用)
+```
+        <dependency>
+            <groupId>com.okcoin.commons</groupId>
+            <artifactId>okex-java-sdk-api</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+```
+### 3.简单使用方式:
+```
+ public static void main(String[] args) {
+
+        APIConfiguration config = new APIConfiguration();
+        config.setEndpoint("http://192.168.80.14:8118");
+        config.setApiKey("75c60758-be16-4acc-8f2d-66403e53072c");
+        config.setSecretKey("8DF095FE9C662F787A60F3133A06414C");
+        config.setPassphrase("19205A%9980");
+        config.setPrint(false);
+
+        GeneralAPIService marketAPIService = new GeneralAPIServiceImpl(config);
+        ServerTime time = marketAPIService.getServerTime();
+        // eg: {"epoch":"1520848286.633","iso":"2018-03-12T09:51:26.633Z"}
+        System.out.println(JSON.toJSONString(time));
+
+        FuturesTradeAPIService tradeAPIService = new FuturesTradeAPIServiceImpl(config);
+
+        Order order = new Order();
+        order.setClient_oid("TYPb040b3daa40f793e69f86344a1839");
+        order.setType(FuturesTransactionTypeEnum.OPEN_SHORT.code());
+        order.setProduct_id("BTC-USD-0331");
+        order.setPrice(99900.00);
+        order.setAmount(123);
+        order.setMatch_price(0);
+        order.setLever_rate(10.00);
+        OrderResult orderResult = tradeAPIService.newOrder(order);
+        // eg : {"client_oid":"TYPb040b3daa40f793e69f86344a1839","order_id":"400574928061440","result":true}
+        System.out.println(JSON.toJSONString(orderResult));
+ }
+```
+### 4.Spring 或 Spring Boot使用方式:
+```
+@RestController
+public class TestOKEXOpenApiV3 {
+
+    @Autowired
+    private GeneralAPIService generalAPIService;
+
+    @GetMapping("/server-time")
+    public ServerTime getServerTime() {
+        return generalAPIService.getServerTime();
+    }
+    
+    @Bean
+    public APIConfiguration okexApiConfig() {
+        APIConfiguration config = new APIConfiguration();
+        config.setEndpoint("http://192.168.80.14:8118");
+        config.setApiKey("75c60758-be16-4acc-8f2d-66403e53072c");
+        config.setSecretKey("8DF095FE9C662F787A60F3133A06414C");
+        config.setPassphrase("19205A%9980");
+        config.setPrint(false);
+        return config;
+    }
+
+    @Bean
+    public GeneralAPIService generalAPIService(APIConfiguration config) {
+        return new GeneralAPIServiceImpl(config);
+    }
+}
+```
+#### 4.1 可使用web测试: http://192.168.150.197:8080/server-time
+```
+{
+"iso": "2018-03-12T10:12:01.468Z",
+"epoch": "1520849521.468"
+}
+```

--- a/xchange-okcoin/src/okex-java-sdk-api/pom.xml
+++ b/xchange-okcoin/src/okex-java-sdk-api/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.okcoin.commons</groupId>
+    <artifactId>okex-java-sdk-api</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <java.version>1.8</java.version>
+        <okhttp3.version>3.10.0</okhttp3.version>
+        <retrofit2.version>2.3.0</retrofit2.version>
+        <fastjson.version>1.2.46</fastjson.version>
+        <commons-lang3.version>3.7</commons-lang3.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
+        <logback.version>1.2.3</logback.version>
+        <junit.version>4.12</junit.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>retrofit</artifactId>
+            <version>${retrofit2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-scalars</artifactId>
+            <version>${retrofit2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-gson</artifactId>
+            <version>${retrofit2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>adapter-rxjava</artifactId>
+            <version>${retrofit2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+            <version>${fastjson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>${commons-collections.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/account/param/Transfer.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/account/param/Transfer.java
@@ -1,0 +1,67 @@
+package com.okcoin.commons.okex.open.api.bean.account.param;
+
+import java.math.BigDecimal;
+
+public class Transfer {
+
+    private String currency;
+
+    private BigDecimal amount;
+
+    private Integer from;
+
+    private Integer to;
+
+    private String sub_account;
+
+    private Integer instrument_id;
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+
+    public String getSub_account() {
+        return sub_account;
+    }
+
+    public void setSub_account(String sub_account) {
+        this.sub_account = sub_account;
+    }
+
+    public Integer getFrom() {
+        return from;
+    }
+
+    public void setFrom(Integer from) {
+        this.from = from;
+    }
+
+    public Integer getTo() {
+        return to;
+    }
+
+    public void setTo(Integer to) {
+        this.to = to;
+    }
+
+    public Integer getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(Integer instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/account/param/Withdraw.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/account/param/Withdraw.java
@@ -1,0 +1,75 @@
+package com.okcoin.commons.okex.open.api.bean.account.param;
+
+import java.math.BigDecimal;
+
+public class Withdraw {
+    private BigDecimal amount;
+
+    private String currency;
+
+    private Integer destination;
+
+    private String to_address;
+
+    private String trade_pwd;
+
+    private BigDecimal fee;
+
+    private String tag;
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public String getTrade_pwd() {
+        return trade_pwd;
+    }
+
+    public void setTrade_pwd(String trade_pwd) {
+        this.trade_pwd = trade_pwd;
+    }
+
+    public BigDecimal getFee() {
+        return fee;
+    }
+
+    public void setFee(BigDecimal fee) {
+        this.fee = fee;
+    }
+
+    public Integer getDestination() {
+        return destination;
+    }
+
+    public void setDestination(Integer destination) {
+        this.destination = destination;
+    }
+
+    public String getTo_address() {
+        return to_address;
+    }
+
+    public void setTo_address(String to_address) {
+        this.to_address = to_address;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public void setTag(String tag) {
+        this.tag = tag;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/account/result/Currency.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/account/result/Currency.java
@@ -1,0 +1,55 @@
+package com.okcoin.commons.okex.open.api.bean.account.result;
+
+import java.math.BigDecimal;
+
+public class Currency {
+    private String currency;
+
+    private String name;
+
+    private Integer can_withdraw;
+
+    private Integer can_deposit;
+
+    private BigDecimal min_withdrawal;
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getCan_withdraw() {
+        return can_withdraw;
+    }
+
+    public void setCan_withdraw(Integer can_withdraw) {
+        this.can_withdraw = can_withdraw;
+    }
+
+    public Integer getCan_deposit() {
+        return can_deposit;
+    }
+
+    public void setCan_deposit(Integer can_deposit) {
+        this.can_deposit = can_deposit;
+    }
+
+    public BigDecimal getMin_withdrawal() {
+        return min_withdrawal;
+    }
+
+    public void setMin_withdrawal(BigDecimal min_withdrawal) {
+        this.min_withdrawal = min_withdrawal;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/account/result/Ledger.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/account/result/Ledger.java
@@ -1,0 +1,77 @@
+package com.okcoin.commons.okex.open.api.bean.account.result;
+
+import java.math.BigDecimal;
+
+public class Ledger {
+
+    private  Long ledger_id;
+
+    private String currency;
+
+    private BigDecimal balance;
+
+    private BigDecimal amount;
+
+    private BigDecimal fee;
+
+    private String typeName;
+
+    private String timestamp;
+
+
+    public Long getLedger_id() {
+        return ledger_id;
+    }
+
+    public void setLedger_id(Long ledger_id) {
+        this.ledger_id = ledger_id;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public BigDecimal getBalance() {
+        return balance;
+    }
+
+    public void setBalance(BigDecimal balance) {
+        this.balance = balance;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public BigDecimal getFee() {
+        return fee;
+    }
+
+    public void setFee(BigDecimal fee) {
+        this.fee = fee;
+    }
+
+    public String getTypeName() {
+        return typeName;
+    }
+
+    public void setTypeName(String typeName) {
+        this.typeName = typeName;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/account/result/Wallet.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/account/result/Wallet.java
@@ -1,0 +1,46 @@
+package com.okcoin.commons.okex.open.api.bean.account.result;
+
+import java.math.BigDecimal;
+
+public class Wallet {
+
+    private String currency;
+
+    private BigDecimal balance;
+
+    private BigDecimal frozen;
+
+    private BigDecimal available;
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public BigDecimal getBalance() {
+        return balance;
+    }
+
+    public void setBalance(BigDecimal balance) {
+        this.balance = balance;
+    }
+
+    public BigDecimal getFrozen() {
+        return frozen;
+    }
+
+    public void setFrozen(BigDecimal frozen) {
+        this.frozen = frozen;
+    }
+
+    public BigDecimal getAvailable() {
+        return available;
+    }
+
+    public void setAvailable(BigDecimal available) {
+        this.available = available;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/account/result/WithdrawFee.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/account/result/WithdrawFee.java
@@ -1,0 +1,37 @@
+package com.okcoin.commons.okex.open.api.bean.account.result;
+
+import java.math.BigDecimal;
+
+public class WithdrawFee {
+
+      private BigDecimal min_fee;
+
+      private BigDecimal max_fee;
+
+
+      private String currency;
+
+    public BigDecimal getMin_fee() {
+        return min_fee;
+    }
+
+    public void setMin_fee(BigDecimal min_fee) {
+        this.min_fee = min_fee;
+    }
+
+    public BigDecimal getMax_fee() {
+        return max_fee;
+    }
+
+    public void setMax_fee(BigDecimal max_fee) {
+        this.max_fee = max_fee;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/param/EttCreateOrderParam.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/param/EttCreateOrderParam.java
@@ -1,0 +1,55 @@
+package com.okcoin.commons.okex.open.api.bean.ett.param;
+
+import java.math.BigDecimal;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/5
+ */
+public class EttCreateOrderParam {
+    private String ett;
+    private Integer type;
+    private BigDecimal amount;
+    private BigDecimal size;
+    private String clientOid;
+
+    public String getEtt() {
+        return ett;
+    }
+
+    public void setEtt(String ett) {
+        this.ett = ett;
+    }
+
+    public Integer getType() {
+        return type;
+    }
+
+    public void setType(Integer type) {
+        this.type = type;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public BigDecimal getSize() {
+        return size;
+    }
+
+    public void setSize(BigDecimal size) {
+        this.size = size;
+    }
+
+    public String getClientOid() {
+        return clientOid;
+    }
+
+    public void setClientOid(String clientOid) {
+        this.clientOid = clientOid;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/result/CursorPager.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/result/CursorPager.java
@@ -1,0 +1,47 @@
+package com.okcoin.commons.okex.open.api.bean.ett.result;
+
+import java.util.List;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/5
+ */
+public class CursorPager<T> {
+
+    private List<T> data;
+    private String before;
+    private String after;
+    private int limit;
+
+    public List<T> getData() {
+        return data;
+    }
+
+    public void setData(List<T> data) {
+        this.data = data;
+    }
+
+    public String getBefore() {
+        return before;
+    }
+
+    public void setBefore(String before) {
+        this.before = before;
+    }
+
+    public String getAfter() {
+        return after;
+    }
+
+    public void setAfter(String after) {
+        this.after = after;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/result/EttAccount.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/result/EttAccount.java
@@ -1,0 +1,73 @@
+package com.okcoin.commons.okex.open.api.bean.ett.result;
+
+import java.util.Objects;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/4
+ */
+public class EttAccount {
+
+    private String currency;
+    private String balance;
+    private String holds;
+    private String available;
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public String getBalance() {
+        return balance;
+    }
+
+    public void setBalance(String balance) {
+        this.balance = balance;
+    }
+
+    public String getHolds() {
+        return holds;
+    }
+
+    public void setHolds(String holds) {
+        this.holds = holds;
+    }
+
+    public String getAvailable() {
+        return available;
+    }
+
+    public void setAvailable(String available) {
+        this.available = available;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+        EttAccount that = (EttAccount)o;
+        return Objects.equals(currency, that.currency) &&
+            Objects.equals(balance, that.balance) &&
+            Objects.equals(holds, that.holds) &&
+            Objects.equals(available, that.available);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(currency, balance, holds, available);
+    }
+
+    @Override
+    public String toString() {
+        return "EttAccount{" +
+            "currency='" + currency + '\'' +
+            ", balance='" + balance + '\'' +
+            ", holds='" + holds + '\'' +
+            ", available='" + available + '\'' +
+            '}';
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/result/EttCancelOrderResult.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/result/EttCancelOrderResult.java
@@ -1,0 +1,9 @@
+package com.okcoin.commons.okex.open.api.bean.ett.result;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/5
+ */
+public class EttCancelOrderResult {
+    private Boolean result;
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/result/EttConstituents.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/result/EttConstituents.java
@@ -1,0 +1,52 @@
+package com.okcoin.commons.okex.open.api.bean.ett.result;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/5
+ */
+public class EttConstituents {
+
+    private String currency;
+    private BigDecimal amount;
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+        EttConstituents that = (EttConstituents)o;
+        return Objects.equals(currency, that.currency) &&
+            Objects.equals(amount, that.amount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(currency, amount);
+    }
+
+    @Override
+    public String toString() {
+        return "EttConstituents{" +
+            "currency='" + currency + '\'' +
+            ", amount=" + amount +
+            '}';
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/result/EttConstituentsResult.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/result/EttConstituentsResult.java
@@ -1,0 +1,63 @@
+package com.okcoin.commons.okex.open.api.bean.ett.result;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/5
+ */
+public class EttConstituentsResult {
+    private String ett;
+    private BigDecimal net_value;
+    private List<EttConstituents> constituents;
+
+    public String getEtt() {
+        return ett;
+    }
+
+    public void setEtt(String ett) {
+        this.ett = ett;
+    }
+
+    public BigDecimal getNet_value() {
+        return net_value;
+    }
+
+    public void setNet_value(BigDecimal net_value) {
+        this.net_value = net_value;
+    }
+
+    public List<EttConstituents> getConstituents() {
+        return constituents;
+    }
+
+    public void setConstituents(List<EttConstituents> constituents) {
+        this.constituents = constituents;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+        EttConstituentsResult that = (EttConstituentsResult)o;
+        return Objects.equals(ett, that.ett) &&
+            Objects.equals(net_value, that.net_value) &&
+            Objects.equals(constituents, that.constituents);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ett, net_value, constituents);
+    }
+
+    @Override
+    public String toString() {
+        return "EttConstituentsResult{" +
+            "ett='" + ett + '\'' +
+            ", net_value=" + net_value +
+            ", constituents=" + constituents +
+            '}';
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/result/EttCreateOrderResult.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/result/EttCreateOrderResult.java
@@ -1,0 +1,62 @@
+package com.okcoin.commons.okex.open.api.bean.ett.result;
+
+import java.util.Objects;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/5
+ */
+public class EttCreateOrderResult {
+
+    private String order_id;
+    private String client_oid;
+    private Boolean result;
+
+    public String getOrder_id() {
+        return order_id;
+    }
+
+    public void setOrder_id(String order_id) {
+        this.order_id = order_id;
+    }
+
+    public String getClient_oid() {
+        return client_oid;
+    }
+
+    public void setClient_oid(String client_oid) {
+        this.client_oid = client_oid;
+    }
+
+    public Boolean getResult() {
+        return result;
+    }
+
+    public void setResult(Boolean result) {
+        this.result = result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+        EttCreateOrderResult that = (EttCreateOrderResult)o;
+        return Objects.equals(order_id, that.order_id) &&
+            Objects.equals(client_oid, that.client_oid) &&
+            Objects.equals(result, that.result);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(order_id, client_oid, result);
+    }
+
+    @Override
+    public String toString() {
+        return "EttCreateOrderResult{" +
+            "order_id='" + order_id + '\'' +
+            ", client_oid='" + client_oid + '\'' +
+            ", result=" + result +
+            '}';
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/result/EttLedger.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/result/EttLedger.java
@@ -1,0 +1,107 @@
+package com.okcoin.commons.okex.open.api.bean.ett.result;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/5
+ */
+public class EttLedger {
+
+    private Long ledger_id;
+    private String currency;
+    private BigDecimal balance;
+    private BigDecimal amount;
+    private String type;
+    private String created_at;
+    private Long details;
+
+    public Long getLedger_id() {
+        return ledger_id;
+    }
+
+    public void setLedger_id(Long ledger_id) {
+        this.ledger_id = ledger_id;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public BigDecimal getBalance() {
+        return balance;
+    }
+
+    public void setBalance(BigDecimal balance) {
+        this.balance = balance;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getCreated_at() {
+        return created_at;
+    }
+
+    public void setCreated_at(String created_at) {
+        this.created_at = created_at;
+    }
+
+    public Long getDetails() {
+        return details;
+    }
+
+    public void setDetails(Long details) {
+        this.details = details;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+        EttLedger ettLedger = (EttLedger)o;
+        return Objects.equals(ledger_id, ettLedger.ledger_id) &&
+            Objects.equals(currency, ettLedger.currency) &&
+            Objects.equals(balance, ettLedger.balance) &&
+            Objects.equals(amount, ettLedger.amount) &&
+            Objects.equals(type, ettLedger.type) &&
+            Objects.equals(created_at, ettLedger.created_at) &&
+            Objects.equals(details, ettLedger.details);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ledger_id, currency, balance, amount, type, created_at, details);
+    }
+
+    @Override
+    public String toString() {
+        return "EttLedger{" +
+            "ledger_id='" + ledger_id + '\'' +
+            ", currency='" + currency + '\'' +
+            ", balance=" + balance +
+            ", amount=" + amount +
+            ", type='" + type + '\'' +
+            ", created_at=" + created_at +
+            ", details='" + details + '\'' +
+            '}';
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/result/EttOrder.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/result/EttOrder.java
@@ -1,0 +1,129 @@
+package com.okcoin.commons.okex.open.api.bean.ett.result;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/5
+ */
+public class EttOrder {
+
+    private String order_id;
+    private String created_at;
+    private Integer type;
+    private String ett;
+    private String quote_currency;
+    private BigDecimal amount;
+    private BigDecimal size;
+    private BigDecimal price;
+    private String status;
+
+    public String getOrder_id() {
+        return order_id;
+    }
+
+    public void setOrder_id(String order_id) {
+        this.order_id = order_id;
+    }
+
+    public String getCreated_at() {
+        return created_at;
+    }
+
+    public void setCreated_at(String created_at) {
+        this.created_at = created_at;
+    }
+
+    public Integer getType() {
+        return type;
+    }
+
+    public void setType(Integer type) {
+        this.type = type;
+    }
+
+    public String getEtt() {
+        return ett;
+    }
+
+    public void setEtt(String ett) {
+        this.ett = ett;
+    }
+
+    public String getQuote_currency() {
+        return quote_currency;
+    }
+
+    public void setQuote_currency(String quote_currency) {
+        this.quote_currency = quote_currency;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public BigDecimal getSize() {
+        return size;
+    }
+
+    public void setSize(BigDecimal size) {
+        this.size = size;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public void setPrice(BigDecimal price) {
+        this.price = price;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+        EttOrder ettOrder = (EttOrder)o;
+        return Objects.equals(order_id, ettOrder.order_id) &&
+            Objects.equals(created_at, ettOrder.created_at) &&
+            Objects.equals(type, ettOrder.type) &&
+            Objects.equals(ett, ettOrder.ett) &&
+            Objects.equals(quote_currency, ettOrder.quote_currency) &&
+            Objects.equals(amount, ettOrder.amount) &&
+            Objects.equals(size, ettOrder.size) &&
+            Objects.equals(price, ettOrder.price) &&
+            Objects.equals(status, ettOrder.status);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(order_id, created_at, type, ett, quote_currency, amount, size, price, status);
+    }
+
+    @Override
+    public String toString() {
+        return "EttOrder{" +
+            "order_id='" + order_id + '\'' +
+            ", created_at=" + created_at +
+            ", type=" + type +
+            ", ett='" + ett + '\'' +
+            ", quote_currency='" + quote_currency + '\'' +
+            ", amount=" + amount +
+            ", size=" + size +
+            ", price=" + price +
+            ", status='" + status + '\'' +
+            '}';
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/result/EttSettlementDefinePrice.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/ett/result/EttSettlementDefinePrice.java
@@ -1,0 +1,51 @@
+package com.okcoin.commons.okex.open.api.bean.ett.result;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/5
+ */
+public class EttSettlementDefinePrice {
+    private String date;
+    private BigDecimal price;
+
+    public String getDate() {
+        return date;
+    }
+
+    public void setDate(String date) {
+        this.date = date;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public void setPrice(BigDecimal price) {
+        this.price = price;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+        EttSettlementDefinePrice that = (EttSettlementDefinePrice)o;
+        return Objects.equals(date, that.date) &&
+            Objects.equals(price, that.price);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(date, price);
+    }
+
+    @Override
+    public String toString() {
+        return "EttSettlementDefinePrice{" +
+            "date=" + date +
+            ", price=" + price +
+            '}';
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/CursorPageParams.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/CursorPageParams.java
@@ -1,0 +1,46 @@
+package com.okcoin.commons.okex.open.api.bean.futures;
+
+/**
+ * Cursor pagination   <br/>
+ * Created by Tony Tian on 2018/2/26 19:55. <br/>
+ */
+public class CursorPageParams {
+    /**
+     * Request page before (newer) this pagination id.
+     * eg: before=2, page number = 1.
+     */
+    protected int before;
+    /**
+     * Request page after (older) this pagination id.
+     * eg: after=2, page number = 3.
+     */
+    protected int after;
+    /**
+     * Number of results per request. Maximum 100. (default 100)
+     */
+    protected int limit;
+
+    public int getBefore() {
+        return before;
+    }
+
+    public void setBefore(int before) {
+        this.before = before;
+    }
+
+    public int getAfter() {
+        return after;
+    }
+
+    public void setAfter(int after) {
+        this.after = after;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/HttpResult.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/HttpResult.java
@@ -1,0 +1,30 @@
+package com.okcoin.commons.okex.open.api.bean.futures;
+
+/**
+ * Http Result
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 17/03/2018 11:36
+ */
+public class HttpResult {
+
+    private int code;
+    private String message;
+
+    public int getCode() {
+        return code;
+    }
+
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/param/CancelOrders.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/param/CancelOrders.java
@@ -1,0 +1,23 @@
+package com.okcoin.commons.okex.open.api.bean.futures.param;
+
+import java.util.List;
+
+/**
+ * Close Position
+ *
+ * @author wc.j
+ * @version 1.0.0
+ * @date 2018/10/19 16:54
+ */
+public class CancelOrders {
+
+    public List<Long> getOrder_ids() {
+        return order_ids;
+    }
+
+    public void setOrder_ids(List<Long> order_ids) {
+        this.order_ids = order_ids;
+    }
+
+    List<Long> order_ids;
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/param/ClosePosition.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/param/ClosePosition.java
@@ -1,0 +1,35 @@
+package com.okcoin.commons.okex.open.api.bean.futures.param;
+
+/**
+ * Close Position
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/9 15:38
+ */
+public class ClosePosition {
+    /**
+     * The id of the futures, eg: BTC_USD_0331
+     */
+    private String instrument_id;
+    /**
+     * The execution type {@link com.okcoin.commons.okex.open.api.enums.FuturesTransactionTypeEnum}
+     */
+    private Integer type;
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public Integer getType() {
+        return type;
+    }
+
+    public void setType(Integer type) {
+        this.type = type;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/param/Order.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/param/Order.java
@@ -1,0 +1,95 @@
+package com.okcoin.commons.okex.open.api.bean.futures.param;
+
+/**
+ * New Order
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/9 15:38
+ */
+public class Order {
+    /**
+     * The id of the futures, eg: BTC-USD-180629
+     */
+    protected String instrument_id;
+    /**
+     * lever, default 10.
+     */
+    protected Double leverage;
+    /**
+     * You setting order id.(optional)
+     */
+    private String client_oid;
+    /**
+     * The execution type {@link com.okcoin.commons.okex.open.api.enums.FuturesTransactionTypeEnum}
+     */
+    private Integer type;
+    /**
+     * The order price: Maximum 1 million
+     */
+    private Double price;
+    /**
+     * The order amount: Maximum 1 million
+     */
+    private Integer size;
+    /**
+     * Match best counter party price (BBO)? 0: No 1: Yes   If yes, the 'price' field is ignored
+     */
+    private Integer match_price;
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setinstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+
+    public String getClient_oid() {
+        return client_oid;
+    }
+
+    public void setClient_oid(String client_oid) {
+        this.client_oid = client_oid;
+    }
+    public Double getLeverage() {
+        return leverage;
+    }
+
+    public void setLeverage(Double leverage) {
+        this.leverage = leverage;
+    }
+
+    public Integer getType() {
+        return type;
+    }
+
+    public void setType(Integer type) {
+        this.type = type;
+    }
+
+    public Double getPrice() {
+        return price;
+    }
+
+    public void setPrice(Double price) {
+        this.price = price;
+    }
+
+    public Integer getSize() {
+        return size;
+    }
+
+    public void setSize(Integer size) {
+        this.size = size;
+    }
+
+    public Integer getMatch_price() {
+        return match_price;
+    }
+
+    public void setMatch_price(Integer match_price) {
+        this.match_price = match_price;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/param/Orders.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/param/Orders.java
@@ -1,0 +1,52 @@
+package com.okcoin.commons.okex.open.api.bean.futures.param;
+
+import java.util.List;
+
+/**
+ * New Order
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/9 15:38
+ */
+public class Orders {
+    /**
+     * The id of the futures, eg: BTC-USD-180629
+     */
+    protected String instrument_id;
+
+
+    /**
+     * lever, default 10.
+     */
+    protected Double leverage;
+
+    /**
+     * batch new order sub element
+     */
+    List<OrdersItem> orders_data;
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setinstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public Double getLeverage() {
+        return leverage;
+    }
+
+    public void setLeverage(Double leverage) {
+        this.leverage = leverage;
+    }
+
+    public List<OrdersItem> getOrders_data() {
+        return orders_data;
+    }
+
+    public void setOrders_data(List<OrdersItem> orders_data) {
+        this.orders_data = orders_data;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/param/OrdersItem.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/param/OrdersItem.java
@@ -1,0 +1,68 @@
+package com.okcoin.commons.okex.open.api.bean.futures.param;
+
+/**
+ * batch new order sub element <br/>
+ * Created by Tony Tian on 2018/2/28 17:57. <br/>
+ */
+public class OrdersItem {
+    /**
+     * You setting order id. (optional)
+     */
+    private String client_oid;
+    /**
+     * The execution type {@link com.okcoin.commons.okex.open.api.enums.FuturesTransactionTypeEnum}
+     */
+    private Integer type;
+    /**
+     * The order price: Maximum 1 million
+     */
+    private Double price;
+    /**
+     * The order amount: Maximum 1 million
+     */
+    private Integer size;
+    /**
+     * Match best counter party price (BBO)? 0: No 1: Yes   If yes, the 'price' field is ignored
+     */
+    private Integer match_price;
+
+    public String getClient_oid() {
+        return client_oid;
+    }
+
+    public void setClient_oid(String client_oid) {
+        this.client_oid = client_oid;
+    }
+
+    public Integer getType() {
+        return type;
+    }
+
+    public void setType(Integer type) {
+        this.type = type;
+    }
+
+    public Double getPrice() {
+        return price;
+    }
+
+    public void setPrice(Double price) {
+        this.price = price;
+    }
+
+    public Integer getSize() {
+        return size;
+    }
+
+    public void setSize(Integer size) {
+        this.size = size;
+    }
+
+    public Integer getMatch_price() {
+        return match_price;
+    }
+
+    public void setMatch_price(Integer match_price) {
+        this.match_price = match_price;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/Book.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/Book.java
@@ -1,0 +1,40 @@
+package com.okcoin.commons.okex.open.api.bean.futures.result;
+
+import com.alibaba.fastjson.JSONArray;
+
+import java.util.List;
+
+/**
+ * futures contract product book
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/12 15:14
+ */
+public class Book {
+
+    /**
+     * asks book
+     */
+    JSONArray asks;
+    /**
+     * bids book
+     */
+    JSONArray bids;
+    /**
+     * time
+     */
+    String timestamp;
+
+    public JSONArray getAsks() { return asks; }
+
+    public void setAsks(JSONArray asks) { this.asks = asks; }
+
+    public JSONArray getBids() { return bids; }
+
+    public void setBids(JSONArray bids) { this.bids = bids; }
+
+    public String getTimestamp() { return timestamp; }
+
+    public void setTimestamp(String timestamp) { this.timestamp = timestamp; }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/Currencies.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/Currencies.java
@@ -1,0 +1,44 @@
+package com.okcoin.commons.okex.open.api.bean.futures.result;
+
+/**
+ * Contract currency  <br/>
+ * Created by Tony Tian on 2018/2/26 21:33. <br/>
+ */
+public class Currencies {
+    /**
+     * symbol
+     */
+    private Integer id;
+    /**
+     * currency name
+     */
+    private String name;
+    /**
+     * Minimum transaction quantity
+     */
+    private Double min_size;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Double getMin_size() {
+        return min_size;
+    }
+
+    public void setMin_size(Double min_size) {
+        this.min_size = min_size;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/EstimatedPrice.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/EstimatedPrice.java
@@ -1,0 +1,36 @@
+package com.okcoin.commons.okex.open.api.bean.futures.result;
+
+/**
+ * Contract price estimate for delivery.  <br/>
+ * Created by Tony Tian on 2018/2/26 15:52. <br/>
+ */
+public class EstimatedPrice {
+    /**
+     * The id of the futures contract
+     */
+    private String instrument_id;
+    /**
+     * Estimated price
+     */
+    private Double settlement_price;
+    /**
+     * time
+     */
+    private String timestamp;
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getInstrument_id() { return instrument_id; }
+
+    public void setInstrument_id(String instrument_id) { this.instrument_id = instrument_id; }
+
+    public Double getSettlement_price() { return settlement_price; }
+
+    public void setSettlement_price(Double settlement_price) { this.settlement_price = settlement_price; }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/ExchangeRate.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/ExchangeRate.java
@@ -1,0 +1,35 @@
+package com.okcoin.commons.okex.open.api.bean.futures.result;
+
+/**
+ * Exchange Rate
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/9 18:31
+ */
+public class ExchangeRate {
+    /**
+     * legal tender pairs
+     */
+    private String product_id;
+    /**
+     * exchange rate
+     */
+    private Double rate;
+
+    public String getProduct_id() {
+        return product_id;
+    }
+
+    public void setProduct_id(String product_id) {
+        this.product_id = product_id;
+    }
+
+    public Double getRate() {
+        return rate;
+    }
+
+    public void setRate(Double rate) {
+        this.rate = rate;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/Holds.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/Holds.java
@@ -1,0 +1,38 @@
+package com.okcoin.commons.okex.open.api.bean.futures.result;
+
+/**
+ * All of contract position  <br/>
+ * Created by Tony Tian on 2018/2/26 16:14. <br/>
+ */
+public class Holds {
+    /**
+     * The id of the futures contract
+     */
+    private String instrument_id;
+    /**
+     * all of position
+     */
+    private Integer amount;
+
+    private String timestamp;
+
+    public String getInstrument_id() { return instrument_id; }
+
+    public void setInstrument_id(String instrument_id) { this.instrument_id = instrument_id; }
+
+    public Integer getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Integer amount) {
+        this.amount = amount;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/Index.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/Index.java
@@ -1,0 +1,36 @@
+package com.okcoin.commons.okex.open.api.bean.futures.result;
+
+/**
+ * The index of futures contract product information  <br/>
+ * Created by Tony Tian on 2018/3/1 18:36. <br/>
+ */
+public class Index {
+    /**
+     * The id of the futures contract
+     */
+    private String instrument_id;
+    /**
+     * index
+     */
+    private Double index = 0.00D;
+    /**
+     * time
+     */
+    private String timestamp;
+
+    public String getInstrument_id() { return instrument_id; }
+
+    public void setInstrument_id(String instrument_id) { this.instrument_id = instrument_id; }
+
+    public Double getIndex() { return index; }
+
+    public void setIndex(Double index) { this.index = index; }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/Instruments.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/Instruments.java
@@ -1,0 +1,96 @@
+package com.okcoin.commons.okex.open.api.bean.futures.result;
+
+/**
+ * futures contract products <br/>
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/2/26 10:49
+ */
+public class Instruments {
+    /**
+     * The id of the futures contract
+     */
+    private String instrument_id;
+    /**
+     * Currency
+     */
+    private String underlying_index;
+    /**
+     * Quote currency
+     */
+    private String quote_currency;
+    /**
+     * Minimum amount: $
+     */
+    private Double tick_size;
+    /**
+     * Unit price per contract
+     */
+    private Double contract_val;
+    /**
+     * Effect of time
+     */
+    private String listing;
+    /**
+     * Settlement price
+     */
+    private String delivery;
+    /**
+     * Minimum amount: cont
+     */
+    private Double trade_increment;
+
+    public String getInstrument_id() { return instrument_id; }
+
+    public void setInstrument_id(String instrument_id) { this.instrument_id = instrument_id; }
+
+
+    public String getQuote_currency() {
+        return quote_currency;
+    }
+
+    public void setQuote_currency(String quote_currency) {
+        this.quote_currency = quote_currency;
+    }
+
+    public Double getTick_size() { return tick_size; }
+
+    public void setTick_size(Double tick_size) { this.tick_size = tick_size; }
+
+    public Double getContract_val() {
+        return contract_val;
+    }
+
+    public void setContract_val(Double contract_val) {
+        this.contract_val = contract_val;
+    }
+
+    public String getListing() {
+        return listing;
+    }
+
+    public void setListing(String listing) {
+        this.listing = listing;
+    }
+
+    public String getDelivery() {
+        return delivery;
+    }
+
+    public void setDelivery(String delivery) {
+        this.delivery = delivery;
+    }
+
+    public Double getTrade_increment() {
+        return trade_increment;
+    }
+
+    public void setTrade_increment(Double trade_increment) {
+        this.trade_increment = trade_increment;
+    }
+
+    public String getUnderlying_index() { return underlying_index; }
+
+    public void setUnderlying_index(String underlying_index) { this.underlying_index = underlying_index; }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/Liquidation.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/Liquidation.java
@@ -1,0 +1,67 @@
+package com.okcoin.commons.okex.open.api.bean.futures.result;
+
+/**
+ * all of contract liquidation <br/>
+ * Created by Tony Tian on 2018/2/26 16:36. <br/>
+ */
+public class Liquidation {
+    /**
+     * The id of the futures contract
+     */
+    private String instrument_id;
+    /**
+     * order price
+     */
+    private Double price;
+    /**
+     * order quantity(unit: contract)
+     */
+    private Double size;
+    /**
+     * The execution type {@link com.okcoin.commons.okex.open.api.enums.FuturesTransactionTypeEnum}
+     */
+    private Integer type;
+    /**
+     * user loss due to forced liquidation
+     */
+    private Double loss;
+    /**
+     * create date
+     */
+    private String created_at;
+
+    public Double getPrice() {
+        return price;
+    }
+
+    public void setPrice(Double price) {
+        this.price = price;
+    }
+
+    public Integer getType() {
+        return type;
+    }
+
+    public void setType(Integer type) {
+        this.type = type;
+    }
+
+    public Double getLoss() {
+        return loss;
+    }
+
+    public void setLoss(Double loss) {
+        this.loss = loss;
+    }
+
+    public String getInstrument_id() { return instrument_id; }
+
+    public void setInstrument_id(String instrument_id) { this.instrument_id = instrument_id; }
+
+    public Double getSize() { return size; }
+
+    public void setSize(Double size) { this.size = size; }
+    public String getCreated_at() { return created_at; }
+
+    public void setCreated_at(String created_at) { this.created_at = created_at; }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/OrderResult.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/OrderResult.java
@@ -1,0 +1,66 @@
+package com.okcoin.commons.okex.open.api.bean.futures.result;
+
+/**
+ * New Order Result
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/9 15:56
+ */
+public class OrderResult {
+    /**
+     * You setting order id.
+     */
+    private String client_oid;
+    /**
+     * The order id provided by OKEx.
+     */
+    private String order_id;
+    /**
+     * The Server processing results: true: successful, false: failure.
+     */
+    private boolean result;
+
+    private int error_code;
+    private String error_message;
+
+    public String getClient_oid() {
+        return client_oid;
+    }
+
+    public void setClient_oid(String client_oid) {
+        this.client_oid = client_oid;
+    }
+
+    public String getOrder_id() {
+        return order_id;
+    }
+
+    public void setOrder_id(String order_id) {
+        this.order_id = order_id;
+    }
+
+    public boolean isResult() {
+        return result;
+    }
+
+    public void setResult(boolean result) {
+        this.result = result;
+    }
+
+    public int getError_code() {
+        return error_code;
+    }
+
+    public void setError_code(int error_code) {
+        this.error_code = error_code;
+    }
+
+    public String getError_messsage() {
+        return error_message;
+    }
+
+    public void setError_messsage(String error_messsage) {
+        this.error_message = error_messsage;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/PriceLimit.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/PriceLimit.java
@@ -1,0 +1,40 @@
+package com.okcoin.commons.okex.open.api.bean.futures.result;
+
+/**
+ * The current limit of the contract.  <br/>
+ * Created by Tony Tian on 2018/2/26 16:21. <br/>
+ */
+public class PriceLimit {
+    /**
+     * The id of the futures contract
+     */
+    private String instrument_id;
+    /**
+     * Highest price
+     */
+    private Double highest;
+    /**
+     * Lowest price
+     */
+    private Double lowest;
+
+    private String timestamp;
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(String instrument_id) { this.instrument_id = instrument_id; }
+
+    public String getTimestamp() { return timestamp; }
+
+    public void setTimestamp(String timestamp) { this.timestamp = timestamp; }
+
+    public Double getHighest() { return highest; }
+
+    public void setHighest(Double highest) { this.highest = highest; }
+
+    public Double getLowest() { return lowest; }
+
+    public void setLowest(Double lowest) { this.lowest = lowest; }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/ServerTime.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/ServerTime.java
@@ -1,0 +1,29 @@
+package com.okcoin.commons.okex.open.api.bean.futures.result;
+
+/**
+ * Time of the server running OKEX's REST API.
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/8 20:58
+ */
+public class ServerTime {
+    private String iso;
+    private String epoch;
+
+    public String getIso() {
+        return iso;
+    }
+
+    public void setIso(String iso) {
+        this.iso = iso;
+    }
+
+    public String getEpoch() {
+        return epoch;
+    }
+
+    public void setEpoch(String epoch) {
+        this.epoch = epoch;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/Stats.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/Stats.java
@@ -1,0 +1,68 @@
+package com.okcoin.commons.okex.open.api.bean.futures.result;
+
+/**
+ * Get 24 hours of contract data.  <br/>
+ * Created by Tony Tian on 2018/2/26 13:59. <br/>
+ */
+public class Stats {
+    /**
+     * The id of the futures contract
+     */
+    private String product_id;
+    /**
+     * Opening price
+     */
+    private Double open;
+    /**
+     * 24 hours of highest price
+     */
+    private Double high;
+    /**
+     * 24 hours of lowest price
+     */
+    private Double low;
+    /**
+     * Volume of sheet
+     */
+    private Double volume;
+
+    public String getProduct_id() {
+        return product_id;
+    }
+
+    public void setProduct_id(String product_id) {
+        this.product_id = product_id;
+    }
+
+    public Double getOpen() {
+        return open;
+    }
+
+    public void setOpen(Double open) {
+        this.open = open;
+    }
+
+    public Double getHigh() {
+        return high;
+    }
+
+    public void setHigh(Double high) {
+        this.high = high;
+    }
+
+    public Double getLow() {
+        return low;
+    }
+
+    public void setLow(Double low) {
+        this.low = low;
+    }
+
+    public Double getVolume() {
+        return volume;
+    }
+
+    public void setVolume(Double volume) {
+        this.volume = volume;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/Ticker.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/Ticker.java
@@ -1,0 +1,100 @@
+package com.okcoin.commons.okex.open.api.bean.futures.result;
+
+/**
+ * The latest data on the futures contract product  <br/>
+ * Created by Tony Tian on 2018/2/26 13;16. <br/>
+ */
+public class Ticker {
+    /**
+     * The id of the futures contract
+     */
+    private String instrument_id;
+    /**
+     * Buy first price
+     */
+    private Double best_bid;
+    /**
+     * Sell first price
+     */
+    private Double best_ask;
+    /**
+     * Highest price
+     */
+    private Double high_24h;
+    /**
+     * Lowest price
+     */
+    private Double low_24h;
+    /**
+     * Latest price
+     */
+    private Double last;
+    /**
+     * Volume (recent 24 hours)
+     */
+    private Double volume_24h;
+    /**
+     * timestamp
+     */
+    private String timestamp;
+
+    public String getInstrument_id() { return instrument_id; }
+
+    public void setInstrument_id(String instrument_id) { this.instrument_id = instrument_id; }
+
+    public Double getBest_bid() {
+        return best_bid;
+    }
+
+    public void setBest_bid(Double best_bid) {
+        this.best_bid = best_bid;
+    }
+
+    public Double getBest_ask() {
+        return best_ask;
+    }
+
+    public void setBest_ask(Double best_ask) {
+        this.best_ask = best_ask;
+    }
+
+    public Double getHigh_24h() {
+        return high_24h;
+    }
+
+    public void setHigh_24h(Double high_24h) {
+        this.high_24h = high_24h;
+    }
+
+    public Double getLow_24h() {
+        return low_24h;
+    }
+
+    public void setLow_24h(Double low_24h) {
+        this.low_24h = low_24h;
+    }
+
+    public Double getLast() {
+        return last;
+    }
+
+    public void setLast(Double last) {
+        this.last = last;
+    }
+
+    public Double getVolume_24h() {
+        return volume_24h;
+    }
+
+    public void setVolume_24h(Double volume_24h) {
+        this.volume_24h = volume_24h;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/Trades.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/futures/result/Trades.java
@@ -1,0 +1,60 @@
+package com.okcoin.commons.okex.open.api.bean.futures.result;
+
+/**
+ * Get the latest transaction log information.  <br/>
+ * Created by Tony Tian on 2018/2/26 13:30. <br/>
+ */
+public class Trades {
+    /**
+     * The id of the futures contract
+     */
+    private String trade_id;
+    /**
+     * Transaction type
+     */
+    private String side;
+    /**
+     * Transaction price
+     */
+    private Double price;
+    /**
+     * Transaction amount
+     */
+    private Double qty;
+    /**
+     * Transaction date
+     */
+    private String timestamp;
+
+
+
+    public String getTrade_id() { return trade_id; }
+
+    public void setTrade_id(String trade_id) { this.trade_id = trade_id; }
+
+    public String getSide() { return side; }
+
+    public void setSide(String side) { this.side = side; }
+
+
+    public Double getPrice() {
+        return price;
+    }
+
+    public void setPrice(Double price) {
+        this.price = price;
+    }
+
+    public Double getQty() {
+        return qty;
+    }
+
+    public void setQty(Double qty) {
+        this.qty = qty;
+    }
+
+    public String getTimestamp() { return timestamp; }
+
+    public void setTimestamp(String timestamp) { this.timestamp = timestamp; }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/param/LoanRequestDTO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/param/LoanRequestDTO.java
@@ -1,0 +1,31 @@
+package com.okcoin.commons.okex.open.api.bean.spot.param;
+
+public class LoanRequestDTO {
+    private Integer productId;
+    private Integer currencyId;
+    private String amount;
+
+    public Integer getProductId() {
+        return this.productId;
+    }
+
+    public void setProductId(final Integer productId) {
+        this.productId = productId;
+    }
+
+    public Integer getCurrencyId() {
+        return this.currencyId;
+    }
+
+    public void setCurrencyId(final Integer currencyId) {
+        this.currencyId = currencyId;
+    }
+
+    public String getAmount() {
+        return this.amount;
+    }
+
+    public void setAmount(final String amount) {
+        this.amount = amount;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/param/MarginConfigRequestDTO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/param/MarginConfigRequestDTO.java
@@ -1,0 +1,13 @@
+package com.okcoin.commons.okex.open.api.bean.spot.param;
+
+public class MarginConfigRequestDTO {
+    private Integer status;
+
+    public Integer getStatus() {
+        return this.status;
+    }
+
+    public void setStatus(final Integer status) {
+        this.status = status;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/param/Order.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/param/Order.java
@@ -1,0 +1,74 @@
+package com.okcoin.commons.okex.open.api.bean.spot.param;
+
+public class Order {
+
+    private String product_id;
+
+    private String side;
+
+    private String type;
+
+    private String size;
+
+    private String price;
+
+    private String funds;
+
+    private String client_oid;
+
+    public String getClient_oid() {
+        return client_oid;
+    }
+
+    public void setClient_oid(String client_oid) {
+        this.client_oid = client_oid;
+    }
+
+    public String getProduct_id() {
+        return product_id;
+    }
+
+    public void setProduct_id(String product_id) {
+        this.product_id = product_id;
+    }
+
+    public String getSide() {
+        return side;
+    }
+
+    public void setSide(String side) {
+        this.side = side;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getSize() {
+        return size;
+    }
+
+    public void setSize(String size) {
+        this.size = size;
+    }
+
+    public String getPrice() {
+        return price;
+    }
+
+    public void setPrice(String price) {
+        this.price = price;
+    }
+
+    public String getFunds() {
+        return funds;
+    }
+
+    public void setFunds(String funds) {
+        this.funds = funds;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/param/OrderParamDto.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/param/OrderParamDto.java
@@ -1,0 +1,25 @@
+package com.okcoin.commons.okex.open.api.bean.spot.param;
+
+import java.util.List;
+
+public class OrderParamDto {
+    private String instrument_id;
+    private List<Long> order_ids;
+
+    public String getInstrument_id() {
+        return this.instrument_id;
+    }
+
+    public void setInstrument_id(final String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+
+    public List<Long> getOrder_ids() {
+        return this.order_ids;
+    }
+
+    public void setOrder_ids(final List<Long> order_ids) {
+        this.order_ids = order_ids;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/param/PlaceOrderParam.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/param/PlaceOrderParam.java
@@ -1,0 +1,117 @@
+package com.okcoin.commons.okex.open.api.bean.spot.param;
+
+public class PlaceOrderParam {
+    /**
+     * 客户端下单 标示id 非必填
+     */
+    private String client_oid;
+    /**
+     * 币对如 etc_eth
+     */
+    private String instrument_id;
+    /**
+     * 买卖类型 buy/sell
+     */
+    private String side;
+    /**
+     * 订单类型 限价单 limit 市价单 market
+     */
+    private String type;
+    /**
+     * 交易数量
+     */
+    private String size;
+    /**
+     * 限价单使用 价格
+     */
+    private String price;
+    /**
+     * 市价单使用 价格
+     */
+    private String notional;
+
+    /**
+     * 来源（web app ios android）
+     */
+    private Byte source = 0;
+
+    /**
+     * 1币币交易 2杠杆交易
+     */
+    private Byte margin_trading;
+
+    public String getClient_oid() {
+        return this.client_oid;
+    }
+
+    public void setClient_oid(final String client_oid) {
+        this.client_oid = client_oid;
+    }
+
+
+    public String getInstrument_id() {
+        return this.instrument_id;
+    }
+
+    public void setInstrument_id(final String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getSide() {
+        return this.side;
+    }
+
+    public void setSide(final String side) {
+        this.side = side;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public void setType(final String type) {
+        this.type = type;
+    }
+
+    public String getSize() {
+        return this.size;
+    }
+
+    public void setSize(final String size) {
+        this.size = size;
+    }
+
+    public String getPrice() {
+        return this.price;
+    }
+
+    public void setPrice(final String price) {
+        this.price = price;
+    }
+
+
+    public String getNotional() {
+        return this.notional;
+    }
+
+    public void setNotional(final String notional) {
+        this.notional = notional;
+    }
+
+    public Byte getSource() {
+        return this.source;
+    }
+
+    public void setSource(final Byte source) {
+        this.source = source;
+    }
+
+
+    public Byte getMargin_trading() {
+        return this.margin_trading;
+    }
+
+    public void setMargin_trading(final Byte margin_trading) {
+        this.margin_trading = margin_trading;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/param/RepayRequestDTO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/param/RepayRequestDTO.java
@@ -1,0 +1,40 @@
+package com.okcoin.commons.okex.open.api.bean.spot.param;
+
+public class RepayRequestDTO {
+    private Integer productId;
+    private Integer currencyId;
+    private String amount;
+    private Long orderId;
+
+    public Integer getProductId() {
+        return this.productId;
+    }
+
+    public void setProductId(final Integer productId) {
+        this.productId = productId;
+    }
+
+    public Integer getCurrencyId() {
+        return this.currencyId;
+    }
+
+    public void setCurrencyId(final Integer currencyId) {
+        this.currencyId = currencyId;
+    }
+
+    public String getAmount() {
+        return this.amount;
+    }
+
+    public void setAmount(final String amount) {
+        this.amount = amount;
+    }
+
+    public Long getOrderId() {
+        return this.orderId;
+    }
+
+    public void setOrderId(final Long orderId) {
+        this.orderId = orderId;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/param/WithdrawalsParamDTO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/param/WithdrawalsParamDTO.java
@@ -1,0 +1,4 @@
+package com.okcoin.commons.okex.open.api.bean.spot.param;
+
+public class WithdrawalsParamDTO {
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/Account.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/Account.java
@@ -1,0 +1,51 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+public class Account {
+
+    private String id;
+    private String currency;
+    private String balance;
+    private String available;
+    private String hold;
+
+    public String getHold() {
+        return this.hold;
+    }
+
+    public void setHold(final String hold) {
+        this.hold = hold;
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public void setId(final String id) {
+        this.id = id;
+    }
+
+    public String getCurrency() {
+        return this.currency;
+    }
+
+    public void setCurrency(final String currency) {
+        this.currency = currency;
+    }
+
+    public String getBalance() {
+        return this.balance;
+    }
+
+    public void setBalance(final String balance) {
+        this.balance = balance;
+    }
+
+    public String getAvailable() {
+        return this.available;
+    }
+
+    public void setAvailable(final String available) {
+        this.available = available;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/BatchOrdersResult.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/BatchOrdersResult.java
@@ -1,0 +1,34 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+import java.util.List;
+
+public class BatchOrdersResult {
+
+    private boolean result;
+    private List<String> order_id;
+    private String client_oid;
+
+    public boolean isResult() {
+        return this.result;
+    }
+
+    public void setResult(final boolean result) {
+        this.result = result;
+    }
+
+    public List<String> getOrder_id() {
+        return this.order_id;
+    }
+
+    public void setOrder_id(final List<String> order_id) {
+        this.order_id = order_id;
+    }
+
+    public String getClient_oid() {
+        return this.client_oid;
+    }
+
+    public void setClient_oid(final String client_oid) {
+        this.client_oid = client_oid;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/Book.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/Book.java
@@ -1,0 +1,25 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+import java.util.List;
+
+public class Book {
+    private List<String[]> asks;
+
+    private List<String[]> bids;
+
+    public List<String[]> getAsks() {
+        return asks;
+    }
+
+    public void setAsks(List<String[]> asks) {
+        this.asks = asks;
+    }
+
+    public List<String[]> getBids() {
+        return bids;
+    }
+
+    public void setBids(List<String[]> bids) {
+        this.bids = bids;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/BorrowConfigDto.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/BorrowConfigDto.java
@@ -1,0 +1,49 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+public class BorrowConfigDto {
+    private String product_id;
+    private String currency;
+    private String available;
+    private String rate;
+    private String leverage_ratio;
+
+    public String getProduct_id() {
+        return this.product_id;
+    }
+
+    public void setProduct_id(final String product_id) {
+        this.product_id = product_id;
+    }
+
+    public String getCurrency() {
+        return this.currency;
+    }
+
+    public void setCurrency(final String currency) {
+        this.currency = currency;
+    }
+
+    public String getAvailable() {
+        return this.available;
+    }
+
+    public void setAvailable(final String available) {
+        this.available = available;
+    }
+
+    public String getRate() {
+        return this.rate;
+    }
+
+    public void setRate(final String rate) {
+        this.rate = rate;
+    }
+
+    public String getLeverage_ratio() {
+        return this.leverage_ratio;
+    }
+
+    public void setLeverage_ratio(final String leverage_ratio) {
+        this.leverage_ratio = leverage_ratio;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/BorrowRequestDto.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/BorrowRequestDto.java
@@ -1,0 +1,32 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+public class BorrowRequestDto {
+    private String instrument_id;
+    private String currency;
+    private String amount;
+
+    public String getInstrument_id() {
+        return this.instrument_id;
+    }
+
+    public void setInstrument_id(final String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getCurrency() {
+        return this.currency;
+    }
+
+    public void setCurrency(final String currency) {
+        this.currency = currency;
+    }
+
+    public String getAmount() {
+        return this.amount;
+    }
+
+    public void setAmount(final String amount) {
+        this.amount = amount;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/BorrowResult.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/BorrowResult.java
@@ -1,0 +1,25 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+
+public class BorrowResult {
+
+    private boolean result;
+    private Long borrow_id;
+
+    public boolean isResult() {
+        return this.result;
+    }
+
+    public void setResult(final boolean result) {
+        this.result = result;
+    }
+
+    public Long getBorrow_id() {
+        return this.borrow_id;
+    }
+
+    public void setBorrow_id(final Long borrow_id) {
+        this.borrow_id = borrow_id;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/Currency.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/Currency.java
@@ -1,0 +1,22 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+public class Currency {
+    private String currency_id;
+    private String name;
+
+    public String getCurrency_id() {
+        return this.currency_id;
+    }
+
+    public void setCurrency_id(final String currency_id) {
+        this.currency_id = currency_id;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/CurrencyDto.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/CurrencyDto.java
@@ -1,0 +1,22 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+public class CurrencyDto {
+    private String currency_id;
+    private String name;
+
+    public String getCurrency_id() {
+        return this.currency_id;
+    }
+
+    public void setCurrency_id(final String currency_id) {
+        this.currency_id = currency_id;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/Fills.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/Fills.java
@@ -1,0 +1,122 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+public class Fills {
+
+    // 账单 id
+    private Long ledger_id;
+    // 币种 id
+    private String instrument_id;
+    private String product_id;
+    // 价格
+    private String price;
+    // 数量
+    private String size;
+    // 订单 id
+    private Long order_id;
+    // 创建时间
+    private String timestamp;
+    private String created_at;
+    // 流动方向
+    private String liquidity;
+    private String exec_type;
+    // 手续费
+    private String fee;
+    // buy、sell
+    private String side;
+
+    public Long getLedger_id() {
+        return this.ledger_id;
+    }
+
+    public void setLedger_id(final Long ledger_id) {
+        this.ledger_id = ledger_id;
+    }
+
+    public String getInstrument_id() {
+        return this.instrument_id;
+    }
+
+    public void setInstrument_id(final String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getProduct_id() {
+        return this.product_id;
+    }
+
+    public void setProduct_id(final String product_id) {
+        this.product_id = product_id;
+    }
+
+    public String getPrice() {
+        return this.price;
+    }
+
+    public void setPrice(final String price) {
+        this.price = price;
+    }
+
+    public String getSize() {
+        return this.size;
+    }
+
+    public void setSize(final String size) {
+        this.size = size;
+    }
+
+    public Long getOrder_id() {
+        return this.order_id;
+    }
+
+    public void setOrder_id(final Long order_id) {
+        this.order_id = order_id;
+    }
+
+    public String getTimestamp() {
+        return this.timestamp;
+    }
+
+    public void setTimestamp(final String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getCreated_at() {
+        return this.created_at;
+    }
+
+    public void setCreated_at(final String created_at) {
+        this.created_at = created_at;
+    }
+
+    public String getLiquidity() {
+        return this.liquidity;
+    }
+
+    public void setLiquidity(final String liquidity) {
+        this.liquidity = liquidity;
+    }
+
+    public String getExec_type() {
+        return this.exec_type;
+    }
+
+    public void setExec_type(final String exec_type) {
+        this.exec_type = exec_type;
+    }
+
+    public String getFee() {
+        return this.fee;
+    }
+
+    public void setFee(final String fee) {
+        this.fee = fee;
+    }
+
+    public String getSide() {
+        return this.side;
+    }
+
+    public void setSide(final String side) {
+        this.side = side;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/KlineDto.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/KlineDto.java
@@ -1,0 +1,58 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+public class KlineDto {
+    private String time;
+    private String low;
+    private String high;
+    private String open;
+    private String close;
+    private String volume;
+
+    public String getTime() {
+        return this.time;
+    }
+
+    public void setTime(final String time) {
+        this.time = time;
+    }
+
+    public String getLow() {
+        return this.low;
+    }
+
+    public void setLow(final String low) {
+        this.low = low;
+    }
+
+    public String getHigh() {
+        return this.high;
+    }
+
+    public void setHigh(final String high) {
+        this.high = high;
+    }
+
+    public String getOpen() {
+        return this.open;
+    }
+
+    public void setOpen(final String open) {
+        this.open = open;
+    }
+
+    public String getClose() {
+        return this.close;
+    }
+
+    public void setClose(final String close) {
+        this.close = close;
+    }
+
+    public String getVolume() {
+        return this.volume;
+    }
+
+    public void setVolume(final String volume) {
+        this.volume = volume;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/Ledger.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/Ledger.java
@@ -1,0 +1,91 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+public class Ledger {
+
+    private Long ledger_id;
+    private String currency;
+    private String amount;
+    private String balance;
+    private String type;
+    private Details details;
+    private String timestamp;
+
+    public Long getLedger_id() {
+        return this.ledger_id;
+    }
+
+    public void setLedger_id(final Long ledger_id) {
+        this.ledger_id = ledger_id;
+    }
+
+
+
+    public String getCurrency() {
+        return this.currency;
+    }
+
+    public void setCurrency(final String currency) {
+        this.currency = currency;
+    }
+
+    public String getAmount() {
+        return this.amount;
+    }
+
+    public void setAmount(final String amount) {
+        this.amount = amount;
+    }
+
+    public String getBalance() {
+        return this.balance;
+    }
+
+    public void setBalance(final String balance) {
+        this.balance = balance;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public void setType(final String type) {
+        this.type = type;
+    }
+
+    public Details getDetails() {
+        return this.details;
+    }
+
+    public void setDetails(final Details details) {
+        this.details = details;
+    }
+
+    public String getTimestamp() {
+        return this.timestamp;
+    }
+
+    public void setTimestamp(final String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public static class Details {
+        private Long order_id;
+        private String instrument_id;
+
+        public Long getOrder_id() {
+            return this.order_id;
+        }
+
+        public void setOrder_id(final Long order_id) {
+            this.order_id = order_id;
+        }
+
+        public String getInstrument_id() {
+            return this.instrument_id;
+        }
+
+        public void setInstrument_id(final String instrument_id) {
+            this.instrument_id = instrument_id;
+        }
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/MarginAccountDetailDto.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/MarginAccountDetailDto.java
@@ -1,0 +1,31 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+public class MarginAccountDetailDto {
+    private String balance;
+    private String available;
+    private String holds;
+
+    public String getBalance() {
+        return this.balance;
+    }
+
+    public void setBalance(final String balance) {
+        this.balance = balance;
+    }
+
+    public String getAvailable() {
+        return this.available;
+    }
+
+    public void setAvailable(final String available) {
+        this.available = available;
+    }
+
+    public String getHolds() {
+        return this.holds;
+    }
+
+    public void setHolds(final String holds) {
+        this.holds = holds;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/MarginAccountDto.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/MarginAccountDto.java
@@ -1,0 +1,24 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+import java.util.List;
+
+public class MarginAccountDto {
+    private String product_id;
+    private List<MarginAccountDetailDto> detailDtos;
+
+    public String getProduct_id() {
+        return this.product_id;
+    }
+
+    public void setProduct_id(final String product_id) {
+        this.product_id = product_id;
+    }
+
+    public List<MarginAccountDetailDto> getDetailDtos() {
+        return this.detailDtos;
+    }
+
+    public void setDetailDtos(final List<MarginAccountDetailDto> detailDtos) {
+        this.detailDtos = detailDtos;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/MarginBorrowOrderDto.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/MarginBorrowOrderDto.java
@@ -1,0 +1,121 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+public class MarginBorrowOrderDto {
+    private Long borrow_id;
+    private String product_id;
+    private String instrument_id;
+    private String currency;
+    private String timestamp;
+    private String created_at;
+    private String last_interest_time;
+    private String amount;
+    private String interest;
+    private String repay_amount;
+    private String returned_amount;
+    private String repay_interest;
+    private String paid_interest;
+
+    public Long getBorrow_id() {
+        return this.borrow_id;
+    }
+
+    public void setBorrow_id(final Long borrow_id) {
+        this.borrow_id = borrow_id;
+    }
+
+    public String getProduct_id() {
+        return this.product_id;
+    }
+
+    public void setProduct_id(final String product_id) {
+        this.product_id = product_id;
+    }
+
+    public String getInstrument_id() {
+        return this.instrument_id;
+    }
+
+    public void setInstrument_id(final String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getCurrency() {
+        return this.currency;
+    }
+
+    public void setCurrency(final String currency) {
+        this.currency = currency;
+    }
+
+    public String getTimestamp() {
+        return this.timestamp;
+    }
+
+    public void setTimestamp(final String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getCreated_at() {
+        return this.created_at;
+    }
+
+    public void setCreated_at(final String created_at) {
+        this.created_at = created_at;
+    }
+
+    public String getLast_interest_time() {
+        return this.last_interest_time;
+    }
+
+    public void setLast_interest_time(final String last_interest_time) {
+        this.last_interest_time = last_interest_time;
+    }
+
+    public String getAmount() {
+        return this.amount;
+    }
+
+    public void setAmount(final String amount) {
+        this.amount = amount;
+    }
+
+    public String getInterest() {
+        return this.interest;
+    }
+
+    public void setInterest(final String interest) {
+        this.interest = interest;
+    }
+
+    public String getRepay_amount() {
+        return this.repay_amount;
+    }
+
+    public void setRepay_amount(final String repay_amount) {
+        this.repay_amount = repay_amount;
+    }
+
+    public String getReturned_amount() {
+        return this.returned_amount;
+    }
+
+    public void setReturned_amount(final String returned_amount) {
+        this.returned_amount = returned_amount;
+    }
+
+    public String getRepay_interest() {
+        return this.repay_interest;
+    }
+
+    public void setRepay_interest(final String repay_interest) {
+        this.repay_interest = repay_interest;
+    }
+
+    public String getPaid_interest() {
+        return this.paid_interest;
+    }
+
+    public void setPaid_interest(final String paid_interest) {
+        this.paid_interest = paid_interest;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/OrderInfo.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/OrderInfo.java
@@ -1,0 +1,149 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+public class OrderInfo {
+
+    /**
+     * 订单id
+     */
+    private Long order_id;
+    /**
+     * limit 订单类型的价格信息
+     */
+    private String price;
+    /**
+     * market 订单类型的价格信息
+     */
+    private String notional;
+    /**
+     * 委托数量
+     */
+    private String size;
+    /**
+     * 平均成交价
+     */
+    //private String avg_price;
+    /**
+     * 委托时间
+     */
+    private String timestamp;
+    /**
+     * 成交数量
+     */
+    private String filled_size;
+    /**
+     * 订单状态 -1 已撤销 0 未成交
+     */
+    private String status;
+    /**
+     * 订单买卖类型 buy/sell
+     */
+    private String side;
+    /**
+     * 订单类型 limit/market
+     */
+    private String type;
+    /**
+     * 币对信息
+     */
+    private String instrument_id;
+
+    /**
+     * 计价成交量
+     */
+    private String filled_notional;
+
+    public Long getOrder_id() {
+        return this.order_id;
+    }
+
+    public void setOrder_id(final Long order_id) {
+        this.order_id = order_id;
+    }
+
+    public String getPrice() {
+        return this.price;
+    }
+
+    public void setPrice(final String price) {
+        this.price = price;
+    }
+
+
+
+    public String getNotional() {
+        return this.notional;
+    }
+
+    public void setNotional(final String notional) {
+        this.notional = notional;
+    }
+
+    public String getSize() {
+        return this.size;
+    }
+
+    public void setSize(final String size) {
+        this.size = size;
+    }
+
+
+    public String getTimestamp() {
+        return this.timestamp;
+    }
+
+    public void setTimestamp(final String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getFilled_size() {
+        return this.filled_size;
+    }
+
+    public void setFilled_size(final String filled_size) {
+        this.filled_size = filled_size;
+    }
+
+    public String getStatus() {
+        return this.status;
+    }
+
+    public void setStatus(final String status) {
+        this.status = status;
+    }
+
+    public String getSide() {
+        return this.side;
+    }
+
+    public void setSide(final String side) {
+        this.side = side;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public void setType(final String type) {
+        this.type = type;
+    }
+
+    public String getInstrument_id() {
+        return this.instrument_id;
+    }
+
+    public void setInstrument_id(final String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+
+
+
+
+    public String getFilled_notional() {
+        return this.filled_notional;
+    }
+
+    public void setFilled_notional(final String filled_notional) {
+        this.filled_notional = filled_notional;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/OrderResult.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/OrderResult.java
@@ -1,0 +1,32 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+public class OrderResult {
+
+    private boolean result;
+    private Long order_id;
+    private String client_oid;
+
+    public String getClient_oid() {
+        return this.client_oid;
+    }
+
+    public void setClient_oid(final String client_oid) {
+        this.client_oid = client_oid;
+    }
+
+    public boolean isResult() {
+        return this.result;
+    }
+
+    public void setResult(final boolean result) {
+        this.result = result;
+    }
+
+    public Long getOrder_id() {
+        return this.order_id;
+    }
+
+    public void setOrder_id(final Long order_id) {
+        this.order_id = order_id;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/Product.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/Product.java
@@ -1,0 +1,98 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+public class Product {
+
+    private String product_id;
+    private String base_currency;
+    private String quote_currency;
+    private String min_size;
+    private String size_increment;
+    private String tick_size;
+
+    private String base_min_size;
+    private String base_increment;
+    private String quote_increment;
+    private String instrument_id;
+
+    public String getInstrument_id() {
+        return this.instrument_id;
+    }
+
+    public void setInstrument_id(final String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getMin_size() {
+        return this.min_size;
+    }
+
+    public void setMin_size(final String min_size) {
+        this.min_size = min_size;
+    }
+
+    public String getSize_increment() {
+        return this.size_increment;
+    }
+
+    public void setSize_increment(final String size_increment) {
+        this.size_increment = size_increment;
+    }
+
+    public String getTick_size() {
+        return this.tick_size;
+    }
+
+    public void setTick_size(final String tick_size) {
+        this.tick_size = tick_size;
+    }
+
+    public String getBase_increment() {
+        return this.base_increment;
+    }
+
+    public void setBase_increment(final String base_increment) {
+        this.base_increment = base_increment;
+    }
+
+    public String getProduct_id() {
+        return this.product_id;
+    }
+
+    public void setProduct_id(final String product_id) {
+        this.product_id = product_id;
+    }
+
+    public String getBase_currency() {
+        return this.base_currency;
+    }
+
+    public void setBase_currency(final String base_currency) {
+        this.base_currency = base_currency;
+    }
+
+    public String getQuote_currency() {
+        return this.quote_currency;
+    }
+
+    public void setQuote_currency(final String quote_currency) {
+        this.quote_currency = quote_currency;
+    }
+
+    public String getBase_min_size() {
+        return this.base_min_size;
+    }
+
+    public void setBase_min_size(final String base_min_size) {
+        this.base_min_size = base_min_size;
+    }
+
+
+
+    public String getQuote_increment() {
+        return this.quote_increment;
+    }
+
+    public void setQuote_increment(final String quote_increment) {
+        this.quote_increment = quote_increment;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/RepaymentRequestDto.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/RepaymentRequestDto.java
@@ -1,0 +1,40 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+public class RepaymentRequestDto {
+    private String instrument_id;
+    private String currency;
+    private String amount;
+    private String borrow_id;
+
+    public String getInstrument_id() {
+        return this.instrument_id;
+    }
+
+    public void setInstrument_id(final String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getCurrency() {
+        return this.currency;
+    }
+
+    public void setCurrency(final String currency) {
+        this.currency = currency;
+    }
+
+    public String getAmount() {
+        return this.amount;
+    }
+
+    public void setAmount(final String amount) {
+        this.amount = amount;
+    }
+
+    public String getBorrow_id() {
+        return this.borrow_id;
+    }
+
+    public void setBorrow_id(final String borrow_id) {
+        this.borrow_id = borrow_id;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/RepaymentResult.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/RepaymentResult.java
@@ -1,0 +1,25 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+
+public class RepaymentResult {
+
+    private boolean result;
+    private Long repayment_id;
+
+    public boolean isResult() {
+        return this.result;
+    }
+
+    public void setResult(final boolean result) {
+        this.result = result;
+    }
+
+    public Long getRepayment_id() {
+        return this.repayment_id;
+    }
+
+    public void setRepayment_id(final Long repayment_id) {
+        this.repayment_id = repayment_id;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/ResponseResult.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/ResponseResult.java
@@ -1,0 +1,24 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+import java.io.Serializable;
+
+public class ResponseResult<T> implements Serializable {
+
+    private final T data;
+
+    private ResponseResult(final T data) {
+        this.data = data;
+    }
+
+    public static ResponseResult success() {
+        return ResponseResult.success(new Object());
+    }
+
+    public static <T> ResponseResult<T> success(final T data) {
+        return ResponseResult.build(data);
+    }
+
+    public static <T> ResponseResult<T> build(final T data) {
+        return new ResponseResult(data);
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/ServerTimeDto.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/ServerTimeDto.java
@@ -1,0 +1,22 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+public class ServerTimeDto {
+    private Long epoch;
+    private String iso;
+
+    public Long getEpoch() {
+        return epoch;
+    }
+
+    public void setEpoch(Long epoch) {
+        this.epoch = epoch;
+    }
+
+    public String getIso() {
+        return iso;
+    }
+
+    public void setIso(String iso) {
+        this.iso = iso;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/Ticker.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/Ticker.java
@@ -1,0 +1,122 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+public class Ticker {
+
+    private String product_id;
+    private String last;
+    private String bid;
+    private String ask;
+    private String open_24h;
+    private String high_24h;
+    private String low_24h;
+    private String base_volume_24h;
+    private String timestamp;
+    private String quote_volume_24h;
+    private String best_ask;
+    private String best_bid;
+    private String instrument_id;
+
+    public String getInstrument_id() {
+        return this.instrument_id;
+    }
+
+    public void setInstrument_id(final String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getProduct_id() {
+        return this.product_id;
+    }
+
+    public void setProduct_id(final String product_id) {
+        this.product_id = product_id;
+    }
+
+    public String getLast() {
+        return this.last;
+    }
+
+    public void setLast(final String last) {
+        this.last = last;
+    }
+
+    public String getBid() {
+        return this.bid;
+    }
+
+    public void setBid(final String bid) {
+        this.bid = bid;
+    }
+
+    public String getAsk() {
+        return this.ask;
+    }
+
+    public void setAsk(final String ask) {
+        this.ask = ask;
+    }
+
+    public String getOpen_24h() {
+        return this.open_24h;
+    }
+
+    public void setOpen_24h(final String open_24h) {
+        this.open_24h = open_24h;
+    }
+
+    public String getHigh_24h() {
+        return this.high_24h;
+    }
+
+    public void setHigh_24h(final String high_24h) {
+        this.high_24h = high_24h;
+    }
+
+    public String getLow_24h() {
+        return this.low_24h;
+    }
+
+    public void setLow_24h(final String low_24h) {
+        this.low_24h = low_24h;
+    }
+
+    public String getBase_volume_24h() {
+        return this.base_volume_24h;
+    }
+
+    public void setBase_volume_24h(final String base_volume_24h) {
+        this.base_volume_24h = base_volume_24h;
+    }
+
+    public String getTimestamp() {
+        return this.timestamp;
+    }
+
+    public void setTimestamp(final String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getQuote_volume_24h() {
+        return this.quote_volume_24h;
+    }
+
+    public void setQuote_volume_24h(final String quote_volume_24h) {
+        this.quote_volume_24h = quote_volume_24h;
+    }
+
+    public String getBest_ask() {
+        return this.best_ask;
+    }
+
+    public void setBest_ask(final String best_ask) {
+        this.best_ask = best_ask;
+    }
+
+    public String getBest_bid() {
+        return this.best_bid;
+    }
+
+    public void setBest_bid(final String best_bid) {
+        this.best_bid = best_bid;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/Trade.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/Trade.java
@@ -1,0 +1,58 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+public class Trade {
+    private String timestamp;
+    private Integer trade_id;
+    private String price;
+    private String size;
+    private String side;
+    private String time;
+
+    public String getTimestamp() {
+        return this.timestamp;
+    }
+
+    public void setTimestamp(final String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public Integer getTrade_id() {
+        return this.trade_id;
+    }
+
+    public void setTrade_id(final Integer trade_id) {
+        this.trade_id = trade_id;
+    }
+
+    public String getPrice() {
+        return this.price;
+    }
+
+    public void setPrice(final String price) {
+        this.price = price;
+    }
+
+    public String getSize() {
+        return this.size;
+    }
+
+    public void setSize(final String size) {
+        this.size = size;
+    }
+
+    public String getSide() {
+        return this.side;
+    }
+
+    public void setSide(final String side) {
+        this.side = side;
+    }
+
+    public String getTime() {
+        return this.time;
+    }
+
+    public void setTime(final String time) {
+        this.time = time;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/UserMarginBillDto.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/spot/result/UserMarginBillDto.java
@@ -1,0 +1,80 @@
+package com.okcoin.commons.okex.open.api.bean.spot.result;
+
+public class UserMarginBillDto {
+    private Long ledger_id;
+    private String timestamp;
+    private String amount;
+    private String balance;
+    private String type;
+    private UserMarginBillDto.Details details;
+
+    public String getTimestamp() {
+        return this.timestamp;
+    }
+
+    public void setTimestamp(final String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public Long getLedger_id() {
+        return this.ledger_id;
+    }
+
+    public void setLedger_id(final Long ledger_id) {
+        this.ledger_id = ledger_id;
+    }
+
+
+    public String getAmount() {
+        return this.amount;
+    }
+
+    public void setAmount(final String amount) {
+        this.amount = amount;
+    }
+
+    public String getBalance() {
+        return this.balance;
+    }
+
+    public void setBalance(final String balance) {
+        this.balance = balance;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public void setType(final String type) {
+        this.type = type;
+    }
+
+    public UserMarginBillDto.Details getDetails() {
+        return this.details;
+    }
+
+    public void setDetails(final UserMarginBillDto.Details details) {
+        this.details = details;
+    }
+
+    public static class Details {
+        private Long order_id;
+        private String instrument_id;
+
+        public Long getOrder_id() {
+            return this.order_id;
+        }
+
+        public void setOrder_id(final Long order_id) {
+            this.order_id = order_id;
+        }
+
+        public String getInstrument_id() {
+            return this.instrument_id;
+        }
+
+        public void setInstrument_id(final String instrument_id) {
+            this.instrument_id = instrument_id;
+        }
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/param/LevelRateParam.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/param/LevelRateParam.java
@@ -1,0 +1,40 @@
+package com.okcoin.commons.okex.open.api.bean.swap.param;
+
+import java.math.BigDecimal;
+
+public class LevelRateParam {
+
+    /**
+     * 1.LONG
+     * 2.SHORT
+     * 3.全仓杠杆
+     */
+    private Integer side;
+    private BigDecimal leverage;
+
+    public LevelRateParam(Integer side, BigDecimal levelRate) {
+        this.side = side;
+        this.leverage = levelRate;
+    }
+
+    public LevelRateParam() {
+    }
+
+    public Integer getSide() {
+        return side;
+    }
+
+    public void setSide(Integer side) {
+        this.side = side;
+    }
+
+    public BigDecimal getLevelRate() {
+        return leverage;
+    }
+
+    public void setLevelRate(BigDecimal levelRate) {
+        this.leverage = levelRate;
+    }
+
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/param/PpBatchOrder.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/param/PpBatchOrder.java
@@ -1,0 +1,77 @@
+package com.okcoin.commons.okex.open.api.bean.swap.param;
+
+public class PpBatchOrder {
+
+    /**
+     * 由您设置的订单id来唯一标识您的订单
+     */
+    private String client_oid;
+    /**
+     * 下单数量
+     */
+    private String size;
+    /**
+     * 1:开多 2:开空 3:平多 4:平空
+     */
+    private String type;
+    /**
+     * 是否以对手价下单 0:不是 1:是
+     */
+    private String match_price;
+    /**
+     * 委托价格
+     */
+    private String price;
+
+    public PpBatchOrder() {
+    }
+
+    public PpBatchOrder(String client_oid, String size, String type, String match_price, String price) {
+        this.client_oid = client_oid;
+        this.size = size;
+        this.type = type;
+        this.match_price = match_price;
+        this.price = price;
+    }
+
+    public String getClient_oid() {
+        return client_oid;
+    }
+
+    public void setClient_oid(String client_oid) {
+        this.client_oid = client_oid;
+    }
+
+    public String getSize() {
+        return size;
+    }
+
+    public void setSize(String size) {
+        this.size = size;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getMatch_price() {
+        return match_price;
+    }
+
+    public void setMatch_price(String match_price) {
+        this.match_price = match_price;
+    }
+
+    public String getPrice() {
+        return price;
+    }
+
+    public void setPrice(String price) {
+        this.price = price;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/param/PpCancelOrderVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/param/PpCancelOrderVO.java
@@ -1,0 +1,23 @@
+package com.okcoin.commons.okex.open.api.bean.swap.param;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class PpCancelOrderVO {
+    private List<String> ids = new LinkedList<>();
+
+    public PpCancelOrderVO() {
+    }
+
+    public List<String> getIds() {
+        return ids;
+    }
+
+    public void setIds(List<String> ids) {
+        this.ids = ids;
+    }
+
+    public PpCancelOrderVO(List<String> ids) {
+        this.ids = ids;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/param/PpOrder.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/param/PpOrder.java
@@ -1,0 +1,90 @@
+package com.okcoin.commons.okex.open.api.bean.swap.param;
+
+public class PpOrder {
+
+    /**
+     * 由您设置的订单id来唯一标识您的订单
+     */
+    private String client_oid;
+    /**
+     * 下单数量
+     */
+    private String size;
+    /**
+     * 1:开多 2:开空 3:平多 4:平空
+     */
+    private String type;
+    /**
+     * 是否以对手价下单 0:不是 1:是
+     */
+    private String match_price;
+    /**
+     * 委托价格
+     */
+    private String price;
+    /**
+     * 合约名称，如BTC-USD-SWAP
+     */
+    private String instrument_id;
+
+    public PpOrder() {
+    }
+
+    public PpOrder(String client_oid, String size, String type, String match_price, String price, String instrument_id) {
+        this.client_oid = client_oid;
+        this.size = size;
+        this.type = type;
+        this.match_price = match_price;
+        this.price = price;
+        this.instrument_id = instrument_id;
+    }
+
+    public String getClient_oid() {
+        return client_oid;
+    }
+
+    public void setClient_oid(String client_oid) {
+        this.client_oid = client_oid;
+    }
+
+    public String getSize() {
+        return size;
+    }
+
+    public void setSize(String size) {
+        this.size = size;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getMatch_price() {
+        return match_price;
+    }
+
+    public void setMatch_price(String match_price) {
+        this.match_price = match_price;
+    }
+
+    public String getPrice() {
+        return price;
+    }
+
+    public void setPrice(String price) {
+        this.price = price;
+    }
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/param/PpOrders.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/param/PpOrders.java
@@ -1,0 +1,34 @@
+package com.okcoin.commons.okex.open.api.bean.swap.param;
+
+import java.util.List;
+
+public class PpOrders {
+
+    private String instrument_id = "";
+    private List<PpBatchOrder> order_data = null;
+
+    public void setInstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public void setOrder_data(List<PpBatchOrder> order_data) {
+        this.order_data = order_data;
+    }
+
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public List<PpBatchOrder> getOrder_data() {
+        return order_data;
+    }
+
+    public PpOrders() {
+    }
+
+    public PpOrders(String instrumentId, List<PpBatchOrder> orderData) {
+        this.instrument_id = instrumentId;
+        this.order_data = orderData;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiAccountVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiAccountVO.java
@@ -1,0 +1,122 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+public class ApiAccountVO {
+
+    private String equity;
+    private String total_avail_balance;
+    private String margin;
+    private String realized_pnl;
+    private String unrealized_pnl;
+    private String margin_ratio;
+    private String instrument_id;
+    private String margin_frozen;
+    private String timestamp;
+    private String margin_mode;
+    private ApiAccountVO info;
+
+    public ApiAccountVO() {
+    }
+
+    public ApiAccountVO(String equity, String total_avail_balance, String margin, String realized_pnl, String unrealized_pnl, String margin_ratio, String instrument_id, String margin_frozen, String timestamp, String margin_mode, ApiAccountVO info) {
+        this.equity = equity;
+        this.total_avail_balance = total_avail_balance;
+        this.margin = margin;
+        this.realized_pnl = realized_pnl;
+        this.unrealized_pnl = unrealized_pnl;
+        this.margin_ratio = margin_ratio;
+        this.instrument_id = instrument_id;
+        this.margin_frozen = margin_frozen;
+        this.timestamp = timestamp;
+        this.margin_mode = margin_mode;
+        this.info = info;
+    }
+
+
+    public String getEquity() {
+        return equity;
+    }
+
+    public void setEquity(String equity) {
+        this.equity = equity;
+    }
+
+    public String getTotal_avail_balance() {
+        return total_avail_balance;
+    }
+
+    public void setTotal_avail_balance(String total_avail_balance) {
+        this.total_avail_balance = total_avail_balance;
+    }
+
+    public String getMargin() {
+        return margin;
+    }
+
+    public void setMargin(String margin) {
+        this.margin = margin;
+    }
+
+    public String getRealized_pnl() {
+        return realized_pnl;
+    }
+
+    public void setRealized_pnl(String realized_pnl) {
+        this.realized_pnl = realized_pnl;
+    }
+
+    public String getUnrealized_pnl() {
+        return unrealized_pnl;
+    }
+
+    public void setUnrealized_pnl(String unrealized_pnl) {
+        this.unrealized_pnl = unrealized_pnl;
+    }
+
+    public String getMargin_ratio() {
+        return margin_ratio;
+    }
+
+    public void setMargin_ratio(String margin_ratio) {
+        this.margin_ratio = margin_ratio;
+    }
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getMargin_frozen() {
+        return margin_frozen;
+    }
+
+    public void setMargin_frozen(String margin_frozen) {
+        this.margin_frozen = margin_frozen;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getMargin_mode() {
+        return margin_mode;
+    }
+
+    public void setMargin_mode(String margin_mode) {
+        this.margin_mode = margin_mode;
+    }
+
+    public ApiAccountVO getInfo() {
+        return info;
+    }
+
+    public void setInfo(ApiAccountVO info) {
+        this.info = info;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiAccountsVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiAccountsVO.java
@@ -1,0 +1,22 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+import java.util.List;
+
+public class ApiAccountsVO {
+    private List<ApiAccountVO> info;
+
+    public List<ApiAccountVO> getInfo() {
+        return info;
+    }
+
+    public void setInfo(List<ApiAccountVO> info) {
+        this.info = info;
+    }
+
+    public ApiAccountsVO() {
+    }
+
+    public ApiAccountsVO(List<ApiAccountVO> info) {
+        this.info = info;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiCancelOrderVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiCancelOrderVO.java
@@ -1,0 +1,32 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+public class ApiCancelOrderVO {
+
+    private String order_id;
+    private String result;
+
+    public ApiCancelOrderVO() {
+    }
+
+    public ApiCancelOrderVO(String order_id, String result) {
+        this.order_id = order_id;
+        this.result = result;
+    }
+
+    public String getOrder_id() {
+        return order_id;
+    }
+
+    public void setOrder_id(String order_id) {
+        this.order_id = order_id;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public void setResult(String result) {
+        this.result = result;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiContractVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiContractVO.java
@@ -1,0 +1,102 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+public class ApiContractVO {
+
+    private String instrument_id;
+    private String underlying_index;
+    private String quote_currency;
+    private String coin;
+    private String contract_val;
+    private String listing;
+    private String delivery;
+    private String size_increment;
+    private String tick_size;
+
+    public ApiContractVO(String instrument_id, String underlying_index, String quote_currency, String coin, String contract_val, String listing, String delivery, String size_increment, String tick_size) {
+        this.instrument_id = instrument_id;
+        this.underlying_index = underlying_index;
+        this.quote_currency = quote_currency;
+        this.coin = coin;
+        this.contract_val = contract_val;
+        this.listing = listing;
+        this.delivery = delivery;
+        this.size_increment = size_increment;
+        this.tick_size = tick_size;
+    }
+
+    public ApiContractVO() {
+    }
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getUnderlying_index() {
+        return underlying_index;
+    }
+
+    public void setUnderlying_index(String underlying_index) {
+        this.underlying_index = underlying_index;
+    }
+
+    public String getQuote_currency() {
+        return quote_currency;
+    }
+
+    public void setQuote_currency(String quote_currency) {
+        this.quote_currency = quote_currency;
+    }
+
+    public String getCoin() {
+        return coin;
+    }
+
+    public void setCoin(String coin) {
+        this.coin = coin;
+    }
+
+    public String getContract_val() {
+        return contract_val;
+    }
+
+    public void setContract_val(String contract_val) {
+        this.contract_val = contract_val;
+    }
+
+    public String getListing() {
+        return listing;
+    }
+
+    public void setListing(String listing) {
+        this.listing = listing;
+    }
+
+    public String getDelivery() {
+        return delivery;
+    }
+
+    public void setDelivery(String delivery) {
+        this.delivery = delivery;
+    }
+
+    public String getSize_increment() {
+        return size_increment;
+    }
+
+    public void setSize_increment(String size_increment) {
+        this.size_increment = size_increment;
+    }
+
+    public String getTick_size() {
+        return tick_size;
+    }
+
+    public void setTick_size(String tick_size) {
+        this.tick_size = tick_size;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiDealDetailVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiDealDetailVO.java
@@ -1,0 +1,101 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+public class ApiDealDetailVO {
+
+    private Long trade_id;
+    private String instrument_id;
+    private String order_id;
+    private String price;
+    private String order_qty;
+    private String fee;
+    private String timestamp;
+    private String exec_type;
+    private String side;
+
+    public ApiDealDetailVO() {
+    }
+
+    public Long getTrade_id() {
+        return trade_id;
+    }
+
+    public void setTrade_id(Long trade_id) {
+        this.trade_id = trade_id;
+    }
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getOrder_id() {
+        return order_id;
+    }
+
+    public void setOrder_id(String order_id) {
+        this.order_id = order_id;
+    }
+
+    public String getPrice() {
+        return price;
+    }
+
+    public void setPrice(String price) {
+        this.price = price;
+    }
+
+    public String getOrder_qty() {
+        return order_qty;
+    }
+
+    public void setOrder_qty(String order_qty) {
+        this.order_qty = order_qty;
+    }
+
+    public String getFee() {
+        return fee;
+    }
+
+    public void setFee(String fee) {
+        this.fee = fee;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getExec_type() {
+        return exec_type;
+    }
+
+    public void setExec_type(String exec_type) {
+        this.exec_type = exec_type;
+    }
+
+    public String getSide() {
+        return side;
+    }
+
+    public void setSide(String side) {
+        this.side = side;
+    }
+
+    public ApiDealDetailVO(Long trade_id, String instrument_id, String order_id, String price, String order_qty, String fee, String timestamp, String exec_type, String side) {
+        this.trade_id = trade_id;
+        this.instrument_id = instrument_id;
+        this.order_id = order_id;
+        this.price = price;
+        this.order_qty = order_qty;
+        this.fee = fee;
+        this.timestamp = timestamp;
+        this.exec_type = exec_type;
+        this.side = side;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiDealVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiDealVO.java
@@ -1,0 +1,62 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+public class ApiDealVO {
+
+    private String trade_id;
+    private String price;
+    private String amount;
+    private String side;
+    private String timestamp;
+
+    public ApiDealVO(String trade_id, String price, String amount, String side, String timestamp) {
+        this.trade_id = trade_id;
+        this.price = price;
+        this.amount = amount;
+        this.side = side;
+        this.timestamp = timestamp;
+    }
+
+    public ApiDealVO() {
+    }
+
+    public String getTrade_id() {
+        return trade_id;
+    }
+
+    public void setTrade_id(String trade_id) {
+        this.trade_id = trade_id;
+    }
+
+    public String getPrice() {
+        return price;
+    }
+
+    public void setPrice(String price) {
+        this.price = price;
+    }
+
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public String getSide() {
+        return side;
+    }
+
+    public void setSide(String side) {
+        this.side = side;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiFundingRateVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiFundingRateVO.java
@@ -1,0 +1,62 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+public class ApiFundingRateVO {
+
+    private String instrument_id;
+    private String funding_rate;
+    private String funding_rate_new;
+    private String interest_rate;
+    private String funding_time;
+
+    public ApiFundingRateVO() {
+    }
+
+    public ApiFundingRateVO(String instrument_id, String funding_rate, String funding_rate_new, String interest_rate, String funding_time) {
+        this.instrument_id = instrument_id;
+        this.funding_rate = funding_rate;
+        this.funding_rate_new = funding_rate_new;
+        this.interest_rate = interest_rate;
+        this.funding_time = funding_time;
+    }
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getFunding_rate() {
+        return funding_rate;
+    }
+
+    public void setFunding_rate(String funding_rate) {
+        this.funding_rate = funding_rate;
+    }
+
+    public String getFunding_rate_new() {
+        return funding_rate_new;
+    }
+
+    public void setFunding_rate_new(String funding_rate_new) {
+        this.funding_rate_new = funding_rate_new;
+    }
+
+    public String getInterest_rate() {
+        return interest_rate;
+    }
+
+    public void setInterest_rate(String interest_rate) {
+        this.interest_rate = interest_rate;
+    }
+
+    public String getFunding_time() {
+        return funding_time;
+    }
+
+    public void setFunding_time(String funding_time) {
+        this.funding_time = funding_time;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiFundingTimeVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiFundingTimeVO.java
@@ -1,0 +1,32 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+public class ApiFundingTimeVO {
+
+    private String instrument_id;
+    private String funding_time;
+
+    public ApiFundingTimeVO() {
+    }
+
+    public ApiFundingTimeVO(String instrument_id, String funding_time) {
+        this.instrument_id = instrument_id;
+        this.funding_time = funding_time;
+    }
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getFunding_time() {
+        return funding_time;
+    }
+
+    public void setFunding_time(String funding_time) {
+        this.funding_time = funding_time;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiIndexVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiIndexVO.java
@@ -1,0 +1,42 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+public class ApiIndexVO {
+
+    private String instrument_id;
+    private String index;
+    private String timestamp;
+
+    public ApiIndexVO() {
+    }
+
+    public ApiIndexVO(String instrument_id, String index, String timestamp) {
+        this.instrument_id = instrument_id;
+        this.index = index;
+        this.timestamp = timestamp;
+    }
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getIndex() {
+        return index;
+    }
+
+    public void setIndex(String index) {
+        this.index = index;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiKlineVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiKlineVO.java
@@ -1,0 +1,81 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+public class ApiKlineVO {
+
+    private String timestamp;
+    private String low;
+    private String high;
+    private String open;
+    private String close;
+    private String volume;
+    private String currency_volume;
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getLow() {
+        return low;
+    }
+
+    public void setLow(String low) {
+        this.low = low;
+    }
+
+    public String getHigh() {
+        return high;
+    }
+
+    public void setHigh(String high) {
+        this.high = high;
+    }
+
+    public String getOpen() {
+        return open;
+    }
+
+    public void setOpen(String open) {
+        this.open = open;
+    }
+
+    public String getClose() {
+        return close;
+    }
+
+    public void setClose(String close) {
+        this.close = close;
+    }
+
+    public String getVolume() {
+        return volume;
+    }
+
+    public void setVolume(String volume) {
+        this.volume = volume;
+    }
+
+    public String getCurrency_volume() {
+        return currency_volume;
+    }
+
+    public void setCurrency_volume(String currency_volume) {
+        this.currency_volume = currency_volume;
+    }
+
+    public ApiKlineVO() {
+    }
+
+    public ApiKlineVO(String timestamp, String low, String high, String open, String close, String volume, String currency_volume) {
+        this.timestamp = timestamp;
+        this.low = low;
+        this.high = high;
+        this.open = open;
+        this.close = close;
+        this.volume = volume;
+        this.currency_volume = currency_volume;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiLiquidationVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiLiquidationVO.java
@@ -1,0 +1,72 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+public class ApiLiquidationVO {
+
+    private String instrument_id;
+    private String size;
+    private String created_at;
+    private String loss;
+    private String price;
+    private String type;
+
+    public ApiLiquidationVO() {
+    }
+
+    public ApiLiquidationVO(String instrument_id, String size, String created_at, String loss, String price, String type) {
+        this.instrument_id = instrument_id;
+        this.size = size;
+        this.created_at = created_at;
+        this.loss = loss;
+        this.price = price;
+        this.type = type;
+    }
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getSize() {
+        return size;
+    }
+
+    public void setSize(String size) {
+        this.size = size;
+    }
+
+    public String getCreated_at() {
+        return created_at;
+    }
+
+    public void setCreated_at(String created_at) {
+        this.created_at = created_at;
+    }
+
+    public String getLoss() {
+        return loss;
+    }
+
+    public void setLoss(String loss) {
+        this.loss = loss;
+    }
+
+    public String getPrice() {
+        return price;
+    }
+
+    public void setPrice(String price) {
+        this.price = price;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiMarkPriceVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiMarkPriceVO.java
@@ -1,0 +1,42 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+public class ApiMarkPriceVO {
+
+    private String instrument_id;
+    private String mark_price;
+    private String timestamp;
+
+    public ApiMarkPriceVO() {
+    }
+
+    public ApiMarkPriceVO(String instrument_id, String mark_price, String timestamp) {
+        this.instrument_id = instrument_id;
+        this.mark_price = mark_price;
+        this.timestamp = timestamp;
+    }
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getMark_price() {
+        return mark_price;
+    }
+
+    public void setMark_price(String mark_price) {
+        this.mark_price = mark_price;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiOpenInterestVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiOpenInterestVO.java
@@ -1,0 +1,42 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+public class ApiOpenInterestVO {
+
+    private String instrument_id;
+    private String amount;
+    private String timestamp;
+
+    public ApiOpenInterestVO() {
+    }
+
+    public ApiOpenInterestVO(String instrument_id, String amount, String timestamp) {
+        this.instrument_id = instrument_id;
+        this.amount = amount;
+        this.timestamp = timestamp;
+    }
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiOrderResultVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiOrderResultVO.java
@@ -1,0 +1,85 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+import java.util.List;
+
+public class ApiOrderResultVO {
+
+    private List<PerOrderResult> order_info;
+    private String result;
+
+    public ApiOrderResultVO() {
+    }
+
+    public ApiOrderResultVO(List<PerOrderResult> order_info, String result) {
+        this.order_info = order_info;
+        this.result = result;
+    }
+
+    public List<PerOrderResult> getOrder_info() {
+        return order_info;
+    }
+
+    public void setOrder_info(List<PerOrderResult> order_info) {
+        this.order_info = order_info;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public void setResult(String result) {
+        this.result = result;
+    }
+
+
+    public class PerOrderResult {
+
+        String order_id;
+        String client_oid;
+        String error_code;
+        String error_message;
+
+        public PerOrderResult() {
+        }
+
+        public PerOrderResult(String order_id, String client_oid, String error_code, String error_message) {
+            this.order_id = order_id;
+            this.client_oid = client_oid;
+            this.error_code = error_code;
+            this.error_message = error_message;
+        }
+
+        public String getOrder_id() {
+            return order_id;
+        }
+
+        public void setOrder_id(String order_id) {
+            this.order_id = order_id;
+        }
+
+        public String getClient_oid() {
+            return client_oid;
+        }
+
+        public void setClient_oid(String client_oid) {
+            this.client_oid = client_oid;
+        }
+
+        public String getError_code() {
+            return error_code;
+        }
+
+        public void setError_code(String error_code) {
+            this.error_code = error_code;
+        }
+
+        public String getError_message() {
+            return error_message;
+        }
+
+        public void setError_message(String error_message) {
+            this.error_message = error_message;
+        }
+
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiOrderVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiOrderVO.java
@@ -1,0 +1,62 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+public class ApiOrderVO {
+
+
+    private String order_id;
+    private String client_oid;
+    private String error_code;
+    private String error_message;
+    private String result;
+
+    public ApiOrderVO() {
+    }
+
+    public String getOrder_id() {
+        return order_id;
+    }
+
+    public void setOrder_id(String order_id) {
+        this.order_id = order_id;
+    }
+
+    public String getClient_oid() {
+        return client_oid;
+    }
+
+    public void setClient_oid(String client_oid) {
+        this.client_oid = client_oid;
+    }
+
+    public String getError_code() {
+        return error_code;
+    }
+
+    public void setError_code(String error_code) {
+        this.error_code = error_code;
+    }
+
+    public String getError_message() {
+        return error_message;
+    }
+
+    public void setError_message(String error_message) {
+        this.error_message = error_message;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public void setResult(String result) {
+        this.result = result;
+    }
+
+    public ApiOrderVO(String order_id, String client_oid, String error_code, String error_message, String result) {
+        this.order_id = order_id;
+        this.client_oid = client_oid;
+        this.error_code = error_code;
+        this.error_message = error_message;
+        this.result = result;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiPositionVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiPositionVO.java
@@ -1,0 +1,112 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+public class ApiPositionVO {
+
+    private String liquidation_price;
+    private String position;
+    private String avail_position;
+    private String avg_cost;
+    private String settlement_price;
+    private String instrument_id;
+    private String leverage;
+    private String realized_pnl;
+    private String side;
+    private String timestamp;
+
+    public ApiPositionVO() {
+    }
+
+    public ApiPositionVO(String liquidation_price, String position, String avail_position, String avg_cost, String settlement_price, String instrument_id, String leverage, String realized_pnl, String side, String timestamp) {
+        this.liquidation_price = liquidation_price;
+        this.position = position;
+        this.avail_position = avail_position;
+        this.avg_cost = avg_cost;
+        this.settlement_price = settlement_price;
+        this.instrument_id = instrument_id;
+        this.leverage = leverage;
+        this.realized_pnl = realized_pnl;
+        this.side = side;
+        this.timestamp = timestamp;
+    }
+
+    public String getLiquidation_price() {
+        return liquidation_price;
+    }
+
+    public void setLiquidation_price(String liquidation_price) {
+        this.liquidation_price = liquidation_price;
+    }
+
+    public String getPosition() {
+        return position;
+    }
+
+    public void setPosition(String position) {
+        this.position = position;
+    }
+
+    public String getAvail_position() {
+        return avail_position;
+    }
+
+    public void setAvail_position(String avail_position) {
+        this.avail_position = avail_position;
+    }
+
+    public String getAvg_cost() {
+        return avg_cost;
+    }
+
+    public void setAvg_cost(String avg_cost) {
+        this.avg_cost = avg_cost;
+    }
+
+    public String getSettlement_price() {
+        return settlement_price;
+    }
+
+    public void setSettlement_price(String settlement_price) {
+        this.settlement_price = settlement_price;
+    }
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getLeverage() {
+        return leverage;
+    }
+
+    public void setLeverage(String leverage) {
+        this.leverage = leverage;
+    }
+
+    public String getRealized_pnl() {
+        return realized_pnl;
+    }
+
+    public void setRealized_pnl(String realized_pnl) {
+        this.realized_pnl = realized_pnl;
+    }
+
+    public String getSide() {
+        return side;
+    }
+
+    public void setSide(String side) {
+        this.side = side;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiPositionsVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiPositionsVO.java
@@ -1,0 +1,34 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+import java.util.List;
+
+public class ApiPositionsVO {
+
+    private String margin_mode;
+    private List<ApiPositionVO> holding;
+
+    public ApiPositionsVO(String margin_mode, List<ApiPositionVO> holding) {
+        this.margin_mode = margin_mode;
+        this.holding = holding;
+    }
+
+    public ApiPositionsVO() {
+    }
+
+    public String getMargin_mode() {
+        return margin_mode;
+    }
+
+    public void setMargin_mode(String margin_mode) {
+        this.margin_mode = margin_mode;
+    }
+
+    public List<ApiPositionVO> getHolding() {
+        return holding;
+    }
+
+    public void setHolding(List<ApiPositionVO> holding) {
+        this.holding = holding;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiPriceLimitVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiPriceLimitVO.java
@@ -1,0 +1,52 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+public class ApiPriceLimitVO {
+
+    private String instrument_id;
+    private String highest;
+    private String lowest;
+    private String timestamp;
+
+    public ApiPriceLimitVO() {
+    }
+
+    public ApiPriceLimitVO(String instrument_id, String highest, String lowest, String timestamp) {
+        this.instrument_id = instrument_id;
+        this.highest = highest;
+        this.lowest = lowest;
+        this.timestamp = timestamp;
+    }
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getHighest() {
+        return highest;
+    }
+
+    public void setHighest(String highest) {
+        this.highest = highest;
+    }
+
+    public String getLowest() {
+        return lowest;
+    }
+
+    public void setLowest(String lowest) {
+        this.lowest = lowest;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiRateVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiRateVO.java
@@ -1,0 +1,42 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+public class ApiRateVO {
+
+    private String instrument_id;
+    private String rate;
+    private String timestamp;
+
+    public ApiRateVO() {
+    }
+
+    public ApiRateVO(String instrument_id, String rate, String timestamp) {
+        this.instrument_id = instrument_id;
+        this.rate = rate;
+        this.timestamp = timestamp;
+    }
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getRate() {
+        return rate;
+    }
+
+    public void setRate(String rate) {
+        this.rate = rate;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiTickerVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiTickerVO.java
@@ -1,0 +1,72 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+public class ApiTickerVO {
+
+    private String instrument_id;
+    private String last;
+    private String high_24h;
+    private String low_24h;
+    private String volume_24h;
+    private String timestamp;
+
+    public ApiTickerVO(String instrument_id, String last, String high_24h, String low_24h, String volume_24h, String timestamp) {
+        this.instrument_id = instrument_id;
+        this.last = last;
+        this.high_24h = high_24h;
+        this.low_24h = low_24h;
+        this.volume_24h = volume_24h;
+        this.timestamp = timestamp;
+    }
+
+    public ApiTickerVO() {
+    }
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public String getLast() {
+        return last;
+    }
+
+    public void setLast(String last) {
+        this.last = last;
+    }
+
+    public String getHigh_24h() {
+        return high_24h;
+    }
+
+    public void setHigh_24h(String high_24h) {
+        this.high_24h = high_24h;
+    }
+
+    public String getLow_24h() {
+        return low_24h;
+    }
+
+    public void setLow_24h(String low_24h) {
+        this.low_24h = low_24h;
+    }
+
+    public String getVolume_24h() {
+        return volume_24h;
+    }
+
+    public void setVolume_24h(String volume_24h) {
+        this.volume_24h = volume_24h;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiUserRiskVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/ApiUserRiskVO.java
@@ -1,0 +1,54 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+import java.math.BigDecimal;
+
+public class ApiUserRiskVO {
+
+    private BigDecimal long_leverage;
+    private BigDecimal short_leverage;
+    private String margin_mode;
+    private String instrument_id;
+
+    public ApiUserRiskVO() {
+    }
+
+    public ApiUserRiskVO(BigDecimal long_leverage, BigDecimal short_leverage, String margin_mode, String instrument_id) {
+        this.long_leverage = long_leverage;
+        this.short_leverage = short_leverage;
+        this.margin_mode = margin_mode;
+        this.instrument_id = instrument_id;
+    }
+
+    public BigDecimal getLong_leverage() {
+        return long_leverage;
+    }
+
+    public void setLong_leverage(BigDecimal long_leverage) {
+        this.long_leverage = long_leverage;
+    }
+
+    public BigDecimal getShort_leverage() {
+        return short_leverage;
+    }
+
+    public void setShort_leverage(BigDecimal short_leverage) {
+        this.short_leverage = short_leverage;
+    }
+
+    public String getMargin_mode() {
+        return margin_mode;
+    }
+
+    public void setMargin_mode(String margin_mode) {
+        this.margin_mode = margin_mode;
+    }
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/DepthVO.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/DepthVO.java
@@ -1,0 +1,44 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+import java.util.List;
+
+public class DepthVO {
+
+    private List<Object[]> asks;
+    private List<Object[]> bids;
+    private String timestamp;
+
+    public DepthVO(List<Object[]> asks, List<Object[]> bids, String timeStamp) {
+        this.asks = asks;
+        this.bids = bids;
+        this.timestamp = timeStamp;
+    }
+
+    public DepthVO() {
+    }
+
+    public List<Object[]> getAsks() {
+        return asks;
+    }
+
+    public void setAsks(List<Object[]> asks) {
+        this.asks = asks;
+    }
+
+    public List<Object[]> getBids() {
+        return bids;
+    }
+
+    public void setBids(List<Object[]> bids) {
+        this.bids = bids;
+    }
+
+    public String getTimeStamp() {
+        return timestamp;
+    }
+
+    public void setTimeStamp(String timeStamp) {
+        this.timestamp = timeStamp;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/OrderCancelResult.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/bean/swap/result/OrderCancelResult.java
@@ -1,0 +1,45 @@
+package com.okcoin.commons.okex.open.api.bean.swap.result;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class OrderCancelResult {
+
+    private String instrument_id = "";
+    private List<String> order_ids = new LinkedList<>();
+    private String result = "";
+
+    public OrderCancelResult(String instrument_id, List<String> order_ids, String result) {
+        this.instrument_id = instrument_id;
+        this.order_ids = order_ids;
+        this.result = result;
+    }
+
+    public OrderCancelResult() {
+    }
+
+    public String getInstrument_id() {
+        return instrument_id;
+    }
+
+    public void setInstrument_id(String instrument_id) {
+        this.instrument_id = instrument_id;
+    }
+
+    public List<String> getOrder_ids() {
+        return order_ids;
+    }
+
+    public void setOrder_ids(List<String> order_ids) {
+        this.order_ids = order_ids;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public void setResult(String result) {
+        this.result = result;
+
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/client/APIClient.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/client/APIClient.java
@@ -1,0 +1,141 @@
+package com.okcoin.commons.okex.open.api.client;
+
+import com.alibaba.fastjson.JSON;
+import com.okcoin.commons.okex.open.api.bean.ett.result.CursorPager;
+import com.okcoin.commons.okex.open.api.bean.futures.HttpResult;
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.constant.APIConstants;
+import com.okcoin.commons.okex.open.api.enums.HttpHeadersEnum;
+import com.okcoin.commons.okex.open.api.exception.APIException;
+import com.okcoin.commons.okex.open.api.utils.DateUtils;
+import okhttp3.Headers;
+import okhttp3.OkHttpClient;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import retrofit2.Call;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * OKEX API Client
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/8 13:43
+ */
+public class APIClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(APIClient.class);
+
+    private final APIConfiguration config;
+    private final APICredentials credentials;
+    private final OkHttpClient client;
+    private final Retrofit retrofit;
+    private final ApiHttp apiHttp;
+
+    /**
+     * Initialize the apis client
+     */
+    public APIClient(final APIConfiguration config) {
+        if (config == null || StringUtils.isEmpty(config.getEndpoint())) {
+            throw new RuntimeException("The APIClient params can't be empty.");
+        }
+        this.config = config;
+        this.credentials = new APICredentials(config);
+        this.client = new APIHttpClient(config, this.credentials).client();
+        this.retrofit = new APIRetrofit(config, this.client).retrofit();
+        this.apiHttp = new ApiHttp(config, this.client);
+    }
+
+    /**
+     * Initialize the retrofit operation service
+     */
+    public <T> T createService(final Class<T> service) {
+        return this.retrofit.create(service);
+    }
+
+    public ApiHttp getApiHttp() {
+        return this.apiHttp;
+    }
+
+    /**
+     * Synchronous send request
+     */
+    public <T> T executeSync(final Call<T> call) {
+        try {
+            final Response<T> response = call.execute();
+            if (this.config.isPrint()) {
+                this.printResponse(response);
+            }
+            final int status = response.code();
+            final String message = new StringBuilder().append(response.code()).append(" / ").append(response.message()).toString();
+            if (response.isSuccessful()) {
+                return response.body();
+            } else if (APIConstants.resultStatusArray.contains(status)) {
+                final HttpResult result = JSON.parseObject(new String(response.errorBody().bytes()), HttpResult.class);
+                throw new APIException(result.getCode(), result.getMessage());
+            } else {
+                throw new APIException(message);
+            }
+        } catch (final IOException e) {
+            throw new APIException("APIClient executeSync exception.", e);
+        }
+    }
+
+    /**
+     * Synchronous send request
+     */
+    public <T> CursorPager<T> executeSyncCursorPager(final Call<List<T>> call) {
+        try {
+            final Response<List<T>> response = call.execute();
+            if (this.config.isPrint()) {
+                this.printResponse(response);
+            }
+            final int status = response.code();
+            final String message = response.code() + " / " + response.message();
+            if (response.isSuccessful()) {
+                final Headers headers = response.headers();
+                final CursorPager<T> cursorPager = new CursorPager<>();
+                cursorPager.setData(response.body());
+                cursorPager.setBefore(headers.get("OK-BEFORE"));
+                cursorPager.setAfter(headers.get("OK-AFTER"));
+                cursorPager.setLimit(Optional.ofNullable(headers.get("OK-LIMIT")).map(Integer::valueOf).orElse(100));
+                return cursorPager;
+            }
+            if (APIConstants.resultStatusArray.contains(status)) {
+                final HttpResult result = JSON.parseObject(new String(response.errorBody().bytes()), HttpResult.class);
+                throw new APIException(result.getCode(), result.getMessage());
+            }
+            throw new APIException(message);
+        } catch (final IOException e) {
+            throw new APIException("APIClient executeSync exception.", e);
+        }
+    }
+
+    private void printResponse(final Response response) {
+        final StringBuilder responseInfo = new StringBuilder();
+        responseInfo.append("\n\tResponse").append("(").append(DateUtils.timeToString(null, 4)).append("):");
+        if (response != null) {
+            final String limit = response.headers().get(HttpHeadersEnum.OK_LIMIT.header());
+            if (StringUtils.isNotEmpty(limit)) {
+                responseInfo.append("\n\t\t").append("Headers: ");
+//                responseInfo.append("\n\t\t\t").append(HttpHeadersEnum.OK_BEFORE.header()).append(": ").append(response.headers().get(HttpHeadersEnum.OK_BEFORE.header()));
+//                responseInfo.append("\n\t\t\t").append(HttpHeadersEnum.OK_AFTER.header()).append(": ").append(response.headers().get(HttpHeadersEnum.OK_AFTER.header()));
+                responseInfo.append("\n\t\t\t").append(HttpHeadersEnum.OK_FROM.header()).append(": ").append(response.headers().get(HttpHeadersEnum.OK_FROM.header()));
+                responseInfo.append("\n\t\t\t").append(HttpHeadersEnum.OK_TO.header()).append(": ").append(response.headers().get(HttpHeadersEnum.OK_TO.header()));
+                responseInfo.append("\n\t\t\t").append(HttpHeadersEnum.OK_LIMIT.header()).append(": ").append(limit);
+            }
+            responseInfo.append("\n\t\t").append("Status: ").append(response.code());
+            responseInfo.append("\n\t\t").append("Message: ").append(response.message());
+            responseInfo.append("\n\t\t").append("Body: ").append(JSON.toJSONString(response.body()));
+        } else {
+            responseInfo.append("\n\t\t").append("\n\tRequest Error: response is null");
+        }
+        APIClient.LOG.info(responseInfo.toString());
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/client/APICredentials.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/client/APICredentials.java
@@ -1,0 +1,58 @@
+package com.okcoin.commons.okex.open.api.client;
+
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+
+/**
+ * API Credentials.<br/>
+ * The api key and secret key will be randomly generated and provided by okex.com.
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/8 14:14
+ */
+public class APICredentials {
+    /**
+     * The user's secret key provided by OKEx.
+     */
+    private String apiKey;
+    /**
+     * The private key used to sign your request data.
+     */
+    private String secretKey;
+    /**
+     * The Passphrase will be provided by you to further secure your API access.
+     */
+    private String passphrase;
+
+
+    public APICredentials(APIConfiguration config) {
+        super();
+        this.apiKey = config.getApiKey();
+        this.secretKey = config.getSecretKey();
+        this.passphrase = config.getPassphrase();
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public void setSecretKey(String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    public String getPassphrase() {
+        return passphrase;
+    }
+
+    public void setPassphrase(String passphrase) {
+        this.passphrase = passphrase;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/client/APIHttpClient.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/client/APIHttpClient.java
@@ -1,0 +1,181 @@
+package com.okcoin.commons.okex.open.api.client;
+
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.constant.APIConstants;
+import com.okcoin.commons.okex.open.api.enums.ContentTypeEnum;
+import com.okcoin.commons.okex.open.api.enums.HttpHeadersEnum;
+import com.okcoin.commons.okex.open.api.exception.APIException;
+import com.okcoin.commons.okex.open.api.utils.DateUtils;
+import com.okcoin.commons.okex.open.api.utils.HmacSHA256Base64Utils;
+import okhttp3.*;
+import okio.Buffer;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * API OkHttpClient.
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/8 14:14
+ */
+public class APIHttpClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(APIHttpClient.class);
+
+    private final APIConfiguration config;
+    private final APICredentials credentials;
+
+    public APIHttpClient(final APIConfiguration config, final APICredentials credentials) {
+        this.config = config;
+        this.credentials = credentials;
+    }
+
+    /**
+     * Get a ok http 3 client object. <br/>
+     * Declare:
+     * <blockquote><pre>
+     *  1. Set default client args:
+     *         connectTimeout=30s
+     *         readTimeout=30s
+     *         writeTimeout=30s
+     *         retryOnConnectionFailure=true.
+     *  2. Set request headers:
+     *      Content-Type: application/json; charset=UTF-8  (default)
+     *      Cookie: locale=en_US        (English)
+     *      OK-ACCESS-KEY: (Your setting)
+     *      OK-ACCESS-SIGN: (Use your setting, auto sign and add)
+     *      OK-ACCESS-TIMESTAMP: (Auto add)
+     *      OK-ACCESS-PASSPHRASE: Your setting
+     *  3. Set default print api info: false.
+     * </pre></blockquote>
+     */
+    public OkHttpClient client() {
+        final OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
+        clientBuilder.connectTimeout(this.config.getConnectTimeout(), TimeUnit.SECONDS);
+        clientBuilder.readTimeout(this.config.getReadTimeout(), TimeUnit.SECONDS);
+        clientBuilder.writeTimeout(this.config.getWriteTimeout(), TimeUnit.SECONDS);
+        clientBuilder.retryOnConnectionFailure(this.config.isRetryOnConnectionFailure());
+        clientBuilder.addInterceptor((Interceptor.Chain chain) -> {
+            final Request.Builder requestBuilder = chain.request().newBuilder();
+            final String timestamp = DateUtils.getUnixTime();
+            System.out.println("timestamp={" + timestamp + "}");
+            requestBuilder.headers(this.headers(chain.request(), timestamp));
+            final Request request = requestBuilder.build();
+            if (this.config.isPrint()) {
+                this.printRequest(request, timestamp);
+            }
+            return chain.proceed(request);
+        });
+        return clientBuilder.build();
+    }
+
+    private Headers headers(final Request request, final String timestamp) {
+        final Headers.Builder builder = new Headers.Builder();
+        builder.add(APIConstants.ACCEPT, ContentTypeEnum.APPLICATION_JSON.contentType());
+        builder.add(APIConstants.CONTENT_TYPE, ContentTypeEnum.APPLICATION_JSON_UTF8.contentType());
+        builder.add(APIConstants.COOKIE, this.getCookie());
+        if (StringUtils.isNotEmpty(this.credentials.getSecretKey())) {
+            builder.add(HttpHeadersEnum.OK_ACCESS_KEY.header(), this.credentials.getApiKey());
+            builder.add(HttpHeadersEnum.OK_ACCESS_SIGN.header(), this.sign(request, timestamp));
+            builder.add(HttpHeadersEnum.OK_ACCESS_TIMESTAMP.header(), timestamp);
+            builder.add(HttpHeadersEnum.OK_ACCESS_PASSPHRASE.header(), this.credentials.getPassphrase());
+        }
+        return builder.build();
+    }
+
+    private String getCookie() {
+        final StringBuilder cookie = new StringBuilder();
+        cookie.append(APIConstants.LOCALE).append(this.config.getI18n().i18n());
+        return cookie.toString();
+    }
+
+    private String sign(final Request request, final String timestamp) {
+        final String sign;
+        try {
+            sign = HmacSHA256Base64Utils.sign(timestamp, this.method(request), this.requestPath(request),
+                    this.queryString(request), this.body(request), this.credentials.getSecretKey());
+        } catch (final IOException e) {
+            throw new APIException("Request get body io exception.", e);
+        } catch (final CloneNotSupportedException e) {
+            throw new APIException("Hmac SHA256 Base64 Signature clone not supported exception.", e);
+        } catch (final InvalidKeyException e) {
+            throw new APIException("Hmac SHA256 Base64 Signature invalid key exception.", e);
+        }
+        return sign;
+    }
+
+    private String url(final Request request) {
+        return request.url().toString();
+    }
+
+    private String method(final Request request) {
+        return request.method().toUpperCase();
+    }
+
+    private String requestPath(final Request request) {
+        String url = this.url(request);
+        url = url.replace(this.config.getEndpoint(), APIConstants.EMPTY);
+        String requestPath = url;
+        if (requestPath.contains(APIConstants.QUESTION)) {
+            requestPath = requestPath.substring(0, url.lastIndexOf(APIConstants.QUESTION));
+        }
+        if(this.config.getEndpoint().endsWith(APIConstants.SLASH)){
+            requestPath = APIConstants.SLASH + requestPath;
+        }
+        return requestPath;
+    }
+
+    private String queryString(final Request request) {
+        final String url = this.url(request);
+        String queryString = APIConstants.EMPTY;
+        if (url.contains(APIConstants.QUESTION)) {
+            queryString = url.substring(url.lastIndexOf(APIConstants.QUESTION) + 1);
+        }
+        return queryString;
+    }
+
+    private String body(final Request request) throws IOException {
+        final RequestBody requestBody = request.body();
+        String body = APIConstants.EMPTY;
+        if (requestBody != null) {
+            final Buffer buffer = new Buffer();
+            requestBody.writeTo(buffer);
+            body = buffer.readString(APIConstants.UTF_8);
+        }
+        return body;
+    }
+
+    private void printRequest(final Request request, final String timestamp) {
+        final String method = this.method(request);
+        final String requestPath = this.requestPath(request);
+        final String queryString = this.queryString(request);
+        final String body;
+        try {
+            body = this.body(request);
+        } catch (final IOException e) {
+            throw new APIException("Request get body io exception.", e);
+        }
+        final StringBuilder requestInfo = new StringBuilder();
+        requestInfo.append("\n").append("\tSecret-Key: ").append(this.credentials.getSecretKey());
+        requestInfo.append("\n\tRequest").append("(").append(DateUtils.timeToString(null, 4)).append("):");
+        requestInfo.append("\n\t\t").append("Url: ").append(this.url(request));
+        requestInfo.append("\n\t\t").append("Method: ").append(method);
+        requestInfo.append("\n\t\t").append("Headers: ");
+        final Headers headers = request.headers();
+        if (headers != null && headers.size() > 0) {
+            for (final String name : headers.names()) {
+                requestInfo.append("\n\t\t\t").append(name).append(": ").append(headers.get(name));
+            }
+        }
+        requestInfo.append("\n\t\t").append("Body: ").append(body);
+        final String preHash = HmacSHA256Base64Utils.preHash(timestamp, method, requestPath, queryString, body);
+        requestInfo.append("\n\t\t").append("preHash: ").append(preHash);
+        APIHttpClient.LOG.info(requestInfo.toString());
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/client/APIRetrofit.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/client/APIRetrofit.java
@@ -1,0 +1,40 @@
+package com.okcoin.commons.okex.open.api.client;
+
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import okhttp3.OkHttpClient;
+import retrofit2.Retrofit;
+import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
+import retrofit2.converter.gson.GsonConverterFactory;
+import retrofit2.converter.scalars.ScalarsConverterFactory;
+
+/**
+ * API Retrofit
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/8 15:40
+ */
+public class APIRetrofit {
+
+
+    private APIConfiguration config;
+    private OkHttpClient client;
+
+    public APIRetrofit(APIConfiguration config, OkHttpClient client) {
+        this.config = config;
+        this.client = client;
+    }
+
+    /**
+     * Get a retrofit 2 object.
+     */
+    public Retrofit retrofit() {
+        Retrofit.Builder builder = new Retrofit.Builder();
+        builder.client(this.client);
+        builder.addConverterFactory(ScalarsConverterFactory.create());
+        builder.addConverterFactory(GsonConverterFactory.create());
+        builder.addCallAdapterFactory(RxJavaCallAdapterFactory.create());
+        builder.baseUrl(this.config.getEndpoint());
+        return builder.build();
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/client/ApiHttp.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/client/ApiHttp.java
@@ -1,0 +1,102 @@
+package com.okcoin.commons.okex.open.api.client;
+
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.futures.HttpResult;
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.constant.APIConstants;
+import com.okcoin.commons.okex.open.api.exception.APIException;
+import com.okcoin.commons.okex.open.api.utils.DateUtils;
+import okhttp3.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Http
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/6/5 11:19
+ */
+public class ApiHttp {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ApiHttp.class);
+
+    private OkHttpClient client;
+    private APIConfiguration config;
+
+    static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+
+    public ApiHttp(APIConfiguration config, OkHttpClient client) {
+        this.config = config;
+        this.client = client;
+    }
+
+    public String get(String url) {
+        Request request = new Request.Builder()
+                .url(url(url))
+                .build();
+        return execute(request);
+    }
+
+    public String post(String url, JSONObject params) {
+        String body = params.toJSONString();
+        RequestBody requestBody = RequestBody.create(JSON, body);
+        Request request = new Request.Builder()
+                .url(url(url))
+                .post(requestBody)
+                .build();
+        return execute(request);
+    }
+
+    public String delete(String url, JSONObject params) {
+        String body = params.toJSONString();
+        RequestBody requestBody = RequestBody.create(JSON, body);
+        Request request = new Request.Builder()
+                .url(url(url))
+                .delete(requestBody)
+                .build();
+        return execute(request);
+    }
+
+    public String execute(Request request) {
+        try {
+            Response response = this.client.newCall(request).execute();
+            int status = response.code();
+            String bodyString = response.body().string();
+            boolean responseIsNotNull = response != null;
+            if (this.config.isPrint()) {
+                printResponse(status, response.message(), bodyString, responseIsNotNull);
+            }
+            String message = new StringBuilder().append(response.code()).append(" / ").append(response.message()).toString();
+            if (response.isSuccessful()) {
+                return bodyString;
+            } else if (APIConstants.resultStatusArray.contains(status)) {
+                HttpResult result = com.alibaba.fastjson.JSON.parseObject(bodyString, HttpResult.class);
+                throw new APIException(result.getCode(), result.getMessage());
+            } else {
+                throw new APIException(message);
+            }
+        } catch (IOException e) {
+            throw new APIException("APIClient executeSync exception.", e);
+        }
+    }
+
+    private void printResponse(int status, String message, String body, boolean responseIsNotNull) {
+        StringBuilder responseInfo = new StringBuilder();
+        responseInfo.append("\n\tResponse").append("(").append(DateUtils.timeToString(null, 4)).append("):");
+        if (responseIsNotNull) {
+            responseInfo.append("\n\t\t").append("Status: ").append(status);
+            responseInfo.append("\n\t\t").append("Message: ").append(message);
+            responseInfo.append("\n\t\t").append("Body: ").append(body);
+        } else {
+            responseInfo.append("\n\t\t").append("\n\tRequest Error: response is null");
+        }
+        LOG.info(responseInfo.toString());
+    }
+
+    public String url(String url) {
+        return new StringBuilder(this.config.getEndpoint()).append(url).toString();
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/config/APIConfiguration.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/config/APIConfiguration.java
@@ -1,0 +1,156 @@
+package com.okcoin.commons.okex.open.api.config;
+
+import com.okcoin.commons.okex.open.api.constant.APIConstants;
+import com.okcoin.commons.okex.open.api.enums.I18nEnum;
+
+/**
+ * API configuration information
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/8 14:29
+ */
+public class APIConfiguration {
+
+    /**
+     * The user's api key provided by OKEx.
+     */
+    private String apiKey;
+    /**
+     * The user's secret key provided by OKEx. The secret key used to sign your request data.
+     */
+    private String secretKey;
+    /**
+     * The Passphrase will be provided by you to further secure your API access.
+     */
+    private String passphrase;
+    /**
+     * Rest api endpoint url.
+     */
+    private String endpoint;
+
+    /**
+     * Host connection timeout.
+     */
+    private long connectTimeout;
+    /**
+     * The host reads the information timeout.
+     */
+    private long readTimeout;
+    /**
+     * The host writes the information timeout.
+     */
+    private long writeTimeout;
+    /**
+     * Failure reconnection, default true.
+     */
+    private boolean retryOnConnectionFailure;
+
+    /**
+     * The print api information.
+     */
+    private boolean print;
+
+    /**
+     * internationalization  {@link com.okcoin.commons.okex.open.api.enums.I18nEnum}
+     */
+    private I18nEnum i18n;
+
+    public APIConfiguration() {
+        this(null);
+    }
+
+    public APIConfiguration(String endpoint) {
+        super();
+        this.apiKey = null;
+        this.secretKey = null;
+        this.passphrase = null;
+        this.endpoint = endpoint;
+        this.connectTimeout = APIConstants.TIMEOUT;
+        this.readTimeout = APIConstants.TIMEOUT;
+        this.writeTimeout = APIConstants.TIMEOUT;
+        this.retryOnConnectionFailure = true;
+        this.print = false;
+        this.i18n = I18nEnum.ENGLISH;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public void setSecretKey(String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    public String getPassphrase() {
+        return passphrase;
+    }
+
+    public void setPassphrase(String passphrase) {
+        this.passphrase = passphrase;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public long getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(long connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    public long getReadTimeout() {
+        return readTimeout;
+    }
+
+    public void setReadTimeout(long readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+
+    public long getWriteTimeout() {
+        return writeTimeout;
+    }
+
+    public void setWriteTimeout(long writeTimeout) {
+        this.writeTimeout = writeTimeout;
+    }
+
+    public boolean isRetryOnConnectionFailure() {
+        return retryOnConnectionFailure;
+    }
+
+    public void setRetryOnConnectionFailure(boolean retryOnConnectionFailure) {
+        this.retryOnConnectionFailure = retryOnConnectionFailure;
+    }
+
+    public boolean isPrint() {
+        return print;
+    }
+
+    public void setPrint(boolean print) {
+        this.print = print;
+    }
+
+    public I18nEnum getI18n() {
+        return i18n;
+    }
+
+    public void setI18n(I18nEnum i18n) {
+        this.i18n = i18n;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/constant/APIConstants.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/constant/APIConstants.java
@@ -1,0 +1,92 @@
+package com.okcoin.commons.okex.open.api.constant;
+
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.enums.CharsetEnum;
+import com.okcoin.commons.okex.open.api.enums.ContentTypeEnum;
+import okhttp3.MediaType;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * API Constants
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/8 14:21
+ */
+public class APIConstants {
+
+    /**
+     * The default timeout is 30 seconds.
+     */
+    public static final long TIMEOUT = 1000 * 30;
+    /**
+     * All requests and responses are application/json content type and follow typical HTTP response status codes for success and failure.
+     */
+    public static final String CONTENT_TYPE = "Content-Type";
+
+    public static final String ACCEPT = "Accept";
+
+    public static final String COOKIE = "Cookie";
+
+    public static final String LOCALE = "locale=";
+
+    public static final MediaType JSON = MediaType.parse(ContentTypeEnum.APPLICATION_JSON.contentType());
+
+    public static final Charset UTF_8 = Charset.forName(CharsetEnum.UTF_8.charset());
+
+    public static final String QUESTION = "?";
+
+    public static final String EMPTY = "";
+
+    public static final JSONObject NOTHING = new JSONObject();
+
+    public static final List<String> toStringTypeArray = Arrays.asList(
+            "class java.lang.Long",
+            "class java.lang.Integer",
+            "long",
+            "int");
+    public static final List<String> toStringTypeDoubleArray = Arrays.asList(
+            "class java.lang.Double",
+            "double");
+
+    public static final List<Integer> resultStatusArray = Arrays.asList(
+            400,401,429,500);
+
+    public static final String BOOLEAN = "boolean";
+    public static final String IS = "is";
+    public static final String get = "get";
+    public static final char a = 'a';
+    public static final char z = 'z';
+    public static final String ZERO_STRING = "0";
+    public static final String DOUBLE_ZERO_STRING = "0.00";
+
+    public static final String DOT1 = ".";
+    public static final String DOT2 = "\\.";
+    public static final String E = "E";
+    public static final String e = "e";
+    public static final int DEFAULT_SCALE = 2;
+    /**
+     * 8900000000.000000000
+     */
+    public static final String DOUBLE_END1 = "0+?$";
+    /**
+     * 8900000000.
+     */
+    public static final String DOUBLE_END2 = "[.]$";
+
+    /**
+     * default cursor id
+     */
+    public static final int ONE = 1;
+    /**
+     * max limit: 100
+     */
+    public static final int HUNDRED = 100;
+
+    public static final String HLINE = "-";
+
+    public static final String SLASH = "/";
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/enums/AlgorithmEnum.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/enums/AlgorithmEnum.java
@@ -1,0 +1,23 @@
+package com.okcoin.commons.okex.open.api.enums;
+
+/**
+ * Algorithm Name
+ *
+ * @author Tony Tian
+ * @date Created in 2018/1/31 13:00
+ */
+public enum AlgorithmEnum {
+
+    HMAC_SHA256("HmacSHA256"),
+    MD5("MD5"),;
+
+    private String algorithm;
+
+    AlgorithmEnum(String algorithm) {
+        this.algorithm = algorithm;
+    }
+
+    public String algorithm() {
+        return algorithm;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/enums/CharsetEnum.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/enums/CharsetEnum.java
@@ -1,0 +1,25 @@
+package com.okcoin.commons.okex.open.api.enums;
+
+/**
+ * Charset Enum
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/2/5 21:22
+ */
+public enum CharsetEnum {
+
+    UTF_8("UTF-8"),
+    ISO_8859_1("ISO-8859-1"),;
+
+
+    private String charset;
+
+    CharsetEnum(String charset) {
+        this.charset = charset;
+    }
+
+    public String charset() {
+        return charset;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/enums/ContentTypeEnum.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/enums/ContentTypeEnum.java
@@ -1,0 +1,27 @@
+package com.okcoin.commons.okex.open.api.enums;
+
+/**
+ * Content-Type Enum: MediaType: Internet Media Type
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/1/31 17:49
+ */
+public enum ContentTypeEnum {
+
+    APPLICATION_JSON("application/json"),
+    APPLICATION_JSON_UTF8("application/json; charset=UTF-8"),
+    // The server does not support types
+    APPLICATION_FORM("application/x-www-form-urlencoded; charset=UTF-8"),;
+
+
+    private String contentType;
+
+    ContentTypeEnum(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public String contentType() {
+        return contentType;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/enums/FuturesCurrenciesEnum.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/enums/FuturesCurrenciesEnum.java
@@ -1,0 +1,22 @@
+package com.okcoin.commons.okex.open.api.enums;
+
+/**
+ * Futures Currencies (Updated on: 2018-03-13 17:39:09)
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/13 17:37
+ */
+public enum FuturesCurrenciesEnum {
+
+    BTC(0), LTC(1), ETH(2), ETC(4), BCH(5), XRP(15), EOS(20), BTG(10);
+    private int symbol;
+
+    FuturesCurrenciesEnum(int symbol) {
+        this.symbol = symbol;
+    }
+
+    public int getSymbol() {
+        return symbol;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/enums/FuturesTransactionTypeEnum.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/enums/FuturesTransactionTypeEnum.java
@@ -1,0 +1,23 @@
+package com.okcoin.commons.okex.open.api.enums;
+
+/**
+ * Transaction type
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/9 15:49
+ */
+public enum FuturesTransactionTypeEnum {
+
+    OPEN_LONG(1), OPEN_SHORT(2), CLOSE_LONG(3), CLOSE_SHORT(4),;
+
+    private int code;
+
+    FuturesTransactionTypeEnum(int code) {
+        this.code = code;
+    }
+
+    public int code() {
+        return code;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/enums/HttpHeadersEnum.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/enums/HttpHeadersEnum.java
@@ -1,0 +1,39 @@
+package com.okcoin.commons.okex.open.api.enums;
+
+/**
+ * Http Headers Enum . <br/>
+ * All REST requests must contain the following headers. <br/>
+ * The api key and secret key will be randomly generated and provided by OKEX. <br/>
+ * The Passphrase will be provided by you to further secure your API access. <br/>
+ * OKEX stores the salted hash of your passphrase for verification, but cannot recover the passphrase if you forget it.<br/>
+ * OKEX cursor pagination response headers.<br/>
+ * Request page before (newer) and after (older) this pagination id,
+ * and limit number of results per request. maximum 100. (default 100). <br/>
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/2/5 20:45
+ */
+public enum HttpHeadersEnum {
+
+    OK_ACCESS_KEY("OK-ACCESS-KEY"),
+    OK_ACCESS_SIGN("OK-ACCESS-SIGN"),
+    OK_ACCESS_TIMESTAMP("OK-ACCESS-TIMESTAMP"),
+    OK_ACCESS_PASSPHRASE("OK-ACCESS-PASSPHRASE"),
+
+    OK_BEFORE("OK-BEFORE"),
+    OK_AFTER("OK-AFTER"),
+    OK_LIMIT("OK-LIMIT"),
+    OK_FROM("OK-FROM"),
+    OK_TO("OK-TO");
+
+    private final String header;
+
+    HttpHeadersEnum(final String header) {
+        this.header = header;
+    }
+
+    public String header() {
+        return this.header;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/enums/HttpMethodEnum.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/enums/HttpMethodEnum.java
@@ -1,0 +1,19 @@
+package com.okcoin.commons.okex.open.api.enums;
+
+/**
+ * Http Method Enum
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/8 13:53
+ */
+public enum HttpMethodEnum {
+    GET,
+    HEAD,
+    POST,
+    PUT,
+    PATCH,
+    DELETE,
+    OPTIONS,
+    TRACE;
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/enums/HttpStatusEnum.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/enums/HttpStatusEnum.java
@@ -1,0 +1,41 @@
+package com.okcoin.commons.okex.open.api.enums;
+
+/**
+ * Http Status  <br/>
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/2/5 20:38
+ */
+public enum HttpStatusEnum {
+
+    OK(200, "OK", "The request is Successful."),
+    BAD_REQUEST(400, "Bad Request", "Invalid request format."),
+    UNAUTHORIZED(401, "Unauthorized", "Invalid authorization."),
+    FORBIDDEN(403, "Forbidden", "You do not have access to the requested resource."),
+    NOT_FOUND(404, "Not Found", "Request resource path error."),
+    TOO_MANY_REQUESTS(429, "Too Many Requests", "When a rate limit is exceeded."),
+    INTERNAL_SERVER_ERROR(500, "Internal Server Error", "We had a problem with our server."),;
+
+    private int status;
+    private String message;
+    private String comment;
+
+    HttpStatusEnum(int status, String message, String comment) {
+        this.status = status;
+        this.message = message;
+        this.comment = comment;
+    }
+
+    public int status() {
+        return status;
+    }
+
+    public String message() {
+        return message;
+    }
+
+    public String comment() {
+        return comment;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/enums/I18nEnum.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/enums/I18nEnum.java
@@ -1,0 +1,25 @@
+package com.okcoin.commons.okex.open.api.enums;
+
+/**
+ * internationalization
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/8 16:20
+ */
+public enum I18nEnum {
+    ENGLISH("en_US"),
+    SIMPLIFIED_CHINESE("zh_CN"),
+    //zh_TW || zh_HK
+    TRADITIONAL_CHINESE("zh_HK"),;
+
+    private String i18n;
+
+    I18nEnum(String i18n) {
+        this.i18n = i18n;
+    }
+
+    public String i18n() {
+        return i18n;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/exception/APIException.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/exception/APIException.java
@@ -1,0 +1,39 @@
+package com.okcoin.commons.okex.open.api.exception;
+
+/**
+ * API Exception
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/8 19:59
+ */
+public class APIException extends RuntimeException {
+
+    private int code;
+
+    public APIException(String message) {
+        super(message);
+    }
+
+    public APIException(int code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+
+    public APIException(Throwable cause) {
+        super(cause);
+    }
+
+    public APIException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    @Override
+    public String getMessage() {
+        if (this.code != 0) {
+            return this.code + " : " + super.getMessage();
+        }
+        return super.getMessage();
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/GeneralAPIService.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/GeneralAPIService.java
@@ -1,0 +1,23 @@
+package com.okcoin.commons.okex.open.api.service;
+
+import com.okcoin.commons.okex.open.api.bean.futures.result.ExchangeRate;
+import com.okcoin.commons.okex.open.api.bean.futures.result.ServerTime;
+
+/**
+ * OKEX general api
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/9 16:06
+ */
+public interface GeneralAPIService {
+    /**
+     * Time of the server running OKEX's REST API.
+     */
+    ServerTime getServerTime();
+
+    /**
+     * The exchange rate of legal tender pairs
+     */
+    ExchangeRate getExchangeRate();
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/account/AccountAPIService.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/account/AccountAPIService.java
@@ -1,0 +1,44 @@
+package com.okcoin.commons.okex.open.api.service.account;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.account.param.Transfer;
+import com.okcoin.commons.okex.open.api.bean.account.param.Withdraw;
+import com.okcoin.commons.okex.open.api.bean.account.result.Currency;
+import com.okcoin.commons.okex.open.api.bean.account.result.Ledger;
+import com.okcoin.commons.okex.open.api.bean.account.result.Wallet;
+import com.okcoin.commons.okex.open.api.bean.account.result.WithdrawFee;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+
+public interface AccountAPIService {
+
+    JSONObject transfer(Transfer transfer);
+
+    JSONObject withdraw(Withdraw withdraw);
+
+    List<Currency> getCurrencies();
+
+    List<Ledger> getLedger(Integer type, String currency, Integer before, Integer after, int limit);
+
+    List<Wallet> getWallet();
+
+    List<Wallet> getWallet(String currency);
+
+    JSONArray getDepositAddress(String currency);
+
+    List<WithdrawFee> getWithdrawFee(String currency);
+
+    JSONArray getOnHold(String currency);
+
+    JSONObject lock(String currency, BigDecimal amount);
+
+    JSONObject unlock(String currency, BigDecimal amount);
+
+    JSONArray getDepositHistory();
+
+    JSONArray getDepositHistory(String currency);
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/account/impl/AccountAPI.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/account/impl/AccountAPI.java
@@ -1,0 +1,64 @@
+package com.okcoin.commons.okex.open.api.service.account.impl;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.account.result.Currency;
+import com.okcoin.commons.okex.open.api.bean.account.result.Ledger;
+import com.okcoin.commons.okex.open.api.bean.account.result.Wallet;
+import com.okcoin.commons.okex.open.api.bean.account.result.WithdrawFee;
+import retrofit2.Call;
+import retrofit2.http.*;
+
+import java.util.List;
+
+/**
+ * Account api
+ *
+ * @author hucj
+ * @version 1.0.0
+ * @date 2018/07/04 20:51
+ */
+public interface AccountAPI {
+
+
+    @POST("/api/account/v3/transfer")
+    Call<JSONObject> transfer(@Body JSONObject jsonObject);
+
+
+    @POST("/api/account/v3/withdrawal")
+    Call<JSONObject> withdraw(@Body JSONObject jsonObject);
+
+    @GET("/api/account/v3/currencies")
+    Call<List<Currency>> getCurrencies();
+
+    @GET("/api/account/v3/ledger")
+    Call<List<Ledger>> getLedger(@Query("txn_type") Integer type, @Query("currency") String currency,
+                                 @Query("before") Integer before, @Query("after") Integer after, @Query("limit") int limit);
+
+    @GET("/api/account/v3/wallet")
+    Call<List<Wallet>> getWallet();
+
+    @GET("/api/account/v3/wallet/{currency}")
+    Call<List<Wallet>> getWallet(@Path("currency") String currency);
+
+    @GET("/api/account/v3/deposit/address")
+    Call<JSONArray> getDepositAddress(@Query("currency") String currency);
+
+    @GET("/api/account/v3/withdrawal/fee")
+    Call<List<WithdrawFee>> getWithdrawFee(@Query("currency") String currency);
+
+    @GET("/api/account/v3/onhold")
+    Call<JSONArray> getOnHold(@Query("currency") String currency);
+
+    @POST("/api/account/v3/lock")
+    Call<JSONObject> lock(@Body JSONObject jsonObject);
+
+    @POST("/api/account/v3/unlock")
+    Call<JSONObject> unlock(@Body JSONObject jsonObject);
+
+    @GET("/api/account/v3/deposit/history")
+    Call<JSONArray> getDepositHistory();
+
+    @GET("/api/account/v3/deposit/history/{currency}")
+    Call<JSONArray> getDepositHistory(@Path("currency") String currency);
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/account/impl/AccountAPIServiceImpl.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/account/impl/AccountAPIServiceImpl.java
@@ -1,0 +1,99 @@
+package com.okcoin.commons.okex.open.api.service.account.impl;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.account.param.Transfer;
+import com.okcoin.commons.okex.open.api.bean.account.param.Withdraw;
+import com.okcoin.commons.okex.open.api.bean.account.result.Currency;
+import com.okcoin.commons.okex.open.api.bean.account.result.Ledger;
+import com.okcoin.commons.okex.open.api.bean.account.result.Wallet;
+import com.okcoin.commons.okex.open.api.bean.account.result.WithdrawFee;
+import com.okcoin.commons.okex.open.api.client.APIClient;
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.service.account.AccountAPIService;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class AccountAPIServiceImpl implements AccountAPIService {
+
+    private APIClient client;
+    private AccountAPI api;
+
+    public AccountAPIServiceImpl(APIConfiguration config) {
+        this.client = new APIClient(config);
+        this.api = client.createService(AccountAPI.class);
+    }
+
+    @Override
+    public JSONObject transfer(Transfer transfer) {
+        return this.client.executeSync(this.api.transfer(JSONObject.parseObject(JSON.toJSONString(transfer))));
+    }
+
+    @Override
+    public JSONObject withdraw(Withdraw withdraw) {
+        return this.client.executeSync(this.api.withdraw(JSONObject.parseObject(JSON.toJSONString(withdraw))));
+    }
+
+    @Override
+    public List<Currency> getCurrencies() {
+        return this.client.executeSync(this.api.getCurrencies());
+    }
+
+    @Override
+    public List<Ledger> getLedger(Integer type, String currency, Integer before, Integer after, int limit) {
+        return this.client.executeSync(this.api.getLedger(type, currency, before, after, limit));
+    }
+
+    @Override
+    public List<Wallet> getWallet() {
+        return this.client.executeSync(this.api.getWallet());
+    }
+
+    @Override
+    public List<Wallet> getWallet(String currency) {
+        return this.client.executeSync(this.api.getWallet(currency));
+    }
+
+    @Override
+    public JSONArray getDepositAddress(String currency) {
+        return this.client.executeSync(this.api.getDepositAddress(currency));
+    }
+
+    @Override
+    public List<WithdrawFee> getWithdrawFee(String currency) {
+        return this.client.executeSync(this.api.getWithdrawFee(currency));
+    }
+
+    @Override
+    public JSONArray getOnHold(String currency) {
+        return this.client.executeSync(this.api.getOnHold(currency));
+    }
+
+    @Override
+    public JSONObject lock(String currency, BigDecimal amount) {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("currency", currency);
+        jsonObject.put("size", amount);
+        return this.client.executeSync(this.api.lock(jsonObject));
+    }
+
+    @Override
+    public JSONObject unlock(String currency, BigDecimal amount) {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("currency", currency);
+        jsonObject.put("size", amount);
+        return this.client.executeSync(this.api.unlock(jsonObject));
+    }
+
+    @Override
+    public JSONArray getDepositHistory() {
+        return this.client.executeSync(this.api.getDepositHistory());
+    }
+
+    @Override
+    public JSONArray getDepositHistory(String currency) {
+        return this.client.executeSync(this.api.getDepositHistory(currency));
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/ett/EttAccountAPIService.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/ett/EttAccountAPIService.java
@@ -1,0 +1,43 @@
+package com.okcoin.commons.okex.open.api.service.ett;
+
+import com.okcoin.commons.okex.open.api.bean.ett.result.CursorPager;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttAccount;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttLedger;
+
+import java.util.List;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/4
+ */
+public interface EttAccountAPIService {
+
+    /**
+     * Get all ett account list
+     *
+     * @return account info list
+     */
+    List<EttAccount> getAccount();
+
+    /**
+     * Get ett currency account
+     *
+     * @param currency currency code
+     * @return account info
+     */
+    EttAccount getAccount(String currency);
+
+    /**
+     * Get ett account ledger list
+     *
+     * @param currency currency code
+     * @param before   before and after cursors are available via response headers OK-BEFORE and OK-AFTER. Your requests should use these cursor values when making requests for pages after the initial
+     *                 request. {@link CursorPager}
+     * @param after    before and after cursors are available via response headers OK-BEFORE and OK-AFTER. Your requests should use these cursor values when making requests for pages after the initial
+     *                 request. {@link CursorPager}
+     * @param limit    number of results per request.
+     * @return
+     */
+    CursorPager<EttLedger> getLedger(String currency, String before, String after, int limit);
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/ett/EttOrderAPIService.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/ett/EttOrderAPIService.java
@@ -1,0 +1,59 @@
+package com.okcoin.commons.okex.open.api.service.ett;
+
+import com.okcoin.commons.okex.open.api.bean.ett.result.CursorPager;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttCancelOrderResult;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttCreateOrderResult;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttOrder;
+
+import java.math.BigDecimal;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/4
+ */
+public interface EttOrderAPIService {
+
+    /**
+     * Create a ett order
+     *
+     * @param ett       ett name
+     * @param type      order type. 1. usdt subscription 2. usdt redemption 3. underlying redemption
+     * @param amount    subscription usdt size
+     * @param size      redemption ett size
+     * @param clientOid client order id
+     * @return create order result
+     */
+    EttCreateOrderResult createOrder(String ett, Integer type, BigDecimal amount, BigDecimal size, String clientOid);
+
+    /**
+     * Cancel order
+     *
+     * @param orderId order id
+     * @return cancel order result
+     */
+    EttCancelOrderResult cancelOrder(String orderId);
+
+    /**
+     * Get all of ett account order list
+     *
+     * @param ett    ett name
+     * @param type   order type. 1. subscription 2. redemption
+     * @param status order status. 0. all 1. waiting 2. done 3. canceled
+     * @param before before and after cursors are available via response headers OK-BEFORE and OK-AFTER. Your requests should use these cursor values when making requests for pages after the initial
+     *               request. {@link CursorPager}
+     * @param after  before and after cursors are available via response headers OK-BEFORE and OK-AFTER. Your requests should use these cursor values when making requests for pages after the initial
+     *               request. {@link CursorPager}
+     * @param limit  Number of results per request.
+     * @return order info list
+     */
+    CursorPager<EttOrder> getOrder(String ett, Integer type, Integer status, String before, String after, int limit);
+
+    /**
+     * Get the ett account order info
+     *
+     * @param orderId order id
+     * @return order info
+     */
+    EttOrder getOrder(String orderId);
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/ett/EttProductAPIService.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/ett/EttProductAPIService.java
@@ -1,0 +1,30 @@
+package com.okcoin.commons.okex.open.api.service.ett;
+
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttConstituentsResult;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttSettlementDefinePrice;
+
+import java.util.List;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/4
+ */
+public interface EttProductAPIService {
+
+    /**
+     * Get ett constituents
+     *
+     * @param ett ett name
+     * @return constituents
+     */
+    EttConstituentsResult getConstituents(String ett);
+
+    /**
+     * Get ett settlement plan define price
+     *
+     * @param ett ett name
+     * @return settlement plan define price list
+     */
+    List<EttSettlementDefinePrice> getDefinePrice(String ett);
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/ett/impl/EttAccountAPI.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/ett/impl/EttAccountAPI.java
@@ -1,0 +1,27 @@
+package com.okcoin.commons.okex.open.api.service.ett.impl;
+
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttAccount;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttLedger;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+import java.util.List;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/5
+ */
+interface EttAccountAPI {
+
+    @GET("/api/ett/v3/accounts")
+    Call<List<EttAccount>> getAccount();
+
+    @GET("/api/ett/v3/accounts/{currency}")
+    Call<EttAccount> getAccount(@Path("currency") String currency);
+
+    @GET("/api/ett/v3/accounts/{currency}/ledger")
+    Call<List<EttLedger>> getLedger(@Path("currency") String currency, @Query("before") String before, @Query("after") String after, @Query("limit") int limit);
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/ett/impl/EttAccountAPIServiceImpl.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/ett/impl/EttAccountAPIServiceImpl.java
@@ -1,0 +1,40 @@
+package com.okcoin.commons.okex.open.api.service.ett.impl;
+
+import com.okcoin.commons.okex.open.api.bean.ett.result.CursorPager;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttAccount;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttLedger;
+import com.okcoin.commons.okex.open.api.client.APIClient;
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.service.ett.EttAccountAPIService;
+
+import java.util.List;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/5
+ */
+public class EttAccountAPIServiceImpl implements EttAccountAPIService {
+
+    private final APIClient client;
+    private final EttAccountAPI api;
+
+    public EttAccountAPIServiceImpl(APIConfiguration config) {
+        this.client = new APIClient(config);
+        this.api = this.client.createService(EttAccountAPI.class);
+    }
+
+    @Override
+    public List<EttAccount> getAccount() {
+        return this.client.executeSync(this.api.getAccount());
+    }
+
+    @Override
+    public EttAccount getAccount(String currency) {
+        return this.client.executeSync(this.api.getAccount(currency));
+    }
+
+    @Override
+    public CursorPager<EttLedger> getLedger(String currency, String before, String after, int limit) {
+        return this.client.executeSyncCursorPager(this.api.getLedger(currency, before, after, limit));
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/ett/impl/EttOrderAPI.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/ett/impl/EttOrderAPI.java
@@ -1,0 +1,31 @@
+package com.okcoin.commons.okex.open.api.service.ett.impl;
+
+import com.okcoin.commons.okex.open.api.bean.ett.param.EttCreateOrderParam;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttCancelOrderResult;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttCreateOrderResult;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttOrder;
+import retrofit2.Call;
+import retrofit2.http.*;
+
+import java.util.List;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/5
+ */
+interface EttOrderAPI {
+
+    @POST("/api/ett/v3/orders")
+    Call<EttCreateOrderResult> createOrder(@Body EttCreateOrderParam param);
+
+    @DELETE("/api/ett/v3/orders/{orderId}")
+    Call<EttCancelOrderResult> cancelOrder(@Path("orderId") String orderId);
+
+    @GET("/api/ett/v3/orders")
+    Call<List<EttOrder>> getOrder(@Query("ett") String ett, @Query("type") Integer type, @Query("status") Integer status, @Query("before") String before, @Query("after") String after,
+                                  @Query("limit") int limit);
+
+    @GET("/api/ett/v3/orders/{orderId}")
+    Call<EttOrder> getOrder(@Path("orderId") String orderId);
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/ett/impl/EttOrderAPIServiceImpl.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/ett/impl/EttOrderAPIServiceImpl.java
@@ -1,0 +1,53 @@
+package com.okcoin.commons.okex.open.api.service.ett.impl;
+
+import com.okcoin.commons.okex.open.api.bean.ett.param.EttCreateOrderParam;
+import com.okcoin.commons.okex.open.api.bean.ett.result.CursorPager;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttCancelOrderResult;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttCreateOrderResult;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttOrder;
+import com.okcoin.commons.okex.open.api.client.APIClient;
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.service.ett.EttOrderAPIService;
+
+import java.math.BigDecimal;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/5
+ */
+public class EttOrderAPIServiceImpl implements EttOrderAPIService {
+
+    private final APIClient client;
+    private final EttOrderAPI api;
+
+    public EttOrderAPIServiceImpl(APIConfiguration config) {
+        this.client = new APIClient(config);
+        this.api = this.client.createService(EttOrderAPI.class);
+    }
+
+    @Override
+    public EttCreateOrderResult createOrder(String ett, Integer type, BigDecimal amount, BigDecimal size, String clientOid) {
+        EttCreateOrderParam param = new EttCreateOrderParam();
+        param.setEtt(ett);
+        param.setType(type);
+        param.setAmount(amount);
+        param.setSize(size);
+        param.setClientOid(clientOid);
+        return this.client.executeSync(this.api.createOrder(param));
+    }
+
+    @Override
+    public EttCancelOrderResult cancelOrder(String orderId) {
+        return this.client.executeSync(this.api.cancelOrder(orderId));
+    }
+
+    @Override
+    public CursorPager<EttOrder> getOrder(String ett, Integer type, Integer status, String before, String after, int limit) {
+        return this.client.executeSyncCursorPager(this.api.getOrder(ett, type, status, before, after, limit));
+    }
+
+    @Override
+    public EttOrder getOrder(String orderId) {
+        return this.client.executeSync(this.api.getOrder(orderId));
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/ett/impl/EttProductAPI.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/ett/impl/EttProductAPI.java
@@ -1,0 +1,23 @@
+package com.okcoin.commons.okex.open.api.service.ett.impl;
+
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttConstituentsResult;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttSettlementDefinePrice;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+
+import java.util.List;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/5
+ */
+interface EttProductAPI {
+
+    @GET("/api/ett/v3/constituents/{ett}")
+    Call<EttConstituentsResult> getConstituents(@Path("ett") String ett);
+
+    @GET("/api/ett/v3/define-price/{ett}")
+    Call<List<EttSettlementDefinePrice>> getDefinePrice(@Path("ett") String ett);
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/ett/impl/EttProductAPIServiceImpl.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/ett/impl/EttProductAPIServiceImpl.java
@@ -1,0 +1,34 @@
+package com.okcoin.commons.okex.open.api.service.ett.impl;
+
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttConstituentsResult;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttSettlementDefinePrice;
+import com.okcoin.commons.okex.open.api.client.APIClient;
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.service.ett.EttProductAPIService;
+
+import java.util.List;
+
+/**
+ * @author chuping.cui
+ * @date 2018/7/5
+ */
+public class EttProductAPIServiceImpl implements EttProductAPIService {
+
+    private final APIClient client;
+    private final EttProductAPI api;
+
+    public EttProductAPIServiceImpl(APIConfiguration config) {
+        this.client = new APIClient(config);
+        this.api = this.client.createService(EttProductAPI.class);
+    }
+
+    @Override
+    public EttConstituentsResult getConstituents(String ett) {
+        return this.client.executeSync(this.api.getConstituents(ett));
+    }
+
+    @Override
+    public List<EttSettlementDefinePrice> getDefinePrice(String ett) {
+        return this.client.executeSync(this.api.getDefinePrice(ett));
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/futures/FuturesMarketAPIService.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/futures/FuturesMarketAPIService.java
@@ -1,0 +1,124 @@
+package com.okcoin.commons.okex.open.api.service.futures;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.futures.result.*;
+
+import java.util.List;
+
+/**
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/9 16:06
+ */
+public interface FuturesMarketAPIService {
+
+    /**
+     * Get all of futures contract list
+     */
+    List<Instruments> getInstruments();
+
+    /**
+     * Get the futures contract currencies
+     */
+    List<Currencies> getCurrencies();
+
+    /**
+     * Get the futures contract product book
+     *
+     * @param instrumentId The id of the futures contract eg: BTC-USD-0331"
+     * @param size     value：1-200
+     * @return
+     */
+    Book getInstrumentBook(String instrumentId, Integer size);
+
+    /**
+     * Get the futures contract product ticker
+     *
+     * @param productId The id of the futures contract eg: BTC-USD-0331"
+     */
+    Ticker getInstrumentTicker(String productId);
+
+    /**
+     * Get all futures contract product ticker
+     *
+     */
+    List<Ticker> getAllInstrumentTicker();
+
+    /**
+     * Get the futures contract product trades
+     *
+     * @param instrumentId The id of the futures contract eg: BTC-USD-0331"
+     */
+    List<Trades> getInstrumentTrades(String instrumentId , int from, int to, int limit);
+
+    /**
+     * Get the futures contract product candles
+     *
+     * @param instrumentId   The id of the futures contract eg: BTC-USD-0331"
+     * @param start       start timestamp of candles, (eg:1530676775258)
+     * @param end         start timestamp of candles, (eg:1530676841895)
+     * @param granularity Time granularity measured in seconds. data after the timestamp will be returned
+     *                    60     ->  1min
+     *                    180    ->  3min
+     *                    300    ->  5min
+     *                    900    ->  15min
+     *                    1800   ->  30min
+     *                    3600   ->  1hour
+     *                    7200   ->  2hour
+     *                    14400  ->  4hour
+     *                    21600  ->  6hour
+     *                    43200  ->  12hour
+     *                    86400  ->  1day
+     *                    604800 ->  1week
+     */
+    JSONArray getInstrumentCandles(String instrumentId, String start, String end, long granularity);
+
+    /**
+     * Get the futures contract product index
+     *
+     * @param instrumentId The id of the futures contract eg: BTC-USD-0331"
+     */
+    Index getInstrumentIndex(String instrumentId);
+
+    /**
+     * Get the futures contract product estimated price
+     *
+     * @param instrumentId The id of the futures contract eg: BTC-USD-0331"
+     */
+    EstimatedPrice getInstrumentEstimatedPrice(String instrumentId);
+
+    /**
+     * Get the futures contract product holds
+     *
+     * @param instrumentId The id of the futures contract eg: BTC-USD-0331"
+     */
+    Holds getInstrumentHolds(String instrumentId);
+
+    /**
+     * Get the futures contract product limit price
+     *
+     * @param instrumentId The id of the futures contract eg: BTC-USD-0331"
+     */
+    PriceLimit getInstrumentPriceLimit(String instrumentId);
+
+    /**
+     * Get the futures contract liquidation
+     *
+     * @param instrumentId The id of the futures contract eg: BTC-USD-0331"
+     * @param status    0:Last 7 days: Open 1:Last 7 days: Filled
+     * @param from    Paging content after requesting this id .
+     * @param to     Paging content prior to requesting this id.
+     * @param limit     Number of results per request. Maximum 100. (default 100)
+     */
+    List<Liquidation> getInstrumentLiquidation(String instrumentId, int status, int from, int to, int limit);
+
+    /**
+     * Get MarkPrice
+     *
+     * @param instrumentId The id of the futures contract eg: BTC-USD-0331"
+     */
+    JSONObject getMarkPrice(String instrumentId);
+
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/futures/FuturesTradeAPIService.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/futures/FuturesTradeAPIService.java
@@ -1,0 +1,138 @@
+package com.okcoin.commons.okex.open.api.service.futures;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.futures.param.CancelOrders;
+import com.okcoin.commons.okex.open.api.bean.futures.param.ClosePosition;
+import com.okcoin.commons.okex.open.api.bean.futures.param.Order;
+import com.okcoin.commons.okex.open.api.bean.futures.param.Orders;
+import com.okcoin.commons.okex.open.api.bean.futures.result.OrderResult;
+
+import java.util.List;
+
+/**
+ * Futures Trade API Service
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/9 18:52
+ */
+public interface FuturesTradeAPIService {
+
+    /**
+     * Get all of futures contract position list
+     */
+    JSONObject getPositions();
+
+    /**
+     * Get the futures contract product position
+     *
+     * @param instrumentId The id of the futures contract eg: BTC-USD-0331"
+     */
+    JSONObject getInstrumentPosition(String instrumentId);
+
+    /**
+     * Get all of futures contract account list
+     */
+    JSONObject getAccounts();
+
+    /**
+     * Get the futures contract currency account
+     *
+     * @param currency {@link com.okcoin.commons.okex.open.api.enums.FuturesCurrenciesEnum}
+     *                 eg: FuturesCurrenciesEnum.BTC.name()
+     */
+    JSONObject getAccountsByCurrency(String currency);
+
+    /**
+     * Get the futures contract currency ledger
+     *
+     * @param currency {@link com.okcoin.commons.okex.open.api.enums.FuturesCurrenciesEnum}
+     *                 eg: FuturesCurrenciesEnum.BTC.name()
+     */
+    JSONArray getAccountsLedgerByCurrency(String currency);
+
+    /**
+     * Get the futures contract product holds
+     *
+     * @param instrumentId The id of the futures contract eg: BTC-USD-0331"
+     */
+    JSONObject getAccountsHoldsByInstrumentId(String instrumentId);
+
+    /**
+     * Create a new order
+     */
+    OrderResult order(Order order);
+
+    /**
+     * Batch create new order.(Max of 5 orders are allowed per request))
+     */
+    JSONObject orders(Orders orders);
+
+    /**
+     * Cancel the order
+     *
+     * @param instrumentId The id of the futures contract eg: BTC-USD-0331"
+     * @param orderId   the order id provided by okex.com eg: 372238304216064
+     */
+    JSONObject cancelOrder(String instrumentId, long orderId);
+
+    /**
+     * Batch Cancel the orders of this product id
+     *
+     * @param instrumentId The id of the futures contract eg: BTC-USD-0331"
+     */
+    JSONObject cancelOrders(String instrumentId, CancelOrders cancelOrders);
+
+    /**
+     * Get all of futures contract order list
+     *
+     * @param status   Order status: 0: waiting for transaction 1: 1: part of the deal 2: all transactions.
+     * @param from    Paging content after requesting this id .
+     * @param to     Paging content prior to requesting this id.
+     * @param limit    Number of results per request. Maximum 100. (default 100)
+     *                 {@link com.okcoin.commons.okex.open.api.bean.futures.CursorPageParams}
+     * @return
+     */
+    JSONObject getOrders(String instrument_id, int status, int from, int to, int limit);
+
+    /**
+     * Get all of futures contract a order by order id
+     *
+     * @param instrumentId  eg: futures id
+     */
+    JSONObject getOrder(String instrumentId,long orderId);
+
+    /**
+     * Get all of futures contract transactions.
+     *
+     * @param instrumentId The id of the futures contract eg: BTC-USD-0331"
+     * @param orderId   the order id provided by okex.com eg: 372238304216064
+     * @param from    Paging content after requesting this id .
+     * @param to     Paging content prior to requesting this id.
+     * @param limit     Number of results per request. Maximum 100. (default 100)
+     *                  {@link com.okcoin.commons.okex.open.api.bean.futures.CursorPageParams}
+     * @return
+     */
+    JSONArray getFills(String instrumentId, long orderId, int from, int to, int limit);
+
+    /**
+     * Get the futures LeverRate
+     *
+     * @param currency eg: btc
+     */
+    JSONObject getInstrumentLeverRate(String currency);
+
+    /**
+     * Change the futures LeverRate
+     *
+     * @param currency  eg: btc
+     * @param instrumentId  eg: BTC-USD-0331
+     * @param leverage  eg: 10/20
+     * @param direction  eg: 1/2
+     */
+    JSONObject changeLevelRate( String currency,String instrumentId,String direction, int leverage);
+
+
+    JSONObject changequancangLevelRate( String currency, int leverage);
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/futures/impl/FuturesMarketAPI.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/futures/impl/FuturesMarketAPI.java
@@ -1,0 +1,67 @@
+package com.okcoin.commons.okex.open.api.service.futures.impl;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.futures.result.*;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+import java.util.List;
+
+/**
+ * Futures market api
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/8 20:51
+ */
+interface FuturesMarketAPI {
+
+    @GET("/api/futures/v3/time")
+    Call<ServerTime> getServerTime();
+
+    @GET("/api/futures/v3/rate")
+    Call<ExchangeRate> getExchangeRate();
+
+    @GET("/api/futures/v3/instruments")
+    Call<List<Instruments>> getInstruments();
+
+    @GET("/api/futures/v3/instruments/currencies")
+    Call<List<Currencies>> getCurrencies();
+
+    @GET("/api/futures/v3/instruments/{instrument_id}/book")
+    Call<Book> getInstrumentBook(@Path("instrument_id") String instrumentId, @Query("size") Integer size);
+
+    @GET("/api/futures/v3/instruments/{instrument_id}/ticker")
+    Call<Ticker> getInstrumentTicker(@Path("instrument_id") String instrumentId);
+
+    @GET("/api/futures/v3/instruments/ticker")
+    Call<List<Ticker>> getAllInstrumentTicker();
+
+    @GET("/api/futures/v3/instruments/{instrument_id}/trades")
+    Call<List<Trades>> getInstrumentTrades(@Path("instrument_id") String instrumentId, @Query("from") int from, @Query("to") int to, @Query("limit") int limit);
+
+    @GET("/api/futures/v3/instruments/{instrument_id}/candles")
+    Call<JSONArray> getInstrumentCandles(@Path("instrument_id") String instrumentId, @Query("start") String start, @Query("end") String end, @Query("granularity") String granularity);
+
+    @GET("/api/futures/v3/instruments/{instrument_id}/index")
+    Call<Index> getInstrumentIndex(@Path("instrument_id") String instrumentId);
+
+    @GET("/api/futures/v3/instruments/{instrument_id}/estimated_price")
+    Call<EstimatedPrice> getInstrumentEstimatedPrice(@Path("instrument_id") String instrumentId);
+
+    @GET("/api/futures/v3/instruments/{instrument_id}/open_interest")
+    Call<Holds> getInstrumentHolds(@Path("instrument_id") String instrumentId);
+
+    @GET("/api/futures/v3/instruments/{instrument_id}/price_limit")
+    Call<PriceLimit> getInstrumentPriceLimit(@Path("instrument_id") String instrumentId);
+
+    @GET("/api/futures/v3/instruments/{instrument_id}/liquidation")
+    Call<List<Liquidation>> getInstrumentLiquidation(@Path("instrument_id") String instrumentId, @Query("status") int status
+            , @Query("from") int from, @Query("to") int to, @Query("limit") int limit);
+
+    @GET("/api/futures/v3/instruments/{instrument_id}/mark_price")
+    Call<JSONObject> getMarkPrice(@Path("instrument_id") String instrumentId);
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/futures/impl/FuturesMarketAPIServiceImpl.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/futures/impl/FuturesMarketAPIServiceImpl.java
@@ -1,0 +1,94 @@
+package com.okcoin.commons.okex.open.api.service.futures.impl;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.futures.result.*;
+import com.okcoin.commons.okex.open.api.client.APIClient;
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.service.futures.FuturesMarketAPIService;
+
+import java.util.List;
+
+/**
+ * Futures market api
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/9 16:09
+ */
+public class FuturesMarketAPIServiceImpl implements FuturesMarketAPIService {
+
+    private APIClient client;
+    private FuturesMarketAPI api;
+
+    public FuturesMarketAPIServiceImpl(APIConfiguration config) {
+        this.client = new APIClient(config);
+        this.api = client.createService(FuturesMarketAPI.class);
+    }
+
+    @Override
+    public List<Instruments> getInstruments() {
+        return this.client.executeSync(this.api.getInstruments());
+    }
+
+    @Override
+    public List<Currencies> getCurrencies() {
+        return this.client.executeSync(this.api.getCurrencies());
+    }
+
+    @Override
+    public Book getInstrumentBook(String instrumentId, Integer size) {
+        return this.client.executeSync(this.api.getInstrumentBook(instrumentId, size));
+    }
+
+    @Override
+    public Ticker getInstrumentTicker(String instrumentId) {
+        return this.client.executeSync(this.api.getInstrumentTicker(instrumentId));
+    }
+
+    @Override
+    public List<Ticker> getAllInstrumentTicker() {
+        return this.client.executeSync(this.api.getAllInstrumentTicker());
+    }
+
+    @Override
+    public List<Trades> getInstrumentTrades(String instrumentId, int from, int to, int limit) {
+        return this.client.executeSync(this.api.getInstrumentTrades(instrumentId,  from,  to,  limit));
+    }
+
+    @Override
+    public JSONArray getInstrumentCandles(String instrumentId, String start, String end, long granularity) {
+        return this.client.executeSync(this.api.getInstrumentCandles(instrumentId, String.valueOf(start), String.valueOf(end), String.valueOf(granularity)));
+    }
+
+    @Override
+    public Index getInstrumentIndex(String instrumentId) {
+        return this.client.executeSync(this.api.getInstrumentIndex(instrumentId));
+    }
+
+    @Override
+    public EstimatedPrice getInstrumentEstimatedPrice(String instrumentId) {
+        return this.client.executeSync(this.api.getInstrumentEstimatedPrice(instrumentId));
+    }
+
+    @Override
+    public Holds getInstrumentHolds(String instrumentId) {
+        return this.client.executeSync(this.api.getInstrumentHolds(instrumentId));
+    }
+
+    @Override
+    public PriceLimit getInstrumentPriceLimit(String instrumentId) {
+        return this.client.executeSync(this.api.getInstrumentPriceLimit(instrumentId));
+    }
+
+    @Override
+    public List<Liquidation> getInstrumentLiquidation(String instrumentId, int status, int from, int to, int limit) {
+        return this.client.executeSync(this.api.getInstrumentLiquidation(instrumentId, status,  from,  to,  limit));
+    }
+
+    @Override
+    public JSONObject getMarkPrice(String instrumentId){
+        return this.client.executeSync(this.api.getMarkPrice(instrumentId));
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/futures/impl/FuturesTradeAPI.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/futures/impl/FuturesTradeAPI.java
@@ -1,0 +1,71 @@
+package com.okcoin.commons.okex.open.api.service.futures.impl;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.futures.result.OrderResult;
+import retrofit2.Call;
+import retrofit2.http.*;
+
+/**
+ * Futures trade api
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/9 19:20
+ */
+interface FuturesTradeAPI {
+
+    @GET("/api/futures/v3/position")
+    Call<JSONObject> getPositions();
+
+    @GET("/api/futures/v3/{instrument_id}/position")
+    Call<JSONObject> getInstrumentPosition(@Path("instrument_id") String instrumentId);
+
+    @GET("/api/futures/v3/accounts")
+    Call<JSONObject> getAccounts();
+
+    @GET("/api/futures/v3/accounts/{currency}")
+    Call<JSONObject> getAccountsByCurrency(@Path("currency") String currency);
+
+    @GET("/api/futures/v3/accounts/{currency}/ledger")
+    Call<JSONArray> getAccountsLedgerByCurrency(@Path("currency") String currency);
+
+    @GET("/api/futures/v3/accounts/{instrument_id}/holds")
+    Call<JSONObject> getAccountsHoldsByInstrumentId(@Path("instrument_id") String instrumentId);
+
+    @POST("/api/futures/v3/order")
+    Call<OrderResult> order(@Body JSONObject order);
+
+    @POST("/api/futures/v3/orders")
+    Call<JSONObject> orders(@Body JSONObject orders);
+
+    @POST("/api/futures/v3/cancel_order/{instrument_id}/{order_id}")
+    Call<JSONObject> cancelOrder(@Path("instrument_id") String instrumentId, @Path("order_id") String orderId);
+
+    @POST("/api/futures/v3/cancel_batch_orders/{instrument_id}")
+    Call<JSONObject> cancelOrders(@Path("instrument_id") String instrumentId, @Body JSONObject order_ids);
+
+    @GET("/api/futures/v3/orders/{instrument_id}")
+    Call<JSONObject> getOrders(@Path("instrument_id") String instrumentId, @Query("status") int status,
+                               @Query("from") int from, @Query("to") int to, @Query("limit") int limit);
+
+    @GET("/api/futures/v3/orders/{instrument_id}/{order_id}")
+    Call<JSONObject> getOrder(@Path("instrument_id") String instrumentId, @Path("order_id") String orderId);
+
+    @GET("/api/futures/v3/fills")
+    Call<JSONArray> getFills(@Query("instrument_id") String instrumentId, @Query("order_id") String orderId,
+                             @Query("from") int before, @Query("to") int after, @Query("limit") int limit);
+
+    @GET("/api/futures/v3/accounts/{currency}/leverage")
+    Call<JSONObject> getLeverRate(@Path("currency") String currency);
+
+    @POST("/api/futures/v3/accounts/{currency}/leverage")
+    Call<JSONObject> changeLevelRate(@Path("currency") String currency,
+                                     @Query("instrument_id") String instrumentId,
+                                     @Query("direction") String direction,
+                                     @Query("leverage") int leverage);
+
+    @POST("/api/futures/v3/accounts/{currency}/leverage")
+    Call<JSONObject> changequancanLevelRate(@Path("currency") String currency,
+                                            @Query("leverage") int leverage);
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/futures/impl/FuturesTradeAPIServiceImpl.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/futures/impl/FuturesTradeAPIServiceImpl.java
@@ -1,0 +1,119 @@
+package com.okcoin.commons.okex.open.api.service.futures.impl;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.futures.param.CancelOrders;
+import com.okcoin.commons.okex.open.api.bean.futures.param.Order;
+import com.okcoin.commons.okex.open.api.bean.futures.param.Orders;
+import com.okcoin.commons.okex.open.api.bean.futures.param.OrdersItem;
+import com.okcoin.commons.okex.open.api.bean.futures.result.OrderResult;
+import com.okcoin.commons.okex.open.api.client.APIClient;
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.service.futures.FuturesTradeAPIService;
+import com.okcoin.commons.okex.open.api.utils.JsonUtils;
+
+/**
+ * Futures trade api
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/9 18:52
+ */
+public class FuturesTradeAPIServiceImpl implements FuturesTradeAPIService {
+
+    private APIClient client;
+    private FuturesTradeAPI api;
+
+    public FuturesTradeAPIServiceImpl(APIConfiguration config) {
+        this.client = new APIClient(config);
+        this.api = client.createService(FuturesTradeAPI.class);
+    }
+
+    @Override
+    public JSONObject getPositions() {
+
+        return this.client.executeSync(this.api.getPositions());
+    }
+
+    @Override
+    public JSONObject getInstrumentPosition(String instrumentId) {
+        return this.client.executeSync(this.api.getInstrumentPosition(instrumentId));
+    }
+
+    @Override
+    public JSONObject getAccounts() {
+        return this.client.executeSync(this.api.getAccounts());
+    }
+
+    @Override
+    public JSONObject getAccountsByCurrency(String currency) {
+        return this.client.executeSync(this.api.getAccountsByCurrency(currency));
+    }
+
+    @Override
+    public JSONArray getAccountsLedgerByCurrency(String currency) {
+        return this.client.executeSync(this.api.getAccountsLedgerByCurrency(currency));
+    }
+
+    @Override
+    public JSONObject getAccountsHoldsByInstrumentId(String instrumentId) {
+        return this.client.executeSync(this.api.getAccountsHoldsByInstrumentId(instrumentId));
+    }
+
+    @Override
+    public OrderResult order(Order order) {
+        System.out.println(JsonUtils.convertObject(order, Order.class));
+        return this.client.executeSync(this.api.order(JsonUtils.convertObject(order, Order.class)));
+    }
+
+    @Override
+    public JSONObject orders(Orders orders) {
+        JSONObject params = new JSONObject();
+        params.put("instrument_id", orders.getInstrument_id());
+        params.put("leverage", orders.getLeverage());
+        params.put("orders_data", JsonUtils.convertList(orders.getOrders_data(), OrdersItem.class));
+        System.out.println(params.toString());
+        return this.client.executeSync(this.api.orders(params));
+    }
+
+    @Override
+    public JSONObject cancelOrder(String instrumentId, long orderId) {
+        return this.client.executeSync(this.api.cancelOrder(instrumentId, String.valueOf(orderId)));
+    }
+
+    @Override
+    public JSONObject cancelOrders(String instrumentId, CancelOrders cancelOrders) {
+        return this.client.executeSync(this.api.cancelOrders(instrumentId, JsonUtils.convertObject(cancelOrders, CancelOrders.class)));
+    }
+
+    @Override
+    public JSONObject getOrders(String instrument_id, int status, int from, int to, int limit) {
+        return this.client.executeSync(this.api.getOrders(instrument_id, status, from, to, limit));
+    }
+
+    @Override
+    public JSONObject getOrder(String instrumentId, long orderId) {
+        return this.client.executeSync(this.api.getOrder(instrumentId, String.valueOf(orderId)));
+    }
+
+    @Override
+    public JSONArray getFills(String instrumentId, long orderId, int from, int to, int limit) {
+        return this.client.executeSync(this.api.getFills(instrumentId, String.valueOf(orderId), from, to, limit));
+    }
+
+    @Override
+    public JSONObject getInstrumentLeverRate(String instrumentId) {
+        return this.client.executeSync(this.api.getLeverRate(instrumentId));
+    }
+
+
+    @Override
+    public JSONObject changeLevelRate(String currency, String instrumentId, String direction, int leverage) {
+        return this.client.executeSync(this.api.changeLevelRate(currency, instrumentId, direction, leverage));
+    }
+
+    @Override
+    public JSONObject changequancangLevelRate(String currency, int leverage) {
+        return this.client.executeSync(this.api.changequancanLevelRate(currency, leverage));
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/futures/impl/GeneralAPIServiceImpl.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/futures/impl/GeneralAPIServiceImpl.java
@@ -1,0 +1,35 @@
+package com.okcoin.commons.okex.open.api.service.futures.impl;
+
+import com.okcoin.commons.okex.open.api.bean.futures.result.ExchangeRate;
+import com.okcoin.commons.okex.open.api.bean.futures.result.ServerTime;
+import com.okcoin.commons.okex.open.api.client.APIClient;
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.service.GeneralAPIService;
+
+/**
+ * General api
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 10/03/2018 19:28
+ */
+public class GeneralAPIServiceImpl implements GeneralAPIService {
+
+    private APIClient client;
+    private FuturesMarketAPI api;
+
+    public GeneralAPIServiceImpl(APIConfiguration config) {
+        this.client = new APIClient(config);
+        this.api = client.createService(FuturesMarketAPI.class);
+    }
+
+    @Override
+    public ServerTime getServerTime() {
+        return this.client.executeSync(this.api.getServerTime());
+    }
+
+    @Override
+    public ExchangeRate getExchangeRate() {
+        return this.client.executeSync(this.api.getExchangeRate());
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/MarginAccountAPIService.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/MarginAccountAPIService.java
@@ -1,0 +1,105 @@
+package com.okcoin.commons.okex.open.api.service.spot;
+
+import com.okcoin.commons.okex.open.api.bean.spot.result.*;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 杠杆资产相关接口
+ */
+public interface MarginAccountAPIService {
+
+    /**
+     * 全部杠杆资产
+     *
+     * @return
+     */
+    List<Map<String, Object>> getAccounts();
+
+    /**
+     * 单个币对杠杆账号资产
+     *
+     * @param product
+     * @return
+     */
+    Map<String, Object> getAccountsByProductId(@Path("instrument_id") final String product);
+
+    /**
+     * 杠杆账单明细
+     *
+     * @param product
+     * @param type
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    List<UserMarginBillDto> getLedger(@Path("instrument_id") final String product,
+                                      @Query("type") final String type,
+                                      @Query("from") final String from,
+                                      @Query("to") final String to,
+                                      @Query("limit") String limit);
+
+    /**
+     * 全部币对配置
+     *
+     * @return
+     */
+    List<Map<String, Object>> getAvailability();
+    /**
+     * 单个币对配置
+     *
+     * @param product
+     * @return
+     */
+    List<Map<String, Object>> getAvailabilityByProductId(@Path("instrument_id") final String product);
+
+    /**
+     * 全部借币历史
+     *
+     * @param status
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    List<MarginBorrowOrderDto> getBorrowedAccounts(
+            @Query("status") final String status,
+            @Query("from") final String from,
+            @Query("to") final String to,
+            @Query("limit") String limit);
+
+    /**
+     * 单个币对借币历史
+     * @param status
+     * @param from
+     * @param to
+     * @param limit
+     * @param product
+     * @return
+     */
+    List<MarginBorrowOrderDto> getBorrowedAccountsByProductId(@Path("instrument_id") final String product,
+                                                              @Query("from") final String from,
+                                                              @Query("to") final String to,
+                                                              @Query("limit") final String limit,
+                                                              @Query("status") final String status);
+
+    /**
+     * 借币
+     *
+     * @param order
+     * @return
+     */
+    BorrowResult borrow_1(BorrowRequestDto order);
+
+    /**
+     * 还币
+     *
+     * @param order
+     * @return
+     */
+    RepaymentResult repayment_1(RepaymentRequestDto order);
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/MarginOrderAPIService.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/MarginOrderAPIService.java
@@ -1,0 +1,105 @@
+package com.okcoin.commons.okex.open.api.service.spot;
+
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.spot.param.OrderParamDto;
+import com.okcoin.commons.okex.open.api.bean.spot.param.PlaceOrderParam;
+import com.okcoin.commons.okex.open.api.bean.spot.result.Fills;
+import com.okcoin.commons.okex.open.api.bean.spot.result.OrderInfo;
+import com.okcoin.commons.okex.open.api.bean.spot.result.OrderResult;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 杠杆订单相关接口
+ */
+public interface MarginOrderAPIService {
+    /**
+     * 添加订单
+     *
+     * @param order
+     * @return
+     */
+    OrderResult addOrder(PlaceOrderParam order);
+
+    /**
+     * 批量下单
+     *
+     * @param order
+     * @return
+     */
+    Map<String, List<OrderResult>> addOrders(List<PlaceOrderParam> order);
+
+    /**
+     * 取消指定的订单 delete协议
+     *
+     * @param orderId
+     */
+    OrderResult cancleOrderByOrderId(final PlaceOrderParam order, String orderId);
+
+    /**
+     * 取消指定的订单 post协议
+     *
+     * @param orderId
+     */
+    OrderResult cancleOrderByOrderId_post(final PlaceOrderParam order, String orderId);
+
+    /**
+     * 批量取消订单 delete协议
+     *
+     * @param cancleOrders
+     * @return
+     */
+    Map<String, JSONObject> cancleOrders(final List<OrderParamDto> cancleOrders);
+
+    /**
+     * 批量取消订单 post协议
+     *
+     * @param cancleOrders
+     * @return
+     */
+    Map<String, JSONObject> cancleOrders_post(final List<OrderParamDto> cancleOrders);
+
+    /**
+     * 查询订单
+     *
+     * @param instrumentId
+     * @param orderId
+     * @return
+     */
+    OrderInfo getOrderByProductIdAndOrderId(String instrumentId, String orderId);
+
+    /**
+     * 订单列表
+     *
+     * @param instrumentId
+     * @param status
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    List<OrderInfo> getOrders(String instrumentId, String status, String from, String to, String limit);
+
+    /**
+     * /* 订单列表
+     *
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    List<OrderInfo> getPendingOrders(String from, String to, String limit, String instrument_id);
+
+    /**
+     * 账单列表
+     *
+     * @param orderId
+     * @param instrumentId
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    List<Fills> getFills(String orderId, String instrumentId, String from, String to, String limit);
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/SpotAccountAPIService.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/SpotAccountAPIService.java
@@ -1,0 +1,55 @@
+package com.okcoin.commons.okex.open.api.service.spot;
+
+import com.okcoin.commons.okex.open.api.bean.spot.result.Account;
+import com.okcoin.commons.okex.open.api.bean.spot.result.Ledger;
+import com.okcoin.commons.okex.open.api.bean.spot.result.ServerTimeDto;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 币币资产相关接口
+ */
+public interface SpotAccountAPIService {
+
+    /**
+     * 系统时间
+     *
+     * @return
+     */
+    ServerTimeDto time();
+
+    /**
+     * 挖矿相关数据
+     *
+     * @return
+     */
+    Map<String, Object> getMiningData();
+
+
+    /**
+     * 账户资产列表
+     *
+     * @return
+     */
+    List<Account> getAccounts();
+
+    /**
+     * 账单列表
+     *
+     * @param currency
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    List<Ledger> getLedgersByCurrency(String currency, String from, String to, String limit);
+
+    /**
+     * 单币资产
+     *
+     * @param currency
+     * @return
+     */
+    Account getAccountByCurrency(final String currency);
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/SpotOrderAPIServive.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/SpotOrderAPIServive.java
@@ -1,0 +1,103 @@
+package com.okcoin.commons.okex.open.api.service.spot;
+
+import com.okcoin.commons.okex.open.api.bean.spot.param.OrderParamDto;
+import com.okcoin.commons.okex.open.api.bean.spot.param.PlaceOrderParam;
+import com.okcoin.commons.okex.open.api.bean.spot.result.BatchOrdersResult;
+import com.okcoin.commons.okex.open.api.bean.spot.result.Fills;
+import com.okcoin.commons.okex.open.api.bean.spot.result.OrderInfo;
+import com.okcoin.commons.okex.open.api.bean.spot.result.OrderResult;
+
+import java.util.List;
+import java.util.Map;
+
+public interface SpotOrderAPIServive {
+    /**
+     * 添加订单
+     *
+     * @param order
+     * @return
+     */
+    OrderResult addOrder(PlaceOrderParam order);
+
+    /**
+     * 批量下单
+     *
+     * @param order
+     * @return
+     */
+    Map<String, List<OrderResult>> addOrders(List<PlaceOrderParam> order);
+
+    /**
+     * 取消单个订单 delete协议
+     *
+     *  @param order
+     * @param orderId
+     */
+    OrderResult cancleOrderByOrderId(final PlaceOrderParam order, String orderId);
+
+    /**
+     * 取消单个订单 post协议
+     *
+     * @param order
+     * @param orderId
+     */
+    OrderResult cancleOrderByOrderId_post(final PlaceOrderParam order, String orderId);
+
+    /**
+     * 批量取消订单 delete协议
+     *
+     * @param cancleOrders
+     * @return
+     */
+    Map<String, BatchOrdersResult> cancleOrders(final List<OrderParamDto> cancleOrders);
+
+    /**
+     * 批量取消订单 post协议
+     *
+     * @param cancleOrders
+     * @return
+     */
+    Map<String, BatchOrdersResult> cancleOrders_post(final List<OrderParamDto> cancleOrders);
+
+    /**
+     * 单个订单
+     * @param product
+     * @param orderId
+     * @return
+     */
+    OrderInfo getOrderByOrderId(String product, String orderId);
+
+    /**
+     * 订单列表
+     *
+     * @param product
+     * @param status
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    List<OrderInfo> getOrders(String product, String status, String from, String to, String limit);
+
+    /**
+     * 订单列表
+     *
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    List<OrderInfo> getPendingOrders(String from, String to, String limit, String instrument_id);
+
+    /**
+     * 账单列表
+     *
+     * @param orderId
+     * @param product
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    List<Fills> getFills(String orderId, String product, String from, String to, String limit);
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/SpotProductAPIService.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/SpotProductAPIService.java
@@ -1,0 +1,62 @@
+package com.okcoin.commons.okex.open.api.service.spot;
+
+import com.okcoin.commons.okex.open.api.bean.spot.result.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public interface SpotProductAPIService {
+
+    /**
+     * 单个币对行情
+     *
+     * @param product
+     * @return
+     */
+    Ticker getTickerByProductId(String product);
+
+    /**
+     * 行情列表
+     *
+     * @return
+     */
+    List<Ticker> getTickers();
+
+    /**
+     * @param product
+     * @param size
+     * @param depth
+     * @return
+     */
+    Book bookProductsByProductId(String product, String size, BigDecimal depth);
+
+    /**
+     * 币对列表
+     *
+     * @return
+     */
+    List<Product> getProducts();
+
+    /**
+     * 交易列表
+     *
+     * @param product
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    List<Trade> getTrades(String product, String from, String to, String limit);
+
+    /**
+     * @param product
+     * @param granularity
+     * @param start
+     * @param end
+     * @return
+     */
+    List<KlineDto> getCandles(String product, String granularity, String start, String end);
+
+    List<String[]> getCandles_1(String product, String granularity, String start, String end);
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/MarginAccountAPI.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/MarginAccountAPI.java
@@ -1,0 +1,114 @@
+package com.okcoin.commons.okex.open.api.service.spot.impl;
+
+import com.okcoin.commons.okex.open.api.bean.spot.result.*;
+import retrofit2.Call;
+import retrofit2.http.*;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 杠杆账号测试
+ */
+public interface MarginAccountAPI {
+    /**
+     * 全部杠杆资产
+     *
+     * @return
+     */
+    @GET("/api/margin/v3/accounts")
+    Call<List<Map<String, Object>>> getAccounts();
+
+    /**
+     * 单个币对杠杆账号资产
+     *
+     * @param product
+     * @return
+     */
+    @GET("/api/margin/v3/accounts/{instrument_id}")
+    Call<Map<String, Object>> getAccountsByProductId(@Path("instrument_id") final String product);
+
+    /**
+     * 杠杆账单明细
+     *
+     * @param product
+     * @param type
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    @GET("/api/margin/v3/accounts/{instrument_id}/ledger")
+    Call<List<UserMarginBillDto>> getLedger(@Path("instrument_id") final String product,
+                                            @Query("type") final String type,
+                                            @Query("from") final String from,
+                                            @Query("to") final String to,
+                                            @Query("limit") String limit);
+
+    /**
+     * 全部币对配置
+     *
+     * @return
+     */
+    @GET("/api/margin/v3/accounts/availability")
+    Call<List<Map<String, Object>>> getAvailability();
+
+    /**
+     * 单个币对配置
+     *
+     * @param product
+     * @return
+     */
+    @GET("/api/margin/v3/accounts/{instrument_id}/availability")
+    Call<List<Map<String, Object>>> getAvailabilityByProductId(@Path("instrument_id") final String product);
+
+    /**
+     * 全部借币历史
+     * @param status
+     * @param before
+     * @param after
+     * @param limit
+     * @return
+     */
+    @GET("/api/margin/v3/accounts/borrowed")
+    Call<List<MarginBorrowOrderDto>> getBorrowedAccounts(
+            @Query("status") final String status,
+            @Query("before") final String before,
+            @Query("after") final String after,
+            @Query("limit") String limit);
+
+    /**
+     * 单个币对借币历史
+     * @param status
+     * @param from
+     * @param to
+     * @param limit
+     * @param product
+     * @return
+     */
+    @GET("/api/margin/v3/accounts/{instrument_id}/borrowed")
+    Call<List<MarginBorrowOrderDto>> getBorrowedAccountsByProductId(@Path("instrument_id") final String product,
+                                                                    @Query("from") final String from,
+                                                                    @Query("to") final String to,
+                                                                    @Query("limit") final String limit,
+                                                                    @Query("status") final String status);
+
+    /**
+     * 借币
+     *
+     * @param param
+     * @return
+     */
+    @POST("/api/margin/v3/accounts/borrow")
+    Call<BorrowResult> borrow_1(@Body BorrowRequestDto param);
+
+    /**
+     * 还币
+     *
+     * @param param
+     * @return
+     */
+    @POST("/api/margin/v3/accounts/repayment")
+    Call<RepaymentResult> repayment_1(@Body RepaymentRequestDto param);
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/MarginAccountAPIServiceImpl.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/MarginAccountAPIServiceImpl.java
@@ -1,0 +1,69 @@
+package com.okcoin.commons.okex.open.api.service.spot.impl;
+
+import com.okcoin.commons.okex.open.api.bean.spot.result.*;
+import com.okcoin.commons.okex.open.api.client.APIClient;
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.service.spot.MarginAccountAPIService;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ */
+public class MarginAccountAPIServiceImpl implements MarginAccountAPIService {
+
+    private final APIClient client;
+    private final MarginAccountAPI api;
+
+    public MarginAccountAPIServiceImpl(final APIConfiguration config) {
+        this.client = new APIClient(config);
+        this.api = this.client.createService(MarginAccountAPI.class);
+    }
+
+
+    @Override
+    public List<Map<String, Object>> getAccounts() {
+        return this.client.executeSync(this.api.getAccounts());
+    }
+
+    @Override
+    public Map<String, Object> getAccountsByProductId(final String product) {
+        return this.client.executeSync(this.api.getAccountsByProductId(product));
+    }
+
+    @Override
+    public List<UserMarginBillDto> getLedger(final String product, final String type, final String from, final String to, final String limit) {
+        return this.client.executeSync(this.api.getLedger(product, type, from, to, limit));
+    }
+
+    @Override
+    public List<Map<String, Object>> getAvailability() {
+        return this.client.executeSync(this.api.getAvailability());
+    }
+
+    @Override
+    public List<Map<String, Object>> getAvailabilityByProductId(final String product) {
+        return this.client.executeSync(this.api.getAvailabilityByProductId(product));
+    }
+
+    @Override
+    public List<MarginBorrowOrderDto> getBorrowedAccounts(final String status, final String from, final String to, final String limit) {
+        return this.client.executeSync(this.api.getBorrowedAccounts(status, from, to, limit));
+    }
+
+    @Override
+    public List<MarginBorrowOrderDto> getBorrowedAccountsByProductId(final String product, final String from, final String to, final String limit, final String status) {
+        return this.client.executeSync(this.api.getBorrowedAccountsByProductId(product, from, to, limit, status));
+    }
+
+    @Override
+    public BorrowResult borrow_1(final BorrowRequestDto order) {
+        return this.client.executeSync(this.api.borrow_1(order));
+    }
+
+    @Override
+    public RepaymentResult repayment_1(final RepaymentRequestDto order) {
+        return this.client.executeSync(this.api.repayment_1(order));
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/MarginOrderAPI.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/MarginOrderAPI.java
@@ -1,0 +1,123 @@
+package com.okcoin.commons.okex.open.api.service.spot.impl;
+
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.spot.param.OrderParamDto;
+import com.okcoin.commons.okex.open.api.bean.spot.param.PlaceOrderParam;
+import com.okcoin.commons.okex.open.api.bean.spot.result.Fills;
+import com.okcoin.commons.okex.open.api.bean.spot.result.OrderInfo;
+import com.okcoin.commons.okex.open.api.bean.spot.result.OrderResult;
+import retrofit2.Call;
+import retrofit2.http.*;
+
+import java.util.List;
+import java.util.Map;
+
+public interface MarginOrderAPI {
+    /**
+     * 单个下单
+     *
+     * @param param
+     * @return
+     */
+    @POST("api/margin/v3/orders")
+    Call<OrderResult> addOrder(@Body PlaceOrderParam param);
+
+    /**
+     * 批量下单
+     *
+     * @param param
+     * @return
+     */
+    @POST("api/margin/v3/batch_orders")
+    Call<Map<String, List<OrderResult>>> addOrders(@Body List<PlaceOrderParam> param);
+
+    /**
+     * 撤销指定订单
+     *
+     * @param orderId
+     * @param order
+     * @return
+     */
+    @HTTP(method = "DELETE", path = "api/margin/v3/orders/{order_id}", hasBody = true)
+    Call<OrderResult> cancleOrdersByProductIdAndOrderId(@Path("order_id") String orderId,
+                                                        @Body PlaceOrderParam order);
+
+    /**
+     * 撤销指定订单
+     *
+     * @param orderId
+     * @param order
+     * @return
+     */
+    @HTTP(method = "POST", path = "api/margin/v3/cancel_orders/{order_id}", hasBody = true)
+    Call<OrderResult> cancleOrdersByProductIdAndOrderId_1(@Path("order_id") String orderId,
+                                                          @Body PlaceOrderParam order);
+
+    /**
+     * 批量撤销订单
+     *
+     * @param cancleOrders
+     * @return
+     */
+    @HTTP(method = "DELETE", path = "api/margin/v3/batch_orders", hasBody = true)
+    Call<Map<String, JSONObject>> batchCancleOrders(@Body List<OrderParamDto> cancleOrders);
+
+    /**
+     * 批量撤销订单
+     *
+     * @param cancleOrders
+     * @return
+     */
+    @HTTP(method = "POST", path = "api/margin/v3/cancel_batch_orders", hasBody = true)
+    Call<Map<String, JSONObject>> batchCancleOrders_1(@Body List<OrderParamDto> cancleOrders);
+
+    /**
+     * 查询指定币对订单
+     *
+     * @param product
+     * @param orderId
+     * @return
+     */
+    @GET("api/margin/v3/orders/{order_id}")
+    Call<OrderInfo> getOrderByProductIdAndOrderId(@Path("order_id") String orderId,
+                                                  @Query("instrument_id") String product);
+
+    /**
+     * 查询订单列表
+     *
+     * @param product
+     * @param status
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    @GET("api/margin/v3/orders")
+    Call<List<OrderInfo>> getOrders(@Query("instrument_id") String product,
+                                    @Query("status") String status,
+                                    @Query("from") String from,
+                                    @Query("to") String to,
+                                    @Query("limit") String limit);
+
+    /**
+     * 查询挂单列表
+     *
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    @GET("api/margin/v3/orders_pending")
+    Call<List<OrderInfo>> getPendingOrders(@Query("from") String from,
+                                           @Query("to") String to,
+                                           @Query("limit") String limit,
+                                           @Query("instrument_id") String instrument_id);
+
+
+    @GET("api/margin/v3/fills")
+    Call<List<Fills>> getFills(@Query("order_id") String orderId,
+                               @Query("instrument_id") String product,
+                               @Query("from") String from,
+                               @Query("to") String to,
+                               @Query("limit") String limit);
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/MarginOrderAPIServiceImpl.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/MarginOrderAPIServiceImpl.java
@@ -1,0 +1,74 @@
+package com.okcoin.commons.okex.open.api.service.spot.impl;
+
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.spot.param.OrderParamDto;
+import com.okcoin.commons.okex.open.api.bean.spot.param.PlaceOrderParam;
+import com.okcoin.commons.okex.open.api.bean.spot.result.Fills;
+import com.okcoin.commons.okex.open.api.bean.spot.result.OrderInfo;
+import com.okcoin.commons.okex.open.api.bean.spot.result.OrderResult;
+import com.okcoin.commons.okex.open.api.client.APIClient;
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.service.spot.MarginOrderAPIService;
+
+import java.util.List;
+import java.util.Map;
+
+public class MarginOrderAPIServiceImpl implements MarginOrderAPIService {
+    private final APIClient client;
+    private final MarginOrderAPI marginOrderAPI;
+
+    public MarginOrderAPIServiceImpl(final APIConfiguration config) {
+        this.client = new APIClient(config);
+        this.marginOrderAPI = this.client.createService(MarginOrderAPI.class);
+    }
+
+    @Override
+    public OrderResult addOrder(final PlaceOrderParam order) {
+        return this.client.executeSync(this.marginOrderAPI.addOrder(order));
+    }
+
+    @Override
+    public Map<String, List<OrderResult>> addOrders(final List<PlaceOrderParam> order) {
+        return this.client.executeSync(this.marginOrderAPI.addOrders(order));
+    }
+
+    @Override
+    public OrderResult cancleOrderByOrderId(final PlaceOrderParam order, final String orderId) {
+        return this.client.executeSync(this.marginOrderAPI.cancleOrdersByProductIdAndOrderId(orderId, order));
+    }
+
+    @Override
+    public OrderResult cancleOrderByOrderId_post(final PlaceOrderParam order, final String orderId) {
+        return this.client.executeSync(this.marginOrderAPI.cancleOrdersByProductIdAndOrderId_1(orderId, order));
+    }
+
+    @Override
+    public Map<String, JSONObject> cancleOrders(final List<OrderParamDto> cancleOrders) {
+        return this.client.executeSync(this.marginOrderAPI.batchCancleOrders(cancleOrders));
+    }
+
+    @Override
+    public Map<String, JSONObject> cancleOrders_post(final List<OrderParamDto> cancleOrders) {
+        return this.client.executeSync(this.marginOrderAPI.batchCancleOrders_1(cancleOrders));
+    }
+
+    @Override
+    public OrderInfo getOrderByProductIdAndOrderId(final String instrumentId, final String orderId) {
+        return this.client.executeSync(this.marginOrderAPI.getOrderByProductIdAndOrderId(orderId, instrumentId));
+    }
+
+    @Override
+    public List<OrderInfo> getOrders(final String instrumentId, final String status, final String from, final String to, final String limit) {
+        return this.client.executeSync(this.marginOrderAPI.getOrders(instrumentId, status, from, to, limit));
+    }
+
+    @Override
+    public List<OrderInfo> getPendingOrders(final String from, final String to, final String limit, final String instrument_id) {
+        return this.client.executeSync(this.marginOrderAPI.getPendingOrders(from, to, limit, instrument_id));
+    }
+
+    @Override
+    public List<Fills> getFills(final String orderId, final String instrumentId, final String from, final String to, final String limit) {
+        return this.client.executeSync(this.marginOrderAPI.getFills(orderId, instrumentId, from, to, limit));
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/SpotAccountAPI.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/SpotAccountAPI.java
@@ -1,0 +1,64 @@
+package com.okcoin.commons.okex.open.api.service.spot.impl;
+
+import com.okcoin.commons.okex.open.api.bean.spot.result.Account;
+import com.okcoin.commons.okex.open.api.bean.spot.result.Ledger;
+import com.okcoin.commons.okex.open.api.bean.spot.result.ServerTimeDto;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+import java.util.List;
+import java.util.Map;
+
+public interface SpotAccountAPI {
+
+    /**
+     * 获取系统时间
+     *
+     * @return
+     */
+    @GET("api/spot/v3/time")
+    Call<ServerTimeDto> time();
+
+    /**
+     * 挖矿相关数据
+     *
+     * @return
+     */
+    @GET("api/spot/v3/miningdata")
+    Call<Map<String, Object>> getMiningdata();
+
+    /**
+     * 币币资产
+     *
+     * @return
+     */
+    @GET("api/spot/v3/accounts")
+    Call<List<Account>> getAccounts();
+
+    /**
+     * 币币指定币资产
+     *
+     * @param currency
+     * @return
+     */
+    @GET("api/spot/v3/accounts/{currency}")
+    Call<Account> getAccountByCurrency(@Path("currency") String currency);
+
+    /**
+     * 币币账单列表
+     *
+     * @param currency
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    @GET("api/spot/v3/accounts/{currency}/ledger")
+    Call<List<Ledger>> getLedgersByCurrency(@Path("currency") String currency,
+                                            @Query("from") String from,
+                                            @Query("to") String to,
+                                            @Query("limit") String limit);
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/SpotAccountAPIServiceImpl.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/SpotAccountAPIServiceImpl.java
@@ -1,0 +1,47 @@
+package com.okcoin.commons.okex.open.api.service.spot.impl;
+
+import com.okcoin.commons.okex.open.api.bean.spot.result.Account;
+import com.okcoin.commons.okex.open.api.bean.spot.result.Ledger;
+import com.okcoin.commons.okex.open.api.bean.spot.result.ServerTimeDto;
+import com.okcoin.commons.okex.open.api.client.APIClient;
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.service.spot.SpotAccountAPIService;
+
+import java.util.List;
+import java.util.Map;
+
+public class SpotAccountAPIServiceImpl implements SpotAccountAPIService {
+
+    private final APIClient client;
+    private final SpotAccountAPI api;
+
+    public SpotAccountAPIServiceImpl(final APIConfiguration config) {
+        this.client = new APIClient(config);
+        this.api = this.client.createService(SpotAccountAPI.class);
+    }
+
+    @Override
+    public ServerTimeDto time() {
+        return this.client.executeSync(this.api.time());
+    }
+
+    @Override
+    public Map<String, Object> getMiningData() {
+        return this.client.executeSync(this.api.getMiningdata());
+    }
+
+    @Override
+    public List<Account> getAccounts() {
+        return this.client.executeSync(this.api.getAccounts());
+    }
+
+    @Override
+    public List<Ledger> getLedgersByCurrency(final String currency, final String from, final String to, final String limit) {
+        return this.client.executeSync(this.api.getLedgersByCurrency(currency, from, to, limit));
+    }
+
+    @Override
+    public Account getAccountByCurrency(final String currency) {
+        return this.client.executeSync(this.api.getAccountByCurrency(currency));
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/SpotOrderAPI.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/SpotOrderAPI.java
@@ -1,0 +1,134 @@
+package com.okcoin.commons.okex.open.api.service.spot.impl;
+
+import com.okcoin.commons.okex.open.api.bean.spot.param.OrderParamDto;
+import com.okcoin.commons.okex.open.api.bean.spot.param.PlaceOrderParam;
+import com.okcoin.commons.okex.open.api.bean.spot.result.BatchOrdersResult;
+import com.okcoin.commons.okex.open.api.bean.spot.result.Fills;
+import com.okcoin.commons.okex.open.api.bean.spot.result.OrderInfo;
+import com.okcoin.commons.okex.open.api.bean.spot.result.OrderResult;
+import retrofit2.Call;
+import retrofit2.http.*;
+
+import java.util.List;
+import java.util.Map;
+
+public interface SpotOrderAPI {
+
+    /**
+     * 单个下单
+     *
+     * @param order
+     * @return
+     */
+    @POST("api/spot/v3/orders")
+    Call<OrderResult> addOrder(@Body PlaceOrderParam order);
+
+    /**
+     * 批量下单
+     *
+     * @param param
+     * @return
+     */
+    @POST("api/spot/v3/batch_orders")
+    Call<Map<String, List<OrderResult>>> addOrders(@Body List<PlaceOrderParam> param);
+
+    /**
+     * 指定订单撤单 delete协议
+     *
+     * @param orderId
+     * @param order
+     * @return
+     */
+    @HTTP(method = "DELETE", path = "api/spot/v3/orders/{order_id}", hasBody = true)
+    Call<OrderResult> cancleOrderByOrderId(@Path("order_id") String orderId,
+                                           @Body PlaceOrderParam order);
+
+    /**
+     * 指定订单撤单 post协议
+     *
+     * @param orderId
+     * @param order
+     * @return
+     */
+    @HTTP(method = "POST", path = "api/spot/v3/cancel_orders/{order_id}", hasBody = true)
+    Call<OrderResult> cancleOrderByOrderId_1(@Path("order_id") String orderId,
+                                             @Body PlaceOrderParam order);
+
+    /**
+     * 批量撤单 delete协议
+     *
+     * @param cancleOrders
+     * @return
+     */
+    @HTTP(method = "DELETE", path = "api/spot/v3/batch_orders", hasBody = true)
+    Call<Map<String, BatchOrdersResult>> batchCancleOrders(@Body List<OrderParamDto> cancleOrders);
+
+    /**
+     * 批量撤单 post协议
+     *
+     * @param cancleOrders
+     * @return
+     */
+    @HTTP(method = "POST", path = "api/spot/v3/cancel_batch_orders", hasBody = true)
+    Call<Map<String, BatchOrdersResult>> batchCancleOrders_1(@Body List<OrderParamDto> cancleOrders);
+
+    /**
+     * 查询指定订单数据
+     *
+     * @param orderId
+     * @param product
+     * @return
+     */
+    @GET("api/spot/v3/orders/{order_id}")
+    Call<OrderInfo> getOrderByOrderId(@Path("order_id") String orderId,
+                                      @Query("instrument_id") String product);
+
+    /**
+     * 分页查询订单
+     *
+     * @param product
+     * @param status
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    @GET("api/spot/v3/orders")
+    Call<List<OrderInfo>> getOrders(@Query("instrument_id") String product,
+                                    @Query("status") String status,
+                                    @Query("from") String from,
+                                    @Query("to") String to,
+                                    @Query("limit") String limit);
+
+    /**
+     * 分页查询挂单
+     *
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    @GET("api/spot/v3/orders_pending")
+    Call<List<OrderInfo>> getPendingOrders(@Query("from") String from,
+                                           @Query("to") String to,
+                                           @Query("limit") String limit,
+                                           @Query("instrument_id") String instrument_id);
+
+    /**
+     * 分页查询账单
+     *
+     * @param order_id
+     * @param product
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    @GET("api/spot/v3/fills")
+    Call<List<Fills>> getFills(@Query("order_id") String order_id,
+                               @Query("instrument_id") String product,
+                               @Query("from") String from,
+                               @Query("to") String to,
+                               @Query("limit") String limit);
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/SpotOrderApiServiceImpl.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/SpotOrderApiServiceImpl.java
@@ -1,0 +1,78 @@
+package com.okcoin.commons.okex.open.api.service.spot.impl;
+
+import com.okcoin.commons.okex.open.api.bean.spot.param.OrderParamDto;
+import com.okcoin.commons.okex.open.api.bean.spot.param.PlaceOrderParam;
+import com.okcoin.commons.okex.open.api.bean.spot.result.BatchOrdersResult;
+import com.okcoin.commons.okex.open.api.bean.spot.result.Fills;
+import com.okcoin.commons.okex.open.api.bean.spot.result.OrderInfo;
+import com.okcoin.commons.okex.open.api.bean.spot.result.OrderResult;
+import com.okcoin.commons.okex.open.api.client.APIClient;
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.service.spot.SpotOrderAPIServive;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 币币订单相关接口
+ **/
+public class SpotOrderApiServiceImpl implements SpotOrderAPIServive {
+    private final APIClient client;
+    private final SpotOrderAPI spotOrderAPI;
+
+    public SpotOrderApiServiceImpl(final APIConfiguration config) {
+        this.client = new APIClient(config);
+        this.spotOrderAPI = this.client.createService(SpotOrderAPI.class);
+    }
+
+    @Override
+    public OrderResult addOrder(final PlaceOrderParam order) {
+        return this.client.executeSync(this.spotOrderAPI.addOrder(order));
+    }
+
+    @Override
+    public Map<String, List<OrderResult>> addOrders(final List<PlaceOrderParam> order) {
+        return this.client.executeSync(this.spotOrderAPI.addOrders(order));
+    }
+
+    @Override
+    public OrderResult cancleOrderByOrderId(final PlaceOrderParam order, final String orderId) {
+        return this.client.executeSync(this.spotOrderAPI.cancleOrderByOrderId(orderId, order));
+    }
+
+    @Override
+    public OrderResult cancleOrderByOrderId_post(final PlaceOrderParam order, final String orderId) {
+        return this.client.executeSync(this.spotOrderAPI.cancleOrderByOrderId_1(orderId, order));
+    }
+
+    @Override
+    public Map<String, BatchOrdersResult> cancleOrders(final List<OrderParamDto> cancleOrders) {
+        return this.client.executeSync(this.spotOrderAPI.batchCancleOrders(cancleOrders));
+    }
+
+    @Override
+    public Map<String, BatchOrdersResult> cancleOrders_post(final List<OrderParamDto> cancleOrders) {
+        return this.client.executeSync(this.spotOrderAPI.batchCancleOrders_1(cancleOrders));
+    }
+
+    @Override
+    public OrderInfo getOrderByOrderId(final String product, final String orderId) {
+        return this.client.executeSync(this.spotOrderAPI.getOrderByOrderId(orderId, product));
+    }
+
+    @Override
+    public List<OrderInfo> getOrders(final String product, final String status, final String from, final String to, final String limit) {
+        return this.client.executeSync(this.spotOrderAPI.getOrders(product, status, from, to, limit));
+    }
+
+    @Override
+    public List<OrderInfo> getPendingOrders(final String from, final String to, final String limit, final String instrument_id) {
+        return this.client.executeSync(this.spotOrderAPI.getPendingOrders(from, to, limit, instrument_id));
+    }
+
+    @Override
+    public List<Fills> getFills(final String orderId, final String product, final String from, final String to, final String limit) {
+        return this.client.executeSync(this.spotOrderAPI.getFills(orderId, product, from, to, limit));
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/SpotProductAPI.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/SpotProductAPI.java
@@ -1,0 +1,47 @@
+package com.okcoin.commons.okex.open.api.service.spot.impl;
+
+import com.okcoin.commons.okex.open.api.bean.spot.result.*;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public interface SpotProductAPI {
+
+    @GET("/api/spot/v3/instruments")
+    Call<List<Product>> getProducts();
+
+    @GET("/api/spot/v3/instruments/{instrument_id}/book")
+    Call<Book> bookProductsByProductId(@Path("instrument_id") String product,
+                                       @Query("size") String size,
+                                       @Query("depth") BigDecimal depth);
+
+    @GET("/api/spot/v3/instruments/ticker")
+    Call<List<Ticker>> getTickers();
+
+    @GET("/api/spot/v3/instruments/{instrument_id}/ticker")
+    Call<Ticker> getTickerByProductId(@Path("instrument_id") String product);
+
+
+    @GET("/api/spot/v3/instruments/{instrument_id}/trades")
+    Call<List<Trade>> getTrades(@Path("instrument_id") String product,
+                                @Query("from") String from,
+                                @Query("to") String to,
+                                @Query("limit") String limit);
+
+    @GET("/api/spot/v3/instruments/{instrument_id}/candles")
+    Call<List<KlineDto>> getCandles(@Path("instrument_id") String product,
+                                    @Query("granularity") String type,
+                                    @Query("start") String start,
+                                    @Query("end") String end);
+
+    @GET("/api/spot/v3/instruments/{instrument_id}/candles")
+    Call<List<String[]>> getCandles_1(@Path("instrument_id") String product,
+                                      @Query("granularity") String type,
+                                      @Query("start") String start,
+                                      @Query("end") String end);
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/SpotProductAPIServiceImpl.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/spot/impl/SpotProductAPIServiceImpl.java
@@ -1,0 +1,61 @@
+package com.okcoin.commons.okex.open.api.service.spot.impl;
+
+import com.okcoin.commons.okex.open.api.bean.spot.result.*;
+import com.okcoin.commons.okex.open.api.client.APIClient;
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.service.spot.SpotProductAPIService;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 公共数据相关接口
+ *
+ **/
+public class SpotProductAPIServiceImpl implements SpotProductAPIService {
+
+    private final APIClient client;
+    private final SpotProductAPI spotProductAPI;
+
+    public SpotProductAPIServiceImpl(final APIConfiguration config) {
+        this.client = new APIClient(config);
+        this.spotProductAPI = this.client.createService(SpotProductAPI.class);
+    }
+
+
+    @Override
+    public Ticker getTickerByProductId(final String product) {
+        return this.client.executeSync(this.spotProductAPI.getTickerByProductId(product));
+    }
+
+    @Override
+    public List<Ticker> getTickers() {
+        return this.client.executeSync(this.spotProductAPI.getTickers());
+    }
+
+    @Override
+    public Book bookProductsByProductId(final String product, final String size, final BigDecimal depth) {
+        return this.client.executeSync(this.spotProductAPI.bookProductsByProductId(product, size, depth));
+    }
+
+    @Override
+    public List<Product> getProducts() {
+        return this.client.executeSync(this.spotProductAPI.getProducts());
+    }
+
+    @Override
+    public List<Trade> getTrades(final String product, final String from, final String to, final String limit) {
+        return this.client.executeSync(this.spotProductAPI.getTrades(product, from, to, limit));
+    }
+
+    @Override
+    public List<KlineDto> getCandles(final String product, final String granularity, final String start, final String end) {
+        return this.client.executeSync(this.spotProductAPI.getCandles(product, granularity, start, end));
+    }
+
+    @Override
+    public List<String[]> getCandles_1(final String product, final String granularity, final String start, final String end) {
+        return this.client.executeSync(this.spotProductAPI.getCandles_1(product, granularity, start, end));
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/swap/SwapMarketAPIService.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/swap/SwapMarketAPIService.java
@@ -1,0 +1,116 @@
+package com.okcoin.commons.okex.open.api.service.swap;
+
+
+public interface SwapMarketAPIService {
+    /**
+     * 获取可用合约的列表。
+     *
+     * @return
+     */
+    String getContractsApi();
+
+    /**
+     * 获取合约的深度列表。
+     *
+     * @param instrumentId
+     * @param size
+     * @return
+     */
+    String getDepthApi(String instrumentId, String size);
+
+    /**
+     * 获取平台全部合约的最新成交价、买一价、卖一价和24交易量。
+     *
+     * @return
+     */
+    String getTickersApi();
+
+    /**
+     * 获取合约的最新成交价、买一价、卖一价和24交易量。
+     *
+     * @param instrumentId
+     * @return
+     */
+    String getTickerApi(String instrumentId);
+
+    /**
+     * 获取合约的成交记录。
+     * @param instrumentId
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    String getTradesApi(String instrumentId, String from, String to, String limit);
+
+    /**
+     * 获取合约的K线数据。
+     * @param instrumentId
+     * @param start
+     * @param end
+     * @param granularity
+     * @return
+     */
+    String getCandlesApi(String instrumentId, String start, String end, String granularity);
+
+    /**
+     * 获取币种指数。
+     * @param instrumentId
+     * @return
+     */
+    String getIndexApi(String instrumentId);
+
+    /**
+     * 获取法币汇率。
+     * @return
+     */
+    String getRateApi();
+
+    /**
+     * 获取合约整个平台的总持仓量。
+     * @param instrumentId
+     * @return
+     */
+    String getOpenInterestApi(String instrumentId);
+
+    /**
+     * 获取合约当前开仓的最高买价和最低卖价。
+     * @param instrumentId
+     * @return
+     */
+    String getPriceLimitApi(String instrumentId);
+
+    /**
+     * 获取合约爆仓单。
+     * @param instrumentId
+     * @param status
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    String getLiquidationApi(String instrumentId, String status, String from, String to, String limit);
+
+    /**
+     * 获取合约下一次的结算时间。
+     * @param instrumentId
+     * @return
+     */
+    String getFundingTimeApi(String instrumentId);
+
+    /**
+     * 获取合约历史资金费率
+     * @param instrumentId
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    String getHistoricalFundingRateApi(String instrumentId, String from, String to, String limit);
+
+    /**
+     * 获取合约标记价格
+     * @return
+     */
+    String getMarkPriceApi(String instrumentId);
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/swap/SwapTradeAPIService.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/swap/SwapTradeAPIService.java
@@ -1,0 +1,37 @@
+package com.okcoin.commons.okex.open.api.service.swap;
+
+import com.okcoin.commons.okex.open.api.bean.swap.param.PpCancelOrderVO;
+import com.okcoin.commons.okex.open.api.bean.swap.param.PpOrder;
+import com.okcoin.commons.okex.open.api.bean.swap.param.PpOrders;
+
+public interface SwapTradeAPIService {
+    /**
+     * 下单
+     * @param ppOrder
+     * @return
+     */
+    String order(PpOrder ppOrder);
+
+    /**
+     * 批量下单
+     * @param ppOrders
+     * @return
+     */
+    String orders(PpOrders ppOrders);
+
+    /**
+     * 撤单
+     * @param instrumentId
+     * @param orderId
+     * @return
+     */
+    String cancelOrder(String instrumentId, String orderId);
+
+    /**
+     * 批量撤单
+     * @param instrumentId
+     * @param ppCancelOrderVO
+     * @return
+     */
+    String cancelOrders(String instrumentId, PpCancelOrderVO ppCancelOrderVO);
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/swap/SwapUserAPIServive.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/swap/SwapUserAPIServive.java
@@ -1,0 +1,98 @@
+package com.okcoin.commons.okex.open.api.service.swap;
+
+import com.okcoin.commons.okex.open.api.bean.swap.param.LevelRateParam;
+
+public interface SwapUserAPIServive {
+
+    /**
+     * 获取单个合约持仓信息
+     *
+     * @param instrumentId
+     * @return
+     */
+    String getPosition(String instrumentId);
+
+    /**
+     * 获取所有币种合约的账户信息
+     *
+     * @return
+     */
+    String getAccounts();
+
+    /**
+     * 获取某个币种合约的账户信息
+     *
+     * @param instrumentId
+     * @return
+     */
+    String selectAccount(String instrumentId);
+
+    /**
+     * 获取某个合约的用户配置
+     *
+     * @param instrumentId
+     * @return
+     */
+    String selectContractSettings(String instrumentId);
+
+    /**
+     * 设定某个合约的杠杆
+     *
+     * @param instrumentId
+     * @param levelRateParam
+     * @return
+     */
+    String updateLevelRate(String instrumentId, LevelRateParam levelRateParam);
+
+    /**
+     * 获取所有订单列表
+     *
+     * @param instrumentId
+     * @param status
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    String selectOrders(String instrumentId, String status, String from, String to, String limit);
+
+    /**
+     * 通过订单id获取单个订单信息
+     *
+     * @param instrumentId
+     * @param orderId
+     * @return
+     */
+    String selectOrder(String instrumentId, String orderId);
+
+    /**
+     * 获取最近的成交明细列表
+     * @param instrumentId
+     * @param orderId
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    String selectDealDetail(String instrumentId, String orderId, String from, String to, String limit);
+
+    /**
+     * 列出账户资产流水，账户资产流水是指导致账户余额增加或减少的行为。
+     * 流水会分页，每页100条数据，并且按照时间倒序排序和存储，最新的排在最前面。
+     *
+     * @param instrumentId
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    String getLedger(String instrumentId, String from, String to, String limit);
+
+    /**
+     * 获取合约挂单冻结数量
+     *
+     * @param instrumentId
+     * @return
+     */
+    String getHolds(String instrumentId);
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/swap/impl/SwapMarketAPI.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/swap/impl/SwapMarketAPI.java
@@ -1,0 +1,52 @@
+package com.okcoin.commons.okex.open.api.service.swap.impl;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+public interface SwapMarketAPI {
+
+    @GET("/api/swap/v3/instruments")
+    Call<String> getContractsApi();
+
+    @GET("/api/swap/v3/instruments/{instrument_id}/depth")
+    Call<String> getDepthApi(@Path("instrument_id") String instrumentId, @Query("size") String size);
+
+    @GET("/api/swap/v3/instruments/ticker")
+    Call<String> getTickersApi();
+
+    @GET("/api/swap/v3/instruments/{instrument_id}/ticker")
+    Call<String> getTickerApi(@Path("instrument_id") String instrumentId);
+
+    @GET("/api/swap/v3/instruments/{instrument_id}/trades")
+    Call<String> getTradesApi(@Path("instrument_id") String instrumentId, @Query("from") String from, @Query("to") String to, @Query("limit") String limit);
+
+    @GET("/api/swap/v3/instruments/{instrument_id}/candles")
+    Call<String> getCandlesApi(@Path("instrument_id") String instrumentId, @Query("start") String start, @Query("end") String end, @Query("granularity") String granularity);
+
+    @GET("/api/swap/v3/instruments/{instrument_id}/index")
+    Call<String> getIndexApi(@Path("instrument_id") String instrumentId);
+
+    @GET("/api/swap/v3/rate")
+    Call<String> getRateApi();
+
+    @GET("/api/swap/v3/instruments/{instrument_id}/open_interest")
+    Call<String> getOpenInterestApi(@Path("instrument_id") String instrumentId);
+
+    @GET("/api/swap/v3/instruments/{instrument_id}/price_limit")
+    Call<String> getPriceLimitApi(@Path("instrument_id") String instrumentId);
+
+    @GET("/api/swap/v3/instruments/{instrument_id}/liquidation")
+    Call<String> getLiquidationApi(@Path("instrument_id") String instrumentId, @Query("status") String status, @Query("from") String from, @Query("to") String to, @Query("limit") String limit);
+
+    @GET("/api/swap/v3/instruments/{instrument_id}/funding_time")
+    Call<String> getFundingTimeApi(@Path("instrument_id") String instrumentId);
+
+    @GET("/api/swap/v3/instruments/{instrument_id}/historical_funding_rate")
+    Call<String> getHistoricalFundingRateApi(@Path("instrument_id") String instrumentId, @Query("from") String from, @Query("to") String to, @Query("limit") String limit);
+
+    @GET("/api/swap/v3/instruments/{instrument_id}/mark_price")
+    Call<String> getMarkPriceApi(@Path("instrument_id") String instrumentId);
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/swap/impl/SwapMarketAPIServiceImpl.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/swap/impl/SwapMarketAPIServiceImpl.java
@@ -1,0 +1,183 @@
+package com.okcoin.commons.okex.open.api.service.swap.impl;
+
+import com.okcoin.commons.okex.open.api.client.APIClient;
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.service.swap.SwapMarketAPIService;
+
+public class SwapMarketAPIServiceImpl implements SwapMarketAPIService {
+    private APIClient client;
+    private SwapMarketAPI api;
+
+    public SwapMarketAPIServiceImpl() {
+    }
+
+    public SwapMarketAPIServiceImpl(APIConfiguration config) {
+        this.client = new APIClient(config);
+        this.api = client.createService(SwapMarketAPI.class);
+    }
+
+    /**
+     * 获取可用合约的列表。
+     *
+     * @return
+     */
+    @Override
+    public String getContractsApi() {
+        return client.executeSync(api.getContractsApi());
+    }
+
+    /**
+     * 获取合约的深度列表。
+     *
+     * @param instrumentId
+     * @param size
+     * @return
+     */
+    @Override
+    public String getDepthApi(String instrumentId, String size) {
+        return client.executeSync(api.getDepthApi(instrumentId, size));
+    }
+
+    /**
+     * 获取平台全部合约的最新成交价、买一价、卖一价和24交易量。
+     *
+     * @return
+     */
+    @Override
+    public String getTickersApi() {
+        return client.executeSync(api.getTickersApi());
+    }
+
+    /**
+     * 获取合约的最新成交价、买一价、卖一价和24交易量。
+     *
+     * @param instrumentId
+     * @return
+     */
+    @Override
+    public String getTickerApi(String instrumentId) {
+        return client.executeSync(api.getTickerApi(instrumentId));
+    }
+
+    /**
+     * 获取合约的成交记录。
+     *
+     * @param instrumentId
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    @Override
+    public String getTradesApi(String instrumentId, String from, String to, String limit) {
+        return client.executeSync(api.getTradesApi(instrumentId, from, to, limit));
+    }
+
+    /**
+     * 获取合约的K线数据。
+     *
+     * @param instrumentId
+     * @param start
+     * @param end
+     * @param granularity
+     * @return
+     */
+    @Override
+    public String getCandlesApi(String instrumentId, String start, String end, String granularity) {
+        return client.executeSync(api.getCandlesApi(instrumentId, start, end, granularity));
+    }
+
+    /**
+     * 获取币种指数。
+     *
+     * @param instrumentId
+     * @return
+     */
+    @Override
+    public String getIndexApi(String instrumentId) {
+        return client.executeSync(api.getIndexApi(instrumentId));
+    }
+
+    /**
+     * 获取法币汇率。
+     *
+     * @return
+     */
+    @Override
+    public String getRateApi() {
+        return client.executeSync(api.getRateApi());
+    }
+
+    /**
+     * 获取合约整个平台的总持仓量。
+     *
+     * @param instrumentId
+     * @return
+     */
+    @Override
+    public String getOpenInterestApi(String instrumentId) {
+        return client.executeSync(api.getOpenInterestApi(instrumentId));
+    }
+
+    /**
+     * 获取合约当前开仓的最高买价和最低卖价。
+     *
+     * @param instrumentId
+     * @return
+     */
+    @Override
+    public String getPriceLimitApi(String instrumentId) {
+        return client.executeSync(api.getPriceLimitApi(instrumentId));
+    }
+
+    /**
+     * 获取合约爆仓单。
+     *
+     * @param instrumentId
+     * @param status
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    @Override
+    public String getLiquidationApi(String instrumentId, String status, String from, String to, String limit) {
+        return client.executeSync(api.getLiquidationApi(instrumentId, status, from, to, limit));
+    }
+
+    /**
+     * 获取合约下一次的结算时间。
+     *
+     * @param instrumentId
+     * @return
+     */
+    @Override
+    public String getFundingTimeApi(String instrumentId) {
+        return client.executeSync(api.getFundingTimeApi(instrumentId));
+    }
+
+    /**
+     * 获取合约历史资金费率
+     *
+     * @param instrumentId
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    @Override
+    public String getHistoricalFundingRateApi(String instrumentId, String from, String to, String limit) {
+        return client.executeSync(api.getHistoricalFundingRateApi(instrumentId, from, to, limit));
+    }
+
+    /**
+     * 获取合约标记价格
+     *
+     * @param instrumentId
+     * @return
+     */
+    @Override
+    public String getMarkPriceApi(String instrumentId) {
+        return client.executeSync(api.getMarkPriceApi(instrumentId));
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/swap/impl/SwapTradeAPI.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/swap/impl/SwapTradeAPI.java
@@ -1,0 +1,23 @@
+package com.okcoin.commons.okex.open.api.service.swap.impl;
+
+import com.alibaba.fastjson.JSONObject;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+
+public interface SwapTradeAPI {
+
+    @POST("/api/swap/v3/order")
+    Call<String> order(@Body JSONObject ppOrder);
+
+    @POST("/api/swap/v3/orders")
+    Call<String> orders(@Body JSONObject ppOrders);
+
+    @POST("/api/swap/v3/cancel_order/{instrument_id}/{order_id}")
+    Call<String> cancelOrder(@Path("instrument_id") String instrumentId, @Path("order_id") String orderId);
+
+    @POST("/api/swap/v3/cancel_batch_orders/{instrument_id}")
+    Call<String> cancelOrders(@Path("instrument_id") String instrumentId, @Body JSONObject ppOrders);
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/swap/impl/SwapTradeAPIServiceImpl.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/swap/impl/SwapTradeAPIServiceImpl.java
@@ -1,0 +1,70 @@
+package com.okcoin.commons.okex.open.api.service.swap.impl;
+
+import com.okcoin.commons.okex.open.api.bean.swap.param.PpCancelOrderVO;
+import com.okcoin.commons.okex.open.api.bean.swap.param.PpOrder;
+import com.okcoin.commons.okex.open.api.bean.swap.param.PpOrders;
+import com.okcoin.commons.okex.open.api.client.APIClient;
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.service.swap.SwapTradeAPIService;
+import com.okcoin.commons.okex.open.api.utils.JsonUtils;
+
+public class SwapTradeAPIServiceImpl implements SwapTradeAPIService {
+    private APIClient client;
+    private SwapTradeAPI api;
+
+    public SwapTradeAPIServiceImpl() {
+    }
+
+    public SwapTradeAPIServiceImpl(APIConfiguration config) {
+        this.client = new APIClient(config);
+        this.api = client.createService(SwapTradeAPI.class);
+    }
+
+    /**
+     * 下单
+     *
+     * @param ppOrder
+     * @return
+     */
+    @Override
+    public String order(PpOrder ppOrder) {
+        System.out.println("下单参数：：：：：：");
+        System.out.println(JsonUtils.convertObject(ppOrder, PpOrder.class));
+        return this.client.executeSync(this.api.order(JsonUtils.convertObject(ppOrder, PpOrder.class)));
+    }
+
+    /**
+     * 批量下单
+     *
+     * @param ppOrders
+     * @return
+     */
+    @Override
+    public String orders(PpOrders ppOrders) {
+        return this.client.executeSync(this.api.orders(JsonUtils.convertObject(ppOrders, PpOrders.class)));
+    }
+
+    /**
+     * 撤单
+     *
+     * @param instrumentId
+     * @param orderId
+     * @return
+     */
+    @Override
+    public String cancelOrder(String instrumentId, String orderId) {
+        return this.client.executeSync(this.api.cancelOrder(instrumentId,orderId));
+    }
+
+    /**
+     * 批量撤单
+     *
+     * @param instrumentId
+     * @param ppCancelOrderVO
+     * @return
+     */
+    @Override
+    public String cancelOrders(String instrumentId, PpCancelOrderVO ppCancelOrderVO) {
+        return this.client.executeSync(this.api.cancelOrders(instrumentId,JsonUtils.convertObject(ppCancelOrderVO, PpCancelOrderVO.class)));
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/swap/impl/SwapUserAPI.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/swap/impl/SwapUserAPI.java
@@ -1,0 +1,40 @@
+package com.okcoin.commons.okex.open.api.service.swap.impl;
+
+import com.alibaba.fastjson.JSONObject;
+import retrofit2.Call;
+import retrofit2.http.*;
+
+public interface SwapUserAPI {
+
+
+    @GET("/api/swap/v3/{instrument_id}/position")
+    Call<String> getPosition(@Path("instrument_id") String instrumentId);
+
+    @GET("/api/swap/v3/accounts")
+    Call<String> getAccounts();
+
+    @GET("/api/swap/v3/{instrument_id}/accounts")
+    Call<String> selectAccount(@Path("instrument_id") String instrumentId);
+
+    @GET("/api/swap/v3/accounts/{instrument_id}/settings")
+    Call<String> selectContractSettings(@Path("instrument_id") String instrumentId);
+
+    @POST("/api/swap/v3/accounts/{instrument_id}/leverage")
+    Call<String> updateLevelRate(@Path("instrument_id") String instrumentId, @Body JSONObject levelRateParam);
+
+    @GET("/api/swap/v3/orders/{instrument_id}")
+    Call<String> selectOrders(@Path("instrument_id") String instrumentId, @Query("status") String status, @Query("from") String from, @Query("to") String to, @Query("limit") String limit);
+
+    @GET("/api/swap/v3/orders/{instrument_id}/{order_id}")
+    Call<String> selectOrder(@Path("instrument_id") String instrumentId, @Path("order_id") String orderId);
+
+    @GET("/api/swap/v3/fills")
+    Call<String> selectDealDetail(@Query("instrument_id") String instrumentId, @Query("order_id") String orderId, @Query("from") String from, @Query("to") String to, @Query("limit") String limit);
+
+    @GET("/api/swap/v3/accounts/{instrument_id}/ledger")
+    Call<String> getLedger(@Path("instrument_id") String instrumentId, @Query("from") String from, @Query("to") String to, @Query("limit") String limit);
+
+    @GET("/api/swap/v3/accounts/{instrument_id}/holds")
+    Call<String> getHolds(@Path("instrument_id") String instrumentId);
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/swap/impl/SwapUserAPIServiceImpl.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/service/swap/impl/SwapUserAPIServiceImpl.java
@@ -1,0 +1,143 @@
+package com.okcoin.commons.okex.open.api.service.swap.impl;
+
+import com.okcoin.commons.okex.open.api.bean.swap.param.LevelRateParam;
+import com.okcoin.commons.okex.open.api.client.APIClient;
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.service.swap.SwapUserAPIServive;
+import com.okcoin.commons.okex.open.api.utils.JsonUtils;
+
+public class SwapUserAPIServiceImpl implements SwapUserAPIServive {
+    private APIClient client;
+    private SwapUserAPI api;
+
+    public SwapUserAPIServiceImpl() {
+    }
+
+    public SwapUserAPIServiceImpl(APIConfiguration config) {
+        this.client = new APIClient(config);
+        this.api = client.createService(SwapUserAPI.class);
+    }
+
+    /**
+     * 获取单个合约持仓信息
+     *
+     * @param instrumentId
+     * @return
+     */
+    @Override
+    public String getPosition(String instrumentId) {
+        return client.executeSync(api.getPosition(instrumentId));
+    }
+
+    /**
+     * 获取所有币种合约的账户信息
+     *
+     * @return
+     */
+    @Override
+    public String getAccounts() {
+        return client.executeSync(api.getAccounts());
+    }
+
+    /**
+     * 获取某个币种合约的账户信息
+     *
+     * @param instrumentId
+     * @return
+     */
+    @Override
+    public String selectAccount(String instrumentId) {
+        return client.executeSync(api.selectAccount(instrumentId));
+    }
+
+    /**
+     * 获取某个合约的用户配置
+     *
+     * @param instrumentId
+     * @return
+     */
+    @Override
+    public String selectContractSettings(String instrumentId) {
+        return client.executeSync(api.selectContractSettings(instrumentId));
+    }
+
+    /**
+     * 设定某个合约的杠杆
+     *
+     * @param instrumentId
+     * @param levelRateParam
+     * @return
+     */
+    @Override
+    public String updateLevelRate(String instrumentId, LevelRateParam levelRateParam) {
+        return client.executeSync(api.updateLevelRate(instrumentId, JsonUtils.convertObject(levelRateParam, LevelRateParam.class)));
+    }
+
+    /**
+     * 获取所有订单列表
+     *
+     * @param instrumentId
+     * @param status
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    @Override
+    public String selectOrders(String instrumentId, String status, String from, String to, String limit) {
+        return client.executeSync(api.selectOrders(instrumentId, status, from, to, limit));
+    }
+
+    /**
+     * 通过订单id获取单个订单信息
+     *
+     * @param instrumentId
+     * @param orderId
+     * @return
+     */
+    @Override
+    public String selectOrder(String instrumentId, String orderId) {
+        return client.executeSync(api.selectOrder(instrumentId, orderId));
+    }
+
+    /**
+     * 获取最近的成交明细列表
+     *
+     * @param instrumentId
+     * @param orderId
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    @Override
+    public String selectDealDetail(String instrumentId, String orderId, String from, String to, String limit) {
+        return client.executeSync(api.selectDealDetail(instrumentId, orderId, from, to, limit));
+    }
+
+    /**
+     * 列出账户资产流水，账户资产流水是指导致账户余额增加或减少的行为。
+     * 流水会分页，每页100条数据，并且按照时间倒序排序和存储，最新的排在最前面。
+     *
+     * @param instrumentId
+     * @param from
+     * @param to
+     * @param limit
+     * @return
+     */
+    @Override
+    public String getLedger(String instrumentId, String from, String to, String limit) {
+        return client.executeSync(api.getLedger(instrumentId, from, to, limit));
+    }
+
+    /**
+     * 获取合约挂单冻结数量
+     *
+     * @param instrumentId
+     * @return
+     */
+    @Override
+    public String getHolds(String instrumentId) {
+        return client.executeSync(api.getHolds(instrumentId));
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/utils/DateUtils.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/utils/DateUtils.java
@@ -1,0 +1,158 @@
+package com.okcoin.commons.okex.open.api.utils;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.math.BigDecimal;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Date;
+import java.util.TimeZone;
+
+/**
+ * Date Utils  <br/>
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/2/3 20:30
+ */
+public class DateUtils {
+
+    public static String TIME_STYLE_S1 = "yyyy-MM-dd";
+    public static String TIME_STYLE_S2 = "yyyy-MM-dd HH:mm";
+    public static String TIME_STYLE_S3 = "yyyy-MM-dd HH:mm:ss";
+    public static String TIME_STYLE_S4 = "yyyy-MM-dd HH:mm:ss:S";
+    public static String TIME_STYLE_S5 = "yyyy-MM-dd HH:mm:ss:S E zZ";
+    public static String TIME_STYLE_S6 = "yyyyMMddHHmmssS";
+    public static String TIME_STYLE_S7 = "yyyy年MM月dd日HH时mm分ss秒";
+    public static SimpleDateFormat SDF = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.S'Z'");
+
+    static {
+        DateUtils.SDF.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    /**
+     * Returns the time string in format. <br/>
+     * Styles:
+     * <p>
+     * <blockquote><pre>
+     *         1:  2018-03-01
+     *         2:  2018-03-01 15:53
+     *         3:  2018-03-01 15:53:43
+     *         4:  2018-03-01 15:53:43:288
+     *         5:  2018-03-01 15:53:43:288 Thu CST+0800
+     *         6:  20180301155343288
+     *         7:  2018年03月01日15时53分43秒
+     *         8:  2018-03-01T07:53:43.288Z
+     *         9:  1519890823.288
+     * `default`:  Thu Mar 01 15:53:43 CST 2018
+     * </pre></blockquote>
+     * </p>
+     *
+     * @param time  Date object, if time=null, returns the current time.
+     * @param style Format number
+     * @return String time string in format
+     */
+    public static String timeToString(Date time, final int style) {
+        if (time == null) {
+            time = new Date();
+        }
+        String timeStyle = null;
+        switch (style) {
+            case 1: {
+                timeStyle = DateUtils.TIME_STYLE_S1;
+                break;
+            }
+            case 2: {
+                timeStyle = DateUtils.TIME_STYLE_S2;
+                break;
+            }
+            case 3: {
+                timeStyle = DateUtils.TIME_STYLE_S3;
+                break;
+            }
+            case 4: {
+                timeStyle = DateUtils.TIME_STYLE_S4;
+                break;
+            }
+            case 5: {
+                timeStyle = DateUtils.TIME_STYLE_S5;
+                break;
+            }
+            case 6: {
+                timeStyle = DateUtils.TIME_STYLE_S6;
+                break;
+            }
+            case 7: {
+                timeStyle = DateUtils.TIME_STYLE_S7;
+                break;
+            }
+            case 8: {
+                final SimpleDateFormat sdf = (SimpleDateFormat) DateUtils.SDF.clone();
+                return sdf.format(time);
+            }
+            case 9: {
+                return DateUtils.getEpochTime(time);
+            }
+            default: {
+                return time.toString();
+            }
+        }
+        return new SimpleDateFormat(timeStyle).format(time);
+    }
+
+    /**
+     * {@link DateUtils#timeToString(Date, int)}
+     *
+     * @param time Date object, if time=null, returns null.
+     */
+    public static String timeToStringNull(final Date time, final int style) {
+        return time == null ? null : DateUtils.timeToString(time, style);
+    }
+
+    /**
+     * UNIX timestamp ISO 8601 rule eg: 2018-02-03T05:34:14.110Z
+     */
+    public static String getUnixTime() {
+        return Instant.now().toString();
+    }
+
+    /**Date
+     * epoch time   eg: 1517662142.557
+     */
+    public static String getEpochTime(final Date... time) {
+        long milliseconds;
+        if (time != null && time.length > 0) {
+            milliseconds = time[0].getTime();
+        } else {
+            milliseconds = Instant.now().toEpochMilli();
+        }
+        milliseconds = milliseconds - 28800000L;
+        final BigDecimal bd1 = new BigDecimal(milliseconds);
+        final BigDecimal bd2 = new BigDecimal(1000);
+        return bd1.divide(bd2).toString();
+    }
+
+    /**
+     * convert UTC timestamp：2018-02-03T16:56:29.919Z  -> object: Sun Feb 04 00:56:29 CST 2018
+     */
+    public static Date parseUTCTime(final String utcTime) throws ParseException {
+        if (StringUtils.isEmpty(utcTime)) {
+            return null;
+        }
+        final SimpleDateFormat sdfi = (SimpleDateFormat) DateUtils.SDF.clone();
+        return sdfi.parse(utcTime);
+    }
+
+    /**
+     * convert decimal timestamp：1517676989.919 ->   -> object: Sun Feb 04 00:56:29 CST 2018
+     */
+    public static Date parseDecimalTime(final String decimalTime) {
+        if (StringUtils.isEmpty(decimalTime)) {
+            return null;
+        }
+        final BigDecimal bd1 = new BigDecimal(decimalTime);
+        final BigDecimal bd2 = new BigDecimal(1000);
+        return new Date(bd1.multiply(bd2).longValue());
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/utils/HmacSHA256Base64Utils.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/utils/HmacSHA256Base64Utils.java
@@ -1,0 +1,92 @@
+package com.okcoin.commons.okex.open.api.utils;
+
+import com.okcoin.commons.okex.open.api.constant.APIConstants;
+import com.okcoin.commons.okex.open.api.enums.AlgorithmEnum;
+import com.okcoin.commons.okex.open.api.enums.CharsetEnum;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import javax.management.RuntimeErrorException;
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+/**
+ * Hmac SHA256 Base64 Signature Utils.<br/>
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/2/1 11:41
+ */
+public class HmacSHA256Base64Utils {
+
+    /**
+     * Signing a Message.<br/>
+     * <p>
+     * using: Hmac SHA256 + base64
+     *
+     * @param timestamp   the number of seconds since Unix Epoch in UTC. Decimal values are allowed.
+     *                    eg: 2018-03-08T10:59:25.789Z
+     * @param method      eg: POST
+     * @param requestPath eg: /orders
+     * @param queryString eg: before=2&limit=30
+     * @param body        json string, eg: {"product_id":"BTC-USD-0309","order_id":"377454671037440"}
+     * @param secretKey   user's secret key eg: E65791902180E9EF4510DB6A77F6EBAE
+     * @return signed string   eg: TO6uwdqz+31SIPkd4I+9NiZGmVH74dXi+Fd5X0EzzSQ=
+     * @throws CloneNotSupportedException
+     * @throws InvalidKeyException
+     * @throws UnsupportedEncodingException
+     */
+    public static String sign(String timestamp, String method, String requestPath,
+                              String queryString, String body, String secretKey)
+            throws CloneNotSupportedException, InvalidKeyException, UnsupportedEncodingException {
+        if (StringUtils.isEmpty(secretKey) || StringUtils.isEmpty(method)) {
+            return APIConstants.EMPTY;
+        }
+        String preHash = preHash(timestamp, method, requestPath, queryString, body);
+        byte[] secretKeyBytes = secretKey.getBytes(CharsetEnum.UTF_8.charset());
+        SecretKeySpec secretKeySpec = new SecretKeySpec(secretKeyBytes, AlgorithmEnum.HMAC_SHA256.algorithm());
+        Mac mac = (Mac) MAC.clone();
+        mac.init(secretKeySpec);
+        return Base64.getEncoder().encodeToString(mac.doFinal(preHash.getBytes(CharsetEnum.UTF_8.charset())));
+    }
+
+    /**
+     * the prehash string = timestamp + method + requestPath + body .<br/>
+     *
+     * @param timestamp   the number of seconds since Unix Epoch in UTC. Decimal values are allowed.
+     *                    eg: 2018-03-08T10:59:25.789Z
+     * @param method      eg: POST
+     * @param requestPath eg: /orders
+     * @param queryString eg: before=2&limit=30
+     * @param body        json string, eg: {"product_id":"BTC-USD-0309","order_id":"377454671037440"}
+     * @return prehash string eg: 2018-03-08T10:59:25.789ZPOST/orders?before=2&limit=30{"product_id":"BTC-USD-0309",
+     * "order_id":"377454671037440"}
+     */
+    public static String preHash(String timestamp, String method, String requestPath,
+                                 String queryString, String body) {
+        StringBuilder preHash = new StringBuilder();
+        preHash.append(timestamp);
+        preHash.append(method.toUpperCase());
+        preHash.append(requestPath);
+        if (StringUtils.isNotEmpty(queryString)) {
+            preHash.append(APIConstants.QUESTION).append(queryString);
+        }
+        if (StringUtils.isNotEmpty(body)) {
+            preHash.append(body);
+        }
+        return preHash.toString();
+    }
+
+    public static Mac MAC;
+
+    static {
+        try {
+            MAC = Mac.getInstance(AlgorithmEnum.HMAC_SHA256.algorithm());
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeErrorException(new Error("Can't get Mac's instance."));
+        }
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/utils/JsonUtils.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/utils/JsonUtils.java
@@ -1,0 +1,104 @@
+package com.okcoin.commons.okex.open.api.utils;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.constant.APIConstants;
+import com.okcoin.commons.okex.open.api.exception.APIException;
+import org.apache.commons.collections.CollectionUtils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * Date Utils  <br/>
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/2/9 18:54
+ */
+
+public class JsonUtils {
+
+    /**
+     * The java object is converted to a JSONObject，ensure precision (as strings). <br/>
+     *
+     * @param t   java object
+     * @param tC  generic class
+     * @param <T> generic flag
+     * @return If null, return {} ，Otherwise the normal
+     */
+    public static <T> JSONObject convertObject(T t, Class<T> tC) {
+        if (t == null) {
+            return APIConstants.NOTHING;
+        }
+        Field[] fields = tC.getDeclaredFields();
+        JSONObject object = new JSONObject();
+        try {
+            for (Field field : fields) {
+                String name = field.getName();
+                String type = field.getType().toString();
+                String methodName = getMethodName(type, name);
+                Method[] methods = tC.getMethods();
+                for (Method method : methods) {
+                    if (methodName.equals(method.getName())) {
+                        Object result = method.invoke(t);
+                        if (APIConstants.toStringTypeArray.contains(type)) {
+                            object.put(field.getName(), toString(result));
+                        } else if (APIConstants.toStringTypeDoubleArray.contains(type) && result != null) {
+                            object.put(field.getName(), NumberUtils.doubleToString((Double) result));
+                        } else {
+                            object.put(field.getName(), result);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new APIException("Java biz bean change JSONObject is exception.", e);
+        }
+        return object;
+    }
+
+    /**
+     * The java object list is converted to a JSONArray，ensure precision (as strings)
+     *
+     * @param list java object list
+     * @param tC   generic class
+     * @param <T>  generic flag
+     * @return If null, return [] ，Otherwise the normal
+     */
+    public static final <T> JSONArray convertList(List<T> list, Class<T> tC) {
+        JSONArray array = new JSONArray();
+        if (CollectionUtils.isEmpty(list)) {
+            return array;
+        }
+
+        for (T t : list) {
+            array.add(convertObject(t, tC));
+        }
+        return array;
+    }
+
+    public static final String getMethodName(String type, String field) {
+        StringBuilder methodName = new StringBuilder();
+        if (type.equals(APIConstants.BOOLEAN)) {
+            methodName.append(APIConstants.IS);
+        } else {
+            methodName.append(APIConstants.get);
+        }
+        return methodName.append(startUpperCase(field)).toString();
+    }
+
+    public static final String startUpperCase(String name) {
+        char[] cs = name.toCharArray();
+        if (cs[0] >= APIConstants.a && cs[0] <= APIConstants.z) {
+            cs[0] -= 32;
+        }
+        return String.valueOf(cs);
+    }
+
+    public static final String toString(Object object) {
+        return object == null ? APIConstants.ZERO_STRING : object.toString();
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/utils/NumberUtils.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/utils/NumberUtils.java
@@ -1,0 +1,91 @@
+package com.okcoin.commons.okex.open.api.utils;
+
+import com.okcoin.commons.okex.open.api.constant.APIConstants;
+import org.apache.commons.lang3.StringUtils;
+
+import java.text.NumberFormat;
+
+/**
+ * Number Utils
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/12 13:57
+ */
+public class NumberUtils {
+
+    /**
+     * scientific notation: double to string <br/>
+     * eg:  <br/>
+     * -4.62E-6 -> -0.00000462  <br/>
+     * 8.9E9    -> 8900000000  <br/>
+     * 5.50    -> 5.5  <br/>
+     */
+    public static String doubleToString(Double arg) {
+        if (arg == null) {
+            return APIConstants.DOUBLE_ZERO_STRING;
+        }
+        String argStr = arg.toString();
+        int scale;
+        if (argStr.contains(APIConstants.E) || argStr.contains(APIConstants.e)) {
+            String[] argArray = argStr.toUpperCase().split(APIConstants.E);
+            int scale1 = Integer.parseInt(argArray[1]);
+            scale = scale1 < 0 ? Math.abs(scale1) : scale1;
+            String scale2 = argArray[0];
+            if (scale2.contains(APIConstants.DOT1)) {
+                String[] argDecimalsArray = scale2.split(APIConstants.DOT2);
+                String decimalsAfter = argDecimalsArray[1];
+                int decimalsAfterI = Integer.parseInt(decimalsAfter);
+                if (decimalsAfterI > 0) {
+                    scale += decimalsAfter.length();
+                }
+            }
+        } else {
+            scale = APIConstants.DEFAULT_SCALE;
+        }
+        NumberFormat format = getNumberFormat(scale);
+        String result = format.format(arg);
+        if (StringUtils.isNotEmpty(result) && result.contains(APIConstants.DOT1)) {
+            result = result.replaceAll(APIConstants.DOUBLE_END1, APIConstants.EMPTY);
+            result = result.replaceAll(APIConstants.DOUBLE_END2, APIConstants.EMPTY);
+        }
+        return result;
+    }
+
+    private static NumberFormat getNumberFormat(int scale) {
+        NumberFormat format = NumberFormat.getInstance();
+        // No comma
+        format.setGroupingUsed(false);
+        // Set the number of decimal places
+        format.setMinimumFractionDigits(scale);
+        return format;
+    }
+
+    public static int toInteger(String string) {
+        return toInteger(string, 0);
+    }
+
+    public static int toInteger(String string, int defaultValue) {
+        if (StringUtils.isNotEmpty(string)) {
+            string = string.trim();
+            if (StringUtils.isNumeric(string)) {
+                return Integer.parseInt(string);
+            }
+        }
+        return defaultValue;
+    }
+
+    public static long toLong(String string) {
+        return toLong(string, 0L);
+    }
+
+    public static long toLong(String string, long defaultValue) {
+        if (StringUtils.isNotEmpty(string)) {
+            string = string.trim();
+            if (StringUtils.isNumeric(string)) {
+                return Long.parseLong(string);
+            }
+        }
+        return defaultValue;
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/utils/OrderIdUtils.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/main/java/com/okcoin/commons/okex/open/api/utils/OrderIdUtils.java
@@ -1,0 +1,29 @@
+package com.okcoin.commons.okex.open.api.utils;
+
+import com.okcoin.commons.okex.open.api.constant.APIConstants;
+
+import java.util.UUID;
+
+/**
+ * Order Id Utils
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/14 10:02
+ */
+public class OrderIdUtils {
+
+    /**
+     * The order ids, use uuid and remove the line dividing line. <br/>
+     * id length = 32
+     *
+     * @return String eg: 39360db0a45e41309511f4fba658b01c
+     */
+    public static String generator() {
+        return UUID.randomUUID().toString().toLowerCase().replace(APIConstants.HLINE, APIConstants.EMPTY);
+    }
+
+    public static void main(String[] args) {
+        System.out.println(generator());
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/BaseTests.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/BaseTests.java
@@ -1,0 +1,23 @@
+package com.okcoin.commons.okex.open.api.test;
+
+import com.alibaba.fastjson.JSON;
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import org.slf4j.Logger;
+
+/**
+ * Junit base Tests
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/12 14:48
+ */
+public class BaseTests {
+
+    public APIConfiguration config;
+
+    public void toResultString(Logger log, String flag, Object object) {
+        StringBuilder su = new StringBuilder();
+        su.append("\n").append("<*> ").append(flag).append(": ").append(JSON.toJSONString(object));
+        log.info(su.toString());
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/GeneralAPITests.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/GeneralAPITests.java
@@ -1,0 +1,45 @@
+package com.okcoin.commons.okex.open.api.test;
+
+import com.okcoin.commons.okex.open.api.bean.futures.result.ExchangeRate;
+import com.okcoin.commons.okex.open.api.bean.futures.result.ServerTime;
+import com.okcoin.commons.okex.open.api.service.GeneralAPIService;
+import com.okcoin.commons.okex.open.api.service.futures.impl.GeneralAPIServiceImpl;
+import com.okcoin.commons.okex.open.api.test.futures.FuturesAPIBaseTests;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * General API Tests
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/12 14:34
+ */
+public class GeneralAPITests extends FuturesAPIBaseTests {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GeneralAPITests.class);
+
+    private GeneralAPIService generalAPIService;
+
+
+    @Before
+    public void before() {
+        config = config();
+        generalAPIService = new GeneralAPIServiceImpl(config);
+    }
+
+
+    @Test
+    public void testServerTime() {
+         ServerTime time = generalAPIService.getServerTime();
+        toResultString(LOG, "ServerTime", time);
+    }
+
+    @Test
+    public void testExchangeRate() {
+        ExchangeRate exchangeRate = generalAPIService.getExchangeRate();
+        toResultString(LOG, "ExchangeRate", exchangeRate);
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/SignatureTest.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/SignatureTest.java
@@ -1,0 +1,54 @@
+package com.okcoin.commons.okex.open.api.test;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+/**
+ * sign test
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/7/9 16:03
+ */
+public class SignatureTest {
+
+    @Test
+    public void test() {
+        try {
+            Assert.assertEquals("TO6uwdqz+31SIPkd4I+9NiZGmVH74dXi+Fd5X0EzzSQ=",
+                    signature("2018-03-08T10:59:25.789Z",
+                            "POST",
+                            "/orders?before=2&limit=30",
+                            "{\"product_id\":\"BTC-USD-0309\",\"order_id\":\"377454671037440\"}",
+                            "E65791902180E9EF4510DB6A77F6EBAE"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    private String signature(String timestamp, String method, String requestPath, String body, String secretKey)
+            throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
+        String signStr = null;
+        if (StringUtils.isNotEmpty(secretKey)) {
+            body = body == null ? "" : body;
+            method = method.toUpperCase();
+            String preHash = timestamp + method + requestPath + body;
+            byte[] secretKeyBytes = secretKey.getBytes("UTF-8");
+            SecretKeySpec secretKeySpec = new SecretKeySpec(secretKeyBytes, "HmacSHA256");
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(secretKeySpec);
+            signStr = Base64.getEncoder().encodeToString(mac.doFinal(preHash.getBytes("UTF-8")));
+        }
+        return signStr;
+    }
+}
+

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/account/AccountAPIBaseTests.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/account/AccountAPIBaseTests.java
@@ -1,0 +1,31 @@
+package com.okcoin.commons.okex.open.api.test.account;
+
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.enums.I18nEnum;
+import com.okcoin.commons.okex.open.api.test.BaseTests;
+
+/**
+ * Account api basetests
+ *
+ * @author hucj
+ * @version 1.0.0
+ * @date 2018/7/04 18:23
+ */
+public class AccountAPIBaseTests extends BaseTests {
+
+    public APIConfiguration config() {
+        APIConfiguration config = new APIConfiguration();
+
+        config.setEndpoint("https://www.okex.com");
+        config.setApiKey("");
+        config.setSecretKey("");
+
+        config.setPassphrase("");
+        config.setPrint(true);
+        config.setI18n(I18nEnum.SIMPLIFIED_CHINESE);
+
+        return config;
+    }
+
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/account/AccountAPITests.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/account/AccountAPITests.java
@@ -1,0 +1,116 @@
+package com.okcoin.commons.okex.open.api.test.account;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.account.param.Transfer;
+import com.okcoin.commons.okex.open.api.bean.account.param.Withdraw;
+import com.okcoin.commons.okex.open.api.bean.account.result.Currency;
+import com.okcoin.commons.okex.open.api.bean.account.result.Ledger;
+import com.okcoin.commons.okex.open.api.bean.account.result.Wallet;
+import com.okcoin.commons.okex.open.api.bean.account.result.WithdrawFee;
+import com.okcoin.commons.okex.open.api.service.account.AccountAPIService;
+import com.okcoin.commons.okex.open.api.service.account.impl.AccountAPIServiceImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class AccountAPITests extends  AccountAPIBaseTests{
+
+    private static final Logger LOG = LoggerFactory.getLogger(AccountAPITests.class);
+
+    private AccountAPIService accountAPIService;
+
+    @Before
+    public void before() {
+        this.config = this.config();
+        this.accountAPIService = new AccountAPIServiceImpl(this.config);
+    }
+
+    @Test
+    public void transfer() {
+        Transfer transfer = new Transfer();
+        transfer.setFrom(1);
+        transfer.setTo(6);
+        transfer.setCurrency("eos");
+        transfer.setAmount(BigDecimal.valueOf(0.0001));
+        JSONObject result = this.accountAPIService.transfer(transfer);
+        this.toResultString(AccountAPITests.LOG, "result", result);
+    }
+
+    @Test
+    public void withdraw() {
+        Withdraw withdraw = new Withdraw();
+        withdraw.setTo_address("xxxxxxxxxxxxxxxxxxxxxxxxxxx");
+        withdraw.setFee(new BigDecimal("0.0005"));
+        withdraw.setCurrency("btc");
+        withdraw.setAmount(BigDecimal.ONE);
+        withdraw.setDestination(4);
+        withdraw.setTrade_pwd("123456");
+        JSONObject result = this.accountAPIService.withdraw(withdraw);
+        this.toResultString(AccountAPITests.LOG, "result", result);
+    }
+
+    @Test
+    public void getCurrencies() {
+        List<Currency> result = this.accountAPIService.getCurrencies();
+        this.toResultString(AccountAPITests.LOG, "result", result);
+    }
+
+    @Test
+    public void getLedger() {
+        List<Ledger> result = this.accountAPIService.getLedger(2, "btc",null, null, 10);
+        this.toResultString(AccountAPITests.LOG, "result", result);
+    }
+
+    @Test
+    public void getWallet() {
+        List<Wallet> result = this.accountAPIService.getWallet();
+        this.toResultString(AccountAPITests.LOG, "result", result);
+        List<Wallet> result2 = this.accountAPIService.getWallet("btc");
+        this.toResultString(AccountAPITests.LOG, "result", result2);
+    }
+
+    @Test
+    public void getDepositAddress() {
+        JSONArray result = this.accountAPIService.getDepositAddress("btc");
+        this.toResultString(AccountAPITests.LOG, "result", result);
+    }
+
+    @Test
+    public void getWithdrawFee() {
+        List<WithdrawFee> result = this.accountAPIService.getWithdrawFee("btc");
+        this.toResultString(AccountAPITests.LOG, "result", result);
+    }
+
+    @Test
+    public void getOnHold() {
+        JSONArray result = this.accountAPIService.getOnHold("cac");
+        this.toResultString(AccountAPITests.LOG, "result", result);
+    }
+
+    @Test
+    public void lock() {
+        JSONObject result = this.accountAPIService.lock("cac", new BigDecimal("10000"));        this.toResultString(AccountAPITests.LOG, "result", result);
+        this.toResultString(AccountAPITests.LOG, "result", result);
+
+    }
+
+    @Test
+    public void unlock() {
+        JSONObject result = this.accountAPIService.unlock("cac", new BigDecimal("10000"));        this.toResultString(AccountAPITests.LOG, "result", result);
+        this.toResultString(AccountAPITests.LOG, "result", result);
+
+    }
+
+    @Test
+    public void getDepositHistory() {
+        JSONArray result = this.accountAPIService.getDepositHistory();
+        this.toResultString(AccountAPITests.LOG, "result", result);
+        JSONArray result2 = this.accountAPIService.getDepositHistory("btc");
+        this.toResultString(AccountAPITests.LOG, "result", result2);
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/ett/EttAPIBaseTests.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/ett/EttAPIBaseTests.java
@@ -1,0 +1,22 @@
+package com.okcoin.commons.okex.open.api.test.ett;
+
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.enums.I18nEnum;
+import com.okcoin.commons.okex.open.api.test.BaseTests;
+
+public class EttAPIBaseTests extends BaseTests {
+
+    public APIConfiguration config() {
+        final APIConfiguration config = new APIConfiguration();
+        config.setEndpoint("https://www.okex.com/");
+        config.setApiKey("");
+        config.setSecretKey("");
+
+        config.setPassphrase("");
+        config.setI18n(I18nEnum.SIMPLIFIED_CHINESE);
+        config.setPrint(true);
+
+        return config;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/ett/EttAccountAPITests.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/ett/EttAccountAPITests.java
@@ -1,0 +1,45 @@
+package com.okcoin.commons.okex.open.api.test.ett;
+
+import com.okcoin.commons.okex.open.api.bean.ett.result.CursorPager;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttAccount;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttLedger;
+import com.okcoin.commons.okex.open.api.service.ett.EttAccountAPIService;
+import com.okcoin.commons.okex.open.api.service.ett.impl.EttAccountAPIServiceImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class EttAccountAPITests extends EttAPIBaseTests {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EttAccountAPITests.class);
+
+    private EttAccountAPIService ettAccountAPIService;
+
+    @Before
+    public void before() {
+        this.config = this.config();
+        this.ettAccountAPIService = new EttAccountAPIServiceImpl(this.config);
+    }
+
+    @Test
+    public void getAccounts() {
+        List<EttAccount> result = this.ettAccountAPIService.getAccount();
+        this.toResultString(EttAccountAPITests.LOG, "result", result);
+    }
+
+    @Test
+    public void getAccount() {
+        EttAccount result = this.ettAccountAPIService.getAccount("btc");
+        this.toResultString(EttAccountAPITests.LOG, "result", result);
+    }
+
+    @Test
+    public void getLedger() {
+        CursorPager<EttLedger> result = this.ettAccountAPIService.getLedger("oka", null, null, 1);
+        this.toResultString(EttAccountAPITests.LOG, "result", result);
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/ett/EttOrderAPITests.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/ett/EttOrderAPITests.java
@@ -1,0 +1,52 @@
+package com.okcoin.commons.okex.open.api.test.ett;
+
+import com.okcoin.commons.okex.open.api.bean.ett.result.CursorPager;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttCancelOrderResult;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttCreateOrderResult;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttOrder;
+import com.okcoin.commons.okex.open.api.service.ett.EttOrderAPIService;
+import com.okcoin.commons.okex.open.api.service.ett.impl.EttOrderAPIServiceImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+
+public class EttOrderAPITests extends EttAPIBaseTests {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EttOrderAPITests.class);
+
+    private EttOrderAPIService ettOrderAPIService;
+
+    @Before
+    public void before() {
+        this.config = this.config();
+        this.ettOrderAPIService = new EttOrderAPIServiceImpl(this.config);
+    }
+
+    @Test
+    public void createOrder() {
+        EttCreateOrderResult result = this.ettOrderAPIService.createOrder("ok06ett", 1, BigDecimal.valueOf(100), null, null);
+        this.toResultString(EttOrderAPITests.LOG, "result", result);
+    }
+
+    @Test
+    public void cancelOrder() {
+        EttCancelOrderResult result = this.ettOrderAPIService.cancelOrder("1805181314012329");
+        this.toResultString(EttOrderAPITests.LOG, "result", result);
+    }
+
+    @Test
+    public void getOrders() {
+        CursorPager<EttOrder> result = this.ettOrderAPIService.getOrder("oka", 1, null, null, null, 1);
+        this.toResultString(EttOrderAPITests.LOG, "result", result);
+    }
+
+    @Test
+    public void getOrder() {
+        EttOrder result = this.ettOrderAPIService.getOrder("1805181314012329");
+        this.toResultString(EttOrderAPITests.LOG, "result", result);
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/ett/EttProductAPITests.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/ett/EttProductAPITests.java
@@ -1,0 +1,38 @@
+package com.okcoin.commons.okex.open.api.test.ett;
+
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttConstituentsResult;
+import com.okcoin.commons.okex.open.api.bean.ett.result.EttSettlementDefinePrice;
+import com.okcoin.commons.okex.open.api.service.ett.EttProductAPIService;
+import com.okcoin.commons.okex.open.api.service.ett.impl.EttProductAPIServiceImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class EttProductAPITests extends EttAPIBaseTests {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EttProductAPITests.class);
+
+    private EttProductAPIService ettProductAPIService;
+
+    @Before
+    public void before() {
+        this.config = this.config();
+        this.ettProductAPIService = new EttProductAPIServiceImpl(this.config);
+    }
+
+    @Test
+    public void getConstituents() {
+        EttConstituentsResult result = this.ettProductAPIService.getConstituents("ok06ett");
+        this.toResultString(EttProductAPITests.LOG, "result", result);
+    }
+
+    @Test
+    public void getDefinePrice() {
+        List<EttSettlementDefinePrice> result = this.ettProductAPIService.getDefinePrice("ok06ett");
+        this.toResultString(EttProductAPITests.LOG, "result", result);
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/futures/FuturesAPIBaseTests.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/futures/FuturesAPIBaseTests.java
@@ -1,0 +1,40 @@
+package com.okcoin.commons.okex.open.api.test.futures;
+
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.enums.I18nEnum;
+import com.okcoin.commons.okex.open.api.test.BaseTests;
+
+/**
+ * Futures api basetests
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/13 18:23
+ */
+public class FuturesAPIBaseTests extends BaseTests {
+
+    public APIConfiguration config() {
+        APIConfiguration config = new APIConfiguration();
+
+        config.setEndpoint("https://www.okex.com");
+
+
+        config.setApiKey("");
+        config.setSecretKey("");
+
+
+        config.setPassphrase("");
+        config.setPrint(true);
+        config.setI18n(I18nEnum.ENGLISH);
+
+        return config;
+    }
+
+    int from = 0;
+    int to = 0;
+    int limit = 20;
+
+    String instrument_id = "EOS-USD-181102";
+
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/futures/FuturesMarketAPITests.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/futures/FuturesMarketAPITests.java
@@ -1,0 +1,113 @@
+package com.okcoin.commons.okex.open.api.test.futures;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.futures.result.*;
+import com.okcoin.commons.okex.open.api.service.futures.FuturesMarketAPIService;
+import com.okcoin.commons.okex.open.api.service.futures.impl.FuturesMarketAPIServiceImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Futures market api tests
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/12 14:54
+ */
+public class FuturesMarketAPITests extends FuturesAPIBaseTests {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FuturesMarketAPITests.class);
+
+    private FuturesMarketAPIService marketAPIService;
+
+    @Before
+    public void before() {
+        config = config();
+        marketAPIService = new FuturesMarketAPIServiceImpl(config);
+    }
+
+    @Test
+    public void testGetInstruments() {
+        List<Instruments> instruments = marketAPIService.getInstruments();
+        toResultString(LOG, "Instruments", instruments);
+    }
+
+    @Test
+    public void testGetCurrencies() {
+        List<Currencies> currencies = marketAPIService.getCurrencies();
+        toResultString(LOG, "Currencies", currencies);
+    }
+
+    @Test
+    public void testGetInstrumentBook() {
+        Book book = marketAPIService.getInstrumentBook(instrument_id, 2);
+        toResultString(LOG, "Instrument-Book", book);
+    }
+
+    @Test
+    public void testGetInstrumentTicker() {
+        Ticker ticker = marketAPIService.getInstrumentTicker(instrument_id);
+        toResultString(LOG, "Instrument-Ticker", ticker);
+    }
+
+    @Test
+    public void testGetAllInstrumentTicker() {
+        List<Ticker> tickers = marketAPIService.getAllInstrumentTicker();
+        toResultString(LOG, "Instrument-Ticker", tickers);
+    }
+
+    @Test
+    public void testGetInstrumentTrades() {
+        List<Trades> trades = marketAPIService.getInstrumentTrades(instrument_id, from, to, limit);
+        toResultString(LOG, "Instrument-Trades", trades);
+    }
+
+    @Test
+    public void testGetInstrumentCandles() {
+        String start = "2018-10-24T07:10:00.000Z";
+        String end = "2018-10-24T07:20:00.000Z";
+        JSONArray array = marketAPIService.getInstrumentCandles(instrument_id, start, end, 180L);
+        toResultString(LOG, "Instrument-Candles", array);
+    }
+
+    @Test
+    public void testGetInstrumentIndex() {
+        Index index = marketAPIService.getInstrumentIndex(instrument_id);
+        toResultString(LOG, "Instrument-Book", index);
+    }
+
+    @Test
+    public void testGetInstrumentEstimatedPrice() {
+        EstimatedPrice estimatedPrice = marketAPIService.getInstrumentEstimatedPrice(instrument_id);
+        toResultString(LOG, "Instrument-Estimated-Price", estimatedPrice);
+    }
+
+    @Test
+    public void testGetInstrumentHolds() {
+        Holds holds = marketAPIService.getInstrumentHolds(instrument_id);
+        toResultString(LOG, "Instrument-Holds", holds);
+    }
+
+    @Test
+    public void testGetInstrumentPriceLimit() {
+        PriceLimit priceLimit = marketAPIService.getInstrumentPriceLimit(instrument_id);
+        toResultString(LOG, "Instrument-Price-Limit", priceLimit);
+    }
+
+    @Test
+    public void testGetInstrumentLiquidation() {
+        List<Liquidation> liquidations = marketAPIService.getInstrumentLiquidation(instrument_id, 1, 0, 0, 2);
+        toResultString(LOG, "Instrument-Liquidation", liquidations);
+    }
+
+    @Test
+    public void testGetMarkPrice() {
+        JSONObject jsonObject = marketAPIService.getMarkPrice(instrument_id);
+        toResultString(LOG, "MarkPrice", jsonObject);
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/futures/FuturesTradeAPITests.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/futures/FuturesTradeAPITests.java
@@ -1,0 +1,193 @@
+package com.okcoin.commons.okex.open.api.test.futures;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.futures.param.CancelOrders;
+import com.okcoin.commons.okex.open.api.bean.futures.param.Order;
+import com.okcoin.commons.okex.open.api.bean.futures.param.Orders;
+import com.okcoin.commons.okex.open.api.bean.futures.param.OrdersItem;
+import com.okcoin.commons.okex.open.api.bean.futures.result.OrderResult;
+import com.okcoin.commons.okex.open.api.enums.FuturesCurrenciesEnum;
+import com.okcoin.commons.okex.open.api.enums.FuturesTransactionTypeEnum;
+import com.okcoin.commons.okex.open.api.service.futures.FuturesTradeAPIService;
+import com.okcoin.commons.okex.open.api.service.futures.impl.FuturesTradeAPIServiceImpl;
+import com.okcoin.commons.okex.open.api.utils.OrderIdUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Futures trade api tests
+ *
+ * @author Tony Tian
+ * @version 1.0.0
+ * @date 2018/3/13 18:21
+ */
+public class FuturesTradeAPITests extends FuturesAPIBaseTests {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FuturesMarketAPITests.class);
+
+    private FuturesTradeAPIService tradeAPIService;
+
+    String currency = FuturesCurrenciesEnum.EOS.name();
+
+    @Before
+    public void before() {
+        config = config();
+        tradeAPIService = new FuturesTradeAPIServiceImpl(config);
+    }
+
+    @Test
+    public void testGetPositions() {
+        JSONObject positions = tradeAPIService.getPositions();
+        toResultString(LOG, "Positions", positions);
+    }
+
+    @Test
+    public void testGetInstrumentPosition() {
+        JSONObject positions = tradeAPIService.getInstrumentPosition(instrument_id);
+        toResultString(LOG, "Instrument-Position", positions);
+    }
+
+    @Test
+    public void testGetAccounts() {
+        JSONObject accounts = tradeAPIService.getAccounts();
+        toResultString(LOG, "Accounts", accounts);
+    }
+
+    @Test
+    public void testGetAccountsByCurrency() {
+        JSONObject accountsByCurrency = tradeAPIService.getAccountsByCurrency(currency);
+        toResultString(LOG, "Accounts-Currency", accountsByCurrency);
+    }
+
+    @Test
+    public void testGetAccountsLedgerByCurrency() {
+        JSONArray ledger = tradeAPIService.getAccountsLedgerByCurrency(currency);
+        toResultString(LOG, "Ledger", ledger);
+    }
+
+    @Test
+    public void testGetAccountsHoldsByinstrument_id() {
+        JSONObject ledger = tradeAPIService.getAccountsHoldsByInstrumentId(instrument_id);
+        toResultString(LOG, "Ledger", ledger);
+    }
+
+    @Test
+    public void testOrder() {
+        Order order = new Order();
+        order.setinstrument_id(instrument_id);
+        order.setClient_oid(OrderIdUtils.generator());
+        order.setType(FuturesTransactionTypeEnum.OPEN_SHORT.code());
+        order.setPrice(10000D);
+        order.setSize(1);
+        order.setMatch_price(0);
+        order.setLeverage(10D);
+        OrderResult result = tradeAPIService.order(order);
+        toResultString(LOG, "New-Order", result);
+    }
+
+    @Test
+    public void testOrders() {
+        Orders orders = new Orders();
+        orders.setinstrument_id(instrument_id);
+        orders.setLeverage(10.0);
+
+        List<OrdersItem> orders_data = new ArrayList<>();
+
+        OrdersItem item1 = new OrdersItem();
+        item1.setClient_oid(OrderIdUtils.generator());
+        item1.setType(FuturesTransactionTypeEnum.OPEN_SHORT.code());
+        item1.setPrice(0.647);
+        item1.setSize(1);
+        item1.setMatch_price(1);
+
+        OrdersItem item2 = new OrdersItem();
+        item2.setClient_oid(OrderIdUtils.generator());
+        item2.setType(FuturesTransactionTypeEnum.OPEN_SHORT.code());
+        item2.setPrice(0.646);
+        item2.setSize(1);
+        item2.setMatch_price(1);
+
+        OrdersItem item3 = new OrdersItem();
+        item3.setClient_oid(OrderIdUtils.generator());
+        item3.setType(FuturesTransactionTypeEnum.OPEN_SHORT.code());
+        item3.setPrice(0.646);
+        item3.setSize(1);
+        item3.setMatch_price(1);
+
+        orders_data.add(item1);
+        orders_data.add(item2);
+        orders_data.add(item3);
+
+        orders.setOrders_data(orders_data);
+
+        JSONObject result = tradeAPIService.orders(orders);
+        toResultString(LOG, "Batch-Orders", result);
+    }
+
+    @Test
+    public void testGetOrders() {
+        int status = 0;
+        JSONObject result = tradeAPIService.getOrders(instrument_id, status, 1, 2, 3);
+        toResultString(LOG, "Get-Orders", result);
+    }
+
+    @Test
+    public void testGetOrder() {
+        long orderId = 1692325459303424L;
+        JSONObject result = tradeAPIService.getOrder(instrument_id, orderId);
+        toResultString(LOG, "Get-Order", result);
+    }
+
+    @Test
+    public void testCancelOrder() {
+        long orderId = 1692325459303424L;
+        JSONObject result = tradeAPIService.cancelOrder(instrument_id, orderId);
+        toResultString(LOG, "Cancel-Instrument-Order", result);
+    }
+
+    @Test
+    public void testCancelOrders() {
+        CancelOrders cancelOrders = new CancelOrders();
+        List<Long> list = new ArrayList<>();
+        list.add(1685508253675520L);
+        list.add(1685508253675520L);
+        list.add(1707122518266880L);
+        list.add(1707122518266880L);
+        cancelOrders.setOrder_ids(list);
+        JSONObject result = tradeAPIService.cancelOrders(instrument_id, cancelOrders);
+        toResultString(LOG, "Cancel-Instrument-Orders", result);
+    }
+
+    @Test
+    public void testGetFills() {
+        long orderId = 1707122518266880L;
+        JSONArray result = tradeAPIService.getFills(instrument_id, orderId, from, to, 2);
+        toResultString(LOG, "Get-Fills", result);
+    }
+
+    @Test
+    public void testGetLeverRate() {
+        JSONObject jsonObject = tradeAPIService.getInstrumentLeverRate(currency);
+        toResultString(LOG, "LeverRate", jsonObject);
+    }
+
+    @Test
+    public void testChangelevelRate() {
+        JSONObject jsonObject = tradeAPIService.changeLevelRate(currency, instrument_id, "short", 20);
+        toResultString(LOG, "LeverRate", jsonObject);
+    }
+
+    @Test
+    public void testquancangChangelevelRate() {
+        JSONObject jsonObject = tradeAPIService.changequancangLevelRate(currency, 20);
+        toResultString(LOG, "LeverRate", jsonObject);
+    }
+
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/spot/MarginAccountAPITest.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/spot/MarginAccountAPITest.java
@@ -1,0 +1,121 @@
+package com.okcoin.commons.okex.open.api.test.spot;
+
+import com.okcoin.commons.okex.open.api.bean.spot.result.*;
+import com.okcoin.commons.okex.open.api.service.spot.MarginAccountAPIService;
+import com.okcoin.commons.okex.open.api.service.spot.impl.MarginAccountAPIServiceImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+public class MarginAccountAPITest extends SpotAPIBaseTests {
+    private static final Logger LOG = LoggerFactory.getLogger(MarginAccountAPITest.class);
+
+    private MarginAccountAPIService marginAccountAPIService;
+
+    @Before
+    public void before() {
+        this.config = this.config();
+        this.marginAccountAPIService = new MarginAccountAPIServiceImpl(this.config);
+    }
+
+    /**
+     * 账号数据
+     */
+    @Test
+    public void getAccounts() {
+        final List<Map<String, Object>> result = this.marginAccountAPIService.getAccounts();
+        this.toResultString(MarginAccountAPITest.LOG, "result", result);
+    }
+
+    /**
+     * 单个账号数据
+     */
+    @Test
+    public void getAccountsByProductId() {
+        final Map<String, Object> result = this.marginAccountAPIService.getAccountsByProductId("eth-usdt");
+        this.toResultString(MarginAccountAPITest.LOG, "result", result);
+    }
+
+    /**
+     * 账单流水
+     */
+    @Test
+    public void getLedger() {
+        final List<UserMarginBillDto> result = this.marginAccountAPIService.getLedger(
+                "eth-usdt", "2",
+                "1", null, "1");
+        this.toResultString(MarginAccountAPITest.LOG, "result", result);
+    }
+
+    /**
+     * 全部币对杠杆配置信息
+     */
+    @Test
+    public void getAvailability() {
+        final List<Map<String, Object>> result = this.marginAccountAPIService.getAvailability();
+        this.toResultString(MarginAccountAPITest.LOG, "result", result);
+    }
+
+    /**
+     * 单个币对杠杆配置信息
+     */
+    @Test
+    public void getAvailabilityByProductId() {
+        final List<Map<String, Object>> result = this.marginAccountAPIService.getAvailabilityByProductId("lTC-usdt");
+        this.toResultString(MarginAccountAPITest.LOG, "result", result);
+    }
+
+
+    /**
+     * 借币记录
+     */
+    @Test
+    public void getBorrowedAccounts() {
+        final List<MarginBorrowOrderDto> result = this.marginAccountAPIService.getBorrowedAccounts("0", null, null, "2");
+        this.toResultString(MarginAccountAPITest.LOG, "result", result);
+    }
+
+    /**
+     * 单个账号借币
+     */
+    @Test
+    public void getBorrowedAccountsByProductId() {
+        final List<MarginBorrowOrderDto> result = this.marginAccountAPIService.getBorrowedAccountsByProductId("lTC_usdt", null, null, "2", "0");
+        this.toResultString(MarginAccountAPITest.LOG, "result", result);
+    }
+    /**
+     * 借币
+     */
+    @Test
+    public void borrow_1() {
+        final BorrowRequestDto dto = new BorrowRequestDto();
+        dto.setAmount("10");
+        dto.setCurrency("usdt");
+        dto.setInstrument_id("ltc_usdt");
+        final BorrowResult result = this.marginAccountAPIService.borrow_1(dto);
+        this.toResultString(MarginAccountAPITest.LOG, "result", result);
+    }
+
+    /**
+     * 还币
+     */
+    @Test
+    public void repayment_1() {
+        for (int i = 0; i < 3; i++) {
+            System.out.println("========= i=" + i);
+            final RepaymentRequestDto dto = new RepaymentRequestDto();
+            dto.setAmount("1");
+            dto.setBorrow_id("185778");
+            dto.setCurrency("usdt");
+            dto.setInstrument_id("ltc_usdt");
+            final RepaymentResult result = this.marginAccountAPIService.repayment_1(dto);
+            this.toResultString(MarginAccountAPITest.LOG, "result", result);
+        }
+
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/spot/MarginOrderAPITest.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/spot/MarginOrderAPITest.java
@@ -1,0 +1,188 @@
+package com.okcoin.commons.okex.open.api.test.spot;
+
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.spot.param.OrderParamDto;
+import com.okcoin.commons.okex.open.api.bean.spot.param.PlaceOrderParam;
+import com.okcoin.commons.okex.open.api.bean.spot.result.Fills;
+import com.okcoin.commons.okex.open.api.bean.spot.result.OrderInfo;
+import com.okcoin.commons.okex.open.api.bean.spot.result.OrderResult;
+import com.okcoin.commons.okex.open.api.service.spot.MarginOrderAPIService;
+import com.okcoin.commons.okex.open.api.service.spot.impl.MarginOrderAPIServiceImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class MarginOrderAPITest extends SpotAPIBaseTests {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MarginOrderAPITest.class);
+
+    private MarginOrderAPIService marginOrderAPIService;
+
+    @Before
+    public void before() {
+        this.config = this.config();
+        this.marginOrderAPIService = new MarginOrderAPIServiceImpl(this.config);
+    }
+
+    /**
+     * 单个下单
+     */
+    @Test
+    public void addOrder() {
+        final PlaceOrderParam order = new PlaceOrderParam();
+        order.setClient_oid("20180910-1");
+        order.setInstrument_id("btc-usdt");
+        order.setPrice("10000");
+        order.setType("limit");
+        order.setSide("sell");
+        order.setSize("0.1");
+        order.setMargin_trading((byte) 2);
+
+        final OrderResult orderResult = this.marginOrderAPIService.addOrder(order);
+        this.toResultString(MarginOrderAPITest.LOG, "orders", orderResult);
+    }
+
+    /**
+     * 批量下单
+     */
+    @Test
+    public void batchAddOrder() {
+        final PlaceOrderParam order = new PlaceOrderParam();
+        order.setClient_oid("20180728-01");
+        order.setInstrument_id("btc-usdt");
+        order.setPrice("1");
+        order.setType("limit");
+        order.setSide("sell");
+        order.setSize("0.1");
+        order.setMargin_trading((byte) 2);
+
+        final List<PlaceOrderParam> list = new ArrayList<>();
+        list.add(order);
+
+        final PlaceOrderParam order1 = new PlaceOrderParam();
+        order1.setClient_oid("20180728-02");
+        order1.setInstrument_id("ltc-usdt");
+        order1.setPrice("1");
+        order1.setType("limit");
+        order1.setSide("sell");
+        order1.setSize("0.1");
+        list.add(order1);
+
+        final Map<String, List<OrderResult>> orderResult = this.marginOrderAPIService.addOrders(list);
+        this.toResultString(MarginOrderAPITest.LOG, "orders", orderResult);
+    }
+
+    /**
+     * 指定订单id撤单 delete协议 暂不使用
+     */
+    @Test
+    public void cancleOrderByProductIdAndOrderId() {
+        final PlaceOrderParam order = new PlaceOrderParam();
+        order.setInstrument_id("btc_usd");
+        order.setClient_oid("20181009-01");
+        final OrderResult orderResult = this.marginOrderAPIService.cancleOrderByOrderId(order, "23850");
+        this.toResultString(MarginOrderAPITest.LOG, "cancleOrder", orderResult);
+    }
+
+    /**
+     * 指定订单id撤单 post协议
+     */
+    @Test
+    public void cancleOrderByProductIdAndOrderId_post() {
+        final PlaceOrderParam order = new PlaceOrderParam();
+        order.setInstrument_id("btc_usdt");
+        order.setClient_oid("20181009-01");
+        final OrderResult orderResult = this.marginOrderAPIService.cancleOrderByOrderId_post(order, "23850");
+        this.toResultString(MarginOrderAPITest.LOG, "cancleOrder", orderResult);
+    }
+
+    /**
+     * 批量撤单 delete协议 暂不使用
+     */
+    @Test
+    public void batchCancleOrders() {
+        final List<OrderParamDto> cancleOrders = new ArrayList<>();
+
+        final OrderParamDto dto = new OrderParamDto();
+        dto.setInstrument_id("btc-usdt");
+        final List<Long> order_ids = new ArrayList<>();
+        order_ids.add(23464L);
+        order_ids.add(23465L);
+        dto.setOrder_ids(order_ids);
+        cancleOrders.add(dto);
+
+        final OrderParamDto dto1 = new OrderParamDto();
+        dto1.setInstrument_id("etc_usdt");
+        cancleOrders.add(dto1);
+
+        final Map<String, JSONObject> orderResult = this.marginOrderAPIService.cancleOrders(cancleOrders);
+        this.toResultString(MarginOrderAPITest.LOG, "cancleOrders", orderResult);
+    }
+
+    /**
+     * 批量撤单 post协议
+     */
+    @Test
+    public void batchCancleOrders_post() {
+        final List<OrderParamDto> cancleOrders = new ArrayList<>();
+
+        final OrderParamDto dto = new OrderParamDto();
+        dto.setInstrument_id("btc-usd");
+        final List<Long> order_ids = new ArrayList<>();
+        order_ids.add(23464L);
+        order_ids.add(23465L);
+        order_ids.add(23465L);
+        order_ids.add(23465L);
+        order_ids.add(23465L);
+        dto.setOrder_ids(order_ids);
+        cancleOrders.add(dto);
+
+//        final OrderParamDto dto1 = new OrderParamDto();
+//        dto1.setInstrument_id("etc_usdt");
+//        cancleOrders.add(dto1);
+
+        final Map<String, JSONObject> orderResult = this.marginOrderAPIService.cancleOrders_post(cancleOrders);
+        this.toResultString(MarginOrderAPITest.LOG, "cancleOrders", orderResult);
+    }
+
+    /**
+     * 指定订单查询订单详情
+     */
+    @Test
+    public void getOrderByProductIdAndOrderId() {
+        final OrderInfo orderInfo = this.marginOrderAPIService.getOrderByProductIdAndOrderId("btc-usdt", "23844");
+        this.toResultString(MarginOrderAPITest.LOG, "orderInfo", orderInfo);
+    }
+
+    /**
+     * 根据状态查询订单
+     */
+    @Test
+    public void getOrders() {
+        final List<OrderInfo> orderInfoList = this.marginOrderAPIService.getOrders("eth_usdt", "open", null, null, "3");
+        this.toResultString(MarginOrderAPITest.LOG, "orderInfoList", orderInfoList);
+    }
+
+    /**
+     * 查询全部挂单
+     */
+    @Test
+    public void getPendingOrders() {
+        final List<OrderInfo> orderInfoList = this.marginOrderAPIService.getPendingOrders(null, null, null, null);
+        this.toResultString(MarginOrderAPITest.LOG, "orderInfoList", orderInfoList);
+    }
+
+    /**
+     * 查询订单交易信息
+     */
+    @Test
+    public void getFills() {
+        final List<Fills> fills = this.marginOrderAPIService.getFills("23855", "btc-usd", null, null, "1");
+        this.toResultString(MarginOrderAPITest.LOG, "fills", fills);
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/spot/SpotAPIBaseTests.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/spot/SpotAPIBaseTests.java
@@ -1,0 +1,24 @@
+package com.okcoin.commons.okex.open.api.test.spot;
+
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.enums.I18nEnum;
+import com.okcoin.commons.okex.open.api.test.BaseTests;
+
+public class SpotAPIBaseTests extends BaseTests {
+
+    public APIConfiguration config() {
+        final APIConfiguration config = new APIConfiguration();
+
+        config.setEndpoint("https://www.okex.com/");
+        // apiKey，api注册成功后页面上有
+        config.setApiKey("");
+        // secretKey，api注册成功后页面上有
+        config.setSecretKey("");
+        config.setPassphrase("");
+        config.setPrint(true);
+        config.setI18n(I18nEnum.SIMPLIFIED_CHINESE);
+
+        return config;
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/spot/SpotAccountAPITest.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/spot/SpotAccountAPITest.java
@@ -1,0 +1,71 @@
+package com.okcoin.commons.okex.open.api.test.spot;
+
+
+import com.okcoin.commons.okex.open.api.bean.spot.result.Account;
+import com.okcoin.commons.okex.open.api.bean.spot.result.Ledger;
+import com.okcoin.commons.okex.open.api.bean.spot.result.ServerTimeDto;
+import com.okcoin.commons.okex.open.api.service.spot.SpotAccountAPIService;
+import com.okcoin.commons.okex.open.api.service.spot.impl.SpotAccountAPIServiceImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+public class SpotAccountAPITest extends SpotAPIBaseTests {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SpotAccountAPITest.class);
+
+    private SpotAccountAPIService spotAccountAPIService;
+
+    @Before
+    public void before() {
+        this.config = this.config();
+        this.spotAccountAPIService = new SpotAccountAPIServiceImpl(this.config);
+    }
+
+    @Test
+    public void time() {
+        final ServerTimeDto serverTimeDto = this.spotAccountAPIService.time();
+        this.toResultString(SpotAccountAPITest.LOG, "time", serverTimeDto);
+        System.out.println(serverTimeDto.getEpoch());
+        System.out.println(serverTimeDto.getIso());
+    }
+
+    @Test
+    public void getMiningData() {
+        final Map<String, Object> miningdata = this.spotAccountAPIService.getMiningData();
+        this.toResultString(SpotAccountAPITest.LOG, "miningdata", miningdata);
+    }
+
+    /**
+     * 账户信息
+     */
+    @Test
+    public void getAccounts() {
+        final List<Account> accounts = this.spotAccountAPIService.getAccounts();
+        this.toResultString(SpotAccountAPITest.LOG, "accounts", accounts);
+    }
+
+    /**
+     * 单一账户信息
+     */
+    @Test
+    public void getAccountByCurrency() {
+        final Account account = this.spotAccountAPIService.getAccountByCurrency("btc");
+        this.toResultString(SpotAccountAPITest.LOG, "account", account);
+    }
+
+    /**
+     * 账单流水
+     */
+    @Test
+    public void getLedgersByCurrency() {
+        final List<Ledger> ledgers = this.spotAccountAPIService.getLedgersByCurrency("usdt", null, null, "2");
+        this.toResultString(SpotAccountAPITest.LOG, "ledges", ledgers);
+    }
+
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/spot/SpotOrderAPITest.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/spot/SpotOrderAPITest.java
@@ -1,0 +1,204 @@
+package com.okcoin.commons.okex.open.api.test.spot;
+
+import com.okcoin.commons.okex.open.api.bean.spot.param.OrderParamDto;
+import com.okcoin.commons.okex.open.api.bean.spot.param.PlaceOrderParam;
+import com.okcoin.commons.okex.open.api.bean.spot.result.BatchOrdersResult;
+import com.okcoin.commons.okex.open.api.bean.spot.result.Fills;
+import com.okcoin.commons.okex.open.api.bean.spot.result.OrderInfo;
+import com.okcoin.commons.okex.open.api.bean.spot.result.OrderResult;
+import com.okcoin.commons.okex.open.api.service.spot.SpotOrderAPIServive;
+import com.okcoin.commons.okex.open.api.service.spot.impl.SpotOrderApiServiceImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class SpotOrderAPITest extends SpotAPIBaseTests {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SpotOrderAPITest.class);
+
+    private SpotOrderAPIServive spotOrderAPIServive;
+
+    @Before
+    public void before() {
+        this.config = this.config();
+        this.spotOrderAPIServive = new SpotOrderApiServiceImpl(this.config);
+    }
+
+    /**
+     * 下单
+     */
+    @Test
+    public void addOrder() {
+        for (int i = 0; i < 1; i++) {
+            final long st = System.currentTimeMillis();
+
+            final PlaceOrderParam order = new PlaceOrderParam();
+            order.setClient_oid("20180728");
+            order.setInstrument_id("btc-usdt");
+            order.setPrice("20000");
+            order.setType("limit");
+            order.setSide("sell");
+            order.setSize("0.001");
+            order.setMargin_trading((byte) 1);
+            final OrderResult orderResult = this.spotOrderAPIServive.addOrder(order);
+            this.toResultString(SpotOrderAPITest.LOG, "orders", orderResult);
+
+            final PlaceOrderParam order1 = new PlaceOrderParam();
+            order1.setInstrument_id("btc-usdt");
+            order1.setClient_oid("1234545");
+            final String orderId = orderResult.getOrder_id().toString();
+            final OrderResult orderResult1 = this.spotOrderAPIServive.cancleOrderByOrderId_post(order, orderId);
+            this.toResultString(SpotOrderAPITest.LOG, "cancleOrder", orderResult1);
+            System.out.println("================ i=" + i + ", st=" + (System.currentTimeMillis() - st));
+
+//            try {
+//                Thread.sleep(100);
+//            } catch (final InterruptedException e) {
+//                e.printStackTrace();
+//            }
+        }
+    }
+
+    /**
+     * 批量下单
+     */
+    @Test
+    public void batchAddOrder() {
+        final List<PlaceOrderParam> list = new ArrayList<>();
+
+        final PlaceOrderParam order = new PlaceOrderParam();
+        order.setClient_oid("20180918");
+        order.setInstrument_id("btc-usdt");
+        order.setPrice("10001");
+        order.setType("limit");
+        order.setSide("sell");
+        order.setSize("0.01");
+        list.add(order);
+
+        final PlaceOrderParam order1 = new PlaceOrderParam();
+        order1.setClient_oid("20180917");
+        order1.setInstrument_id("btc-usdt");
+        order1.setPrice("10002");
+        order1.setType("limit");
+        order1.setSide("sell");
+        order1.setSize("0.01");
+        list.add(order1);
+
+        final Map<String, List<OrderResult>> orderResult = this.spotOrderAPIServive.addOrders(list);
+        this.toResultString(SpotOrderAPITest.LOG, "orders", orderResult);
+    }
+
+    /**
+     * 撤销指定订单 delete协议 暂不使用
+     */
+    @Test
+    public void cancleOrderByOrderId() {
+        final PlaceOrderParam order = new PlaceOrderParam();
+        order.setInstrument_id("btc-usdt");
+        order.setClient_oid("1234545");
+        final OrderResult orderResult = this.spotOrderAPIServive.cancleOrderByOrderId(order, "1644664675964928");
+        this.toResultString(SpotOrderAPITest.LOG, "cancleOrder", orderResult);
+    }
+
+    /**
+     * 撤销指定订单 post协议
+     */
+    @Test
+    public void cancleOrderByOrderId_post() {
+        final PlaceOrderParam order = new PlaceOrderParam();
+        order.setInstrument_id("btc-usdt");
+        order.setClient_oid("1234545");
+        final OrderResult orderResult = this.spotOrderAPIServive.cancleOrderByOrderId_post(order, "1644664675964928");
+        this.toResultString(SpotOrderAPITest.LOG, "cancleOrder", orderResult);
+    }
+
+    /**
+     * 批量撤单 delete协议 暂不使用
+     */
+    @Test
+    public void batchCancleOrders() {
+        final List<OrderParamDto> cancleOrders = new ArrayList<>();
+
+        final OrderParamDto dto = new OrderParamDto();
+        dto.setInstrument_id("btc-usdt");
+        final List<Long> order_ids = new ArrayList<>();
+//        order_ids.add(1600593327162368L);
+        dto.setOrder_ids(order_ids);
+        cancleOrders.add(dto);
+
+//        final OrderParamDto dto1 = new OrderParamDto();
+//        dto1.setInstrument_id("etc_usdt");
+//        cancleOrders.add(dto1);
+
+        final Map<String, BatchOrdersResult> orderResult = this.spotOrderAPIServive.cancleOrders(cancleOrders);
+        this.toResultString(SpotOrderAPITest.LOG, "cancleOrders", orderResult);
+    }
+
+    /**
+     * 批量撤单 post协议
+     */
+    @Test
+    public void batchCancleOrders_post() {
+        final List<OrderParamDto> cancleOrders = new ArrayList<>();
+
+        final OrderParamDto dto = new OrderParamDto();
+        dto.setInstrument_id("btc-usdt");
+        final List<Long> order_ids = new ArrayList<>();
+//        order_ids.add(1600593327162368L);
+//        order_ids.add(1600593327162369L);
+//        order_ids.add(1600593327162364L);
+//        order_ids.add(1600593327162363L);
+//        order_ids.add(1600593327162362L);
+        dto.setOrder_ids(order_ids);
+        cancleOrders.add(dto);
+
+//        final OrderParamDto dto1 = new OrderParamDto();
+//        dto1.setInstrument_id("etc_usdt");
+//        cancleOrders.add(dto1);
+
+        final Map<String, BatchOrdersResult> orderResult = this.spotOrderAPIServive.cancleOrders_post(cancleOrders);
+        this.toResultString(SpotOrderAPITest.LOG, "cancleOrders", orderResult);
+    }
+
+    /**
+     * 获取指定订单信息
+     */
+    @Test
+    public void getOrderByOrderId() {
+        final OrderInfo orderInfo = this.spotOrderAPIServive.getOrderByOrderId("bTC-USDT", "1673831663603712");
+        this.toResultString(SpotOrderAPITest.LOG, "orderInfo", orderInfo);
+    }
+
+    /**
+     * 查询订单列表
+     */
+    @Test
+    public void getOrders() {
+        final List<OrderInfo> orderInfoList = this.spotOrderAPIServive.getOrders("Btc-usdT", "all", null, null, "2");
+            this.toResultString(SpotOrderAPITest.LOG, "orderInfoList", orderInfoList);
+    }
+
+    /**
+     * 批量查询挂单
+     */
+    @Test
+    public void getPendingOrders() {
+        final List<OrderInfo> orderInfoList = this.spotOrderAPIServive.getPendingOrders(null, null, "3", null);
+        this.toResultString(SpotOrderAPITest.LOG, "orderInfoList", orderInfoList);
+    }
+
+    /**
+     * 成交明细
+     */
+    @Test
+    public void getFills() {
+        final List<Fills> fillsList = this.spotOrderAPIServive.getFills("23852", "btc-usdt", null, null, "2");
+        this.toResultString(SpotOrderAPITest.LOG, "fillsList", fillsList);
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/spot/SpotProductAPITest.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/spot/SpotProductAPITest.java
@@ -1,0 +1,88 @@
+package com.okcoin.commons.okex.open.api.test.spot;
+
+import com.okcoin.commons.okex.open.api.bean.spot.result.*;
+import com.okcoin.commons.okex.open.api.service.spot.SpotProductAPIService;
+import com.okcoin.commons.okex.open.api.service.spot.impl.SpotProductAPIServiceImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class SpotProductAPITest extends SpotAPIBaseTests {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SpotProductAPITest.class);
+
+    private SpotProductAPIService spotProductAPIService;
+
+    @Before
+    public void before() {
+        this.config = this.config();
+        this.spotProductAPIService = new SpotProductAPIServiceImpl(this.config);
+    }
+
+    /**
+     * 币对信息
+     */
+    @Test
+    public void getProducts() {
+        final List<Product> products = this.spotProductAPIService.getProducts();
+        this.toResultString(SpotProductAPITest.LOG, "products", products);
+    }
+
+    /**
+     * 深度数据
+     */
+    @Test
+    public void bookProductsByProductId() {
+        for (int i = 0; i < 1; i++) {
+            final Book book = this.spotProductAPIService.bookProductsByProductId("BTC-usdt", "10", null);
+            this.toResultString(SpotProductAPITest.LOG, "book", book);
+            System.out.println("==========i=" + i);
+            try {
+                Thread.sleep(400);
+            } catch (final InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    /**
+     * 全部ticker数据
+     */
+    @Test
+    public void getTickers() {
+        final List<Ticker> tickers = this.spotProductAPIService.getTickers();
+        this.toResultString(SpotProductAPITest.LOG, "tickers", tickers);
+
+    }
+
+    /**
+     * 单个币对ticker数据
+     */
+    @Test
+    public void getTickerByProductId() {
+        final Ticker ticker = this.spotProductAPIService.getTickerByProductId("btc-USDt");
+        this.toResultString(SpotProductAPITest.LOG, "ticker", ticker);
+    }
+
+    /**
+     * 成交数据
+     */
+    @Test
+    public void getTrades() {
+        final List<Trade> trades = this.spotProductAPIService.getTrades("btc-USDt", null, null, "2");
+        this.toResultString(SpotProductAPITest.LOG, "trades", trades);
+    }
+
+    /**
+     * Kline数据
+     */
+    @Test
+    public void getCandles() {
+        final List<KlineDto> klines = this.spotProductAPIService.getCandles("BTC-usdt", "60", null, null);
+        this.toResultString(SpotProductAPITest.LOG, "klines", klines);
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/swap/SwapBaseTest.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/swap/SwapBaseTest.java
@@ -1,0 +1,28 @@
+package com.okcoin.commons.okex.open.api.test.swap;
+
+import com.okcoin.commons.okex.open.api.config.APIConfiguration;
+import com.okcoin.commons.okex.open.api.enums.I18nEnum;
+
+public class SwapBaseTest {
+    public APIConfiguration config;
+
+    public APIConfiguration config() {
+        APIConfiguration config = new APIConfiguration();
+
+        config.setEndpoint("http:");
+        config.setApiKey("");
+        config.setSecretKey("");
+
+        config.setPassphrase("");
+        config.setPrint(true);
+        config.setI18n(I18nEnum.SIMPLIFIED_CHINESE);
+
+        return config;
+    }
+
+    int from = 0;
+    int to = 0;
+    int limit = 20;
+
+    String instrument_id = "BTC-USD-SWAP";
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/swap/SwapMarketTest.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/swap/SwapMarketTest.java
@@ -1,0 +1,171 @@
+package com.okcoin.commons.okex.open.api.test.swap;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.swap.result.*;
+import com.okcoin.commons.okex.open.api.service.swap.SwapMarketAPIService;
+import com.okcoin.commons.okex.open.api.service.swap.impl.SwapMarketAPIServiceImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+public class SwapMarketTest extends SwapBaseTest {
+    private SwapMarketAPIService swapMarketAPIService;
+
+    @Before
+    public void before() {
+        config = config();
+        swapMarketAPIService = new SwapMarketAPIServiceImpl(config);
+    }
+
+
+    @Test
+    public void getContractsApi() {
+        String contractsApi = swapMarketAPIService.getContractsApi();
+        if (contractsApi.startsWith("{")) {
+            System.out.println(contractsApi);
+        } else {
+            List<ApiContractVO> list = JSONArray.parseArray(contractsApi, ApiContractVO.class);
+            System.out.println(contractsApi);
+            list.forEach(contract -> System.out.println(contract.getInstrument_id()));
+        }
+    }
+
+    @Test
+    public void getDepthApi() {
+        String depthApi = swapMarketAPIService.getDepthApi(instrument_id, "1");
+        DepthVO depthVO = JSONObject.parseObject(depthApi, DepthVO.class);
+        System.out.println(depthVO.getAsks());
+    }
+
+
+    @Test
+    public void getTickersApi() {
+        String tickersApi = swapMarketAPIService.getTickersApi();
+        if (tickersApi.startsWith("{")) {
+            System.out.println(tickersApi);
+        } else {
+            List<ApiTickerVO> list = JSONArray.parseArray(tickersApi, ApiTickerVO.class);
+            list.forEach(vo -> System.out.println(vo.getInstrument_id()));
+            System.out.println(tickersApi);
+        }
+    }
+
+
+    @Test
+    public void getTickerApi() {
+        String tickerApi = swapMarketAPIService.getTickerApi(instrument_id);
+        ApiTickerVO apiTickerVO = JSONObject.parseObject(tickerApi, ApiTickerVO.class);
+        System.out.println(tickerApi);
+        System.out.println(apiTickerVO.getInstrument_id());
+    }
+
+
+    @Test
+    public void getTradesApi() {
+        String tradesApi = swapMarketAPIService.getTradesApi(instrument_id, null, null, null);
+        if (tradesApi.startsWith("{")) {
+            System.out.println(tradesApi);
+        } else {
+            List<ApiDealVO> apiDealVOS = JSONArray.parseArray(tradesApi, ApiDealVO.class);
+            apiDealVOS.forEach(vo -> System.out.println(vo.getTimestamp()));
+            System.out.println(tradesApi);
+        }
+    }
+
+
+    @Test
+    public void getCandlesApi() {
+        String candlesApi = swapMarketAPIService.getCandlesApi(instrument_id, null, null, "60");
+        candlesApi = candlesApi.replaceAll("\\[", "\\{");
+        if (candlesApi.lastIndexOf("\\]") != candlesApi.length()) {
+            candlesApi = candlesApi.replace("\\]", "\\}");
+        }
+        if (candlesApi.startsWith("{")) {
+            System.out.println(candlesApi);
+        } else {
+            List<ApiKlineVO> apiKlineVOS = JSONArray.parseArray(candlesApi, ApiKlineVO.class);
+            apiKlineVOS.forEach(vo -> System.out.println(vo.getTimestamp()));
+            System.out.println(candlesApi);
+        }
+
+    }
+
+
+    @Test
+    public void getIndexApi() {
+        String indexApi = swapMarketAPIService.getIndexApi(instrument_id);
+        ApiIndexVO apiIndexVO = JSONObject.parseObject(indexApi, ApiIndexVO.class);
+        System.out.println(indexApi);
+        System.out.println(apiIndexVO);
+    }
+
+
+    @Test
+    public void getRateApi() {
+        String rateApi = swapMarketAPIService.getRateApi();
+        ApiRateVO apiRateVO = JSONObject.parseObject(rateApi, ApiRateVO.class);
+        System.out.println(apiRateVO.getInstrument_id());
+        System.out.println(rateApi);
+    }
+
+
+    @Test
+    public void getOpenInterestApi() {
+        String openInterestApi = swapMarketAPIService.getOpenInterestApi(instrument_id);
+        ApiOpenInterestVO apiOpenInterestVO = JSONObject.parseObject(openInterestApi, ApiOpenInterestVO.class);
+        System.out.println(apiOpenInterestVO.getTimestamp());
+        System.out.println(openInterestApi);
+    }
+
+
+    @Test
+    public void getPriceLimitApi() {
+        String priceLimitApi = swapMarketAPIService.getPriceLimitApi(instrument_id);
+        ApiPriceLimitVO apiPriceLimitVO = JSONObject.parseObject(priceLimitApi, ApiPriceLimitVO.class);
+        System.out.println(apiPriceLimitVO);
+        System.out.println(priceLimitApi);
+    }
+
+
+    @Test
+    public void getLiquidationApi() {
+        String liquidationApi = swapMarketAPIService.getLiquidationApi(instrument_id, "1", "1", "", "10");
+        if (liquidationApi.startsWith("{")) {
+            System.out.println(liquidationApi);
+        } else {
+            List<ApiLiquidationVO> apiLiquidationVOS = JSONArray.parseArray(liquidationApi, ApiLiquidationVO.class);
+            apiLiquidationVOS.forEach(vo -> System.out.println(vo.getInstrument_id()));
+        }
+    }
+
+
+    @Test
+    public void getFundingTimeApi() {
+        String fundingTimeApi = swapMarketAPIService.getFundingTimeApi(instrument_id);
+        ApiFundingTimeVO apiFundingTimeVO = JSONObject.parseObject(fundingTimeApi, ApiFundingTimeVO.class);
+        System.out.println(apiFundingTimeVO.getInstrument_id());
+    }
+
+
+    @Test
+    public void getHistoricalFundingRateApi() {
+        String historicalFundingRateApi = swapMarketAPIService.getHistoricalFundingRateApi(instrument_id, "1", "", "10");
+        if (historicalFundingRateApi.startsWith("{")) {
+            System.out.println(historicalFundingRateApi);
+        } else {
+            List<ApiFundingRateVO> apiFundingRateVOS = JSONArray.parseArray(historicalFundingRateApi, ApiFundingRateVO.class);
+            apiFundingRateVOS.forEach(vo -> System.out.println(vo.getFunding_rate()));
+        }
+    }
+
+
+    @Test
+    public void getMarkPriceApi() {
+        String markPriceApi = swapMarketAPIService.getMarkPriceApi(instrument_id);
+        ApiMarkPriceVO apiMarkPriceVO = JSONObject.parseObject(markPriceApi, ApiMarkPriceVO.class);
+        System.out.println(apiMarkPriceVO.getInstrument_id());
+    }
+
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/swap/SwapTradeTest.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/swap/SwapTradeTest.java
@@ -1,0 +1,71 @@
+package com.okcoin.commons.okex.open.api.test.swap;
+
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.swap.param.PpBatchOrder;
+import com.okcoin.commons.okex.open.api.bean.swap.param.PpCancelOrderVO;
+import com.okcoin.commons.okex.open.api.bean.swap.param.PpOrder;
+import com.okcoin.commons.okex.open.api.bean.swap.param.PpOrders;
+import com.okcoin.commons.okex.open.api.bean.swap.result.ApiCancelOrderVO;
+import com.okcoin.commons.okex.open.api.bean.swap.result.ApiOrderResultVO;
+import com.okcoin.commons.okex.open.api.bean.swap.result.ApiOrderVO;
+import com.okcoin.commons.okex.open.api.bean.swap.result.OrderCancelResult;
+import com.okcoin.commons.okex.open.api.service.swap.SwapTradeAPIService;
+import com.okcoin.commons.okex.open.api.service.swap.impl.SwapTradeAPIServiceImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class SwapTradeTest extends SwapBaseTest {
+    private SwapTradeAPIService tradeAPIService;
+
+    @Before
+    public void before() {
+        config = config();
+        tradeAPIService = new SwapTradeAPIServiceImpl(config);
+    }
+
+    @Test
+    public void order() {
+        PpOrder ppOrder = new PpOrder(null, "1", "1", "1", "", "BTC-USD-SWAP");
+        String jsonObject = tradeAPIService.order(ppOrder);
+        ApiOrderVO apiOrderVO = JSONObject.parseObject(jsonObject, ApiOrderVO.class);
+        System.out.println("success");
+        System.out.println(apiOrderVO.getError_code());
+    }
+
+
+    @Test
+    public void batchOrder() {
+        List<PpBatchOrder> list = new LinkedList<>();
+        list.add(new PpBatchOrder("123qqqq", "2", "1", "0", "5"));
+        list.add(new PpBatchOrder("qwerry", "1", "2", "0", "12"));
+        PpOrders ppOrders = new PpOrders();
+        ppOrders.setInstrument_id(instrument_id);
+        ppOrders.setOrder_data(list);
+        String jsonObject = tradeAPIService.orders(ppOrders);
+        ApiOrderResultVO apiOrderResultVO = JSONObject.parseObject(jsonObject, ApiOrderResultVO.class);
+        System.out.println("success");
+        apiOrderResultVO.getOrder_info().forEach(vo -> System.out.println(vo.getClient_oid()));
+    }
+
+    @Test
+    public void cancelOrder() {
+        String jsonObject = tradeAPIService.cancelOrder(instrument_id, "64-5e-30bc50302-0");
+        ApiCancelOrderVO apiCancelOrderVO = JSONObject.parseObject(jsonObject, ApiCancelOrderVO.class);
+        System.out.println("success");
+        System.out.println(apiCancelOrderVO.getOrder_id());
+    }
+
+    @Test
+    public void batchCancelOrder() {
+        PpCancelOrderVO ppCancelOrderVO = new PpCancelOrderVO();
+        ppCancelOrderVO.getIds().add("");
+        System.out.println(JSONObject.toJSONString(ppCancelOrderVO));
+        String jsonObject = tradeAPIService.cancelOrders(instrument_id, ppCancelOrderVO);
+        OrderCancelResult orderCancelResult = JSONObject.parseObject(jsonObject, OrderCancelResult.class);
+        System.out.println("success");
+        System.out.println(orderCancelResult.getInstrument_id());
+    }
+}

--- a/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/swap/SwapUserTest.java
+++ b/xchange-okcoin/src/okex-java-sdk-api/src/test/java/com/okcoin/commons/okex/open/api/test/swap/SwapUserTest.java
@@ -1,0 +1,109 @@
+package com.okcoin.commons.okex.open.api.test.swap;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.okcoin.commons.okex.open.api.bean.swap.param.LevelRateParam;
+import com.okcoin.commons.okex.open.api.bean.swap.result.ApiAccountsVO;
+import com.okcoin.commons.okex.open.api.bean.swap.result.ApiDealDetailVO;
+import com.okcoin.commons.okex.open.api.bean.swap.result.ApiPositionsVO;
+import com.okcoin.commons.okex.open.api.bean.swap.result.ApiUserRiskVO;
+import com.okcoin.commons.okex.open.api.service.swap.SwapUserAPIServive;
+import com.okcoin.commons.okex.open.api.service.swap.impl.SwapUserAPIServiceImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class SwapUserTest extends SwapBaseTest {
+    private SwapUserAPIServive swapUserAPIServive;
+
+    @Before
+    public void before() {
+        config = config();
+        swapUserAPIServive = new SwapUserAPIServiceImpl(config);
+    }
+
+    @Test
+    public void getPosition() {
+        String jsonObject = swapUserAPIServive.getPosition("LTC-USD-SWAP");
+        ApiPositionsVO apiPositionsVO = JSONObject.parseObject(jsonObject, ApiPositionsVO.class);
+        System.out.println("success");
+        apiPositionsVO.getHolding().forEach(vp -> System.out.println(apiPositionsVO.getMargin_mode()));
+    }
+
+    @Test
+    public void getAccounts() {
+        String jsonObject = swapUserAPIServive.getAccounts();
+        ApiAccountsVO apiAccountsVO = JSONObject.parseObject(jsonObject, ApiAccountsVO.class);
+        System.out.println("success");
+        apiAccountsVO.getInfo().forEach(vo -> System.out.println(vo.getInstrument_id()));
+    }
+
+    @Test
+    public void selectAccount() {
+        String jsonObject = swapUserAPIServive.selectAccount(instrument_id);
+        System.out.println("success");
+        System.out.println(jsonObject);
+
+    }
+
+    @Test
+    public void selectContractSettings() {
+        String jsonObject = swapUserAPIServive.selectContractSettings(instrument_id);
+        ApiUserRiskVO apiUserRiskVO = JSONObject.parseObject(jsonObject, ApiUserRiskVO.class);
+        System.out.println("success");
+        System.out.println(apiUserRiskVO.getInstrument_id());
+    }
+
+    @Test
+    public void updateLevelRate() {
+        LevelRateParam levelRateParam = new LevelRateParam();
+        levelRateParam.setLevelRate(new BigDecimal(1));
+        levelRateParam.setSide(1);
+        String jsonObject = swapUserAPIServive.updateLevelRate(instrument_id, levelRateParam);
+        ApiUserRiskVO apiUserRiskVO = JSONObject.parseObject(jsonObject, ApiUserRiskVO.class);
+        System.out.println("success");
+        System.out.println(apiUserRiskVO.getInstrument_id());
+    }
+
+    @Test
+    public void selectOrders() {
+        String jsonObject = swapUserAPIServive.selectOrders(instrument_id, "1", "", "", "20");
+        System.out.println("success");
+        System.out.println(jsonObject);
+    }
+
+    @Test
+    public void selectOrder() {
+        String jsonObject = swapUserAPIServive.selectOrder(instrument_id, "123123");
+        System.out.println("success");
+        System.out.println(jsonObject);
+    }
+
+    @Test
+    public void selectDealDetail(){
+        String jsonArray = swapUserAPIServive.selectDealDetail(instrument_id,"123123","","","");
+        if(jsonArray.startsWith("{")){
+            System.out.println(jsonArray);
+        }
+        else {
+            List<ApiDealDetailVO> apiDealDetailVOS = JSONArray.parseArray(jsonArray, ApiDealDetailVO.class);
+            apiDealDetailVOS.forEach(vo -> System.out.println(vo.getInstrument_id()));
+        }
+    }
+    @Test
+    public void getLedger() {
+        String jsonArray = swapUserAPIServive.getLedger(instrument_id, "1", "", "30");
+        System.out.println("success");
+        System.out.println(jsonArray);
+    }
+
+    @Test
+    public void getHolds() {
+        String jsonObject = swapUserAPIServive.getHolds(instrument_id);
+        System.out.println("success");
+        System.out.println(jsonObject);
+    }
+
+}


### PR DESCRIPTION
New functionality added using API v3:
* Withdrawals support
* Transfer support
* Request deposit address

Instead of writing new v3 API over mazi, I took a different approach and implemented the missing methods using the Okex official java SDK. 

As the repo is not on maven, I also committed the SDK project (taken from https://github.com/okcoin-okex/open-api-v3-sdk/tree/master/okex-java-sdk-api) 

In order to use api V3 methods, user must set provide 'apikey_v3' and 'secretkey_v3' on exchange specifications.