### PR TITLE
[bitflyer] more forgiving date parsing

### DIFF
--- a/xchange-bitflyer/src/main/java/org/knowm/xchange/bitflyer/BitflyerAdapters.java
+++ b/xchange-bitflyer/src/main/java/org/knowm/xchange/bitflyer/BitflyerAdapters.java
@@ -157,7 +157,7 @@ public class BitflyerAdapters {
                             new CurrencyPair(result.getProductCode().replace("_", "/")))
                         .id(result.getChildOrderId())
                         .orderStatus(adaptOrderStatus(result.getChildOrderState()))
-                        .timestamp(BitflyerUtils.parseShortDate(result.getChildOrderDate()))
+                        .timestamp(BitflyerUtils.parseDate(result.getChildOrderDate()))
                         .limitPrice(result.getPrice())
                         .averagePrice(result.getAveragePrice())
                         .originalAmount(result.getSize())

--- a/xchange-bitflyer/src/main/java/org/knowm/xchange/bitflyer/BitflyerUtils.java
+++ b/xchange-bitflyer/src/main/java/org/knowm/xchange/bitflyer/BitflyerUtils.java
@@ -22,6 +22,14 @@ public class BitflyerUtils {
   private BitflyerUtils() {}
 
   public static Date parseDate(final String date) {
+    if (date.contains(".")) {
+      return parseLongDate(date);
+    } else {
+      return parseShortDate(date);
+    }
+  }
+
+  private static Date parseLongDate(final String date) {
     try {
       SimpleDateFormat threadSafeClone = (SimpleDateFormat) DATE_FORMAT.clone();
       return threadSafeClone.parse(date);
@@ -30,7 +38,7 @@ public class BitflyerUtils {
     }
   }
 
-  public static Date parseShortDate(final String date) {
+  private static Date parseShortDate(final String date) {
     try {
       SimpleDateFormat threadSafeClone = (SimpleDateFormat) DATE_FORMAT_SHORT.clone();
       return threadSafeClone.parse(date);


### PR DESCRIPTION
Bitflyer sometimes sends dates with a millisecond `.SSS` on the end and sometimes without. This change detects the dot and selects the appropriate `SimpleDateFormat` to match both date variants as necessary.