### PR TITLE
[bibox] lombok dependency scope

### DIFF
--- a/xchange-bibox/pom.xml
+++ b/xchange-bibox/pom.xml
@@ -32,7 +32,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
lombok dependency scope must be "provided", which is actually set correctly in the [root pom.xml](https://github.com/knowm/XChange/blob/develop/pom.xml#L316)
otherwise the lombok dependency is propagated and added to final artifacts, which is "_not necessary_"