### PR TITLE
 [poloniex] Added new Transfer-Object: PoloniexAdjustment

### DIFF
--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAdapters.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAdapters.java
@@ -1,11 +1,5 @@
 package org.knowm.xchange.poloniex;
 
-import static org.knowm.xchange.dto.account.FundingRecord.Type.DEPOSIT;
-import static org.knowm.xchange.dto.account.FundingRecord.Type.WITHDRAWAL;
-
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.util.*;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.LoanOrder;
@@ -30,6 +24,13 @@ import org.knowm.xchange.poloniex.dto.account.PoloniexBalance;
 import org.knowm.xchange.poloniex.dto.account.PoloniexLoan;
 import org.knowm.xchange.poloniex.dto.marketdata.*;
 import org.knowm.xchange.poloniex.dto.trade.*;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.*;
+
+import static org.knowm.xchange.dto.account.FundingRecord.Type.DEPOSIT;
+import static org.knowm.xchange.dto.account.FundingRecord.Type.WITHDRAWAL;
 
 /**
  * @author Zach Holmes
@@ -269,6 +270,29 @@ public class PoloniexAdapters {
   public static List<FundingRecord> adaptFundingRecords(
       PoloniexDepositsWithdrawalsResponse poloFundings) {
     final ArrayList<FundingRecord> fundingRecords = new ArrayList<>();
+    for (PoloniexAdjustment a : poloFundings.getAdjustments()) {
+      fundingRecords.add(
+          new FundingRecord(
+              null,
+              a.getTimestamp(),
+              Currency.getInstance(a.getCurrency()),
+              a.getAmount(),
+              null,
+              null,
+              DEPOSIT,
+              FundingRecord.Status.resolveStatus(a.getStatus()),
+              null,
+              null,
+              a.getCategory()
+                  + ":"
+                  + a.getReason()
+                  + "\n"
+                  + a.getAdjustmentTitle()
+                  + "\n"
+                  + a.getAdjustmentDesc()
+                  + "\n"
+                  + a.getAdjustmentHelp()));
+    }
     for (PoloniexDeposit d : poloFundings.getDeposits()) {
       fundingRecords.add(
           new FundingRecord(

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAdapters.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAdapters.java
@@ -1,5 +1,11 @@
 package org.knowm.xchange.poloniex;
 
+import static org.knowm.xchange.dto.account.FundingRecord.Type.DEPOSIT;
+import static org.knowm.xchange.dto.account.FundingRecord.Type.WITHDRAWAL;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.*;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.LoanOrder;
@@ -24,13 +30,6 @@ import org.knowm.xchange.poloniex.dto.account.PoloniexBalance;
 import org.knowm.xchange.poloniex.dto.account.PoloniexLoan;
 import org.knowm.xchange.poloniex.dto.marketdata.*;
 import org.knowm.xchange.poloniex.dto.trade.*;
-
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.util.*;
-
-import static org.knowm.xchange.dto.account.FundingRecord.Type.DEPOSIT;
-import static org.knowm.xchange.dto.account.FundingRecord.Type.WITHDRAWAL;
 
 /**
  * @author Zach Holmes

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/trade/PoloniexAdjustment.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/trade/PoloniexAdjustment.java
@@ -1,0 +1,127 @@
+package org.knowm.xchange.poloniex.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.util.Date;
+
+public class PoloniexAdjustment {
+
+  private final String currency;
+  private final BigDecimal amount;
+  private final Date timestamp;
+  private final String status;
+  private final String category;
+  private final String reason;
+  private final String adjustmentTitle;
+  private final String adjustmentShortTitle;
+  private final String adjustmentDesc;
+  private final String adjustmentShortDesc;
+  private final String adjustmentHelp;
+
+  public PoloniexAdjustment(
+      @JsonProperty("currency") String currency,
+      @JsonProperty("amount") BigDecimal amount,
+      @JsonProperty("timestamp") long timestamp,
+      @JsonProperty("status") String status,
+      @JsonProperty("category") String category,
+      @JsonProperty("reason") String reason,
+      @JsonProperty("adjustmentTitle") String adjustmentTitle,
+      @JsonProperty("adjustmentShortTitle") String adjustmentShortTitle,
+      @JsonProperty("adjustmentDesc") String adjustmentDesc,
+      @JsonProperty("adjustmentShortDesc") String adjustmentShortDesc,
+      @JsonProperty("adjustmentHelp") String adjustmentHelp) {
+    super();
+    this.currency = currency;
+    this.amount = amount;
+    this.timestamp = new Date(timestamp * 1000);
+    this.status = status;
+    this.category = category;
+    this.reason = reason;
+    this.adjustmentTitle = adjustmentTitle;
+    this.adjustmentShortTitle = adjustmentShortTitle;
+    this.adjustmentDesc = adjustmentDesc;
+    this.adjustmentShortDesc = adjustmentShortDesc;
+    this.adjustmentHelp = adjustmentHelp;
+  }
+
+  public String getCurrency() {
+    return currency;
+  }
+
+  public BigDecimal getAmount() {
+    return amount;
+  }
+
+  public Date getTimestamp() {
+    return timestamp;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public String getCategory() {
+    return category;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public String getAdjustmentTitle() {
+    return adjustmentTitle;
+  }
+
+  public String getAdjustmentShortTitle() {
+    return adjustmentShortTitle;
+  }
+
+  public String getAdjustmentDesc() {
+    return adjustmentDesc;
+  }
+
+  public String getAdjustmentShortDesc() {
+    return adjustmentShortDesc;
+  }
+
+  public String getAdjustmentHelp() {
+    return adjustmentHelp;
+  }
+
+  @Override
+  public String toString() {
+    return "PoloniexAdjustment{"
+        + "currency='"
+        + currency
+        + '\''
+        + ", amount="
+        + amount
+        + ", timestamp="
+        + timestamp
+        + ", status='"
+        + status
+        + '\''
+        + ", category='"
+        + category
+        + '\''
+        + ", reason='"
+        + reason
+        + '\''
+        + ", adjustmentTitle='"
+        + adjustmentTitle
+        + '\''
+        + ", adjustmentShortTitle='"
+        + adjustmentShortTitle
+        + '\''
+        + ", adjustmentDesc='"
+        + adjustmentDesc
+        + '\''
+        + ", adjustmentShortDesc='"
+        + adjustmentShortDesc
+        + '\''
+        + ", adjustmentHelp='"
+        + adjustmentHelp
+        + '\''
+        + '}';
+  }
+}

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/trade/PoloniexDepositsWithdrawalsResponse.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/trade/PoloniexDepositsWithdrawalsResponse.java
@@ -7,19 +7,27 @@ import org.knowm.xchange.exceptions.ExchangeException;
 
 public class PoloniexDepositsWithdrawalsResponse {
 
+  private final List<PoloniexAdjustment> adjustments;
   private final List<PoloniexDeposit> deposits;
   private final List<PoloniexWithdrawal> withdrawals;
 
   @JsonCreator
   public PoloniexDepositsWithdrawalsResponse(
       @JsonProperty("error") String error,
+      @JsonProperty("adjustments") List<PoloniexAdjustment> adjustments,
       @JsonProperty("deposits") List<PoloniexDeposit> deposits,
       @JsonProperty("withdrawals") List<PoloniexWithdrawal> withdrawals) {
     if (error != null) {
       throw new ExchangeException(error);
     }
+
+    this.adjustments = adjustments;
     this.deposits = deposits;
     this.withdrawals = withdrawals;
+  }
+
+  public List<PoloniexAdjustment> getAdjustments() {
+    return adjustments;
   }
 
   public List<PoloniexDeposit> getDeposits() {
@@ -32,10 +40,13 @@ public class PoloniexDepositsWithdrawalsResponse {
 
   @Override
   public String toString() {
-    return "DepositsWithdrawalsResponse [deposits="
+    return "PoloniexDepositsWithdrawalsResponse{"
+        + "adjustments="
+        + adjustments
+        + ", deposits="
         + deposits
         + ", withdrawals="
         + withdrawals
-        + "]";
+        + '}';
   }
 }

--- a/xchange-poloniex/src/test/java/org/knowm/xchange/poloniex/PoloniexAdapterTest.java
+++ b/xchange-poloniex/src/test/java/org/knowm/xchange/poloniex/PoloniexAdapterTest.java
@@ -59,10 +59,32 @@ public class PoloniexAdapterTest {
 
     final List<FundingRecord> fundingRecords = PoloniexAdapters.adaptFundingRecords(response);
 
-    assertThat(fundingRecords).hasSize(2);
+    assertThat(fundingRecords).hasSize(3);
+    final FundingRecord adjustment =
+        fundingRecords.stream()
+            .filter(record -> record.getType() == FundingRecord.Type.DEPOSIT)
+            .findFirst()
+            .orElseThrow(NullPointerException::new);
+
+    assertThat(adjustment.getAddress()).isNull();
+    assertThat(adjustment.getDate()).isEqualTo(new Date(1564782686000L));
+    assertThat(adjustment.getCurrency()).isEqualTo(Currency.USDT);
+    assertThat(adjustment.getAmount())
+        .isCloseTo(new BigDecimal("0.01752476"), Offset.offset(BigDecimal.ZERO));
+    assertThat(adjustment.getInternalId()).isNull();
+    assertThat(adjustment.getBlockchainTransactionHash()).isNull();
+    assertThat(adjustment.getType()).isEqualTo(FundingRecord.Type.DEPOSIT);
+    assertThat(adjustment.getStatus()).isEqualTo(FundingRecord.Status.COMPLETE);
+    assertThat(adjustment.getBalance()).isNull();
+    assertThat(adjustment.getFee()).isNull();
+    assertThat(adjustment.getDescription())
+        .isEqualTo(
+            "adjustment:USDT_AIDROP\nUSDT-TRON Airdrop\nYour airdrop for Aug 2, 2019.\nhttps://support.poloniex.circle.com/hc/en-us/articles/360029433451-USDT-TRON-Airdrop-and-Other-Frequently-Asked-Questions");
+
     final FundingRecord deposit =
         fundingRecords.stream()
             .filter(record -> record.getType() == FundingRecord.Type.DEPOSIT)
+            .skip(1)
             .findFirst()
             .orElseThrow(NullPointerException::new);
 

--- a/xchange-poloniex/src/test/java/org/knowm/xchange/poloniex/dto/account/PoloniexFundingsDataTest.java
+++ b/xchange-poloniex/src/test/java/org/knowm/xchange/poloniex/dto/account/PoloniexFundingsDataTest.java
@@ -14,6 +14,7 @@ import org.assertj.core.data.Offset;
 import org.junit.Test;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.poloniex.dto.marketdata.PoloniexLoansDataTest;
+import org.knowm.xchange.poloniex.dto.trade.PoloniexAdjustment;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexDeposit;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexDepositsWithdrawalsResponse;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexWithdrawal;
@@ -35,6 +36,24 @@ public class PoloniexFundingsDataTest {
         mapper.readValue(is, PoloniexDepositsWithdrawalsResponse.class);
 
     assertThat(response.getDeposits()).hasSize(1);
+
+    final PoloniexAdjustment adjustment = response.getAdjustments().get(0);
+    assertThat(adjustment.getCurrency()).isEqualTo(Currency.USDT.getCurrencyCode());
+    assertThat(adjustment.getAmount())
+        .isCloseTo(new BigDecimal("0.01752476"), Offset.offset(BigDecimal.ZERO));
+    assertThat(adjustment.getTimestamp()).isEqualTo(new Date(1564782686000L));
+    assertThat(adjustment.getStatus()).isEqualTo("COMPLETE");
+    assertThat(adjustment.getCategory()).isEqualTo("adjustment");
+    assertThat(adjustment.getReason()).isEqualTo("USDT_AIDROP");
+    assertThat(adjustment.getAdjustmentTitle()).isEqualTo("USDT-TRON Airdrop");
+    assertThat(adjustment.getAdjustmentShortTitle()).isEqualTo("");
+    assertThat(adjustment.getAdjustmentDesc()).isEqualTo("Your airdrop for Aug 2, 2019.");
+    assertThat(adjustment.getAdjustmentShortDesc()).isEqualTo("For Aug 2, 2019");
+    assertThat(adjustment.getAdjustmentHelp())
+        .isEqualTo(
+            "https://support.poloniex.circle.com/hc/en-us/articles/360029433451-USDT-TRON-Airdrop-and-Other-Frequently-Asked-Questions");
+
+    assertThat(response.getWithdrawals()).hasSize(1);
 
     final PoloniexDeposit deposit = response.getDeposits().get(0);
     assertThat(deposit.getCurrency()).isEqualTo(Currency.ETH.getCurrencyCode());

--- a/xchange-poloniex/src/test/resources/org/knowm/xchange/poloniex/dto/account/deposits-withdrawals.json
+++ b/xchange-poloniex/src/test/resources/org/knowm/xchange/poloniex/dto/account/deposits-withdrawals.json
@@ -1,5 +1,19 @@
 {
-  "adjustments": [],
+  "adjustments": [
+    {
+    "currency": "USDT",
+    "amount": "0.01752476",
+    "timestamp": 1564782686,
+    "status": "COMPLETE",
+    "category": "adjustment",
+    "reason": "USDT_AIDROP",
+    "adjustmentTitle": "USDT-TRON Airdrop",
+    "adjustmentShortTitle": "",
+    "adjustmentDesc": "Your airdrop for Aug 2, 2019.",
+    "adjustmentShortDesc": "For Aug 2, 2019",
+    "adjustmentHelp": "https://support.poloniex.circle.com/hc/en-us/articles/360029433451-USDT-TRON-Airdrop-and-Other-Frequently-Asked-Questions"
+    }
+  ],
   "deposits": [
     {
       "currency": "ETH",


### PR DESCRIPTION
Added new Type PoloniexAdjustment to the PoloniexDepositsWithrawalsResponse-Object and changed adapter to convert it to a Deposit-FundingRecord

API mothod for AccountService.getFundingHistory returns an additional type named Adjustment, which can be airdrops other other forms of "gifted" funds:
[Documentation](https://docs.poloniex.com/#returndepositswithdrawals)

This commit adds the new Type to the PoloniexDepositsWithdrawalsResponse and proposes a non-invasive way to adapt it to a Deposit-FundingRecord. It (miss)uses the description field to place all the extra information until there is a better solution to handle this kind of deposit variation.