### PR TITLE
Add ledger type settled to Kraken ledger

### DIFF
--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/LedgerType.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/LedgerType.java
@@ -16,6 +16,7 @@ import org.knowm.xchange.kraken.dto.account.LedgerType.LedgerTypeDeserializer;
 public enum LedgerType {
   DEPOSIT,
   WITHDRAWAL,
+  SETTLED,
   TRADE,
   MARGIN,
   CREDIT,

--- a/xchange-kraken/src/test/java/org/knowm/xchange/kraken/dto/account/KrakenAccountJSONTest.java
+++ b/xchange-kraken/src/test/java/org/knowm/xchange/kraken/dto/account/KrakenAccountJSONTest.java
@@ -67,16 +67,27 @@ public class KrakenAccountJSONTest {
     ObjectMapper mapper = new ObjectMapper();
     KrakenLedgerResult krakenResult = mapper.readValue(is, KrakenLedgerResult.class);
     Map<String, KrakenLedger> ledgerInfo = krakenResult.getResult().getLedgerMap();
-    KrakenLedger ledger = ledgerInfo.get("LQY6IE-WNT47-JRBOJV");
+    KrakenLedger deposit = ledgerInfo.get("LQY6IE-WNT47-JRBOJV");
 
-    assertThat(ledger.getAsset()).isEqualTo("XXBT");
-    assertThat(ledger.getAssetClass()).isEqualTo("currency");
-    assertThat(ledger.getBalance()).isEqualTo("0.1000000000");
-    assertThat(ledger.getFee()).isEqualTo("0.0000000000");
-    assertThat(ledger.getTransactionAmount()).isEqualTo("0.1000000000");
-    assertThat(ledger.getLedgerType()).isEqualTo(LedgerType.DEPOSIT);
-    assertThat(ledger.getRefId()).isEqualTo("QGBJIZV-4F6SPK-ZCBT5O");
-    assertThat(ledger.getUnixTime()).isEqualTo(1391400160.0679);
+    assertThat(deposit.getAsset()).isEqualTo("XXBT");
+    assertThat(deposit.getAssetClass()).isEqualTo("currency");
+    assertThat(deposit.getBalance()).isEqualTo("0.1000000000");
+    assertThat(deposit.getFee()).isEqualTo("0.0000000000");
+    assertThat(deposit.getTransactionAmount()).isEqualTo("0.1000000000");
+    assertThat(deposit.getLedgerType()).isEqualTo(LedgerType.DEPOSIT);
+    assertThat(deposit.getRefId()).isEqualTo("QGBJIZV-4F6SPK-ZCBT5O");
+    assertThat(deposit.getUnixTime()).isEqualTo(1391400160.0679);
+
+    KrakenLedger settled = ledgerInfo.get("L23XKW-ZZHEP-FJINZ3");
+
+    assertThat(settled.getAsset()).isEqualTo("XETH");
+    assertThat(settled.getAssetClass()).isEqualTo("currency");
+    assertThat(settled.getBalance()).isEqualTo("0.5000000000");
+    assertThat(settled.getFee()).isEqualTo("0.0000000000");
+    assertThat(settled.getTransactionAmount()).isEqualTo("0.5000000000");
+    assertThat(settled.getLedgerType()).isEqualTo(LedgerType.SETTLED);
+    assertThat(settled.getRefId()).isEqualTo("TPYCPK-GLBCV-NGPDDI");
+    assertThat(settled.getUnixTime()).isEqualTo(1388739905.0371);
   }
 
   @Test

--- a/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/account/example-ledgerinfo-data.json
+++ b/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/account/example-ledgerinfo-data.json
@@ -62,8 +62,18 @@
         "amount": "0.5000000000",
         "fee": "0.0000000000",
         "balance": "0.5000000000"
+      },
+      "L23XKW-ZZHEP-FJINZ3": {
+        "refid": "TPYCPK-GLBCV-NGPDDI",
+        "time": 1388739905.0371,
+        "type": "settled",
+        "aclass": "currency",
+        "asset": "XETH",
+        "amount": "0.5000000000",
+        "fee": "0.0000000000",
+        "balance": "0.5000000000"
       }
     },
-    "count": "5"
+    "count": "6"
   }
 }


### PR DESCRIPTION
Kraken has another ledger type "settled" which is absent in documentation but exists in API and csv