### PR TITLE
[Binance] added allBookTickers API call

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/Binance.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/Binance.java
@@ -149,7 +149,7 @@ public interface Binance {
   List<BinancePrice> tickerAllPrices() throws IOException, BinanceException;
 
   @GET
-  @Path("api/v1/ticker/allBookTickers")
+  @Path("api/v3/ticker/bookTicker")
   /**
    * Best price/qty on the order book for all symbols.
    *

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAdapters.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAdapters.java
@@ -1,9 +1,9 @@
 package org.knowm.xchange.binance;
 
 import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.knowm.xchange.binance.dto.marketdata.BinancePriceQuantity;
 import org.knowm.xchange.binance.dto.trade.BinanceOrder;
 import org.knowm.xchange.binance.dto.trade.OrderSide;
 import org.knowm.xchange.binance.dto.trade.OrderStatus;
@@ -13,6 +13,7 @@ import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.IOrderFlags;
 import org.knowm.xchange.dto.Order.OrderType;
+import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
 import org.knowm.xchange.dto.trade.StopOrder;
@@ -182,5 +183,21 @@ public class BinanceAdapters {
     }
     result.setOrderFlags(flags);
     return result;
+  }
+
+  private static Ticker adaptPriceQuantity(BinancePriceQuantity priceQuantity) {
+    return new Ticker.Builder()
+        .currencyPair(adaptSymbol(priceQuantity.symbol))
+        .ask(priceQuantity.askPrice)
+        .askSize(priceQuantity.askQty)
+        .bid(priceQuantity.bidPrice)
+        .bidSize(priceQuantity.bidQty)
+        .build();
+  }
+
+  public static List<Ticker> adaptPriceQuantities(List<BinancePriceQuantity> priceQuantities) {
+    return priceQuantities.stream()
+        .map(BinanceAdapters::adaptPriceQuantity)
+        .collect(Collectors.toList());
   }
 }

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceMarketDataService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceMarketDataService.java
@@ -10,6 +10,7 @@ import org.knowm.xchange.binance.BinanceErrorAdapter;
 import org.knowm.xchange.binance.dto.BinanceException;
 import org.knowm.xchange.binance.dto.marketdata.BinanceAggTrades;
 import org.knowm.xchange.binance.dto.marketdata.BinanceOrderbook;
+import org.knowm.xchange.binance.dto.marketdata.BinancePriceQuantity;
 import org.knowm.xchange.binance.dto.marketdata.BinanceTicker24h;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
@@ -136,5 +137,10 @@ public class BinanceMarketDataService extends BinanceMarketDataServiceRaw
       throw new IllegalArgumentException(
           "Argument on index " + index + " is not a number: " + argStr, e);
     }
+  }
+
+  public List<Ticker> getAllBookTickers() throws IOException {
+    List<BinancePriceQuantity> binanceTickers = tickerAllBookTickers();
+    return BinanceAdapters.adaptPriceQuantities(binanceTickers);
   }
 }


### PR DESCRIPTION
- Implemented missing API call to retrieve all book tickers from Binance
- Since the base getTickers() function has been implemented yet and returns the 24h tickers data, a new method getAllBookTickers() has been implemented
- In order to call it, it is necessary to explicitly cast a generic MarketDataService instance to a more specific BinanceMarketDataService first