### PR TITLE
[Kraken] Changed deafult sorting to timestamps rather than ids

### DIFF
--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java
@@ -253,7 +253,7 @@ public class KrakenAdapters {
       trades.add(adaptTrade(krakenTradeEntry.getValue(), krakenTradeEntry.getKey()));
     }
 
-    return new UserTrades(trades, TradeSortType.SortByID);
+    return new UserTrades(trades, TradeSortType.SortByTimestamp);
   }
 
   public static KrakenUserTrade adaptTrade(KrakenTrade krakenTrade, String tradeId) {


### PR DESCRIPTION
The function getTradeHistory(TradeHistoryParams params) in KrakenTradeService sorts the trades by ID. However, the ids in Kraken have no natural order so the trade history should be sorted by timestamp as default. The ids have the format of A-B-C which A, B, C being strings. I believe they refer to individual ledger entries in Kraken.

Fixes issue #3126.