### PR TITLE
Fix handling of unknown 5-letter currencies in Kraken

### DIFF
--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenUtils.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenUtils.java
@@ -53,22 +53,13 @@ public class KrakenUtils {
     CurrencyPair pair = assetPairMap.get(currencyPairIn);
     if (pair == null) {
       // kraken can give short pairs back from open orders ?
-      if (currencyPairIn.length() == 6) {
-        Currency base = Currency.getInstance(currencyPairIn.substring(0, 3));
+      if (currencyPairIn.length() >= 6 && currencyPairIn.length() <= 8) {
+        int firstCurrencyLength = currencyPairIn.length() - 3;
+        Currency base = Currency.getInstance(currencyPairIn.substring(0, firstCurrencyLength));
         if (base.getCommonlyUsedCurrency() != null) {
           base = base.getCommonlyUsedCurrency();
         }
-        Currency counter = Currency.getInstance(currencyPairIn.substring(3, 6));
-        if (counter.getCommonlyUsedCurrency() != null) {
-          counter = counter.getCommonlyUsedCurrency();
-        }
-        pair = new CurrencyPair(base, counter);
-      } else if (currencyPairIn.length() == 7) {
-        Currency base = Currency.getInstance(currencyPairIn.substring(0, 4));
-        if (base.getCommonlyUsedCurrency() != null) {
-          base = base.getCommonlyUsedCurrency();
-        }
-        Currency counter = Currency.getInstance(currencyPairIn.substring(4, 7));
+        Currency counter = Currency.getInstance(currencyPairIn.substring(firstCurrencyLength, currencyPairIn.length()));
         if (counter.getCommonlyUsedCurrency() != null) {
           counter = counter.getCommonlyUsedCurrency();
         }

--- a/xchange-kraken/src/test/java/org/knowm/xchange/kraken/KrakenAdaptersTest.java
+++ b/xchange-kraken/src/test/java/org/knowm/xchange/kraken/KrakenAdaptersTest.java
@@ -243,20 +243,7 @@ public class KrakenAdaptersTest {
 
   @Test
   public void testAdaptTradeHistory() throws JsonParseException, JsonMappingException, IOException {
-
-    // Read in the JSON from the example resources
-    InputStream is =
-        KrakenAdaptersTest.class.getResourceAsStream(
-            "/org/knowm/xchange/kraken/dto/trading/example-tradehistory-data.json");
-
-    // Use Jackson to parse it
-    ObjectMapper mapper = new ObjectMapper();
-    KrakenTradeHistoryResult krakenResult = mapper.readValue(is, KrakenTradeHistoryResult.class);
-    KrakenTradeHistory krakenTradeHistory = krakenResult.getResult();
-    Map<String, KrakenTrade> krakenTradeHistoryMap = krakenTradeHistory.getTrades();
-
-    UserTrades trades = KrakenAdapters.adaptTradesHistory(krakenTradeHistoryMap);
-    List<UserTrade> tradeList = trades.getUserTrades();
+    List<UserTrade> tradeList = loadUserTrades("/org/knowm/xchange/kraken/dto/trading/example-tradehistory-data.json");
 
     assertThat(tradeList.size()).isEqualTo(1);
     UserTrade trade = tradeList.get(0);
@@ -270,6 +257,40 @@ public class KrakenAdaptersTest {
     assertThat(trade.getFeeAmount()).isEqualTo("0.03208");
     assertThat(trade.getFeeCurrency()).isEqualTo(Currency.BTC);
     assertThat(((KrakenUserTrade) trade).getCost()).isEqualTo("16.03781");
+  }
+
+  @Test
+  public void testIcnTradeHistory() throws JsonParseException, JsonMappingException, IOException {
+    List<UserTrade> tradeList = loadUserTrades("/org/knowm/xchange/kraken/dto/trading/example-tradehistory-icn.json");
+
+    assertThat(tradeList.size()).isEqualTo(1);
+    UserTrade trade = tradeList.get(0);
+    assertThat(trade).isInstanceOf(KrakenUserTrade.class);
+    assertThat(trade.getId()).isEqualTo("TY5BYV-WJUQF-XPYEYD");
+    assertThat(trade.getPrice()).isEqualTo("32.07562");
+    assertThat(trade.getOriginalAmount()).isEqualTo("0.50000000");
+    assertThat(trade.getCurrencyPair().base).isEqualTo(Currency.getInstance("XICNX"));
+    assertThat(trade.getCurrencyPair().counter).isEqualTo(Currency.BTC);
+    assertThat(trade.getType()).isEqualTo(OrderType.ASK);
+    assertThat(trade.getFeeAmount()).isEqualTo("0.03208");
+    assertThat(trade.getFeeCurrency()).isEqualTo(Currency.BTC);
+    assertThat(((KrakenUserTrade) trade).getCost()).isEqualTo("16.03781");
+  }
+
+
+  private static List<UserTrade> loadUserTrades(String resourceName) throws IOException {
+    // Read in the JSON from the example resources
+    InputStream is =
+        KrakenAdaptersTest.class.getResourceAsStream(resourceName);
+
+    // Use Jackson to parse it
+    ObjectMapper mapper = new ObjectMapper();
+    KrakenTradeHistoryResult krakenResult = mapper.readValue(is, KrakenTradeHistoryResult.class);
+    KrakenTradeHistory krakenTradeHistory = krakenResult.getResult();
+    Map<String, KrakenTrade> krakenTradeHistoryMap = krakenTradeHistory.getTrades();
+
+    UserTrades trades = KrakenAdapters.adaptTradesHistory(krakenTradeHistoryMap);
+    return trades.getUserTrades();
   }
 
   @Test

--- a/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/trading/example-tradehistory-icn.json
+++ b/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/trading/example-tradehistory-icn.json
@@ -1,0 +1,22 @@
+{
+  "error": [
+  ],
+  "result": {
+    "trades": {
+      "TY5BYV-WJUQF-XPYEYD": {
+        "ordertxid": "ONRNOX-DVI4W-76DL6Q",
+        "pair": "XICNXXBT",
+        "time": 1389071942.2089,
+        "type": "sell",
+        "ordertype": "market",
+        "price": "32.07562",
+        "cost": "16.03781",
+        "fee": "0.03208",
+        "vol": "0.50000000",
+        "margin": "0.00000",
+        "misc": ""
+      }
+    },
+    "count": "1"
+  }
+}


### PR DESCRIPTION
The xchange library currently throws an NullPointerException when downloading historic trades from Kraken for my account because it can't handle a trade with trading pair "XICNXXBT":

```
Exception in thread "main" java.lang.NullPointerException
	at org.knowm.xchange.kraken.KrakenAdapters.adaptTrade(KrakenAdapters.java:283)
	at org.knowm.xchange.kraken.KrakenAdapters.adaptTradesHistory(KrakenAdapters.java:259)
	at org.knowm.xchange.kraken.service.KrakenTradeService.getTradeHistory(KrakenTradeService.java:93)
```

This change fixes that. Probably this also closes #1826.
