### PR TITLE
[kraken] Fix handling of ICN ledger entries

### DIFF
--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenUtils.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenUtils.java
@@ -2,6 +2,7 @@ package org.knowm.xchange.kraken;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.exceptions.ExchangeException;
@@ -16,6 +17,16 @@ public class KrakenUtils {
       new HashMap<CurrencyPair, String>();
   private static Map<String, Currency> assetsMap = new HashMap<String, Currency>();
   private static Map<Currency, String> assetsMapReverse = new HashMap<Currency, String>();
+
+  /**
+   * Mapping of discontinued currencies to their standard name.
+   */
+  private static Map<String, String> discontinuedCurrencies;
+
+  static {
+    discontinuedCurrencies = new HashMap<>();
+    discontinuedCurrencies.put("XICN", "ICN");
+  }
 
   /** Private Constructor */
   private KrakenUtils() {}
@@ -94,6 +105,9 @@ public class KrakenUtils {
   }
 
   public static Currency translateKrakenCurrencyCode(String currencyIn) {
+    if (discontinuedCurrencies.containsKey(currencyIn)) {
+      return Currency.getInstance(discontinuedCurrencies.get(currencyIn));
+    }
     Currency currencyOut = assetsMap.get(currencyIn);
     if (currencyOut == null) {
       throw new ExchangeException("Kraken does not support the currency code " + currencyIn);

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/LedgerType.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/LedgerType.java
@@ -20,7 +20,8 @@ public enum LedgerType {
   MARGIN,
   CREDIT,
   ROLLOVER,
-  TRANSFER;
+  TRANSFER,
+  ADJUSTMENT;
 
   private static final Map<String, LedgerType> fromString = new HashMap<>();
 

--- a/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/account/example-ledgerinfo-data.json
+++ b/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/account/example-ledgerinfo-data.json
@@ -3,6 +3,16 @@
   ],
   "result": {
     "ledger": {
+      "LDVXGZ-2FJSK-FJWOGJ": {
+        "refid": "LAJSKG3-35JF4-JF0JG3",
+        "time": 1549990357.125,
+        "type": "adjustment",
+        "aclass": "currency",
+        "asset": "XICN",
+        "amount": "-350.0000000000",
+        "fee": "0.0000000000",
+        "balance": "0.0000000000"
+      },
       "LQY6IE-WNT47-JRBOJV": {
         "refid": "QGBJIZV-4F6SPK-ZCBT5O",
         "time": 1391400160.0679,


### PR DESCRIPTION
ICN was discontinued by kraken in Feb 2019. This gave two "adjustment" ledger entries (removing the ICN and adding some ETH), which crash xchange at this moment.
