### PR TITLE
[Coinmate] fix - coinmate.json configuration

### DIFF
--- a/xchange-coinmate/src/main/resources/coinmate.json
+++ b/xchange-coinmate/src/main/resources/coinmate.json
@@ -2,59 +2,59 @@
   "currency_pairs": {
     "BTC/EUR": {
       "price_scale": 2,
-      "min_amount": 0.0002
+      "min_amount": 0.00020000
     },
     "BTC/CZK": {
       "price_scale": 2,
-      "min_amount": 0.0002
+      "min_amount": 0.00020000
     },
     "LTC/BTC": {
       "price_scale": 5,
-      "min_amount": 0.01
+      "min_amount": 0.01000000
     },
     "LTC/EUR": {
       "price_scale": 2,
-      "min_amount": 0.01
+      "min_amount": 0.01000000
     },
     "LTC/CZK": {
       "price_scale": 2,
-      "min_amount": 0.01
+      "min_amount": 0.01000000
     },
     "BCH/BTC": {
       "price_scale": 5,
-      "min_amount": 0.001
+      "min_amount": 0.00100000
     },
     "ETH/EUR": {
       "price_scale": 2,
-      "min_amount": 0.01
+      "min_amount": 0.01000000
     },
     "ETH/CZK": {
       "price_scale": 2,
-      "min_amount": 0.01
+      "min_amount": 0.01000000
     },
     "ETH/BTC": {
       "price_scale": 5,
-      "min_amount": 0.01
+      "min_amount": 0.01000000
     },
     "XRP/EUR": {
       "price_scale": 5,
-      "min_amount": 1
+      "min_amount": 1.00000000
     },
     "XRP/CZK": {
       "price_scale": 5,
-      "min_amount": 1
+      "min_amount": 1.00000000
     },
     "XRP/BTC": {
       "price_scale": 8,
-      "min_amount": 1
+      "min_amount": 1.00000000
     },
     "BCH/EUR": {
       "price_scale": 2,
-      "min_amount": 0.001
+      "min_amount": 0.00100000
     },
     "BCH/CZK": {
       "price_scale": 2,
-      "min_amount": 0.001
+      "min_amount": 0.00100000
     }
   },
   "currencies": {


### PR DESCRIPTION
Core validation of  XChange lib (verifyOrder) get scale from minimum amount:

Class: org.knowm.xchange.service.BaseExchangeService:
`
BigDecimal minimumAmount = metaData.getMinimumAmount();
if (minimumAmount != null) {
    if (amount.scale() > minimumAmount.scale()) {
        throw new IllegalArgumentException("Unsupported amount scale " + amount.scale());
    ....
`

So coinmate.json min_amount cannot be: 0.0002 (scale = 4) but 0.00020000 (scale = 8) 

Example configuration of Bitstamp:
`
"BTC/EUR": {

	      "price_scale": 2,

	      "trading_fee": 0.0025,

	      "min_amount": 0.00085000

	    }
`