### PR TITLE
[Core] Currency.compareTo #3358

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
@@ -482,13 +482,7 @@ public class Currency implements Comparable<Currency>, Serializable {
 
   @Override
   public int compareTo(Currency o) {
-
-    if (attributes.equals(o.attributes)) return 0;
-
-    int comparison = code.compareTo(o.code);
-    if (comparison == 0) comparison = getDisplayName().compareTo(o.getDisplayName());
-    if (comparison == 0) comparison = hashCode() - o.hashCode();
-    return comparison;
+    return attributes.equals(o.attributes) ? 0 : toString().compareTo(o.toString());
   }
 
   private static class CurrencyAttributes implements Serializable {


### PR DESCRIPTION
The following test fails for the last two lines. compareTo returns
btc.compareTo(Currency.LTC) --> -10,
xbt.compareTo(Currency.LTC) --> 12

To fix, I think we need to add look at Currency.compareTo, subtracting hashcodes looks like it should work. CurrencyPair.compareTo looks ok too. so wondering how to fix.