### PR TITLE
[Bitmex] Changing value of ClOrdId from order.getId to order.getUserReference...

### DIFF
--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexTradeService.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexTradeService.java
@@ -82,7 +82,7 @@ public class BitmexTradeService extends BitmexTradeServiceRaw implements TradeSe
             .setOrderQuantity(limitOrder.getOriginalAmount())
             .setPrice(limitOrder.getLimitPrice())
             .setSide(fromOrderType(limitOrder.getType()))
-            .setClOrdId(limitOrder.getId());
+            .setClOrdId(limitOrder.getUserReference());
     if (limitOrder.hasFlag(BitmexOrderFlags.POST)) {
       b.addExecutionInstruction(BitmexExecutionInstruction.PARTICIPATE_DO_NOT_INITIATE);
     }
@@ -98,7 +98,7 @@ public class BitmexTradeService extends BitmexTradeServiceRaw implements TradeSe
                 .setSide(fromOrderType(stopOrder.getType()))
                 .setOrderQuantity(stopOrder.getOriginalAmount())
                 .setStopPrice(stopOrder.getStopPrice())
-                .setClOrdId(stopOrder.getId())
+                .setClOrdId(stopOrder.getUserReference())
                 .build())
         .getId();
   }
@@ -112,6 +112,7 @@ public class BitmexTradeService extends BitmexTradeServiceRaw implements TradeSe
                 .setOrderId(limitOrder.getId())
                 .setOrderQuantity(limitOrder.getOriginalAmount())
                 .setPrice(limitOrder.getLimitPrice())
+                .setClOrdId(limitOrder.getUserReference())
                 .build());
     return order.getId();
   }


### PR DESCRIPTION
in order to be consistent with the rest library.