### PR TITLE
Added serialVersionUID to serializable dto objects

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
@@ -16,6 +16,7 @@ import java.util.TreeSet;
  */
 public class Currency implements Comparable<Currency>, Serializable {
 
+  private static final long serialVersionUID = -7340731832345284129L;
   private static final Map<String, Currency> currencies = new HashMap<>();
 
   /** Global currency codes */
@@ -300,6 +301,7 @@ public class Currency implements Comparable<Currency>, Serializable {
   public static final Currency ELF = createCurrency("ELF", "aelf", null);
   public static final Currency STORJ = createCurrency("STORJ", "Storj", null);
   public static final Currency MOD = createCurrency("MOD", "Modum", null);
+
   private final String code;
   private final CurrencyAttributes attributes;
 
@@ -486,6 +488,8 @@ public class Currency implements Comparable<Currency>, Serializable {
 
   private static class CurrencyAttributes implements Serializable {
 
+    private static final long serialVersionUID = -5575649542242146958L;
+    
     public final Set<String> codes;
     public final String isoCode;
     public final String commonCode;

--- a/xchange-core/src/main/java/org/knowm/xchange/currency/CurrencyPair.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/CurrencyPair.java
@@ -18,6 +18,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @JsonSerialize(using = CustomCurrencyPairSerializer.class)
 public class CurrencyPair implements Comparable<CurrencyPair>, Serializable {
 
+  private static final long serialVersionUID = 414711266389792746L;
+
   // Provide some standard major symbols
   public static final CurrencyPair EUR_USD = new CurrencyPair(Currency.EUR, Currency.USD);
   public static final CurrencyPair GBP_USD = new CurrencyPair(Currency.GBP, Currency.USD);

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/LoanOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/LoanOrder.java
@@ -8,6 +8,8 @@ import org.knowm.xchange.dto.Order.OrderType;
 /** Data object representing an order for a loan */
 public class LoanOrder implements Serializable {
 
+  private static final long serialVersionUID = -8311018082902024121L;
+
   /** Order type i.e. bid or ask */
   private final OrderType type;
 

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/Order.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/Order.java
@@ -10,6 +10,8 @@ import org.knowm.xchange.currency.CurrencyPair;
 /** Data object representing an order */
 public abstract class Order implements Serializable {
 
+  private static final long serialVersionUID = -8132103343647993249L;
+
   /** Order type i.e. bid or ask */
   private final OrderType type;
   /** Amount to be ordered / amount that was ordered */

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/account/AccountInfo.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/account/AccountInfo.java
@@ -17,6 +17,8 @@ import javax.annotation.Nullable;
  */
 public final class AccountInfo implements Serializable {
 
+  private static final long serialVersionUID = -3572240060624800060L;
+
   /** The name on the account */
   private final String username;
 

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/account/Balance.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/account/Balance.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class Balance implements Comparable<Balance>, Serializable {
 
+  private static final long serialVersionUID = -1460694403597268635L;
   private static final Logger log = LoggerFactory.getLogger(Balance.class);
 
   private final Currency currency;

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/account/Fee.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/account/Fee.java
@@ -5,6 +5,9 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 
 public final class Fee implements Serializable {
+
+  private static final long serialVersionUID = -6235230375777573680L;
+
   @JsonProperty("maker_fee")
   private final BigDecimal makerFee;
 

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/account/FundingRecord.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/account/FundingRecord.java
@@ -15,6 +15,8 @@ import org.knowm.xchange.currency.Currency;
  */
 public final class FundingRecord implements Serializable {
 
+  private static final long serialVersionUID = 3788398035845873448L;
+
   /** Crypto currency address for deposit/withdrawal */
   private final String address;
 

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/account/Wallet.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/account/Wallet.java
@@ -16,6 +16,8 @@ import org.knowm.xchange.currency.Currency;
  */
 public final class Wallet implements Serializable {
 
+  private static final long serialVersionUID = -4136681413143690633L;
+
   /** The keys represent the currency of the wallet. */
   private final Map<Currency, Balance> balances;
   /** A unique identifier for this wallet */

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/LoanOrderBook.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/LoanOrderBook.java
@@ -11,6 +11,8 @@ import org.knowm.xchange.dto.trade.FloatingRateLoanOrder;
 /** DTO representing the exchange loan order book */
 public final class LoanOrderBook implements Serializable {
 
+  private static final long serialVersionUID = -2894416631375841830L;
+
   private final List<FixedRateLoanOrder> fixedRateAsks;
   private final List<FixedRateLoanOrder> fixedRateBids;
   private final List<FloatingRateLoanOrder> floatingRateAsks;

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/OrderBook.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/OrderBook.java
@@ -15,6 +15,8 @@ import org.knowm.xchange.dto.trade.LimitOrder;
 /** DTO representing the exchange order book */
 public final class OrderBook implements Serializable {
 
+  private static final long serialVersionUID = -7788306758114464314L;
+
   /** the asks */
   private final List<LimitOrder> asks;
   /** the bids */

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/OrderBookUpdate.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/OrderBookUpdate.java
@@ -10,6 +10,8 @@ import org.knowm.xchange.dto.trade.LimitOrder;
 /** Immutable data object representing a Market Depth update. */
 public final class OrderBookUpdate implements Serializable {
 
+  private static final long serialVersionUID = -7283757982319511254L;
+
   private final LimitOrder limitOrder;
 
   /** this is the total volume at this price in the order book */

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/Ticker.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/Ticker.java
@@ -15,6 +15,8 @@ import org.knowm.xchange.utils.DateUtils;
  */
 public final class Ticker implements Serializable {
 
+  private static final long serialVersionUID = -3247730106987193154L;
+
   private final CurrencyPair currencyPair;
   private final BigDecimal open;
   private final BigDecimal last;

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/Trade.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/Trade.java
@@ -11,6 +11,8 @@ import org.knowm.xchange.service.marketdata.MarketDataService;
 /** Data object representing a Trade */
 public class Trade implements Serializable {
 
+  private static final long serialVersionUID = -4078893146776655648L;
+  
   /** Did this trade result from the execution of a bid or a ask? */
   protected final OrderType type;
 

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/Trades.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/Trades.java
@@ -12,6 +12,8 @@ import java.util.List;
 /** DTO representing a collection of trades */
 public class Trades implements Serializable {
 
+  private static final long serialVersionUID = 5790082783307641329L;
+
   private static final TradeIDComparator TRADE_ID_COMPARATOR = new TradeIDComparator();
   private static final TradeTimestampComparator TRADE_TIMESTAMP_COMPARATOR =
       new TradeTimestampComparator();

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/meta/CurrencyMetaData.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/meta/CurrencyMetaData.java
@@ -6,6 +6,8 @@ import java.math.BigDecimal;
 
 public class CurrencyMetaData implements Serializable {
 
+  private static final long serialVersionUID = -247899067657358542L;
+
   @JsonProperty("scale")
   private final Integer scale;
 

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/meta/CurrencyPairMetaData.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/meta/CurrencyPairMetaData.java
@@ -8,6 +8,8 @@ import org.knowm.xchange.currency.Currency;
 
 public class CurrencyPairMetaData implements Serializable {
 
+  private static final long serialVersionUID = 4749144540694704221L;
+
   /** Trading fee (fraction) */
   @JsonProperty("trading_fee")
   private final BigDecimal tradingFee;

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/meta/ExchangeMetaData.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/meta/ExchangeMetaData.java
@@ -21,6 +21,8 @@ import org.knowm.xchange.utils.ObjectMapperHelper;
  */
 public class ExchangeMetaData implements Serializable {
 
+  private static final long serialVersionUID = -1495610469981534977L;
+
   @JsonProperty("currency_pairs")
   private Map<CurrencyPair, CurrencyPairMetaData> currencyPairs;
 

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/meta/FeeTier.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/meta/FeeTier.java
@@ -6,6 +6,9 @@ import java.math.BigDecimal;
 import org.knowm.xchange.dto.account.Fee;
 
 public class FeeTier implements Serializable, Comparable<FeeTier> {
+
+  private static final long serialVersionUID = -4350427635840047928L;
+
   @JsonProperty("begin_quantity")
   public final BigDecimal beginQuantity;
 

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/meta/RateLimit.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/meta/RateLimit.java
@@ -13,6 +13,8 @@ import java.util.concurrent.TimeUnit;
 /** Describe a call rate limit as a number of calls per some time span. */
 public class RateLimit implements Serializable {
 
+  private static final long serialVersionUID = 90431040086828390L;
+  
   @JsonProperty("calls")
   public int calls = 1;
 

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/FixedRateLoanOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/FixedRateLoanOrder.java
@@ -13,6 +13,8 @@ import org.knowm.xchange.dto.Order.OrderType;
  */
 public final class FixedRateLoanOrder extends LoanOrder implements Comparable<FixedRateLoanOrder> {
 
+  private static final long serialVersionUID = 2627042395091155053L;
+
   /** The fixed rate of return for a day */
   private final BigDecimal rate;
 

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/FloatingRateLoanOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/FloatingRateLoanOrder.java
@@ -14,6 +14,8 @@ import org.knowm.xchange.dto.Order;
 public final class FloatingRateLoanOrder extends LoanOrder
     implements Comparable<FloatingRateLoanOrder> {
 
+  private static final long serialVersionUID = -1474202797547840095L;
+
   private BigDecimal rate;
 
   /**

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
@@ -16,6 +16,8 @@ import org.knowm.xchange.dto.Order;
  */
 public class LimitOrder extends Order implements Comparable<LimitOrder> {
 
+  private static final long serialVersionUID = -5166848178471347540L;
+
   /** The limit price */
   protected final BigDecimal limitPrice;
 

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/MarketOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/MarketOrder.java
@@ -16,6 +16,8 @@ import org.knowm.xchange.dto.Order;
  */
 public class MarketOrder extends Order {
 
+  private static final long serialVersionUID = -3393286268772319210L;
+
   /**
    * @param type Either BID (buying) or ASK (selling)
    * @param originalAmount The amount to trade

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/OpenLoanOrders.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/OpenLoanOrders.java
@@ -9,6 +9,8 @@ import java.util.List;
  */
 public final class OpenLoanOrders implements Serializable {
 
+  private static final long serialVersionUID = -8880758230367635109L;
+
   private final List<FixedRateLoanOrder> openFixedRateLoanOrders;
   private final List<FloatingRateLoanOrder> openFloatingRateLoanOrders;
 

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/OpenOrders.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/OpenOrders.java
@@ -14,6 +14,8 @@ import org.knowm.xchange.dto.Order;
  */
 public final class OpenOrders implements Serializable {
 
+  private static final long serialVersionUID = 6641558609478576563L;
+
   private final List<LimitOrder> openOrders;
   private final List<? extends Order> hiddenOrders;
 

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/StopOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/StopOrder.java
@@ -15,6 +15,8 @@ import org.knowm.xchange.dto.Order;
  */
 public class StopOrder extends Order implements Comparable<StopOrder> {
 
+  private static final long serialVersionUID = -7341286101341375106L;
+
   /** The stop price */
   protected final BigDecimal stopPrice;
   /**

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/UserTrade.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/UserTrade.java
@@ -13,6 +13,8 @@ import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 /** Data object representing a user trade */
 public class UserTrade extends Trade {
 
+  private static final long serialVersionUID = -3021617981214969292L;
+
   /** The id of the order responsible for execution of this trade */
   private final String orderId;
 

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/UserTrades.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/UserTrades.java
@@ -5,6 +5,8 @@ import org.knowm.xchange.dto.marketdata.Trades;
 
 public class UserTrades extends Trades {
 
+  private static final long serialVersionUID = 1647451200702821967L;
+
   public UserTrades(List<UserTrade> trades, TradeSortType tradeSortType) {
 
     super((List) trades, tradeSortType);


### PR DESCRIPTION
In order to improve serialization portability across different versions of the library, explicit serialVersionUID has been added to all currency and dto objects in xchange-core module