### PR TITLE
Changing matchNumber in ItBitTrade DTO to String to address Issue #3242

### DIFF
--- a/xchange-anx/src/test/java/org/knowm/xchange/anx/v2/ANXAdapterTest.java
+++ b/xchange-anx/src/test/java/org/knowm/xchange/anx/v2/ANXAdapterTest.java
@@ -136,7 +136,7 @@ public class ANXAdapterTest {
     List<ANXTrade> anxTrades = anxTradesWrapper.getANXTrades();
 
     Trades trades = ANXAdapters.adaptTrades(anxTrades);
-    assertThat(trades.getlastID()).isEqualTo(1402189349725L);
+    assertThat(trades.getlastID()).isEqualTo("1402189349725");
 
     List<Trade> tradeList = trades.getTrades();
     assertThat(tradeList.size()).isEqualTo(2);

--- a/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/BitcoindeAdapterTest.java
+++ b/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/BitcoindeAdapterTest.java
@@ -61,7 +61,7 @@ public class BitcoindeAdapterTest {
 
     // Make sure the adapter got all the data
     assertThat(trades.getTrades().size()).isEqualTo(92);
-    assertThat(trades.getlastID()).isEqualTo(2844384);
+    assertThat(trades.getlastID()).isEqualTo("2844384");
 
     // Verify that all fields are filled
     assertThat(trades.getTrades().get(0).getId()).isEqualTo("2844111");

--- a/xchange-bitstamp/src/test/java/org/knowm/xchange/bitstamp/BitstampAdapterTest.java
+++ b/xchange-bitstamp/src/test/java/org/knowm/xchange/bitstamp/BitstampAdapterTest.java
@@ -120,7 +120,7 @@ public class BitstampAdapterTest {
 
     Trades trades = BitstampAdapters.adaptTrades(transactions, CurrencyPair.BTC_USD);
     assertThat(trades.getTrades().size()).isEqualTo(125);
-    assertThat(trades.getlastID()).isEqualTo(122260);
+    assertThat(trades.getlastID()).isEqualTo("122260");
     // verify all fields filled
     assertThat(trades.getTrades().get(0).getId()).isEqualTo("121984");
     assertThat(trades.getTrades().get(0).getPrice().toString()).isEqualTo("13.14");

--- a/xchange-bleutrade/src/test/java/org/knowm/xchange/bleutrade/dto/BleutradeAdaptersTest.java
+++ b/xchange-bleutrade/src/test/java/org/knowm/xchange/bleutrade/dto/BleutradeAdaptersTest.java
@@ -72,7 +72,7 @@ public class BleutradeAdaptersTest extends BleutradeDtoTestSupport {
         BleutradeAdapters.adaptBleutradeMarketHistory(response.getResult(), CurrencyPair.BTC_AUD);
 
     // then
-    assertThat(trades.getlastID()).isEqualTo(0);
+    assertThat(trades.getlastID()).isEqualTo("0");
 
     List<Trade> tradeList = trades.getTrades();
     assertThat(tradeList).hasSize(2);

--- a/xchange-coinfloor/src/test/java/org/knowm/xchange/coinfloor/CoinfloorAdaptersTests.java
+++ b/xchange-coinfloor/src/test/java/org/knowm/xchange/coinfloor/CoinfloorAdaptersTests.java
@@ -143,7 +143,7 @@ public class CoinfloorAdaptersTests {
     UserTrades trades = CoinfloorAdapters.adaptTradeHistory(Arrays.asList(transactions));
 
     assertThat(trades.getTrades()).hasSize(2);
-    assertThat(trades.getlastID()).isEqualTo(2489586572518770L);
+    assertThat(trades.getlastID()).isEqualTo("2489586572518770");
     assertThat(trades.getTradeSortType()).isEqualTo(TradeSortType.SortByID);
 
     UserTrade trade0 = (UserTrade) trades.getTrades().get(0);

--- a/xchange-coinfloor/src/test/java/org/knowm/xchange/coinfloor/service/CoinfloorPublicTradesIntegration.java
+++ b/xchange-coinfloor/src/test/java/org/knowm/xchange/coinfloor/service/CoinfloorPublicTradesIntegration.java
@@ -29,6 +29,6 @@ public class CoinfloorPublicTradesIntegration {
     assertThat(mostRecentTrade.getPrice()).isGreaterThan(BigDecimal.ZERO);
     assertThat(mostRecentTrade.getOriginalAmount()).isGreaterThan(BigDecimal.ZERO);
 
-    assertThat(trades.getlastID()).isEqualTo(Long.parseLong(mostRecentTrade.getId()));
+    assertThat(trades.getlastID()).isEqualTo(mostRecentTrade.getId());
   }
 }

--- a/xchange-coinone/src/main/java/org/knowm/xchange/coinone/CoinoneAdapters.java
+++ b/xchange-coinone/src/main/java/org/knowm/xchange/coinone/CoinoneAdapters.java
@@ -180,10 +180,12 @@ public final class CoinoneAdapters {
       throw new CoinoneException(trades.getResult());
     }
     List<Trade> tradeList = new ArrayList<>(trades.getCompleteOrders().length);
+    String lastTrade = "0";
     for (CoinoneTradeData trade : trades.getCompleteOrders()) {
       tradeList.add(adaptTrade(trade, currencyPair));
+      lastTrade = trade.getTimestamp();
     }
-    return new Trades(tradeList, 0, Trades.TradeSortType.SortByTimestamp);
+    return new Trades(tradeList, lastTrade, Trades.TradeSortType.SortByTimestamp);
   }
 
   private static Trade adaptTrade(CoinoneTradeData trade, CurrencyPair currencyPair) {

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/Trades.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/Trades.java
@@ -19,7 +19,7 @@ public class Trades implements Serializable {
       new TradeTimestampComparator();
 
   private final List<Trade> trades;
-  private final long lastID;
+  private final String lastID;
   private final String nextPageCursor;
   private final TradeSortType tradeSortType;
 
@@ -51,8 +51,19 @@ public class Trades implements Serializable {
    * @param lastID Last Unique ID
    * @param tradeSortType Trade sort type
    */
-  public Trades(List<Trade> trades, long lastID, TradeSortType tradeSortType) {
+  public Trades(List<Trade> trades, String lastID, TradeSortType tradeSortType) {
     this(trades, lastID, tradeSortType, null);
+  }
+
+  /**
+   * Constructor
+   *
+   * @param trades A list of trades
+   * @param lastID Last Unique ID
+   * @param tradeSortType Trade sort type
+   */
+  public Trades(List<Trade> trades, Long lastID, TradeSortType tradeSortType) {
+    this(trades, String.valueOf(lastID), tradeSortType, null);
   }
 
   /**
@@ -65,7 +76,7 @@ public class Trades implements Serializable {
    *     TradeHistoryParamNextPageCursor
    */
   public Trades(
-      List<Trade> trades, long lastID, TradeSortType tradeSortType, String nextPageCursor) {
+      List<Trade> trades, String lastID, TradeSortType tradeSortType, String nextPageCursor) {
 
     this.trades = new ArrayList<>(trades);
     this.lastID = lastID;
@@ -92,7 +103,7 @@ public class Trades implements Serializable {
   }
 
   /** @return a Unique ID for the fetched trades */
-  public long getlastID() {
+  public String getlastID() {
 
     return lastID;
   }

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/UserTrades.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/UserTrades.java
@@ -1,29 +1,40 @@
 package org.knowm.xchange.dto.trade;
 
 import java.util.List;
+
 import org.knowm.xchange.dto.marketdata.Trades;
 
 public class UserTrades extends Trades {
 
-  private static final long serialVersionUID = 1647451200702821967L;
+    private static final long serialVersionUID = 1647451200702821967L;
 
-  public UserTrades(List<UserTrade> trades, TradeSortType tradeSortType) {
+    public UserTrades(List<UserTrade> trades, TradeSortType tradeSortType) {
 
-    super((List) trades, tradeSortType);
-  }
+        super((List) trades, tradeSortType);
+    }
 
-  public UserTrades(List<UserTrade> trades, long lastID, TradeSortType tradeSortType) {
+    public UserTrades(List<UserTrade> trades, String lastID, TradeSortType tradeSortType) {
 
-    super((List) trades, lastID, tradeSortType);
-  }
+        super((List) trades, lastID, tradeSortType);
+    }
 
-  public UserTrades(
-      List<UserTrade> trades, long lastID, TradeSortType tradeSortType, String nextPageCursor) {
-    super((List) trades, lastID, tradeSortType, nextPageCursor);
-  }
+    public UserTrades(List<UserTrade> trades, Long lastID, TradeSortType tradeSortType) {
 
-  public List<UserTrade> getUserTrades() {
+        super((List) trades, String.valueOf(lastID), tradeSortType);
+    }
 
-    return (List) getTrades();
-  }
+    public UserTrades(
+            List<UserTrade> trades, String lastID, TradeSortType tradeSortType, String nextPageCursor) {
+        super((List) trades, lastID, tradeSortType, nextPageCursor);
+    }
+
+    public UserTrades(
+            List<UserTrade> trades, Long lastID, TradeSortType tradeSortType, String nextPageCursor) {
+        super((List) trades, String.valueOf(lastID), tradeSortType, nextPageCursor);
+    }
+
+    public List<UserTrade> getUserTrades() {
+
+        return (List) getTrades();
+    }
 }

--- a/xchange-cryptonit/src/test/java/org/knowm/xchange/cryptonit2/CryptonitAdapterTest.java
+++ b/xchange-cryptonit/src/test/java/org/knowm/xchange/cryptonit2/CryptonitAdapterTest.java
@@ -121,7 +121,7 @@ public class CryptonitAdapterTest {
 
     Trades trades = CryptonitAdapters.adaptTrades(transactions, CurrencyPair.BTC_USD);
     assertThat(trades.getTrades().size()).isEqualTo(125);
-    assertThat(trades.getlastID()).isEqualTo(122260);
+    assertThat(trades.getlastID()).isEqualTo("122260");
     // verify all fields filled
     assertThat(trades.getTrades().get(0).getId()).isEqualTo("121984");
     assertThat(trades.getTrades().get(0).getPrice().toString()).isEqualTo("13.14");

--- a/xchange-cryptopia/src/test/java/org/knowm/xchange/cryptopia/CryptopiaAdaptersTest.java
+++ b/xchange-cryptopia/src/test/java/org/knowm/xchange/cryptopia/CryptopiaAdaptersTest.java
@@ -134,7 +134,7 @@ public class CryptopiaAdaptersTest {
     Trades trades = CryptopiaAdapters.adaptTrades(cryptopiaMarketHistory.getData());
     assertThat(trades).isNotNull();
 
-    assertThat(trades.getlastID()).isEqualTo(1501995183);
+    assertThat(trades.getlastID()).isEqualTo("1501995183");
     assertThat(trades.getTradeSortType()).isEqualTo(Trades.TradeSortType.SortByTimestamp);
     assertThat(trades.getTrades().size()).isGreaterThan(1);
   }

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/okcoin/marketdata/OkCoinTradesDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/okcoin/marketdata/OkCoinTradesDemo.java
@@ -91,7 +91,7 @@ public class OkCoinTradesDemo {
     System.out.println("Trades size: " + trades.getTrades().size());
 
     // Get the latest trades data for BTC_CNY for the past couple of trades
-    trades = marketDataService.getTrades(CurrencyPair.BTC_CNY, trades.getlastID() - 10);
+    trades = marketDataService.getTrades(CurrencyPair.BTC_CNY, trades.getlastID());
     System.out.println(trades);
     System.out.println("Trades size: " + trades.getTrades().size());
   }

--- a/xchange-itbit/src/main/java/org/knowm/xchange/itbit/ItBitAdapters.java
+++ b/xchange-itbit/src/main/java/org/knowm/xchange/itbit/ItBitAdapters.java
@@ -90,11 +90,10 @@ public final class ItBitAdapters {
       throws InvalidFormatException {
 
     List<Trade> tradesList = new ArrayList<>(trades.getCount());
-    long lastMatchNumber = 0;
+    String lastMatchNumber = "0";
     for (int i = 0; i < trades.getCount(); i++) {
       ItBitTrade trade = trades.getTrades()[i];
-      long matchNumber = trade.getMatchNumber();
-      if (matchNumber > lastMatchNumber) lastMatchNumber = matchNumber;
+      lastMatchNumber = trade.getMatchNumber();
       tradesList.add(adaptTrade(trade, currencyPair));
     }
     return new Trades(tradesList, lastMatchNumber, TradeSortType.SortByID);

--- a/xchange-itbit/src/main/java/org/knowm/xchange/itbit/dto/marketdata/ItBitTrade.java
+++ b/xchange-itbit/src/main/java/org/knowm/xchange/itbit/dto/marketdata/ItBitTrade.java
@@ -8,13 +8,13 @@ public class ItBitTrade {
   private final BigDecimal amount;
   private final String timestamp;
   private final BigDecimal price;
-  private final long matchNumber;
+  private final String matchNumber;
 
   public ItBitTrade(
       @JsonProperty("amount") BigDecimal amount,
       @JsonProperty("timestamp") String timestamp,
       @JsonProperty("price") BigDecimal price,
-      @JsonProperty("matchNumber") long matchNumber) {
+      @JsonProperty("matchNumber") String matchNumber) {
 
     this.amount = amount;
     this.timestamp = timestamp;
@@ -37,7 +37,7 @@ public class ItBitTrade {
     return price;
   }
 
-  public long getMatchNumber() {
+  public String getMatchNumber() {
 
     return matchNumber;
   }

--- a/xchange-kraken/src/test/java/org/knowm/xchange/kraken/KrakenAdaptersTest.java
+++ b/xchange-kraken/src/test/java/org/knowm/xchange/kraken/KrakenAdaptersTest.java
@@ -143,7 +143,7 @@ public class KrakenAdaptersTest {
     assertThat(trades.getTrades().get(0).getType()).isEqualTo(OrderType.ASK);
     assertThat(trades.getTrades().get(0).getTimestamp()).isEqualTo(new Date(1385579841777L));
     assertThat(trades.getTrades().get(1).getOriginalAmount()).isEqualTo("0.01500000");
-    assertThat(trades.getlastID()).isEqualTo(1385579841881785998L);
+    assertThat(trades.getlastID()).isEqualTo("1385579841881785998");
   }
 
   @Test

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinTradeService.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinTradeService.java
@@ -166,7 +166,7 @@ public class KucoinTradeService extends KucoinTradeServiceRaw implements TradeSe
       }
     }
 
-    return new UserTrades(userTrades, 0, TradeSortType.SortByTimestamp, nextPageCursor);
+    return new UserTrades(userTrades, "0", TradeSortType.SortByTimestamp, nextPageCursor);
   }
 
   @Override

--- a/xchange-mercadobitcoin/src/test/java/org/knowm/xchange/mercadobitcoin/MercadoBitcoinAdapterTest.java
+++ b/xchange-mercadobitcoin/src/test/java/org/knowm/xchange/mercadobitcoin/MercadoBitcoinAdapterTest.java
@@ -73,7 +73,7 @@ public class MercadoBitcoinAdapterTest {
 
     Trades trades = MercadoBitcoinAdapters.adaptTrades(transactions, CurrencyPair.BTC_BRL);
     assertThat(trades.getTrades().size()).isEqualTo(1000);
-    assertThat(trades.getlastID()).isEqualTo(99518);
+    assertThat(trades.getlastID()).isEqualTo("99518");
     // verify all fields filled
     assertThat(trades.getTrades().get(0).getId()).isEqualTo("98519");
     assertThat(trades.getTrades().get(0).getPrice().toString()).isEqualTo("1015");

--- a/xchange-upbit/src/main/java/org/knowm/xchange/upbit/UpbitAdapters.java
+++ b/xchange-upbit/src/main/java/org/knowm/xchange/upbit/UpbitAdapters.java
@@ -89,7 +89,8 @@ public final class UpbitAdapters {
     for (UpbitTrade trade : trades.getUpbitTrades()) {
       tradeList.add(adaptTrade(trade, currencyPair));
     }
-    return new Trades(tradeList, 0, Trades.TradeSortType.SortByTimestamp);
+    String lastTrade = tradeList.size() > 0 ? String.valueOf(tradeList.get(tradeList.size()-1).getId()) : "0";
+    return new Trades(tradeList, lastTrade, Trades.TradeSortType.SortByTimestamp);
   }
 
   private static Trade adaptTrade(UpbitTrade trade, CurrencyPair currencyPair) {


### PR DESCRIPTION
Changing matchNumber in ItBitTrade DTO to String to address Issue #3242
Adding new constructors to allow for both long and String types as lastTradeIds