### PR TITLE
[Kraken] send userReference to the exchange

### DIFF
--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenTradeServiceRaw.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenTradeServiceRaw.java
@@ -188,6 +188,7 @@ public class KrakenTradeServiceRaw extends KrakenBaseService {
     KrakenOrderBuilder orderBuilder =
         KrakenStandardOrder.getMarketOrderBuilder(
                 marketOrder.getCurrencyPair(), type, marketOrder.getOriginalAmount())
+            .withUserRefId(marketOrder.getUserReference())
             .withOrderFlags(marketOrder.getOrderFlags())
             .withLeverage(marketOrder.getLeverage());
 
@@ -200,7 +201,8 @@ public class KrakenTradeServiceRaw extends KrakenBaseService {
     KrakenType type = KrakenType.fromOrderType(marketOrder.getType());
     KrakenOrderBuilder orderBuilder =
         KrakenStandardOrder.getSettlePositionOrderBuilder(
-            marketOrder.getCurrencyPair(), type, marketOrder.getOriginalAmount());
+                marketOrder.getCurrencyPair(), type, marketOrder.getOriginalAmount())            
+            .withUserRefId(marketOrder.getUserReference());
 
     return placeKrakenOrder(orderBuilder.buildOrder());
   }
@@ -214,6 +216,7 @@ public class KrakenTradeServiceRaw extends KrakenBaseService {
                 type,
                 limitOrder.getLimitPrice().toPlainString(),
                 limitOrder.getOriginalAmount())
+            .withUserRefId(limitOrder.getUserReference())
             .withOrderFlags(limitOrder.getOrderFlags())
             .withLeverage(limitOrder.getLeverage());
 


### PR DESCRIPTION
So that it hopefully comes back on the webSocket.
NB: Kraken userReference is a 32-integer stuffed in a string