### PR TITLE
Fix bug where a potentially null exchange spec was read

### DIFF
--- a/xchange-bleutrade/src/test/java/org/knowm/xchange/bleutrade/BleutradeExchangeIntegration.java
+++ b/xchange-bleutrade/src/test/java/org/knowm/xchange/bleutrade/BleutradeExchangeIntegration.java
@@ -2,7 +2,6 @@ package org.knowm.xchange.bleutrade;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -54,14 +53,11 @@ public class BleutradeExchangeIntegration extends BleutradeServiceTestSupport {
     verify(exchange).remoteInit();
   }
 
-  @Test(expected = NullPointerException.class)
-  public void shouldFailWhenApplyNullSpecification() {
-    // when
+  @Test
+  public void shouldUseDefaultExchangeSpecForNullSpecification() {
     exchange.applySpecification(null);
-
-    // then
-    fail(
-        "BTCMarketsExchange should throw NullPointerException when tries to apply null specification");
+    assertThat(exchange.getExchangeSpecification())
+        .isEqualToComparingFieldByField(exchange.getDefaultExchangeSpecification());
   }
 
   @Test

--- a/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/BTCMarketsExchangeTest.java
+++ b/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/BTCMarketsExchangeTest.java
@@ -1,7 +1,6 @@
 package org.knowm.xchange.btcmarkets;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -128,14 +127,11 @@ public class BTCMarketsExchangeTest extends BTCMarketsTestSupport {
     assertThat(exchange.getAccountService()).isNull();
   }
 
-  @Test(expected = NullPointerException.class)
-  public void shouldFailWhenApplyNullSpecification() {
-    // when
+  @Test
+  public void shouldUseDefaultExchangeSpecForNullSpecification() {
     exchange.applySpecification(null);
-
-    // then
-    fail(
-        "BTCMarketsExchange should throw NullPointerException when tries to apply null specification");
+    assertThat(exchange.getExchangeSpecification())
+        .isEqualToComparingFieldByField(exchange.getDefaultExchangeSpecification());
   }
 
   @Test

--- a/xchange-core/src/main/java/org/knowm/xchange/BaseExchange.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/BaseExchange.java
@@ -96,7 +96,7 @@ public abstract class BaseExchange implements Exchange {
         is =
             BaseExchangeService.class
                 .getClassLoader()
-                .getResourceAsStream(getMetaDataFileName(exchangeSpecification) + ".json");
+                .getResourceAsStream(getMetaDataFileName(this.exchangeSpecification) + ".json");
         loadExchangeMetaData(is);
       } finally {
         IOUtils.closeQuietly(is);


### PR DESCRIPTION
The input exchange spec name was used here instead of the member initialized in the above code and checked before executing this read. This bug was causing crashes during the initialization of the cexio streaming exchange in the xchange-stream project.