### PR TITLE
[bitfinex] Unexpected market order on book

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
@@ -57,6 +57,7 @@ import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
 import org.knowm.xchange.dto.meta.ExchangeMetaData;
 import org.knowm.xchange.dto.trade.FixedRateLoanOrder;
 import org.knowm.xchange.dto.trade.FloatingRateLoanOrder;
+import org.knowm.xchange.dto.trade.MarketOrder;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.dto.trade.StopOrder;

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
@@ -515,7 +515,6 @@ public final class BitfinexAdapters {
           case MARGIN_MARKET:
           case MARKET:
             marketOrder = marketOrderCreator.get();
-            limitOrder = limitOrderCreator.get();
             break;
           default:
             log.warn(


### PR DESCRIPTION
"BitfinexAdapters - Unexpected market order on book. Defaulting to limit order"

I sent in a market order via XStream and got a dozen these warnings.  Two proposals:
a) this patch
b) just remove the warning at line 503

this is probably because XStream is also using this adaptOrders function when getting updates on the socket

Personally, I prefer this patch, as it extends the functionality of adaptOrders