### PR TITLE
[bitfinex] Bugfix getTradeHistory

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAccountServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAccountServiceRaw.java
@@ -3,7 +3,6 @@ package org.knowm.xchange.bitfinex.service;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Date;
-
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitfinex.v1.dto.BitfinexException;
 import org.knowm.xchange.bitfinex.v1.dto.account.BitfinexAccountFeesResponse;

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
@@ -1,16 +1,8 @@
 package org.knowm.xchange.bitfinex.service;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -21,12 +13,7 @@ import org.knowm.xchange.bitfinex.v1.dto.account.BitfinexAccountFeesResponse;
 import org.knowm.xchange.bitfinex.v1.dto.account.BitfinexBalancesResponse;
 import org.knowm.xchange.bitfinex.v1.dto.account.BitfinexDepositWithdrawalHistoryResponse;
 import org.knowm.xchange.bitfinex.v1.dto.account.BitfinexTradingFeeResponse;
-import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexDepth;
-import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexLendLevel;
-import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexLevel;
-import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexSymbolDetail;
-import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexTicker;
-import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexTrade;
+import org.knowm.xchange.bitfinex.v1.dto.marketdata.*;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexAccountInfosResponse;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrderFlags;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrderStatusResponse;
@@ -49,13 +36,7 @@ import org.knowm.xchange.dto.marketdata.Trades.TradeSortType;
 import org.knowm.xchange.dto.meta.CurrencyMetaData;
 import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
 import org.knowm.xchange.dto.meta.ExchangeMetaData;
-import org.knowm.xchange.dto.trade.FixedRateLoanOrder;
-import org.knowm.xchange.dto.trade.FloatingRateLoanOrder;
-import org.knowm.xchange.dto.trade.LimitOrder;
-import org.knowm.xchange.dto.trade.OpenOrders;
-import org.knowm.xchange.dto.trade.StopOrder;
-import org.knowm.xchange.dto.trade.UserTrade;
-import org.knowm.xchange.dto.trade.UserTrades;
+import org.knowm.xchange.dto.trade.*;
 import org.knowm.xchange.utils.DateUtils;
 import org.knowm.xchange.utils.jackson.CurrencyPairDeserializer;
 import org.slf4j.Logger;
