### PR TITLE
[Bitmex] Reverting back stepSize on bitmex placeOrder

### DIFF
--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexTradeService.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexTradeService.java
@@ -3,7 +3,6 @@ package org.knowm.xchange.bitmex.service;
 import static org.knowm.xchange.bitmex.dto.trade.BitmexSide.fromOrderType;
 
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -84,7 +83,7 @@ public class BitmexTradeService extends BitmexTradeServiceRaw implements TradeSe
   @Override
   public String placeLimitOrder(LimitOrder limitOrder) throws ExchangeException {
     String symbol = BitmexAdapters.adaptCurrencyPairToSymbol(limitOrder.getCurrencyPair());
-    
+
     Builder b =
         new BitmexPlaceOrderParameters.Builder(symbol)
             .setOrderQuantity(limitOrder.getOriginalAmount())

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexTradeService.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexTradeService.java
@@ -84,13 +84,11 @@ public class BitmexTradeService extends BitmexTradeServiceRaw implements TradeSe
   @Override
   public String placeLimitOrder(LimitOrder limitOrder) throws ExchangeException {
     String symbol = BitmexAdapters.adaptCurrencyPairToSymbol(limitOrder.getCurrencyPair());
-    BigDecimal priceAfterRounding =
-        BigDecimalUtils.roundToStepSize(limitOrder.getLimitPrice(), BigDecimal.valueOf(0.5));
-
+    
     Builder b =
         new BitmexPlaceOrderParameters.Builder(symbol)
             .setOrderQuantity(limitOrder.getOriginalAmount())
-            .setPrice(priceAfterRounding)
+            .setPrice(limitOrder.getLimitPrice())
             .setSide(fromOrderType(limitOrder.getType()))
             .setClOrdId(limitOrder.getId());
     if (limitOrder.hasFlag(BitmexOrderFlags.POST)) {
@@ -116,15 +114,12 @@ public class BitmexTradeService extends BitmexTradeServiceRaw implements TradeSe
   @Override
   public String changeOrder(LimitOrder limitOrder) throws ExchangeException {
 
-    BigDecimal priceAfterRounding =
-        BigDecimalUtils.roundToStepSize(limitOrder.getLimitPrice(), BigDecimal.valueOf(0.5));
-
     BitmexPrivateOrder order =
         replaceOrder(
             new BitmexReplaceOrderParameters.Builder()
                 .setOrderId(limitOrder.getId())
                 .setOrderQuantity(limitOrder.getOriginalAmount())
-                .setPrice(priceAfterRounding)
+                .setPrice(limitOrder.getLimitPrice())
                 .build());
     return order.getId();
   }


### PR DESCRIPTION
This stepSize works only for XBT/USD pair. I am sorry for this mistake on the implementation.