### PR TITLE
Make testing for JSON serialization/deserialization stricter

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/dto/Order.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/Order.java
@@ -1,5 +1,6 @@
 package org.knowm.xchange.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -148,6 +149,7 @@ public abstract class Order implements Serializable {
     this.cumulativeAmount = cumulativeAmount;
   }
 
+  @JsonIgnore
   public BigDecimal getCumulativeCounterAmount() {
     if (cumulativeAmount != null
         && averagePrice != null
@@ -414,6 +416,7 @@ public abstract class Order implements Serializable {
     protected BigDecimal averagePrice;
     protected OrderStatus status;
     protected BigDecimal fee;
+    protected String leverage;
 
     protected Builder(OrderType orderType, CurrencyPair currencyPair) {
 
@@ -480,6 +483,12 @@ public abstract class Order implements Serializable {
     public Builder timestamp(Date timestamp) {
 
       this.timestamp = timestamp;
+      return this;
+    }
+
+    public Builder leverage(String leverage) {
+
+      this.leverage = leverage;
       return this;
     }
 

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/account/Balance.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/account/Balance.java
@@ -1,5 +1,6 @@
 package org.knowm.xchange.dto.account;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.Serializable;
@@ -212,6 +213,7 @@ public final class Balance implements Comparable<Balance>, Serializable {
    *
    * @return the amount that is available to withdraw.
    */
+  @JsonIgnore
   public BigDecimal getAvailableForWithdrawal() {
 
     return getAvailable().subtract(getBorrowed());

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/Trade.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/Trade.java
@@ -164,6 +164,8 @@ public class Trade implements Serializable {
     protected BigDecimal price;
     protected Date timestamp;
     protected String id;
+    protected String makerOrderId;
+    protected String takerOrderId;
 
     public static Builder from(Trade trade) {
       return new Builder()
@@ -211,9 +213,24 @@ public class Trade implements Serializable {
       return this;
     }
 
+    public Builder makerOrderId(String makerOrderId) {
+
+      this.makerOrderId = makerOrderId;
+      return this;
+    }
+
+    public Builder takerOrderId(String takerOrderId) {
+
+      this.takerOrderId = takerOrderId;
+      return this;
+    }
+
     public Trade build() {
 
-      return new Trade(type, originalAmount, currencyPair, price, timestamp, id);
+      Trade trade = new Trade(type, originalAmount, currencyPair, price, timestamp, id);
+      trade.setMakerOrderId(makerOrderId);
+      trade.setTakerOrderId(takerOrderId);
+      return trade;
     }
   }
 }

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
@@ -307,6 +307,7 @@ public class LimitOrder extends Order implements Comparable<LimitOrder> {
               fee,
               status);
       order.setOrderFlags(flags);
+      order.setLeverage(leverage);
       return order;
     }
   }

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/MarketOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/MarketOrder.java
@@ -201,6 +201,7 @@ public class MarketOrder extends Order {
               fee,
               status);
       order.setOrderFlags(flags);
+      order.setLeverage(leverage);
       return order;
     }
   }

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/StopOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/StopOrder.java
@@ -412,6 +412,7 @@ public class StopOrder extends Order implements Comparable<StopOrder> {
               status);
 
       order.setOrderFlags(flags);
+      order.setLeverage(leverage);
       return order;
     }
   }

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/UserTrade.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/UserTrade.java
@@ -183,16 +183,20 @@ public class UserTrade extends Trade {
 
     @Override
     public UserTrade build() {
-      return new UserTrade(
-          type,
-          originalAmount,
-          currencyPair,
-          price,
-          timestamp,
-          id,
-          orderId,
-          feeAmount,
-          feeCurrency);
+      UserTrade userTrade =
+          new UserTrade(
+              type,
+              originalAmount,
+              currencyPair,
+              price,
+              timestamp,
+              id,
+              orderId,
+              feeAmount,
+              feeCurrency);
+      userTrade.setMakerOrderId(makerOrderId);
+      userTrade.setTakerOrderId(takerOrderId);
+      return userTrade;
     }
   }
 }

