### PR TITLE
[Binance] handle new deposit status "6: credited but cannot withdraw"

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceAccountService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceAccountService.java
@@ -59,10 +59,11 @@ public class BinanceAccountService extends BinanceAccountServiceRaw implements A
     }
   }
 
-  /** (0:pending,1:success) */
+  /** (0:pending,6: credited but cannot withdraw,1:success) */
   private static FundingRecord.Status depositStatus(int status) {
     switch (status) {
       case 0:
+      case 6:
         return Status.PROCESSING;
       case 1:
         return Status.COMPLETE;


### PR DESCRIPTION
Binance started to return new deposit status, please check the docs: https://binance-docs.github.io/apidocs/spot/en/#deposit-history-supporting-network-user_data

Without this fix requesting deposit history fails with RuntimeException("Unknown binance deposit status: 6") while BTC deposit has just 1 confirmation.