### PR TITLE
Added GBP markets for Bitbay

### DIFF
--- a/xchange-bitbay/src/main/resources/bitbay.json
+++ b/xchange-bitbay/src/main/resources/bitbay.json
@@ -2,11 +2,13 @@
   "currency_pairs": {
 
     "BTC/EUR": {"min_amount": 0.00000001, "price_scale": 2},
+    "BTC/GBP": {"min_amount": 0.00000001, "price_scale": 2},
     "BTC/PLN": {"min_amount": 0.00000001, "price_scale": 2},
     "BTC/USD": {"min_amount": 0.00000001, "price_scale": 2},
     "BTC/USDC": {"min_amount": 0.00000001, "price_scale": 2},
 
     "ETH/EUR": {"min_amount": 0.00000001, "price_scale": 2},
+    "ETH/GBP": {"min_amount": 0.00000001, "price_scale": 2},
     "ETH/PLN": {"min_amount": 0.00000001, "price_scale": 2},
     "ETH/USD": {"min_amount": 0.00000001, "price_scale": 2},
     "ETH/USDC": {"min_amount": 0.00000001, "price_scale": 2},
@@ -23,6 +25,7 @@
     "GAME/BTC": {"min_amount": 0.00000001, "price_scale": 8},
 
     "BCC/EUR": {"min_amount": 0.00000001, "price_scale": 2},
+    "BCC/GBP": {"min_amount": 0.00000001, "price_scale": 2},
     "BCC/PLN": {"min_amount": 0.00000001, "price_scale": 2},
     "BCC/USD": {"min_amount": 0.00000001, "price_scale": 2},
     "BCC/USDC": {"min_amount": 0.00000001, "price_scale": 2},
@@ -34,6 +37,7 @@
     "BTG/BTC": {"min_amount": 0.00000001, "price_scale": 8},
 
     "LTC/EUR": {"min_amount": 0.00000001, "price_scale": 2},
+    "LTC/GBP": {"min_amount": 0.00000001, "price_scale": 2},
     "LTC/PLN": {"min_amount": 0.00000001, "price_scale": 2},
     "LTC/USD": {"min_amount": 0.00000001, "price_scale": 2},
     "LTC/BTC": {"min_amount": 0.00000001, "price_scale": 8},
@@ -44,6 +48,7 @@
     "DASH/BTC": {"min_amount": 0.00000001, "price_scale": 8},
 
     "XRP/EUR": {"min_amount": 0.00000001, "price_scale": 2},
+    "XRP/GBP": {"min_amount": 0.00000001, "price_scale": 2},
     "XRP/PLN": {"min_amount": 0.00000001, "price_scale": 2},
     "XRP/USD": {"min_amount": 0.00000001, "price_scale": 2},
     "XRP/BTC": {"min_amount": 0.00000001, "price_scale": 8},
@@ -89,6 +94,9 @@
       "scale": 8
     },
     "EUR": {
+      "scale": 2
+    },
+    "GBP": {
       "scale": 2
     },
     "PLN": {


### PR DESCRIPTION
Added missing GBP markets for Bitbay metadata: https://bitbay.net/en