### PR TITLE
Added tradingPairs and remoteInit to Cobinhood exchange

### DIFF
--- a/xchange-cobinhood/src/main/java/org/knowm/xchange/cobinhood/Cobinhood.java
+++ b/xchange-cobinhood/src/main/java/org/knowm/xchange/cobinhood/Cobinhood.java
@@ -56,6 +56,16 @@ public interface Cobinhood {
       throws IOException, CobinhoodException;
 
   /**
+   * Retrieves a list of all trading pairs.
+   *
+   * @return
+   * @throws IOException
+   */
+  @GET
+  @Path("market/trading_pairs")
+  CobinhoodResponse<CobinhoodTradingPairs> tradingPairs() throws IOException, CobinhoodException;
+
+  /**
    * The call for recent trades
    *
    * @param symbol the currency pair

--- a/xchange-cobinhood/src/main/java/org/knowm/xchange/cobinhood/CobinhoodAdapters.java
+++ b/xchange-cobinhood/src/main/java/org/knowm/xchange/cobinhood/CobinhoodAdapters.java
@@ -1,12 +1,11 @@
 package org.knowm.xchange.cobinhood;
 
 import java.math.BigDecimal;
-import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.knowm.xchange.cobinhood.dto.CobinhoodResponse;
 import org.knowm.xchange.cobinhood.dto.account.CobinhoodCoinBalances;
+import org.knowm.xchange.cobinhood.dto.marketdata.CobinhoodCurrencyPair;
 import org.knowm.xchange.cobinhood.dto.marketdata.CobinhoodOrderBook;
 import org.knowm.xchange.cobinhood.dto.marketdata.CobinhoodTicker;
 import org.knowm.xchange.cobinhood.dto.marketdata.CobinhoodTrade;
@@ -21,6 +20,8 @@ import org.knowm.xchange.dto.account.Wallet;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trade;
+import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
+import org.knowm.xchange.dto.meta.ExchangeMetaData;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
 
@@ -122,5 +123,15 @@ public class CobinhoodAdapters {
         .cumulativeAmount(order.getFilled())
         .originalAmount(order.getSize())
         .build();
+  }
+
+  public static ExchangeMetaData adaptMetadata(List<CobinhoodCurrencyPair> pairs) {
+    Map<CurrencyPair, CurrencyPairMetaData> pairMeta = new HashMap<>();
+    for (CobinhoodCurrencyPair pair : pairs) {
+      pairMeta.put(
+          new CurrencyPair(pair.getBaseCurrencyId(), pair.getQuoteCurrencyId()),
+          new CurrencyPairMetaData(null, pair.getBaseMinSize(), pair.getBaseMaxSize(), null, null));
+    }
+    return new ExchangeMetaData(pairMeta, null, null, null, null);
   }
 }

--- a/xchange-cobinhood/src/main/java/org/knowm/xchange/cobinhood/CobinhoodExchange.java
+++ b/xchange-cobinhood/src/main/java/org/knowm/xchange/cobinhood/CobinhoodExchange.java
@@ -46,6 +46,6 @@ public class CobinhoodExchange extends BaseExchange implements Exchange {
   @Override
   public void remoteInit() throws IOException, ExchangeException {
 
-    //            exchangeMetaData = ((CobinhoodMarketDataService) marketDataService).getMetadata();
+    exchangeMetaData = ((CobinhoodMarketDataService) marketDataService).getMetadata();
   }
 }

--- a/xchange-cobinhood/src/main/java/org/knowm/xchange/cobinhood/dto/marketdata/CobinhoodCurrencyPair.java
+++ b/xchange-cobinhood/src/main/java/org/knowm/xchange/cobinhood/dto/marketdata/CobinhoodCurrencyPair.java
@@ -5,104 +5,97 @@ import java.math.BigDecimal;
 
 public class CobinhoodCurrencyPair {
 
+  private final String baseCurrencyId;
+  private final boolean marginEnabled;
+  private final BigDecimal makerFee;
+  private final BigDecimal quoteIncrement;
+  private final BigDecimal baseMaxSize;
+  private final BigDecimal takerFee;
+  private final String quoteCurrencyId;
   private final String id;
-  private final BigDecimal last_price;
-  private final BigDecimal lowest_ask;
-  private final BigDecimal highest_bid;
-  private final BigDecimal base_volume;
-  private final BigDecimal quote_volume;
-  private final boolean is_frozen;
-  private final BigDecimal high_24hr;
-  private final BigDecimal low_24hr;
-  private final BigDecimal percent_changed_24hr;
+  private final BigDecimal baseMinSize;
 
   public CobinhoodCurrencyPair(
+      @JsonProperty("base_currency_id") String baseCurrencyId,
+      @JsonProperty("margin_enabled") boolean marginEnabled,
+      @JsonProperty("maker_fee") BigDecimal makerFee,
+      @JsonProperty("quote_increment") BigDecimal quoteIncrement,
+      @JsonProperty("base_max_size") BigDecimal baseMaxSize,
+      @JsonProperty("taker_fee") BigDecimal takerFee,
+      @JsonProperty("quote_currency_id") String quoteCurrencyId,
       @JsonProperty("id") String id,
-      @JsonProperty("last_price") BigDecimal last_price,
-      @JsonProperty("lowest_ask") BigDecimal lowest_ask,
-      @JsonProperty("highest_bid") BigDecimal highest_bid,
-      @JsonProperty("base_volume") BigDecimal base_volume,
-      @JsonProperty("quote_volume") BigDecimal quote_volume,
-      @JsonProperty("is_frozen") boolean is_frozen,
-      @JsonProperty("high_24hr") BigDecimal high_24hr,
-      @JsonProperty("low_24hr") BigDecimal low_24hr,
-      @JsonProperty("percent_changed_24hr") BigDecimal percent_changed_24hr) {
+      @JsonProperty("base_min_size") BigDecimal baseMinSize) {
+    this.baseCurrencyId = baseCurrencyId;
+    this.marginEnabled = marginEnabled;
+    this.makerFee = makerFee;
+    this.quoteIncrement = quoteIncrement;
+    this.baseMaxSize = baseMaxSize;
+    this.takerFee = takerFee;
+    this.quoteCurrencyId = quoteCurrencyId;
     this.id = id;
-    this.last_price = last_price;
-    this.lowest_ask = lowest_ask;
-    this.highest_bid = highest_bid;
-    this.base_volume = base_volume;
-    this.quote_volume = quote_volume;
-    this.is_frozen = is_frozen;
-    this.high_24hr = high_24hr;
-    this.low_24hr = low_24hr;
-    this.percent_changed_24hr = percent_changed_24hr;
+    this.baseMinSize = baseMinSize;
+  }
+
+  public String getBaseCurrencyId() {
+    return baseCurrencyId;
+  }
+
+  public boolean isMarginEnabled() {
+    return marginEnabled;
+  }
+
+  public BigDecimal getMakerFee() {
+    return makerFee;
+  }
+
+  public BigDecimal getQuoteIncrement() {
+    return quoteIncrement;
+  }
+
+  public BigDecimal getBaseMaxSize() {
+    return baseMaxSize;
+  }
+
+  public BigDecimal getTakerFee() {
+    return takerFee;
+  }
+
+  public String getQuoteCurrencyId() {
+    return quoteCurrencyId;
   }
 
   public String getId() {
     return id;
   }
 
-  public BigDecimal getLast_price() {
-    return last_price;
-  }
-
-  public BigDecimal getLowest_ask() {
-    return lowest_ask;
-  }
-
-  public BigDecimal getHighest_bid() {
-    return highest_bid;
-  }
-
-  public BigDecimal getBase_volume() {
-    return base_volume;
-  }
-
-  public BigDecimal getQuote_volume() {
-    return quote_volume;
-  }
-
-  public boolean isIs_frozen() {
-    return is_frozen;
-  }
-
-  public BigDecimal getHigh_24hr() {
-    return high_24hr;
-  }
-
-  public BigDecimal getLow_24hr() {
-    return low_24hr;
-  }
-
-  public BigDecimal getPercent_changed_24hr() {
-    return percent_changed_24hr;
+  public BigDecimal getBaseMinSize() {
+    return baseMinSize;
   }
 
   @Override
   public String toString() {
     return "CobinhoodCurrencyPair{"
-        + "id='"
+        + "baseCurrencyId='"
+        + baseCurrencyId
+        + '\''
+        + ", marginEnabled="
+        + marginEnabled
+        + ", makerFee="
+        + makerFee
+        + ", quoteIncrement="
+        + quoteIncrement
+        + ", baseMaxSize="
+        + baseMaxSize
+        + ", takerFee="
+        + takerFee
+        + ", quoteCurrencyId='"
+        + quoteCurrencyId
+        + '\''
+        + ", id='"
         + id
         + '\''
-        + ", last_price="
-        + last_price
-        + ", lowest_ask="
-        + lowest_ask
-        + ", highest_bid="
-        + highest_bid
-        + ", base_volume="
-        + base_volume
-        + ", quote_volume="
-        + quote_volume
-        + ", is_frozen="
-        + is_frozen
-        + ", high_24hr="
-        + high_24hr
-        + ", low_24hr="
-        + low_24hr
-        + ", percent_changed_24hr="
-        + percent_changed_24hr
+        + ", baseMinSize="
+        + baseMinSize
         + '}';
   }
 }

--- a/xchange-cobinhood/src/main/java/org/knowm/xchange/cobinhood/dto/marketdata/CobinhoodTradingPairs.java
+++ b/xchange-cobinhood/src/main/java/org/knowm/xchange/cobinhood/dto/marketdata/CobinhoodTradingPairs.java
@@ -1,0 +1,16 @@
+package org.knowm.xchange.cobinhood.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class CobinhoodTradingPairs {
+  private final List<CobinhoodCurrencyPair> pairs;
+
+  public CobinhoodTradingPairs(@JsonProperty("trading_pairs") List<CobinhoodCurrencyPair> pairs) {
+    this.pairs = pairs;
+  }
+
+  public List<CobinhoodCurrencyPair> getPairs() {
+    return pairs;
+  }
+}

--- a/xchange-cobinhood/src/main/java/org/knowm/xchange/cobinhood/service/CobinhoodMarketDataService.java
+++ b/xchange-cobinhood/src/main/java/org/knowm/xchange/cobinhood/service/CobinhoodMarketDataService.java
@@ -7,12 +7,15 @@ import java.util.stream.Collectors;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.cobinhood.CobinhoodAdapters;
 import org.knowm.xchange.cobinhood.dto.CobinhoodResponse;
+import org.knowm.xchange.cobinhood.dto.marketdata.CobinhoodCurrencyPair;
 import org.knowm.xchange.cobinhood.dto.marketdata.CobinhoodTrades;
+import org.knowm.xchange.cobinhood.dto.marketdata.CobinhoodTradingPairs;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trade;
 import org.knowm.xchange.dto.marketdata.Trades;
+import org.knowm.xchange.dto.meta.ExchangeMetaData;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 import org.knowm.xchange.service.marketdata.params.Params;
 
@@ -78,5 +81,12 @@ public class CobinhoodMarketDataService extends CobinhoodMarketDataServiceRaw
             .map(trade -> CobinhoodAdapters.adaptTrade(trade, currencyPair))
             .collect(Collectors.toList());
     return new Trades(trades, Trades.TradeSortType.SortByTimestamp);
+  }
+
+  public ExchangeMetaData getMetadata() throws IOException {
+
+    CobinhoodResponse<CobinhoodTradingPairs> response = getCobinhoodTradingPairs();
+    List<CobinhoodCurrencyPair> pairs = response.getResult().getPairs();
+    return CobinhoodAdapters.adaptMetadata(pairs);
   }
 }

--- a/xchange-cobinhood/src/main/java/org/knowm/xchange/cobinhood/service/CobinhoodMarketDataServiceRaw.java
+++ b/xchange-cobinhood/src/main/java/org/knowm/xchange/cobinhood/service/CobinhoodMarketDataServiceRaw.java
@@ -65,6 +65,14 @@ public class CobinhoodMarketDataServiceRaw extends CobinhoodBaseService {
     }
   }
 
+  public CobinhoodResponse<CobinhoodTradingPairs> getCobinhoodTradingPairs() throws IOException {
+    try {
+      return checkSuccess(cobinhood.tradingPairs());
+    } catch (CobinhoodException e) {
+      throw new ExchangeException(e.getMessage(), e);
+    }
+  }
+
   public static <D> CobinhoodResponse<D> checkSuccess(CobinhoodResponse<D> response) {
 
     if (response.isSuccess()) {

--- a/xchange-cobinhood/src/test/java/org/knowm/xchange/cobinhood/service/dto/CobinhoodMarketDataDtoTest.java
+++ b/xchange-cobinhood/src/test/java/org/knowm/xchange/cobinhood/service/dto/CobinhoodMarketDataDtoTest.java
@@ -27,8 +27,8 @@ public class CobinhoodMarketDataDtoTest {
             is, new TypeReference<CobinhoodResponse<List<CobinhoodCurrencyPair>>>() {});
 
     //        verify that the example data was unmarshalled correctly
-    assertThat(cobinhoodResponse.getResult().get(0).getId()).isEqualTo("ABT-BTC");
-    assertThat(cobinhoodResponse.getResult().get(0).getLast_price()).isEqualTo("0.000041");
-    assertThat(cobinhoodResponse.getResult().get(0).getLowest_ask()).isEqualTo("0.00006697");
+    assertThat(cobinhoodResponse.getResult().get(0).getId()).isEqualTo("BCHSV-USDT");
+    assertThat(cobinhoodResponse.getResult().get(0).getBaseMaxSize()).isEqualTo("4590.393");
+    assertThat(cobinhoodResponse.getResult().get(0).getTakerFee()).isEqualTo("0");
   }
 }

--- a/xchange-cobinhood/src/test/resources/org/knowm/xchange/cobinhood/dto/currencypair-example.json
+++ b/xchange-cobinhood/src/test/resources/org/knowm/xchange/cobinhood/dto/currencypair-example.json
@@ -2,28 +2,26 @@
   "success": true,
   "result": [
     {
-      "id": "ABT-BTC",
-      "last_price": "0.000041",
-      "lowest_ask": "0.00006697",
-      "highest_bid": "0.000058",
-      "base_volume": "1101.80348524",
-      "quote_volume": "0.0694091344446196",
-      "is_frozen": false,
-      "high_24hr": "0.000072",
-      "low_24hr": "0.000041",
-      "percent_changed_24hr": "-0.4305555555555556"
+      "id": "BCHSV-USDT",
+      "base_currency_id": "BCHSV",
+      "quote_currency_id": "USDT",
+      "base_max_size": "4590.393",
+      "base_min_size": "0.046",
+      "quote_increment": "0.01",
+      "maker_fee": "0",
+      "taker_fee": "0",
+      "margin_enabled": false
     },
     {
-      "id": "ABT-ETH",
-      "last_price": "0.0010169",
-      "lowest_ask": "0.0009879",
-      "highest_bid": "0.0009382",
-      "base_volume": "5098.92892637",
-      "quote_volume": "4.731106176394585",
-      "is_frozen": false,
-      "high_24hr": "0.00104",
-      "low_24hr": "0.0009117",
-      "percent_changed_24hr": "-0.0222115384615385"
+      "id": "BCH-USDT",
+      "base_currency_id": "BCH",
+      "quote_currency_id": "USDT",
+      "base_max_size": "2407.278",
+      "base_min_size": "0.025",
+      "quote_increment": "0.01",
+      "maker_fee": "0",
+      "taker_fee": "0",
+      "margin_enabled": false
     }
   ]
 }


### PR DESCRIPTION
- Implemented remote Metadata retrieval for Cobinhood Exchange
- Added trading_pairs API call to get the list of currency pairs
- Fixed the CobinhoodCurrencyPair DTO to align it with the structure of the API response
- Fixed test according to modifications of CobinhoodCurrencyPair DTO