### PR TITLE
[Core] Fix order DTO builders

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
@@ -85,6 +85,7 @@ public class LimitOrder extends Order implements Comparable<LimitOrder> {
    *     acceptable price
    * @param averagePrice the weighted average price of any fills belonging to the order
    * @param cumulativeAmount the amount that has been filled
+   * @param fee the fee associated with this order
    * @param status the status of the order at the exchange or broker
    */
   public LimitOrder(
@@ -184,15 +185,15 @@ public class LimitOrder extends Order implements Comparable<LimitOrder> {
     public static Builder from(Order order) {
 
       Builder builder =
-          (Builder)
-              new Builder(order.getType(), order.getCurrencyPair())
-                  .originalAmount(order.getOriginalAmount())
-                  .cumulativeAmount(order.getCumulativeAmount())
-                  .timestamp(order.getTimestamp())
-                  .id(order.getId())
-                  .flags(order.getOrderFlags())
-                  .orderStatus(order.getStatus())
-                  .averagePrice(order.getAveragePrice());
+          new Builder(order.getType(), order.getCurrencyPair())
+              .originalAmount(order.getOriginalAmount())
+              .cumulativeAmount(order.getCumulativeAmount())
+              .timestamp(order.getTimestamp())
+              .id(order.getId())
+              .flags(order.getOrderFlags())
+              .orderStatus(order.getStatus())
+              .fee(order.getFee())
+              .averagePrice(order.getAveragePrice());
       if (order instanceof LimitOrder) {
         LimitOrder limitOrder = (LimitOrder) order;
         builder.limitPrice(limitOrder.getLimitPrice());

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/MarketOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/MarketOrder.java
@@ -24,6 +24,8 @@ public class MarketOrder extends Order {
    * @param timestamp a Date object representing the order's timestamp according to the exchange's
    *     server, null if not provided
    * @param averagePrice the weighted average price of any fills belonging to the order
+   * @param cumulativeAmount the amount that has been filled
+   * @param fee the fee associated with this order
    * @param status the status of the order at the exchange or broker
    */
   public MarketOrder(
@@ -98,10 +100,12 @@ public class MarketOrder extends Order {
 
       return new Builder(order.getType(), order.getCurrencyPair())
           .originalAmount(order.getOriginalAmount())
+          .cumulativeAmount(order.getCumulativeAmount())
           .timestamp(order.getTimestamp())
           .id(order.getId())
           .flags(order.getOrderFlags())
           .averagePrice(order.getAveragePrice())
+          .fee(order.getFee())
           .orderStatus(order.getStatus());
     }
 
@@ -132,7 +136,7 @@ public class MarketOrder extends Order {
     @Override
     public Builder fee(BigDecimal fee) {
 
-      return (Builder) super.cumulativeAmount(fee);
+      return (Builder) super.fee(fee);
     }
 
     @Override

--- a/xchange-core/src/test/java/org/knowm/xchange/dto/trade/LimitOrderTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/dto/trade/LimitOrderTest.java
@@ -16,8 +16,11 @@ public class LimitOrderTest {
   public void testBuilder() {
     final OrderType type = OrderType.BID;
     final BigDecimal originalAmount = new BigDecimal("99.401");
+    final BigDecimal averagePrice = new BigDecimal("255.00");
+    final BigDecimal cumulativeAmount = new BigDecimal("0.00");
     final CurrencyPair currencyPair = CurrencyPair.LTC_BTC;
     final BigDecimal limitPrice = new BigDecimal("251.64");
+    final BigDecimal fee = new BigDecimal("22.2");
     final Date timestamp = new Date();
     final String id = "id";
     final Order.OrderStatus status = Order.OrderStatus.FILLED;
@@ -25,54 +28,60 @@ public class LimitOrderTest {
     final LimitOrder copy =
         new LimitOrder.Builder(type, currencyPair)
             .originalAmount(originalAmount)
+            .averagePrice(averagePrice)
+            .cumulativeAmount(cumulativeAmount)
             .limitPrice(limitPrice)
             .orderStatus(status)
             .timestamp(timestamp)
             .id(id)
-            .flag(TestFlags.TEST1)
+            .flag(LimitOrderTest.TestFlags.TEST1)
+            .fee(fee)
             .build();
-
     assertThat(copy.getType()).isEqualTo(type);
     assertThat(copy.getOriginalAmount()).isEqualTo(originalAmount);
+    assertThat(copy.getAveragePrice()).isEqualTo(averagePrice);
+    assertThat(copy.getCumulativeAmount()).isEqualTo(cumulativeAmount);
     assertThat(copy.getCurrencyPair()).isEqualTo(currencyPair);
     assertThat(copy.getLimitPrice()).isEqualTo(limitPrice);
     assertThat(copy.getTimestamp()).isEqualTo(timestamp);
     assertThat(copy.getId()).isEqualTo(id);
     assertThat(copy.getOrderFlags()).hasSize(1);
-    assertThat(copy.getOrderFlags()).contains(TestFlags.TEST1);
+    assertThat(copy.getOrderFlags()).containsExactly(TestFlags.TEST1);
     assertThat(copy.hasFlag(TestFlags.TEST1));
     assertThat(copy.getStatus()).isEqualTo(status);
+    assertThat(copy.getFee()).isEqualTo(fee);
   }
 
   @Test
   public void testBuilderFrom() {
     final OrderType type = OrderType.ASK;
     final BigDecimal originalAmount = new BigDecimal("100.501");
+    final BigDecimal averagePrice = new BigDecimal("255.00");
+    final BigDecimal cumulativeAmount = new BigDecimal("0.00");
     final CurrencyPair currencyPair = CurrencyPair.BTC_USD;
     final BigDecimal limitPrice = new BigDecimal("250.34");
+    final BigDecimal fee = new BigDecimal("22.2");
     final Date timestamp = new Date();
     final String id = "id";
     final Order.OrderStatus status = Order.OrderStatus.FILLED;
 
     final LimitOrder original =
-        new LimitOrder(type, originalAmount, currencyPair, id, timestamp, limitPrice);
+        new LimitOrder(
+            type,
+            originalAmount,
+            currencyPair,
+            id,
+            timestamp,
+            limitPrice,
+            averagePrice,
+            cumulativeAmount,
+            fee,
+            status);
     original.addOrderFlag(TestFlags.TEST1);
     original.addOrderFlag(TestFlags.TEST3);
-    original.setOrderStatus(status);
     final LimitOrder copy = LimitOrder.Builder.from(original).build();
 
-    assertThat(copy.getType()).isEqualTo(original.getType());
-    assertThat(copy.getOriginalAmount()).isEqualTo(original.getOriginalAmount());
-    assertThat(copy.getCurrencyPair()).isEqualTo(original.getCurrencyPair());
-    assertThat(copy.getLimitPrice()).isEqualTo(original.getLimitPrice());
-    assertThat(copy.getTimestamp()).isEqualTo(original.getTimestamp());
-    assertThat(copy.getId()).isEqualTo(original.getId());
-    assertThat(copy.getOrderFlags()).hasSize(2);
-    assertThat(copy.getOrderFlags()).contains(TestFlags.TEST1);
-    assertThat(copy.hasFlag(TestFlags.TEST1));
-    assertThat(copy.getOrderFlags()).contains(TestFlags.TEST3);
-    assertThat(copy.hasFlag(TestFlags.TEST3));
-    assertThat(copy.getStatus()).isEqualTo(status);
+    assertThat(copy).isEqualToComparingFieldByField(original);
   }
 
   @Test

--- a/xchange-core/src/test/java/org/knowm/xchange/dto/trade/LimitOrderTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/dto/trade/LimitOrderTest.java
@@ -34,7 +34,7 @@ public class LimitOrderTest {
             .orderStatus(status)
             .timestamp(timestamp)
             .id(id)
-            .flag(LimitOrderTest.TestFlags.TEST1)
+            .flag(TestFlags.TEST1)
             .fee(fee)
             .build();
     assertThat(copy.getType()).isEqualTo(type);

--- a/xchange-core/src/test/java/org/knowm/xchange/dto/trade/MarketOrderTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/dto/trade/MarketOrderTest.java
@@ -1,0 +1,85 @@
+package org.knowm.xchange.dto.trade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import org.junit.Test;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
+
+public class MarketOrderTest {
+  @Test
+  public void testBuilder() {
+    final Order.OrderType type = Order.OrderType.BID;
+    final BigDecimal originalAmount = new BigDecimal("99.401");
+    final BigDecimal cumulativeAmount = new BigDecimal("44.401");
+    final BigDecimal averagePrice = new BigDecimal("255.00");
+    final CurrencyPair currencyPair = CurrencyPair.LTC_BTC;
+    final BigDecimal fee = new BigDecimal("22.2");
+    final Date timestamp = new Date();
+    final String id = "id";
+    final Order.OrderStatus status = Order.OrderStatus.FILLED;
+
+    final MarketOrder copy =
+        new MarketOrder.Builder(type, currencyPair)
+            .originalAmount(originalAmount)
+            .averagePrice(averagePrice)
+            .cumulativeAmount(cumulativeAmount)
+            .orderStatus(status)
+            .timestamp(timestamp)
+            .id(id)
+            .flag(TestFlags.TEST1)
+            .fee(fee)
+            .build();
+
+    assertThat(copy.getType()).isEqualTo(type);
+    assertThat(copy.getOriginalAmount()).isEqualTo(originalAmount);
+    assertThat(copy.getCumulativeAmount()).isEqualTo(cumulativeAmount);
+    assertThat(copy.getAveragePrice()).isEqualTo(averagePrice);
+    assertThat(copy.getCurrencyPair()).isEqualTo(currencyPair);
+    assertThat(copy.getTimestamp()).isEqualTo(timestamp);
+    assertThat(copy.getId()).isEqualTo(id);
+    assertThat(copy.getOrderFlags()).hasSize(1);
+    assertThat(copy.getOrderFlags()).containsExactly(TestFlags.TEST1);
+    assertThat(copy.hasFlag(TestFlags.TEST1));
+    assertThat(copy.getStatus()).isEqualTo(status);
+    assertThat(copy.getFee()).isEqualTo(fee);
+  }
+
+  @Test
+  public void testBuilderFrom() {
+    final Order.OrderType type = Order.OrderType.ASK;
+    final BigDecimal originalAmount = new BigDecimal("100.501");
+    final BigDecimal cumulativeAmount = new BigDecimal("44.401");
+    final BigDecimal averagePrice = new BigDecimal("255.00");
+    final CurrencyPair currencyPair = CurrencyPair.BTC_USD;
+    final BigDecimal fee = new BigDecimal("22.2");
+    final Date timestamp = new Date();
+    final String id = "id";
+    final Order.OrderStatus status = Order.OrderStatus.FILLED;
+
+    final MarketOrder original =
+        new MarketOrder(
+            type,
+            originalAmount,
+            currencyPair,
+            id,
+            timestamp,
+            averagePrice,
+            cumulativeAmount,
+            fee,
+            status);
+    original.addOrderFlag(TestFlags.TEST1);
+    original.addOrderFlag(TestFlags.TEST3);
+    final MarketOrder copy = MarketOrder.Builder.from(original).build();
+
+    assertThat(copy).isEqualToComparingFieldByField(original);
+  }
+
+  private enum TestFlags implements Order.IOrderFlags {
+    TEST1,
+    TEST2,
+    TEST3
+  }
+}

--- a/xchange-core/src/test/java/org/knowm/xchange/dto/trade/StopOrderTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/dto/trade/StopOrderTest.java
@@ -1,0 +1,95 @@
+package org.knowm.xchange.dto.trade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import org.junit.Test;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
+
+public class StopOrderTest {
+  @Test
+  public void testBuilder() {
+    final Order.OrderType type = Order.OrderType.BID;
+    final BigDecimal originalAmount = new BigDecimal("99.401");
+    final BigDecimal averagePrice = new BigDecimal("255.00");
+    final BigDecimal cumulativeAmount = new BigDecimal("0.00");
+    final CurrencyPair currencyPair = CurrencyPair.LTC_BTC;
+    final BigDecimal limitPrice = new BigDecimal("251.64");
+    final BigDecimal stopPrice = new BigDecimal("266.21");
+    final BigDecimal fee = new BigDecimal("22.2");
+    final Date timestamp = new Date();
+    final String id = "id";
+    final Order.OrderStatus status = Order.OrderStatus.FILLED;
+
+    final StopOrder copy =
+        new StopOrder.Builder(type, currencyPair)
+            .originalAmount(originalAmount)
+            .averagePrice(averagePrice)
+            .cumulativeAmount(cumulativeAmount)
+            .limitPrice(limitPrice)
+            .stopPrice(stopPrice)
+            .orderStatus(status)
+            .timestamp(timestamp)
+            .id(id)
+            .flag(StopOrderTest.TestFlags.TEST1)
+            .fee(fee)
+            .build();
+
+    assertThat(copy.getType()).isEqualTo(type);
+    assertThat(copy.getOriginalAmount()).isEqualTo(originalAmount);
+    assertThat(copy.getAveragePrice()).isEqualTo(averagePrice);
+    assertThat(copy.getCumulativeAmount()).isEqualTo(cumulativeAmount);
+    assertThat(copy.getCurrencyPair()).isEqualTo(currencyPair);
+    assertThat(copy.getStopPrice()).isEqualTo(stopPrice);
+    assertThat(copy.getLimitPrice()).isEqualTo(limitPrice);
+    assertThat(copy.getTimestamp()).isEqualTo(timestamp);
+    assertThat(copy.getId()).isEqualTo(id);
+    assertThat(copy.getOrderFlags()).hasSize(1);
+    assertThat(copy.getOrderFlags()).containsExactly(StopOrderTest.TestFlags.TEST1);
+    assertThat(copy.hasFlag(StopOrderTest.TestFlags.TEST1));
+    assertThat(copy.getStatus()).isEqualTo(status);
+    assertThat(copy.getFee()).isEqualTo(fee);
+  }
+
+  @Test
+  public void testBuilderFrom() {
+    final Order.OrderType type = Order.OrderType.ASK;
+    final BigDecimal originalAmount = new BigDecimal("100.501");
+    final CurrencyPair currencyPair = CurrencyPair.BTC_USD;
+    final BigDecimal limitPrice = new BigDecimal("250.34");
+    final BigDecimal averagePrice = new BigDecimal("255.00");
+    final BigDecimal cumulativeAmount = new BigDecimal("0.00");
+    final BigDecimal stopPrice = new BigDecimal("266.21");
+    final BigDecimal fee = new BigDecimal("22.2");
+    final Date timestamp = new Date();
+    final String id = "id";
+    final Order.OrderStatus status = Order.OrderStatus.FILLED;
+
+    final StopOrder original =
+        new StopOrder(
+            type,
+            originalAmount,
+            currencyPair,
+            id,
+            timestamp,
+            stopPrice,
+            limitPrice,
+            averagePrice,
+            cumulativeAmount,
+            fee,
+            status);
+    original.addOrderFlag(StopOrderTest.TestFlags.TEST1);
+    original.addOrderFlag(StopOrderTest.TestFlags.TEST3);
+    final StopOrder copy = StopOrder.Builder.from(original).build();
+
+    assertThat(copy).isEqualToComparingFieldByField(original);
+  }
+
+  private enum TestFlags implements Order.IOrderFlags {
+    TEST1,
+    TEST2,
+    TEST3
+  }
+}

--- a/xchange-core/src/test/java/org/knowm/xchange/dto/trade/StopOrderTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/dto/trade/StopOrderTest.java
@@ -33,7 +33,7 @@ public class StopOrderTest {
             .orderStatus(status)
             .timestamp(timestamp)
             .id(id)
-            .flag(StopOrderTest.TestFlags.TEST1)
+            .flag(TestFlags.TEST1)
             .fee(fee)
             .build();
 
@@ -47,8 +47,8 @@ public class StopOrderTest {
     assertThat(copy.getTimestamp()).isEqualTo(timestamp);
     assertThat(copy.getId()).isEqualTo(id);
     assertThat(copy.getOrderFlags()).hasSize(1);
-    assertThat(copy.getOrderFlags()).containsExactly(StopOrderTest.TestFlags.TEST1);
-    assertThat(copy.hasFlag(StopOrderTest.TestFlags.TEST1));
+    assertThat(copy.getOrderFlags()).containsExactly(TestFlags.TEST1);
+    assertThat(copy.hasFlag(TestFlags.TEST1));
     assertThat(copy.getStatus()).isEqualTo(status);
     assertThat(copy.getFee()).isEqualTo(fee);
   }
@@ -80,8 +80,8 @@ public class StopOrderTest {
             cumulativeAmount,
             fee,
             status);
-    original.addOrderFlag(StopOrderTest.TestFlags.TEST1);
-    original.addOrderFlag(StopOrderTest.TestFlags.TEST3);
+    original.addOrderFlag(TestFlags.TEST1);
+    original.addOrderFlag(TestFlags.TEST3);
     final StopOrder copy = StopOrder.Builder.from(original).build();
 
     assertThat(copy).isEqualToComparingFieldByField(original);


### PR DESCRIPTION
Fix order builders:
- missing fee/cumulativeAmount copy in Builder.from methods
- MarketOrder.fee method was setting cumulativeAmount instead of fee
- missing javadoc
- missing tests