### PR TITLE
Coinbene Tickers API and Custom BigDecimal Deserializer

### DIFF
--- a/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/CoinbeneBigDecimalDeserializer.java
+++ b/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/CoinbeneBigDecimalDeserializer.java
@@ -1,0 +1,25 @@
+package org.knowm.xchange.coinbene;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import java.math.BigDecimal;
+
+public class CoinbeneBigDecimalDeserializer extends JsonDeserializer<BigDecimal> {
+
+  @Override
+  public BigDecimal deserialize(
+      JsonParser jsonParser, DeserializationContext deserializationContext)
+      throws IOException, JsonProcessingException {
+
+    String value = jsonParser.getValueAsString();
+
+    if ("--".equals(value)) {
+      return BigDecimal.ZERO;
+    } else {
+      return new BigDecimal(value);
+    }
+  }
+}

--- a/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/dto/CoinbeneAdapters.java
+++ b/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/dto/CoinbeneAdapters.java
@@ -1,11 +1,6 @@
 package org.knowm.xchange.coinbene.dto;
 
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.knowm.xchange.coinbene.dto.account.CoinbeneCoinBalances;
 import org.knowm.xchange.coinbene.dto.marketdata.CoinbeneOrder;
@@ -55,9 +50,7 @@ public class CoinbeneAdapters {
     }
   }
 
-  public static Ticker adaptTicker(CoinbeneTicker.Container container) {
-    CoinbeneTicker ticker = container.getTicker();
-
+  private static Ticker adaptCoinbeneTicker(CoinbeneTicker ticker, long timestamp) {
     return new Ticker.Builder()
         .currencyPair(adaptSymbol(ticker.getSymbol()))
         .bid(ticker.getBid())
@@ -66,8 +59,20 @@ public class CoinbeneAdapters {
         .low(ticker.getDayLow())
         .last(ticker.getLast())
         .volume(ticker.getDayVolume())
-        .timestamp(new Date(container.getTimestamp()))
+        .timestamp(new Date(timestamp))
         .build();
+  }
+
+  public static Ticker adaptTicker(CoinbeneTicker.Container container) {
+    return adaptCoinbeneTicker(container.getTicker(), container.getTimestamp());
+  }
+
+  public static List<Ticker> adaptTickers(CoinbeneTicker.Container container) {
+    long timestamp = container.getTimestamp();
+
+    return container.getTickers().stream()
+        .map(coinbeneTicker -> adaptCoinbeneTicker(coinbeneTicker, timestamp))
+        .collect(Collectors.toList());
   }
 
   public static OrderBook adaptOrderBook(

--- a/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/dto/marketdata/CoinbeneTicker.java
+++ b/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/dto/marketdata/CoinbeneTicker.java
@@ -1,8 +1,10 @@
 package org.knowm.xchange.coinbene.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.math.BigDecimal;
 import java.util.List;
+import org.knowm.xchange.coinbene.CoinbeneBigDecimalDeserializer;
 import org.knowm.xchange.coinbene.dto.CoinbeneResponse;
 
 public class CoinbeneTicker {
@@ -20,8 +22,10 @@ public class CoinbeneTicker {
       @JsonProperty("24hrHigh") BigDecimal dayHigh,
       @JsonProperty("24hrLow") BigDecimal dayLow,
       @JsonProperty("last") BigDecimal last,
-      @JsonProperty("ask") BigDecimal ask,
-      @JsonProperty("bid") BigDecimal bid,
+      @JsonProperty("ask") @JsonDeserialize(using = CoinbeneBigDecimalDeserializer.class)
+          BigDecimal ask,
+      @JsonProperty("bid") @JsonDeserialize(using = CoinbeneBigDecimalDeserializer.class)
+          BigDecimal bid,
       @JsonProperty("24hrVol") BigDecimal dayVolume,
       @JsonProperty("24hrAmt") BigDecimal dayAmount) {
     this.symbol = symbol;

--- a/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/dto/marketdata/CoinbeneTicker.java
+++ b/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/dto/marketdata/CoinbeneTicker.java
@@ -104,6 +104,10 @@ public class CoinbeneTicker {
       return tickers.get(0);
     }
 
+    public List<CoinbeneTicker> getTickers() {
+      return tickers;
+    }
+
     public long getTimestamp() {
       return timestamp;
     }

--- a/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/service/CoinbeneMarketDataService.java
+++ b/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/service/CoinbeneMarketDataService.java
@@ -13,6 +13,7 @@ import org.knowm.xchange.dto.marketdata.Trade;
 import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.dto.meta.ExchangeMetaData;
 import org.knowm.xchange.service.marketdata.MarketDataService;
+import org.knowm.xchange.service.marketdata.params.Params;
 
 public class CoinbeneMarketDataService extends CoinbeneMarketDataServiceRaw
     implements MarketDataService {
@@ -30,6 +31,11 @@ public class CoinbeneMarketDataService extends CoinbeneMarketDataServiceRaw
   @Override
   public Ticker getTicker(CurrencyPair currencyPair, Object... args) throws IOException {
     return CoinbeneAdapters.adaptTicker(getCoinbeneTicker(currencyPair));
+  }
+
+  @Override
+  public List<Ticker> getTickers(Params params) throws IOException {
+    return CoinbeneAdapters.adaptTickers(getCoinbeneTickers());
   }
 
   @Override

--- a/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/service/CoinbeneMarketDataServiceRaw.java
+++ b/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/service/CoinbeneMarketDataServiceRaw.java
@@ -25,6 +25,14 @@ public class CoinbeneMarketDataServiceRaw extends CoinbeneBaseService {
     }
   }
 
+  public CoinbeneTicker.Container getCoinbeneTickers() throws IOException {
+    try {
+      return checkSuccess(coinbene.ticker("all"));
+    } catch (CoinbeneException e) {
+      throw new ExchangeException(e.getMessage(), e);
+    }
+  }
+
   public CoinbeneOrderBook.Container getCoinbeneOrderBook(CurrencyPair currencyPair)
       throws IOException {
     return getCoinbeneOrderBook(currencyPair, null);


### PR DESCRIPTION
- Added API call to retrieve all tickers from Coinbene XChange, as documented [here](https://github.com/Coinbene/API-Documents/wiki/1.1.0-Get-Ticker-[Market])
- Created custom BigDecimal deserializer for "bid" and "ask" values of a ticker, in order to handle the "--" string case