@@ -542,6 +523,35 @@ public final class BitfinexAdapters {
               trade.getPrice(),
               timestamp,
               trade.getTradeId(),
+              trade.getOrderId(),
+              fee,
+              Currency.getInstance(trade.getFeeCurrency())));
+    }
+
+    return new UserTrades(pastTrades, TradeSortType.SortByTimestamp);
+  }
+
+  public static UserTrades adaptTradeHistoryV2(
+      List<org.knowm.xchange.bitfinex.v2.dto.trade.Trade> trades) {
+
+    List<UserTrade> pastTrades = new ArrayList<>(trades.size());
+
+    for (org.knowm.xchange.bitfinex.v2.dto.trade.Trade trade : trades) {
+      OrderType orderType = trade.getExecAmount().signum() <= 0 ? OrderType.BID : OrderType.ASK;
+      BigDecimal amount =
+          trade.getExecAmount().signum() == -1
+              ? trade.getExecAmount().negate()
+              : trade.getExecAmount();
+      Date timestamp = DateUtils.fromMillisUtc(trade.getTimestamp());
+      final BigDecimal fee = trade.getFee() != null ? trade.getFee().negate() : null;
+      pastTrades.add(
+          new UserTrade(
+              orderType,
+              amount,
+              adaptCurrencyPair(trade.getSymbol()),
+              trade.getExecPrice(),
+              timestamp,
+              trade.getId(),
               trade.getOrderId(),
               fee,
               Currency.getInstance(trade.getFeeCurrency())));

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
@@ -125,17 +125,17 @@ public final class BitfinexAdapters {
   }
 
   public static CurrencyPair adaptCurrencyPair(String bitfinexSymbol) {
-
     String tradableIdentifier;
     String transactionCurrency;
+    int startIndex = bitfinexSymbol.startsWith("t") ? 1 : 0;
     if (bitfinexSymbol.contains(":")) {
       // ie 'dusk:usd' or 'btc:cnht'
       int idx = bitfinexSymbol.indexOf(":");
-      tradableIdentifier = bitfinexSymbol.substring(0, idx);
+      tradableIdentifier = bitfinexSymbol.substring(startIndex, idx);
       transactionCurrency = bitfinexSymbol.substring(idx + 1);
     } else {
-      tradableIdentifier = bitfinexSymbol.substring(0, 3);
-      transactionCurrency = bitfinexSymbol.substring(3);
+      tradableIdentifier = bitfinexSymbol.substring(startIndex, startIndex + 3);
+      transactionCurrency = bitfinexSymbol.substring(startIndex + 3);
     }
 
     return new CurrencyPair(

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
@@ -537,24 +537,24 @@ public final class BitfinexAdapters {
     List<UserTrade> pastTrades = new ArrayList<>(trades.size());
 
     for (org.knowm.xchange.bitfinex.v2.dto.trade.Trade trade : trades) {
-      OrderType orderType = trade.getExecAmount().signum() <= 0 ? OrderType.BID : OrderType.ASK;
+      OrderType orderType = trade.getExecAmount().signum() >= 0 ? OrderType.BID : OrderType.ASK;
       BigDecimal amount =
           trade.getExecAmount().signum() == -1
               ? trade.getExecAmount().negate()
               : trade.getExecAmount();
-      Date timestamp = DateUtils.fromMillisUtc(trade.getTimestamp());
       final BigDecimal fee = trade.getFee() != null ? trade.getFee().negate() : null;
       pastTrades.add(
-          new UserTrade(
-              orderType,
-              amount,
-              adaptCurrencyPair(trade.getSymbol()),
-              trade.getExecPrice(),
-              timestamp,
-              trade.getId(),
-              trade.getOrderId(),
-              fee,
-              Currency.getInstance(trade.getFeeCurrency())));
+          new UserTrade.Builder()
+              .type(orderType)
+              .originalAmount(amount)
+              .currencyPair(adaptCurrencyPair(trade.getSymbol()))
+              .price(trade.getExecPrice())
+              .timestamp(trade.getTimestamp())
+              .id(trade.getId())
+              .orderId(trade.getOrderId())
+              .feeAmount(fee)
+              .feeCurrency(Currency.getInstance(trade.getFeeCurrency()))
+              .build());
     }
 
     return new UserTrades(pastTrades, TradeSortType.SortByTimestamp);

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexTradeService.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexTradeService.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitfinex.BitfinexErrorAdapter;
@@ -13,26 +12,13 @@ import org.knowm.xchange.bitfinex.v1.dto.BitfinexException;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrderFlags;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrderStatusResponse;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexReplaceOrderRequest;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexTradeResponse;
+import org.knowm.xchange.bitfinex.v2.dto.trade.Trade;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
-import org.knowm.xchange.dto.trade.LimitOrder;
-import org.knowm.xchange.dto.trade.MarketOrder;
-import org.knowm.xchange.dto.trade.OpenOrders;
-import org.knowm.xchange.dto.trade.StopOrder;
-import org.knowm.xchange.dto.trade.UserTrades;
-import org.knowm.xchange.exceptions.ExchangeException;
+import org.knowm.xchange.dto.trade.*;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.trade.TradeService;
-import org.knowm.xchange.service.trade.params.CancelAllOrders;
-import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
-import org.knowm.xchange.service.trade.params.CancelOrderParams;
-import org.knowm.xchange.service.trade.params.DefaultTradeHistoryParamsTimeSpan;
-import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
-import org.knowm.xchange.service.trade.params.TradeHistoryParamLimit;
-import org.knowm.xchange.service.trade.params.TradeHistoryParamPaging;
-import org.knowm.xchange.service.trade.params.TradeHistoryParams;
-import org.knowm.xchange.service.trade.params.TradeHistoryParamsTimeSpan;
+import org.knowm.xchange.service.trade.params.*;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
 import org.knowm.xchange.utils.DateUtils;
 
@@ -186,44 +172,38 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Tra
   @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
     try {
-      final String symbol;
+      String symbol = null;
       if (params instanceof TradeHistoryParamCurrencyPair
           && ((TradeHistoryParamCurrencyPair) params).getCurrencyPair() != null) {
         symbol =
             BitfinexAdapters.adaptCurrencyPair(
                 ((TradeHistoryParamCurrencyPair) params).getCurrencyPair());
-      } else {
-        // Exchange will return the errors below if CurrencyPair is not provided.
-        // field not on request: "Key symbol was not present."
-        // field supplied but blank: "Key symbol may not be the empty string"
-        throw new ExchangeException("CurrencyPair must be supplied");
       }
 
       long startTime = 0;
       Long endTime = null;
-      Integer limit = 50;
+      Long limit = 50L;
 
       if (params instanceof TradeHistoryParamsTimeSpan) {
         TradeHistoryParamsTimeSpan paramsTimeSpan = (TradeHistoryParamsTimeSpan) params;
-        startTime = DateUtils.toUnixTimeNullSafe(paramsTimeSpan.getStartTime());
-        endTime = DateUtils.toUnixTimeNullSafe(paramsTimeSpan.getEndTime());
+        startTime = DateUtils.toMillisNullSafe(paramsTimeSpan.getStartTime());
+        endTime = DateUtils.toMillisNullSafe(paramsTimeSpan.getEndTime());
       }
 
       if (params instanceof TradeHistoryParamPaging) {
         TradeHistoryParamPaging pagingParams = (TradeHistoryParamPaging) params;
         Integer pageLength = pagingParams.getPageLength();
         Integer pageNum = pagingParams.getPageNumber();
-        limit = (pageLength != null && pageNum != null) ? pageLength * (pageNum + 1) : 50;
+        limit = (pageLength != null && pageNum != null) ? pageLength * (pageNum + 1) : 50L;
       }
 
       if (params instanceof TradeHistoryParamLimit) {
         TradeHistoryParamLimit tradeHistoryParamLimit = (TradeHistoryParamLimit) params;
-        limit = tradeHistoryParamLimit.getLimit();
+        limit = Long.valueOf(tradeHistoryParamLimit.getLimit());
       }
 
-      final BitfinexTradeResponse[] trades =
-          getBitfinexTradeHistory(symbol, startTime, endTime, limit, null);
-      return BitfinexAdapters.adaptTradeHistory(trades, symbol);
+      final List<Trade> trades = getBitfinexTradesV2(symbol, startTime, endTime, limit);
+      return BitfinexAdapters.adaptTradeHistoryV2(trades);
     } catch (BitfinexException e) {
       throw BitfinexErrorAdapter.adapt(e);
     }
@@ -232,7 +212,7 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Tra
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
 
-    return new BitfinexTradeHistoryParams(new Date(0), 50, CurrencyPair.BTC_USD);
+    return new BitfinexTradeHistoryParams();
   }
 
   @Override
@@ -270,19 +250,14 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Tra
   }
 
   public static class BitfinexTradeHistoryParams extends DefaultTradeHistoryParamsTimeSpan
-      implements TradeHistoryParamCurrencyPair, TradeHistoryParamPaging {
+      implements TradeHistoryParamCurrencyPair, TradeHistoryParamPaging, TradeHistoryParamLimit {
 
     private int count;
     private CurrencyPair pair;
     private Integer pageNumber;
+    private Integer limit;
 
-    public BitfinexTradeHistoryParams(Date startTime, int count, CurrencyPair pair) {
-
-      super(startTime);
-
-      this.count = count;
-      this.pair = pair;
-    }
+    public BitfinexTradeHistoryParams() {}
 
     @Override
     public Integer getPageLength() {
@@ -318,6 +293,16 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Tra
     public void setCurrencyPair(CurrencyPair pair) {
 
       this.pair = pair;
+    }
+
+    @Override
+    public Integer getLimit() {
+      return this.limit;
+    }
+
+    @Override
+    public void setLimit(Integer limit) {
+      this.limit = limit;
     }
   }
 }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexTradeService.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexTradeService.java
@@ -191,13 +191,6 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Tra
         endTime = DateUtils.toMillisNullSafe(paramsTimeSpan.getEndTime());
       }
 
-      if (params instanceof TradeHistoryParamPaging) {
-        TradeHistoryParamPaging pagingParams = (TradeHistoryParamPaging) params;
-        Integer pageLength = pagingParams.getPageLength();
-        Integer pageNum = pagingParams.getPageNumber();
-        limit = (pageLength != null && pageNum != null) ? pageLength * (pageNum + 1) : 50L;
-      }
-
       if (params instanceof TradeHistoryParamLimit) {
         TradeHistoryParamLimit tradeHistoryParamLimit = (TradeHistoryParamLimit) params;
         limit = Long.valueOf(tradeHistoryParamLimit.getLimit());
@@ -256,42 +249,13 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Tra
   }
 
   public static class BitfinexTradeHistoryParams extends DefaultTradeHistoryParamsTimeSpan
-      implements TradeHistoryParamCurrencyPair,
-          TradeHistoryParamPaging,
-          TradeHistoryParamLimit,
-          TradeHistoryParamsSorted {
+      implements TradeHistoryParamCurrencyPair, TradeHistoryParamLimit, TradeHistoryParamsSorted {
 
-    private int count;
     private CurrencyPair pair;
-    private Integer pageNumber;
     private Integer limit;
     private Order order;
 
     public BitfinexTradeHistoryParams() {}
-
-    @Override
-    public Integer getPageLength() {
-
-      return count;
-    }
-
-    @Override
-    public void setPageLength(Integer count) {
-
-      this.count = count;
-    }
-
-    @Override
-    public Integer getPageNumber() {
-
-      return pageNumber;
-    }
-
-    @Override
-    public void setPageNumber(Integer pageNumber) {
-
-      this.pageNumber = pageNumber;
-    }
 
     @Override
     public CurrencyPair getCurrencyPair() {

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexTradeService.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexTradeService.java
@@ -183,6 +183,7 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Tra
       long startTime = 0;
       Long endTime = null;
       Long limit = 50L;
+      Long sort = null;
 
       if (params instanceof TradeHistoryParamsTimeSpan) {
         TradeHistoryParamsTimeSpan paramsTimeSpan = (TradeHistoryParamsTimeSpan) params;
@@ -202,7 +203,12 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Tra
         limit = Long.valueOf(tradeHistoryParamLimit.getLimit());
       }
 
-      final List<Trade> trades = getBitfinexTradesV2(symbol, startTime, endTime, limit);
+      if (params instanceof TradeHistoryParamsSorted) {
+        TradeHistoryParamsSorted tradeHistoryParamsSorted = (TradeHistoryParamsSorted) params;
+        sort = tradeHistoryParamsSorted.getOrder() == TradeHistoryParamsSorted.Order.asc ? 1L : -1L;
+      }
+
+      final List<Trade> trades = getBitfinexTradesV2(symbol, startTime, endTime, limit, sort);
       return BitfinexAdapters.adaptTradeHistoryV2(trades);
     } catch (BitfinexException e) {
       throw BitfinexErrorAdapter.adapt(e);
@@ -250,12 +256,16 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Tra
   }
 
   public static class BitfinexTradeHistoryParams extends DefaultTradeHistoryParamsTimeSpan
-      implements TradeHistoryParamCurrencyPair, TradeHistoryParamPaging, TradeHistoryParamLimit {
+      implements TradeHistoryParamCurrencyPair,
+          TradeHistoryParamPaging,
+          TradeHistoryParamLimit,
+          TradeHistoryParamsSorted {
 
     private int count;
     private CurrencyPair pair;
     private Integer pageNumber;
     private Integer limit;
+    private Order order;
 
     public BitfinexTradeHistoryParams() {}
 
@@ -303,6 +313,16 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Tra
     @Override
     public void setLimit(Integer limit) {
       this.limit = limit;
+    }
+
+    @Override
+    public Order getOrder() {
+      return this.order;
+    }
+
+    @Override
+    public void setOrder(Order order) {
+      this.order = order;
     }
   }
 }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexTradeServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexTradeServiceRaw.java
@@ -4,38 +4,14 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitfinex.v1.BitfinexOrderType;
 import org.knowm.xchange.bitfinex.v1.BitfinexUtils;
 import org.knowm.xchange.bitfinex.v1.dto.BitfinexException;
 import org.knowm.xchange.bitfinex.v1.dto.account.BitfinexWithdrawalRequest;
 import org.knowm.xchange.bitfinex.v1.dto.account.BitfinexWithdrawalResponse;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexAccountInfosResponse;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexActiveCreditsRequest;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexActivePositionsResponse;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexCancelAllOrdersRequest;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexCancelOfferRequest;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexCancelOrderMultiRequest;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexCancelOrderRequest;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexCreditResponse;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexFundingTradeResponse;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexLimitOrder;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexNewOfferRequest;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexNewOrder;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexNewOrderMultiRequest;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexNewOrderMultiResponse;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexNewOrderRequest;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexNonceOnlyRequest;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOfferStatusRequest;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOfferStatusResponse;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrderFlags;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrderStatusRequest;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrderStatusResponse;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrdersHistoryRequest;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexPastFundingTradesRequest;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexPastTradesRequest;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexReplaceOrderRequest;
-import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexTradeResponse;
+import org.knowm.xchange.bitfinex.v1.dto.trade.*;
 import org.knowm.xchange.bitfinex.v2.dto.EmptyRequest;
 import org.knowm.xchange.bitfinex.v2.dto.trade.ActiveOrder;
 import org.knowm.xchange.bitfinex.v2.dto.trade.Position;
@@ -488,6 +464,17 @@ public class BitfinexTradeServiceRaw extends BitfinexBaseService {
 
   public List<Trade> getBitfinexTradesV2(
       String symbol, Long startTimeMillis, Long endTimeMillis, Long limit) throws IOException {
+    if (StringUtils.isBlank(symbol)) {
+      return bitfinexV2.getTrades(
+          exchange.getNonceFactory(),
+          apiKey,
+          signatureV2,
+          startTimeMillis,
+          endTimeMillis,
+          limit,
+          EmptyRequest.INSTANCE);
+    }
+
     return bitfinexV2.getTrades(
         exchange.getNonceFactory(),
         apiKey,

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexTradeServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexTradeServiceRaw.java
@@ -463,7 +463,8 @@ public class BitfinexTradeServiceRaw extends BitfinexBaseService {
   }
 
   public List<Trade> getBitfinexTradesV2(
-      String symbol, Long startTimeMillis, Long endTimeMillis, Long limit) throws IOException {
+      String symbol, Long startTimeMillis, Long endTimeMillis, Long limit, Long sort)
+      throws IOException {
     if (StringUtils.isBlank(symbol)) {
       return bitfinexV2.getTrades(
           exchange.getNonceFactory(),
@@ -472,6 +473,7 @@ public class BitfinexTradeServiceRaw extends BitfinexBaseService {
           startTimeMillis,
           endTimeMillis,
           limit,
+          sort,
           EmptyRequest.INSTANCE);
     }
 
@@ -483,6 +485,7 @@ public class BitfinexTradeServiceRaw extends BitfinexBaseService {
         startTimeMillis,
         endTimeMillis,
         limit,
+        sort,
         EmptyRequest.INSTANCE);
   }
 

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexUtils.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexUtils.java
@@ -41,7 +41,7 @@ public final class BitfinexUtils {
    * @return
    */
   private static String currencySeparator(String base, String counter) {
-    if (base.toLowerCase().equals("dusk") || counter.toLowerCase().equals("cnht")) {
+    if (base.length() > 3 || counter.length() > 3) {
       return ":";
     }
     return "";

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/BitfinexAuthenticated.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/BitfinexAuthenticated.java
@@ -2,13 +2,7 @@ package org.knowm.xchange.bitfinex.v2;
 
 import java.io.IOException;
 import java.util.List;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import org.knowm.xchange.bitfinex.v2.dto.BitfinexExceptionV2;
 import org.knowm.xchange.bitfinex.v2.dto.EmptyRequest;
@@ -37,7 +31,26 @@ public interface BitfinexAuthenticated extends Bitfinex {
       EmptyRequest empty)
       throws IOException, BitfinexExceptionV2;
 
-  /** https://docs.bitfinex.com/v2/reference#rest-auth-trades-hist */
+  /**
+   * https://docs.bitfinex.com/v2/reference#rest-auth-trades-hist
+   *
+   * <p>Two implementations: 1. returns trades of all symboles 2. returns trades of a specific
+   * symbol
+   *
+   * <p>This is necessary because @Path doesn't seems to support optional parameters
+   */
+  @POST
+  @Path("auth/r/trades/hist")
+  List<Trade> getTrades(
+      @HeaderParam(BFX_NONCE) SynchronizedValueFactory<Long> nonce,
+      @HeaderParam(BFX_APIKEY) String apiKey,
+      @HeaderParam(BFX_SIGNATURE) ParamsDigest signature,
+      @QueryParam("start") Long startTimeMillis,
+      @QueryParam("end") Long endTimeMillis,
+      @QueryParam("limit") Long limit,
+      EmptyRequest empty)
+      throws IOException, BitfinexExceptionV2;
+
   @POST
   @Path("auth/r/trades/{symbol}/hist")
   List<Trade> getTrades(

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/BitfinexAuthenticated.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/BitfinexAuthenticated.java
@@ -48,6 +48,7 @@ public interface BitfinexAuthenticated extends Bitfinex {
       @QueryParam("start") Long startTimeMillis,
       @QueryParam("end") Long endTimeMillis,
       @QueryParam("limit") Long limit,
+      @QueryParam("sort") Long sort,
       EmptyRequest empty)
       throws IOException, BitfinexExceptionV2;
 
@@ -61,6 +62,7 @@ public interface BitfinexAuthenticated extends Bitfinex {
       @QueryParam("start") Long startTimeMillis,
       @QueryParam("end") Long endTimeMillis,
       @QueryParam("limit") Long limit,
+      @QueryParam("sort") Long sort,
       EmptyRequest empty)
       throws IOException, BitfinexExceptionV2;
 

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/BitfinexHmacSignature.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/BitfinexHmacSignature.java
@@ -2,14 +2,11 @@ package org.knowm.xchange.bitfinex.v2;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-
 import javax.ws.rs.HeaderParam;
-
+import lombok.extern.slf4j.Slf4j;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.service.BaseParamsDigest;
 import org.knowm.xchange.utils.DigestUtils;
-
-import lombok.extern.slf4j.Slf4j;
 import si.mazi.rescu.RestInvocation;
 
 @Slf4j
@@ -41,7 +38,7 @@ public class BitfinexHmacSignature extends BaseParamsDigest {
     try {
       path = URLDecoder.decode(path, "utf8");
     } catch (UnsupportedEncodingException e) {
-        log.warn("Could not url decode the path {}.", path, e);
+      log.warn("Could not url decode the path {}.", path, e);
     }
 
     Object nonce = i.getParamValue(HeaderParam.class, BitfinexAuthenticated.BFX_NONCE);

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/trade/Trade.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/trade/Trade.java
@@ -2,7 +2,6 @@ package org.knowm.xchange.bitfinex.v2.dto.trade;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.math.BigDecimal;
-import java.util.Date;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -37,7 +36,91 @@ public class Trade {
   /** Fee currency */
   private String feeCurrency;
 
-  public Date getTimestamp() {
-    return new Date(timestamp);
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getSymbol() {
+    return symbol;
+  }
+
+  public void setSymbol(String symbol) {
+    this.symbol = symbol;
+  }
+
+  public void setTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public String getOrderId() {
+    return orderId;
+  }
+
+  public void setOrderId(String orderId) {
+    this.orderId = orderId;
+  }
+
+  public BigDecimal getExecAmount() {
+    return execAmount;
+  }
+
+  public void setExecAmount(BigDecimal execAmount) {
+    this.execAmount = execAmount;
+  }
+
+  public BigDecimal getExecPrice() {
+    return execPrice;
+  }
+
+  public void setExecPrice(BigDecimal execPrice) {
+    this.execPrice = execPrice;
+  }
+
+  public String getOrderType() {
+    return orderType;
+  }
+
+  public void setOrderType(String orderType) {
+    this.orderType = orderType;
+  }
+
+  public BigDecimal getOrderPrice() {
+    return orderPrice;
+  }
+
+  public void setOrderPrice(BigDecimal orderPrice) {
+    this.orderPrice = orderPrice;
+  }
+
+  public int getMaker() {
+    return maker;
+  }
+
+  public void setMaker(int maker) {
+    this.maker = maker;
+  }
+
+  public BigDecimal getFee() {
+    return fee;
+  }
+
+  public void setFee(BigDecimal fee) {
+    this.fee = fee;
+  }
+
+  public String getFeeCurrency() {
+    return feeCurrency;
+  }
+
+  public void setFeeCurrency(String feeCurrency) {
+    this.feeCurrency = feeCurrency;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
   }
 }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/trade/Trade.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/trade/Trade.java
@@ -2,6 +2,7 @@ package org.knowm.xchange.bitfinex.v2.dto.trade;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.math.BigDecimal;
+import java.util.Date;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -36,91 +37,7 @@ public class Trade {
   /** Fee currency */
   private String feeCurrency;
 
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getSymbol() {
-    return symbol;
-  }
-
-  public void setSymbol(String symbol) {
-    this.symbol = symbol;
-  }
-
-  public void setTimestamp(long timestamp) {
-    this.timestamp = timestamp;
-  }
-
-  public String getOrderId() {
-    return orderId;
-  }
-
-  public void setOrderId(String orderId) {
-    this.orderId = orderId;
-  }
-
-  public BigDecimal getExecAmount() {
-    return execAmount;
-  }
-
-  public void setExecAmount(BigDecimal execAmount) {
-    this.execAmount = execAmount;
-  }
-
-  public BigDecimal getExecPrice() {
-    return execPrice;
-  }
-
-  public void setExecPrice(BigDecimal execPrice) {
-    this.execPrice = execPrice;
-  }
-
-  public String getOrderType() {
-    return orderType;
-  }
-
-  public void setOrderType(String orderType) {
-    this.orderType = orderType;
-  }
-
-  public BigDecimal getOrderPrice() {
-    return orderPrice;
-  }
-
-  public void setOrderPrice(BigDecimal orderPrice) {
-    this.orderPrice = orderPrice;
-  }
-
-  public int getMaker() {
-    return maker;
-  }
-
-  public void setMaker(int maker) {
-    this.maker = maker;
-  }
-
-  public BigDecimal getFee() {
-    return fee;
-  }
-
-  public void setFee(BigDecimal fee) {
-    this.fee = fee;
-  }
-
-  public String getFeeCurrency() {
-    return feeCurrency;
-  }
-
-  public void setFeeCurrency(String feeCurrency) {
-    this.feeCurrency = feeCurrency;
-  }
-
-  public long getTimestamp() {
-    return timestamp;
+  public Date getTimestamp() {
+    return new Date(timestamp);
   }
 }


### PR DESCRIPTION
A bugfix was necessary because the adapt CurrencyPair method was using the format for API V2 and the getBitfinexTrades Methode was using the API V1
The current version get all Trades via V2.