--- a/xchange-core/src/main/java/org/knowm/xchange/utils/ObjectMapperHelper.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/utils/ObjectMapperHelper.java
@@ -17,9 +17,10 @@ import org.slf4j.LoggerFactory;
 public class ObjectMapperHelper {
 
   private static final Logger logger = LoggerFactory.getLogger(ObjectMapperHelper.class);
-  private static final ObjectMapper objectMapperWithIndentation = initWithIndentation();
 
+  private static final ObjectMapper objectMapperWithIndentation = initWithIndentation();
   private static final ObjectMapper objectMapperWithoutIndentation = initWithoutIndentation();
+  private static final ObjectMapper objectMapperStrict = initStrict();
 
   private ObjectMapperHelper() {}
 
@@ -34,6 +35,10 @@ public class ObjectMapperHelper {
     return objectMapperWithoutIndentation.readValue(value, valueType);
   }
 
+  private static <T> T readValueStrict(String value, Class<T> valueType) throws IOException {
+    return objectMapperStrict.readValue(value, valueType);
+  }
+
   public static <T> String toJSON(T valueType) {
     return toJSON(objectMapperWithIndentation, valueType);
   }
@@ -43,8 +48,11 @@ public class ObjectMapperHelper {
   }
 
   /**
-   * Useful for testing. Performs a round trip via a JSON string allowing ser/deser to be tested and
-   * verified.
+   * Useful for testing. Performs a round trip via a JSON string allowing ser/deser to be tested
+   * andv erified.
+   *
+   * <p>Note that this deliberately uses a very strict {@link ObjectMapper} since we need to be sure
+   * that the source object is fully recreated without errors.
    *
    * @param <T> The object type
    * @param valueType The object to be converted
@@ -53,9 +61,9 @@ public class ObjectMapperHelper {
    */
   @SuppressWarnings("unchecked")
   public static <T> T viaJSON(T valueType) throws IOException {
-    String json = toJSON(valueType);
+    String json = toJSON(objectMapperStrict, valueType);
     logger.debug("Converted " + valueType + " to " + json);
-    return readValue(json, (Class<T>) valueType.getClass());
+    return readValueStrict(json, (Class<T>) valueType.getClass());
   }
 
   private static <T> String toJSON(ObjectMapper objectMapper, T valueType) {
@@ -77,5 +85,9 @@ public class ObjectMapperHelper {
     return new ObjectMapper()
         .setSerializationInclusion(JsonInclude.Include.NON_NULL)
         .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+  }
+
+  private static ObjectMapper initStrict() {
+    return new ObjectMapper();
   }
 }

--- a/xchange-core/src/test/java/org/knowm/xchange/dto/account/BalanceTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/dto/account/BalanceTest.java
@@ -2,16 +2,21 @@ package org.knowm.xchange.dto.account;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.math.BigDecimal;
 import org.junit.Test;
 import org.knowm.xchange.currency.Currency;
-import org.knowm.xchange.utils.ObjectMapperHelper;
 
 public class BalanceTest {
 
   @Test
   public void testSerializeDeserialize() throws IOException {
+
+    // This deliberately doesn't use FAIL_ON_UNKNOWN_PROPERTIES so that
+    // we ensure serialization/deserialization is symmetrical.
+    ObjectMapper objectMapper = new ObjectMapper();
+
     Balance balance =
         new Balance.Builder()
             .available(new BigDecimal("0.12"))
@@ -23,10 +28,12 @@ public class BalanceTest {
             .withdrawing(new BigDecimal("0.17"))
             .build();
 
-    String json = ObjectMapperHelper.toCompactJSON(balance);
+    String json = objectMapper.writeValueAsString(balance);
+
+    System.out.println(json);
     assertThat(json).contains("\"currency\":\"ADA\"");
 
-    Balance jsonCopy = ObjectMapperHelper.readValue(json, Balance.class);
+    Balance jsonCopy = objectMapper.readValue(json, Balance.class);
     assertThat(jsonCopy).isEqualToComparingFieldByField(balance);
   }
 }

--- a/xchange-core/src/test/java/org/knowm/xchange/dto/trade/LimitOrderTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/dto/trade/LimitOrderTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Date;
@@ -89,6 +90,11 @@ public class LimitOrderTest {
 
   @Test
   public void testSerializeDeserialize() throws IOException {
+
+    // This deliberately doesn't use FAIL_ON_UNKNOWN_PROPERTIES so that
+    // we ensure serialization/deserialization is symmetrical.
+    ObjectMapper objectMapper = new ObjectMapper();
+
     final OrderType type = OrderType.ASK;
     final BigDecimal originalAmount = new BigDecimal("100.501");
     final BigDecimal averagePrice = new BigDecimal("255.00");

--- a/xchange-core/src/test/java/org/knowm/xchange/dto/trade/UserTradeTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/dto/trade/UserTradeTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Date;
@@ -11,7 +12,6 @@ import org.junit.Test;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
-import org.knowm.xchange.utils.ObjectMapperHelper;
 
 public class UserTradeTest {
 
@@ -89,6 +89,11 @@ public class UserTradeTest {
 
   @Test
   public void testSerializeDeserialize() throws IOException {
+
+    // This deliberately doesn't use FAIL_ON_UNKNOWN_PROPERTIES so that
+    // we ensure serialization/deserialization is symmetrical.
+    ObjectMapper objectMapper = new ObjectMapper();
+
     final OrderType type = OrderType.ASK;
     final BigDecimal originalAmount = new BigDecimal("100.501");
     final CurrencyPair currencyPair = CurrencyPair.BTC_USD;
@@ -110,10 +115,10 @@ public class UserTradeTest {
             feeAmount,
             feeCurrency);
 
-    String json = ObjectMapperHelper.toCompactJSON(original);
+    String json = objectMapper.writeValueAsString(original);
     assertThat(json).contains("\"currencyPair\":\"BTC/USD\"");
 
-    UserTrade jsonCopy = ObjectMapperHelper.readValue(json, UserTrade.class);
+    UserTrade jsonCopy = objectMapper.readValue(json, UserTrade.class);
     assertThat(jsonCopy).isEqualToComparingFieldByField(original);
   }
 


### PR DESCRIPTION
Previously it allowed deserialization not to work when new properties were added.
Fixed a number of broken properties.