### PR TITLE
Fixed bug in BinanceErrorAdapter

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceErrorAdapter.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceErrorAdapter.java
@@ -36,7 +36,7 @@ public final class BinanceErrorAdapter {
           return new ExchangeException(message, e);
         }
       case -1013:
-        createOrderNotValidException(message, e);
+        return createOrderNotValidException(message, e);
       case -1016:
         return new ExchangeUnavailableException(message, e);
       case -1021:
@@ -45,15 +45,16 @@ public final class BinanceErrorAdapter {
         return new CurrencyPairNotValidException(message, e);
       case -1122:
         return new ExchangeSecurityException(message, e);
+      default:
+        return new ExchangeException(message, e);
     }
-    return new ExchangeException(message, e);
   }
 
-  private static ExchangeException createOrderNotValidException(
-      String message, BinanceException e) {
+  private static ExchangeException createOrderNotValidException(String message, BinanceException e) {
     if (e.getMessage().contains("MIN_NOTIONAL")) {
       return new OrderAmountUnderMinimumException(message, e);
+    } else {
+      return new OrderNotValidException(message, e);
     }
-    return new OrderNotValidException(message, e);
   }
 }

--- a/xchange-binance/src/test/java/org/knowm/xchange/binance/BinanceErrorAdapterTest.java
+++ b/xchange-binance/src/test/java/org/knowm/xchange/binance/BinanceErrorAdapterTest.java
@@ -1,0 +1,26 @@
+package org.knowm.xchange.binance;
+
+import org.junit.Test;
+import org.knowm.xchange.binance.dto.BinanceException;
+import org.knowm.xchange.exceptions.ExchangeException;
+import org.knowm.xchange.exceptions.OrderAmountUnderMinimumException;
+import org.knowm.xchange.exceptions.OrderNotValidException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BinanceErrorAdapterTest {
+
+    @Test
+    public void testBinanceExceptionWithCode1013MsgLotSize() {
+        final ExchangeException adaptedException = BinanceErrorAdapter.adapt(new BinanceException(-1013, "LOT_SIZE"));
+
+        assertThat(adaptedException).isInstanceOf(OrderNotValidException.class);
+    }
+
+    @Test
+    public void testBinanceExceptionWithCode1013MsgMinNotional() {
+        final ExchangeException adaptedException = BinanceErrorAdapter.adapt(new BinanceException(-1013, "MIN_NOTIONAL"));
+
+        assertThat(adaptedException).isInstanceOf(OrderAmountUnderMinimumException.class);
+    }
+}


### PR DESCRIPTION
Fixed bug introduced in https://github.com/knowm/XChange/pull/3299.
It was introduced in 4.4.2-SNAPSHOT, so it was not released.

Bug description:
For error code -1013 from Binance was returned ExchangeUnavailableException instead of OrderAmountUnderMinimumException or OrderNotValidException.

Fixed in this PR.