### PR TITLE
Issue 3403 - Introduce support for Bitfinex V2 API get order trades

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexTradeServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexTradeServiceRaw.java
@@ -42,7 +42,6 @@ import org.knowm.xchange.bitfinex.v2.dto.trade.ActiveOrder;
 import org.knowm.xchange.bitfinex.v2.dto.trade.OrderTrade;
 import org.knowm.xchange.bitfinex.v2.dto.trade.Position;
 import org.knowm.xchange.bitfinex.v2.dto.trade.Trade;
-import org.knowm.xchange.bitfinex.v2.dto.trade.OrderTrade;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.trade.FixedRateLoanOrder;

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexTradeServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexTradeServiceRaw.java
@@ -528,7 +528,10 @@ public class BitfinexTradeServiceRaw extends BitfinexBaseService {
           throws IOException {
     if (symbol == null || orderId == null)
       throw new NullPointerException(
-              "Invalid request fields symbol [%s] and orderId [%s] are mandatory for get order trades call");
+              String.format("Invalid request fields symbol [%s] and orderId [%s] are mandatory for get order trades call"
+              , symbol
+              , orderId)
+      );
 
     return bitfinexV2.getOrderTrades(
             exchange.getNonceFactory(), apiKey, signatureV2, symbol, orderId, EmptyRequest.INSTANCE);

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexTradeServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexTradeServiceRaw.java
@@ -39,8 +39,10 @@ import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexReplaceOrderRequest;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexTradeResponse;
 import org.knowm.xchange.bitfinex.v2.dto.EmptyRequest;
 import org.knowm.xchange.bitfinex.v2.dto.trade.ActiveOrder;
+import org.knowm.xchange.bitfinex.v2.dto.trade.OrderTrade;
 import org.knowm.xchange.bitfinex.v2.dto.trade.Position;
 import org.knowm.xchange.bitfinex.v2.dto.trade.Trade;
+import org.knowm.xchange.bitfinex.v2.dto.trade.OrderTrade;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.trade.FixedRateLoanOrder;
@@ -521,5 +523,15 @@ public class BitfinexTradeServiceRaw extends BitfinexBaseService {
     }
     return bitfinexV2.getActiveOrders(
         exchange.getNonceFactory(), apiKey, signatureV2, symbol, EmptyRequest.INSTANCE);
+  }
+
+  public List<OrderTrade> getBitfinexOrderTradesV2(final String symbol, final Long orderId)
+          throws IOException {
+    if (symbol == null || orderId == null)
+      throw new NullPointerException(
+              "Invalid request fields symbol [%s] and orderId [%s] are mandatory for get order trades call");
+
+    return bitfinexV2.getOrderTrades(
+            exchange.getNonceFactory(), apiKey, signatureV2, symbol, orderId, EmptyRequest.INSTANCE);
   }
 }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/BitfinexAuthenticated.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/BitfinexAuthenticated.java
@@ -14,6 +14,7 @@ import org.knowm.xchange.bitfinex.v2.dto.BitfinexExceptionV2;
 import org.knowm.xchange.bitfinex.v2.dto.EmptyRequest;
 import org.knowm.xchange.bitfinex.v2.dto.account.LedgerEntry;
 import org.knowm.xchange.bitfinex.v2.dto.trade.ActiveOrder;
+import org.knowm.xchange.bitfinex.v2.dto.trade.OrderTrade;
 import org.knowm.xchange.bitfinex.v2.dto.trade.Position;
 import org.knowm.xchange.bitfinex.v2.dto.trade.Trade;
 import si.mazi.rescu.ParamsDigest;
@@ -110,4 +111,17 @@ public interface BitfinexAuthenticated extends Bitfinex {
       @QueryParam("limit") Long limit,
       EmptyRequest empty)
       throws IOException, BitfinexExceptionV2;
+
+
+  /** https://docs.bitfinex.com/reference#rest-auth-order-trades * */
+  @POST
+  @Path("auth/r/order/{symbol}:{orderId}/trades")
+  List<OrderTrade> getOrderTrades(
+          @HeaderParam(BFX_NONCE) SynchronizedValueFactory<Long> nonce,
+          @HeaderParam(BFX_APIKEY) String apiKey,
+          @HeaderParam(BFX_SIGNATURE) ParamsDigest signature,
+          @PathParam("symbol") String symbol,
+          @PathParam("orderId") Long orderId,
+          EmptyRequest empty)
+          throws IOException, BitfinexExceptionV2;
 }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/trade/OrderTrade.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/trade/OrderTrade.java
@@ -1,0 +1,43 @@
+package org.knowm.xchange.bitfinex.v2.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.math.BigDecimal;
+import java.util.Date;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/** https://docs.bitfinex.com/reference#rest-auth-order-trades */
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@Setter
+@Getter
+@ToString
+public class OrderTrade {
+
+    /** Trade database id */
+    private String id;
+    /** Pair (BTCUSD, …) */
+    private String symbol;
+    /** Execution timestamp millis */
+    private long timestamp;
+    /** Order id */
+    private String orderId;
+    /** Positive means buy, negative means sell */
+    private BigDecimal execAmount;
+    /** Execution price */
+    private BigDecimal execPrice;
+    /** placeHolder1 */
+    private String placeHolder1;
+    /** placeHolder1 */
+    private String placeHolder2;
+    /** 1 if true, -1 if false */
+    private int maker;
+    /** Fee */
+    private BigDecimal fee;
+    /** Fee currency */
+    private String feeCurrency;
+
+    public Date getTimestamp() {
+        return new Date(timestamp);
+    }
+}


### PR DESCRIPTION
Change to support bitfinex v2 call - https://docs.bitfinex.com/reference#rest-auth-order-trades