### PR TITLE
Fix string to currency pair conversion when base name starts with "t"

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
@@ -127,7 +127,7 @@ public final class BitfinexAdapters {
   public static CurrencyPair adaptCurrencyPair(String bitfinexSymbol) {
     String tradableIdentifier;
     String transactionCurrency;
-    int startIndex = bitfinexSymbol.startsWith("t") ? 1 : 0;
+    int startIndex = bitfinexSymbol.startsWith("t") && Character.isUpperCase(bitfinexSymbol.charAt(1)) ? 1 : 0;
     if (bitfinexSymbol.contains(":")) {
       // ie 'dusk:usd' or 'btc:cnht'
       int idx = bitfinexSymbol.indexOf(":");

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
@@ -1,17 +1,19 @@
 package org.knowm.xchange.bitfinex.service;
 
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.knowm.xchange.bitfinex.v1.BitfinexOrderType;
 import org.knowm.xchange.bitfinex.v1.BitfinexUtils;
 import org.knowm.xchange.bitfinex.v1.dto.account.BitfinexAccountFeesResponse;
 import org.knowm.xchange.bitfinex.v1.dto.account.BitfinexBalancesResponse;
 import org.knowm.xchange.bitfinex.v1.dto.account.BitfinexDepositWithdrawalHistoryResponse;
 import org.knowm.xchange.bitfinex.v1.dto.account.BitfinexTradingFeeResponse;
-import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexDepth;
-import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexLendLevel;
-import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexLevel;
-import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexSymbolDetail;
-import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexTicker;
-import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexTrade;
+import org.knowm.xchange.bitfinex.v1.dto.marketdata.*;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexAccountInfosResponse;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrderFlags;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrderStatusResponse;
@@ -34,33 +36,11 @@ import org.knowm.xchange.dto.marketdata.Trades.TradeSortType;
 import org.knowm.xchange.dto.meta.CurrencyMetaData;
 import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
 import org.knowm.xchange.dto.meta.ExchangeMetaData;
-import org.knowm.xchange.dto.trade.FixedRateLoanOrder;
-import org.knowm.xchange.dto.trade.FloatingRateLoanOrder;
-import org.knowm.xchange.dto.trade.LimitOrder;
-import org.knowm.xchange.dto.trade.OpenOrders;
-import org.knowm.xchange.dto.trade.StopOrder;
-import org.knowm.xchange.dto.trade.UserTrade;
-import org.knowm.xchange.dto.trade.UserTrades;
+import org.knowm.xchange.dto.trade.*;
 import org.knowm.xchange.utils.DateUtils;
 import org.knowm.xchange.utils.jackson.CurrencyPairDeserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public final class BitfinexAdapters {
 
@@ -147,7 +127,7 @@ public final class BitfinexAdapters {
   public static CurrencyPair adaptCurrencyPair(String bitfinexSymbol) {
     String tradableIdentifier;
     String transactionCurrency;
-    int startIndex = bitfinexSymbol.startsWith("t") && Character.isUpperCase(bitfinexSymbol.charAt(1)) ? 1 : 0;
+    int startIndex = bitfinexSymbol.startsWith("t") ? 1 : 0;
     if (bitfinexSymbol.contains(":")) {
       // ie 'dusk:usd' or 'btc:cnht'
       int idx = bitfinexSymbol.indexOf(":");

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
@@ -1,19 +1,17 @@
 package org.knowm.xchange.bitfinex.service;
 
-import java.math.BigDecimal;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.knowm.xchange.bitfinex.v1.BitfinexOrderType;
 import org.knowm.xchange.bitfinex.v1.BitfinexUtils;
 import org.knowm.xchange.bitfinex.v1.dto.account.BitfinexAccountFeesResponse;
 import org.knowm.xchange.bitfinex.v1.dto.account.BitfinexBalancesResponse;
 import org.knowm.xchange.bitfinex.v1.dto.account.BitfinexDepositWithdrawalHistoryResponse;
 import org.knowm.xchange.bitfinex.v1.dto.account.BitfinexTradingFeeResponse;
-import org.knowm.xchange.bitfinex.v1.dto.marketdata.*;
+import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexDepth;
+import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexLendLevel;
+import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexLevel;
+import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexSymbolDetail;
+import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexTicker;
+import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexTrade;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexAccountInfosResponse;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrderFlags;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrderStatusResponse;
@@ -36,11 +34,33 @@ import org.knowm.xchange.dto.marketdata.Trades.TradeSortType;
 import org.knowm.xchange.dto.meta.CurrencyMetaData;
 import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
 import org.knowm.xchange.dto.meta.ExchangeMetaData;
-import org.knowm.xchange.dto.trade.*;
+import org.knowm.xchange.dto.trade.FixedRateLoanOrder;
+import org.knowm.xchange.dto.trade.FloatingRateLoanOrder;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.dto.trade.OpenOrders;
+import org.knowm.xchange.dto.trade.StopOrder;
+import org.knowm.xchange.dto.trade.UserTrade;
+import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.utils.DateUtils;
 import org.knowm.xchange.utils.jackson.CurrencyPairDeserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public final class BitfinexAdapters {
 
@@ -127,7 +147,7 @@ public final class BitfinexAdapters {
   public static CurrencyPair adaptCurrencyPair(String bitfinexSymbol) {
     String tradableIdentifier;
     String transactionCurrency;
-    int startIndex = bitfinexSymbol.startsWith("t") ? 1 : 0;
+    int startIndex = bitfinexSymbol.startsWith("t") && Character.isUpperCase(bitfinexSymbol.charAt(1)) ? 1 : 0;
     if (bitfinexSymbol.contains(":")) {
       // ie 'dusk:usd' or 'btc:cnht'
       int idx = bitfinexSymbol.indexOf(":");

--- a/xchange-bitfinex/src/test/java/org/knowm/xchange/bitfinex/v1/BitfinexAdaptersTest.java
+++ b/xchange-bitfinex/src/test/java/org/knowm/xchange/bitfinex/v1/BitfinexAdaptersTest.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.Test;
 import org.knowm.xchange.bitfinex.service.BitfinexAdapters;
 import org.knowm.xchange.bitfinex.v1.dto.account.BitfinexBalancesResponse;
@@ -358,5 +359,22 @@ public class BitfinexAdaptersTest {
         assertEquals(Currency.BTC, record.getCurrency());
       }
     }
+  }
+
+  @Test
+  public void adaptCurrencyPair() {
+    final List<String> currencyPairStrings = Arrays.asList("btcusd", "ethusd", "ethbtc", "dusk:usd", "tknusd");
+    final List<CurrencyPair> currencyPairs = currencyPairStrings.stream()
+            .map(BitfinexAdapters::adaptCurrencyPair).collect(Collectors.toList());
+    assertEquals(
+            Arrays.asList(
+                    CurrencyPair.BTC_USD,
+                    CurrencyPair.ETH_USD,
+                    CurrencyPair.ETH_BTC,
+                    new CurrencyPair("DUSK/USD"),
+                    new CurrencyPair("TKN/USD")
+            ),
+            currencyPairs
+    );
   }
 }

--- a/xchange-bitfinex/src/test/java/org/knowm/xchange/bitfinex/v2/BitfinexAdaptersTest.java
+++ b/xchange-bitfinex/src/test/java/org/knowm/xchange/bitfinex/v2/BitfinexAdaptersTest.java
@@ -1,5 +1,6 @@
 package org.knowm.xchange.bitfinex.v2;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -17,5 +18,22 @@ public class BitfinexAdaptersTest {
             .collect(Collectors.toList());
     String formattedPairs = BitfinexAdapters.adaptCurrencyPairsToTickersParam(currencyPairs);
     Assert.assertEquals("tBTCUSD,tETHUSD,tETHBTC", formattedPairs);
+  }
+
+  @Test
+  public void adaptCurrencyPair() {
+    final List<String> currencyPairStrings = Arrays.asList("tBTCUSD", "tETHUSD", "tETHBTC", "tDUSK:USD", "tTKN:USD");
+    final List<CurrencyPair> currencyPairs = currencyPairStrings.stream()
+            .map(BitfinexAdapters::adaptCurrencyPair).collect(Collectors.toList());
+    Assert.assertEquals(
+            Arrays.asList(
+                    CurrencyPair.BTC_USD,
+                    CurrencyPair.ETH_USD,
+                    CurrencyPair.ETH_BTC,
+                    new CurrencyPair("DUSK/USD"),
+                    new CurrencyPair("TKN/USD")
+            ),
+            currencyPairs
+    );
   }
 }


### PR DESCRIPTION
Was not working correctly for example for TKN/USD