### PR TITLE
[KuCoin] Enable trade history queries before 28th Feb 2019 (using old API endpoint)

### DIFF
--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/kucoin/trade/KucoinTradeHistoryDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/kucoin/trade/KucoinTradeHistoryDemo.java
@@ -1,0 +1,70 @@
+package org.knowm.xchange.examples.kucoin.trade;
+
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.trade.UserTrades;
+import org.knowm.xchange.examples.kucoin.KucoinExamplesUtils;
+import org.knowm.xchange.kucoin.KucoinTradeHistoryParams;
+import org.knowm.xchange.service.trade.TradeService;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+public class KucoinTradeHistoryDemo {
+
+  public static void main(String[] args) throws Exception {
+
+    Exchange exchange = KucoinExamplesUtils.getExchange();
+
+    TradeService tradeService = exchange.getTradeService();
+
+    getRecentTrades(tradeService);
+//    getHistoricalTrades(tradeService);      // historical trades API endpoint not supported on Sandbox
+    getPagedTrades(tradeService);
+  }
+
+  private static void getRecentTrades(TradeService tradeService) throws IOException {
+    System.out.println("Requesting trades from the last 8 days (API allows up to 8 days)...");
+    KucoinTradeHistoryParams tradeHistoryParams =
+        (KucoinTradeHistoryParams) tradeService.createTradeHistoryParams();
+    UserTrades tradeHistory = tradeService.getTradeHistory(tradeHistoryParams);
+    tradeHistory.getUserTrades().forEach(System.out::println);
+  }
+
+  private static void getHistoricalTrades(TradeService tradeService) throws IOException {
+    System.out.println(
+        "Requesting trades from the old API (before 18 Feb 2019 UTC+8, no time span limitation)...");
+    KucoinTradeHistoryParams tradeHistoryParams =
+        (KucoinTradeHistoryParams) tradeService.createTradeHistoryParams();
+    Date aWhileBack =
+        Date.from(
+            LocalDate.of(2019, 2, 1).atStartOfDay().atZone(ZoneId.systemDefault()).toInstant());
+    tradeHistoryParams.setEndTime(aWhileBack);
+    UserTrades tradeHistory = tradeService.getTradeHistory(tradeHistoryParams);
+    tradeHistory.getUserTrades().forEach(System.out::println);
+  }
+
+  private static void getPagedTrades(TradeService tradeService) throws IOException {
+    System.out.println("Requesting trades from the last 3 days...");
+    KucoinTradeHistoryParams tradeHistoryParams =
+        (KucoinTradeHistoryParams) tradeService.createTradeHistoryParams();
+
+    Date threeDaysAgo =
+        Date.from(
+            LocalDate.now().minusDays(3).atStartOfDay().atZone(ZoneId.systemDefault()).toInstant());
+    tradeHistoryParams.setStartTime(threeDaysAgo);
+    // end time could be set here if desired
+    tradeHistoryParams.setCurrencyPair(CurrencyPair.ETH_BTC);
+
+    UserTrades tradeHistory = tradeService.getTradeHistory(tradeHistoryParams);
+
+    tradeHistory.getUserTrades().forEach(System.out::println);
+    while (tradeHistory.getNextPageCursor() != null) {
+      tradeHistoryParams.setNextPageCursor(tradeHistory.getNextPageCursor());
+      tradeHistory = tradeService.getTradeHistory(tradeHistoryParams);
+      tradeHistory.getUserTrades().forEach(System.out::println);
+    }
+  }
+}

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/kucoin/trade/KucoinTradeRawDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/kucoin/trade/KucoinTradeRawDemo.java
@@ -20,16 +20,16 @@ import org.knowm.xchange.service.trade.TradeService;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamCurrencyPair;
 
-public class KucoinTradeDemo {
+public class KucoinTradeRawDemo {
 
-  private static final CurrencyPair PAIR = new CurrencyPair("DRGN", "BTC");
-  private static final String SYMBOL = "DRGN-BTC";
+  private static final CurrencyPair PAIR = new CurrencyPair("ETH", "BTC");
+  private static final String SYMBOL = "ETH-BTC";
   private static final OrderType ORDER_TYPE = OrderType.ASK;
-  private static final BigDecimal AMOUNT = new BigDecimal("100");
-  private static final BigDecimal PRICE = new BigDecimal("0.1");
+  private static final BigDecimal AMOUNT = new BigDecimal("0.1");
+  private static final BigDecimal PRICE = new BigDecimal("0.05");
 
-  private static final BigDecimal STOP_PRICE = new BigDecimal("0.000002");
-  private static final BigDecimal STOP_LIMIT = new BigDecimal("0.0000019");
+  private static final BigDecimal STOP_PRICE = new BigDecimal("0.01");
+  private static final BigDecimal STOP_LIMIT = new BigDecimal("0.005");
 
   public static void main(String[] args) throws Exception {
 
@@ -223,10 +223,10 @@ public class KucoinTradeDemo {
 
     Thread.sleep(3000); // wait for order to propagate
 
-    System.out.println("All orders: " + tradeService.getKucoinOpenOrders(null, 0, 1000));
-    System.out.println(SYMBOL + " orders: " + tradeService.getKucoinOpenOrders(SYMBOL, 0, 1000));
-    System.out.println("All fills: " + tradeService.getKucoinFills(null, 0, 1000));
-    System.out.println(SYMBOL + " fills: " + tradeService.getKucoinFills(SYMBOL, 0, 1000));
+    System.out.println("All orders: " + tradeService.getKucoinOpenOrders(null, 1, 500));
+    System.out.println(SYMBOL + " orders: " + tradeService.getKucoinOpenOrders(SYMBOL, 1, 500));
+    System.out.println("All fills: " + tradeService.getKucoinFills(null, 1, 500, null, null));
+    System.out.println(SYMBOL + " fills: " + tradeService.getKucoinFills(SYMBOL, 1, 500, null, null));
 
     // Not yet implemented
     System.out.println("Attempting to cancel order " + orderId);
@@ -240,6 +240,6 @@ public class KucoinTradeDemo {
 
     Thread.sleep(3000); // wait for cancellation to propagate
 
-    System.out.println(SYMBOL + " orders: " + tradeService.getKucoinOpenOrders(SYMBOL, 1, 1000));
+    System.out.println(SYMBOL + " orders: " + tradeService.getKucoinOpenOrders(SYMBOL, 1, 500));
   }
 }

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinAdapters.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinAdapters.java
@@ -48,16 +48,7 @@ import org.knowm.xchange.dto.trade.UserTrade;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.kucoin.KucoinTradeService.KucoinOrderFlags;
 import org.knowm.xchange.kucoin.dto.request.OrderCreateApiRequest;
-import org.knowm.xchange.kucoin.dto.response.AccountBalancesResponse;
-import org.knowm.xchange.kucoin.dto.response.AllTickersResponse;
-import org.knowm.xchange.kucoin.dto.response.DepositResponse;
-import org.knowm.xchange.kucoin.dto.response.OrderBookResponse;
-import org.knowm.xchange.kucoin.dto.response.OrderResponse;
-import org.knowm.xchange.kucoin.dto.response.SymbolResponse;
-import org.knowm.xchange.kucoin.dto.response.SymbolTickResponse;
-import org.knowm.xchange.kucoin.dto.response.TradeHistoryResponse;
-import org.knowm.xchange.kucoin.dto.response.TradeResponse;
-import org.knowm.xchange.kucoin.dto.response.WithdrawalResponse;
+import org.knowm.xchange.kucoin.dto.response.*;
 
 public class KucoinAdapters {
 
@@ -267,6 +258,20 @@ public class KucoinAdapters {
         .price(trade.getPrice())
         .timestamp(trade.getTradeCreatedAt())
         .type(adaptSide(trade.getSide()))
+        .build();
+  }
+
+  public static UserTrade adaptHistOrder(HistOrdersResponse histOrder) {
+    CurrencyPair currencyPair = adaptCurrencyPair(histOrder.getSymbol());
+    return new UserTrade.Builder()
+        .currencyPair(currencyPair)
+        .feeAmount(histOrder.getFee())
+        .feeCurrency(currencyPair.base)
+        .id(histOrder.getId())
+        .originalAmount(histOrder.getAmount())
+        .price(histOrder.getPrice())
+        .timestamp(histOrder.getTradeCreatedAt())
+        .type(adaptSide(histOrder.getSide()))
         .build();
   }
 

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinAdapters.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinAdapters.java
@@ -1,26 +1,16 @@
 package org.knowm.xchange.kucoin;
 
 import static java.util.stream.Collectors.toCollection;
-import static org.knowm.xchange.dto.Order.OrderStatus.CANCELED;
-import static org.knowm.xchange.dto.Order.OrderStatus.NEW;
-import static org.knowm.xchange.dto.Order.OrderStatus.PARTIALLY_FILLED;
-import static org.knowm.xchange.dto.Order.OrderStatus.UNKNOWN;
+import static org.knowm.xchange.dto.Order.OrderStatus.*;
 import static org.knowm.xchange.dto.Order.OrderType.ASK;
 import static org.knowm.xchange.dto.Order.OrderType.BID;
-import static org.knowm.xchange.kucoin.dto.KucoinOrderFlags.HIDDEN;
-import static org.knowm.xchange.kucoin.dto.KucoinOrderFlags.ICEBERG;
-import static org.knowm.xchange.kucoin.dto.KucoinOrderFlags.POST_ONLY;
+import static org.knowm.xchange.kucoin.dto.KucoinOrderFlags.*;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Ordering;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.knowm.xchange.currency.Currency;

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinBaseService.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinBaseService.java
@@ -1,16 +1,7 @@
 package org.knowm.xchange.kucoin;
 
 import com.google.common.base.Strings;
-import org.knowm.xchange.kucoin.service.AccountAPI;
-import org.knowm.xchange.kucoin.service.DepositAPI;
-import org.knowm.xchange.kucoin.service.FillAPI;
-import org.knowm.xchange.kucoin.service.HistoryAPI;
-import org.knowm.xchange.kucoin.service.KucoinApiException;
-import org.knowm.xchange.kucoin.service.KucoinDigest;
-import org.knowm.xchange.kucoin.service.OrderAPI;
-import org.knowm.xchange.kucoin.service.OrderBookAPI;
-import org.knowm.xchange.kucoin.service.SymbolAPI;
-import org.knowm.xchange.kucoin.service.WithdrawalAPI;
+import org.knowm.xchange.kucoin.service.*;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.RestProxyFactory;
@@ -26,6 +17,7 @@ public class KucoinBaseService extends BaseExchangeService<KucoinExchange> imple
   protected final DepositAPI depositAPI;
   protected final OrderAPI orderApi;
   protected final FillAPI fillApi;
+  protected final HistOrdersAPI histOrdersApi;
 
   protected KucoinDigest digest;
   protected String apiKey;
@@ -42,6 +34,7 @@ public class KucoinBaseService extends BaseExchangeService<KucoinExchange> imple
     this.depositAPI = service(exchange, DepositAPI.class);
     this.orderApi = service(exchange, OrderAPI.class);
     this.fillApi = service(exchange, FillAPI.class);
+    this.histOrdersApi = service(exchange, HistOrdersAPI.class);
 
     this.digest = KucoinDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
     this.apiKey = exchange.getExchangeSpecification().getApiKey();

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinTradeHistoryParams.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinTradeHistoryParams.java
@@ -2,22 +2,21 @@ package org.knowm.xchange.kucoin;
 
 import java.util.Date;
 import lombok.Data;
-import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.account.FundingRecord.Type;
-import org.knowm.xchange.service.trade.params.HistoryParamsFundingType;
-import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrency;
-import org.knowm.xchange.service.trade.params.TradeHistoryParams;
-import org.knowm.xchange.service.trade.params.TradeHistoryParamsTimeSpan;
+import org.knowm.xchange.service.trade.params.*;
 
 @Data
 public class KucoinTradeHistoryParams
     implements TradeHistoryParams,
-        TradeHistoryParamCurrency,
+        TradeHistoryParamCurrencyPair,
         HistoryParamsFundingType,
-        TradeHistoryParamsTimeSpan {
+        TradeHistoryParamsTimeSpan,
+        TradeHistoryParamNextPageCursor {
 
   private Date startTime;
   private Date endTime;
   private Type type;
-  private Currency currency;
+  private CurrencyPair currencyPair;
+  private String nextPageCursor;
 }

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinTradeService.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinTradeService.java
@@ -1,12 +1,10 @@
 package org.knowm.xchange.kucoin;
 
-import static java.util.stream.Collectors.toCollection;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
-
 import java.io.IOException;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -14,7 +12,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.IOrderFlags;
 import org.knowm.xchange.dto.marketdata.Trades.TradeSortType;
@@ -37,7 +34,8 @@ public class KucoinTradeService extends KucoinTradeServiceRaw implements TradeSe
   private static final long cutoffHistOrdersMillis =
       Date.from(java.time.LocalDate.of(2019, 2, 18).atStartOfDay(ZoneId.of("UTC+8")).toInstant())
           .getTime();
-  private static final long oneWeekMillis = 7 * 24 * 60 * 60 * 1000;
+  // Although API doc says 7 days max timespan, KuCoin actually allows (almost) 8 days :)
+  private static final long oneWeekMillis = (8 * 24 * 60 * 60 * 1000) - 1000;
 
   KucoinTradeService(KucoinExchange exchange) {
     super(exchange);
@@ -62,42 +60,70 @@ public class KucoinTradeService extends KucoinTradeServiceRaw implements TradeSe
   @Override
   public UserTrades getTradeHistory(TradeHistoryParams genericParams) throws IOException {
     String symbol = null;
-    if (genericParams != null) {
-      // TODO Currency pair is actually optional on KuCoin API, i.e. it should be possible to
-      // proceed with genericParams = null
-      Preconditions.checkArgument(
-          genericParams instanceof TradeHistoryParamCurrencyPair,
-          "Only currency pair parameters are currently supported.");
-      TradeHistoryParamCurrencyPair params = (TradeHistoryParamCurrencyPair) genericParams;
-      symbol = KucoinAdapters.adaptCurrencyPair(params.getCurrencyPair());
-    }
-
-    List<UserTrade> userTrades = new ArrayList<>();
     Long startTime = null;
     Long endTime = null;
-    if (genericParams instanceof TradeHistoryParamsTimeSpan) {
-      if (((TradeHistoryParamsTimeSpan) genericParams).getStartTime() != null) {
-        startTime = ((TradeHistoryParamsTimeSpan) genericParams).getStartTime().getTime();
-      }
-      if (((TradeHistoryParamsTimeSpan) genericParams).getEndTime() != null) {
-        endTime = ((TradeHistoryParamsTimeSpan) genericParams).getEndTime().getTime();
-      }
-      /*
-        KuCoin restricts time spans to 7 days on new fills API but not hist-orders. I.e. you could request a whole year of
-        trades before 2019-2-18 but only 7 days of trades after that date.
-        It would be nice to check and enforce this rule here but that could end up being confusing for users.
-      */
-      if (startTime == null && endTime == null) {
-        startTime = new Date().getTime() - oneWeekMillis;
-        logger.warn(
-            "No start or end time for trade history request specified, defaulting to last 7 days!");
+
+    if (genericParams != null) {
+      TradeHistoryParamCurrencyPair params = (TradeHistoryParamCurrencyPair) genericParams;
+      symbol = KucoinAdapters.adaptCurrencyPair(params.getCurrencyPair());
+
+      if (genericParams instanceof TradeHistoryParamsTimeSpan) {
+        if (((TradeHistoryParamsTimeSpan) genericParams).getStartTime() != null) {
+          startTime = ((TradeHistoryParamsTimeSpan) genericParams).getStartTime().getTime();
+        }
+        if (((TradeHistoryParamsTimeSpan) genericParams).getEndTime() != null) {
+          endTime = ((TradeHistoryParamsTimeSpan) genericParams).getEndTime().getTime();
+        }
+        /*
+          KuCoin restricts time spans to 7 days (as per API docs) on new fills API but not hist-orders. I.e. you could request
+           a whole year of trades before 2019-2-18 but only 7 days of trades after that date.
+        */
+        if (startTime != null) {
+          if (endTime == null) {
+            if (startTime < cutoffHistOrdersMillis) {
+              endTime = Math.max(cutoffHistOrdersMillis - 1, startTime + oneWeekMillis);
+            } else {
+              endTime = startTime + oneWeekMillis;
+            }
+            logger.warn(
+                "End time not specified, adjusted to the following time span {} - {}",
+                Date.from(Instant.ofEpochMilli(startTime)),
+                Date.from(Instant.ofEpochMilli(endTime)));
+          } else if (endTime >= cutoffHistOrdersMillis && endTime - startTime > oneWeekMillis) {
+            endTime = startTime + oneWeekMillis;
+            logger.warn(
+                "End time more than one week from start time, adjusted to the following time span {} - {}",
+                Date.from(Instant.ofEpochMilli(startTime)),
+                Date.from(Instant.ofEpochMilli(endTime)));
+          }
+        }
+
+        if (endTime != null && startTime == null) {
+          if (endTime > cutoffHistOrdersMillis) {
+            startTime = endTime - oneWeekMillis;
+            logger.warn(
+                "Start time not specified, adjusted to the following time span {} - {}",
+                Date.from(Instant.ofEpochMilli(startTime)),
+                Date.from(Instant.ofEpochMilli(endTime)));
+          }
+        }
+        if (startTime == null && endTime == null) {
+          endTime = new Date().getTime();
+          startTime = endTime - oneWeekMillis;
+          logger.warn(
+              "No start or end time for trade history request specified, adjusted to the following time span {} - {}",
+              Date.from(Instant.ofEpochMilli(startTime)),
+              Date.from(Instant.ofEpochMilli(endTime)));
+        }
       }
     }
+
     // TODO getKucoinFills(...).getItems will just get the current items and silently ignore any
     // other pages if present!
     Long startTimeSecs = startTime != null ? startTime / 1000 : null;
     Long endTimeSecs = endTime != null ? endTime / 1000 : null;
 
+    List<UserTrade> userTrades;
     if (startTime != null && startTime > cutoffHistOrdersMillis) {
       userTrades =
           getKucoinFills(symbol, 1, TRADE_HISTORIES_TO_FETCH, startTime, endTime).getItems()
@@ -113,14 +139,14 @@ public class KucoinTradeService extends KucoinTradeServiceRaw implements TradeSe
     } else {
       userTrades =
           Stream.concat(
-              getKucoinHistOrders(
-                  symbol, 1, TRADE_HISTORIES_TO_FETCH, startTimeSecs, endTimeSecs)
-                  .getItems().stream()
-                  .map(KucoinAdapters::adaptHistOrder),
-              getKucoinFills(symbol, 1, TRADE_HISTORIES_TO_FETCH, startTime, endTime).getItems()
-                  .stream()
-                  .map(KucoinAdapters::adaptUserTrade))
-              .collect(toCollection(ArrayList::new));
+                  getKucoinHistOrders(
+                          symbol, 1, TRADE_HISTORIES_TO_FETCH, startTimeSecs, endTimeSecs)
+                      .getItems().stream()
+                      .map(KucoinAdapters::adaptHistOrder),
+                  getKucoinFills(symbol, 1, TRADE_HISTORIES_TO_FETCH, startTime, endTime).getItems()
+                      .stream()
+                      .map(KucoinAdapters::adaptUserTrade))
+              .collect(Collectors.toList());
     }
 
     return new UserTrades(userTrades, TradeSortType.SortByTimestamp);
@@ -172,7 +198,7 @@ public class KucoinTradeService extends KucoinTradeServiceRaw implements TradeSe
     Builder<Order> hiddenOrders = ImmutableList.builder();
     orders.stream()
         .map(KucoinAdapters::adaptOrder)
-        .filter(o -> params == null ? true : params.accept(o))
+        .filter(o -> params == null || params.accept(o))
         .forEach(
             o -> {
               if (o instanceof LimitOrder) {
@@ -184,9 +210,7 @@ public class KucoinTradeService extends KucoinTradeServiceRaw implements TradeSe
     return new OpenOrders(openOrders.build(), hiddenOrders.build());
   }
 
-  /**
-   * TODO same as Binance. Should be merged into generic API
-   */
+  /** TODO same as Binance. Should be merged into generic API */
   public interface KucoinOrderFlags extends IOrderFlags {
     String getClientId();
   }

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinTradeService.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinTradeService.java
@@ -17,15 +17,12 @@ import org.knowm.xchange.dto.trade.MarketOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.dto.trade.StopOrder;
 import org.knowm.xchange.dto.trade.UserTrades;
+import org.knowm.xchange.kucoin.dto.response.HistOrdersResponse;
 import org.knowm.xchange.kucoin.dto.response.OrderCancelResponse;
 import org.knowm.xchange.kucoin.dto.response.OrderResponse;
 import org.knowm.xchange.kucoin.dto.response.TradeResponse;
 import org.knowm.xchange.service.trade.TradeService;
-import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
-import org.knowm.xchange.service.trade.params.CancelOrderParams;
-import org.knowm.xchange.service.trade.params.DefaultTradeHistoryParamCurrencyPair;
-import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
-import org.knowm.xchange.service.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.trade.params.*;
 import org.knowm.xchange.service.trade.params.orders.DefaultOpenOrdersParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
@@ -129,6 +126,14 @@ public class KucoinTradeService extends KucoinTradeServiceRaw implements TradeSe
   private UserTrades convertUserTrades(List<TradeResponse> fills) {
     return new UserTrades(
         fills.stream().map(KucoinAdapters::adaptUserTrade).collect(toCollection(ArrayList::new)),
+        TradeSortType.SortByTimestamp);
+  }
+
+  public UserTrades convertHistOrders(List<HistOrdersResponse> histOrders) {
+    return new UserTrades(
+        histOrders.stream()
+            .map(KucoinAdapters::adaptHistOrder)
+            .collect(toCollection(ArrayList::new)),
         TradeSortType.SortByTimestamp);
   }
 

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinTradeServiceRaw.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinTradeServiceRaw.java
@@ -4,11 +4,7 @@ import static org.knowm.xchange.kucoin.KucoinExceptionClassifier.classifyingExce
 
 import java.io.IOException;
 import org.knowm.xchange.kucoin.dto.request.OrderCreateApiRequest;
-import org.knowm.xchange.kucoin.dto.response.OrderCancelResponse;
-import org.knowm.xchange.kucoin.dto.response.OrderCreateResponse;
-import org.knowm.xchange.kucoin.dto.response.OrderResponse;
-import org.knowm.xchange.kucoin.dto.response.Pagination;
-import org.knowm.xchange.kucoin.dto.response.TradeResponse;
+import org.knowm.xchange.kucoin.dto.response.*;
 
 public class KucoinTradeServiceRaw extends KucoinBaseService {
 
@@ -36,8 +32,8 @@ public class KucoinTradeServiceRaw extends KucoinBaseService {
                 page));
   }
 
-  public Pagination<TradeResponse> getKucoinFills(String symbol, int page, int pageSize)
-      throws IOException {
+  public Pagination<TradeResponse> getKucoinFills(
+      String symbol, int page, int pageSize, Long startAt, Long endAt) throws IOException {
     checkAuthenticated();
     return classifyingExceptions(
         () ->
@@ -50,8 +46,26 @@ public class KucoinTradeServiceRaw extends KucoinBaseService {
                 null,
                 null,
                 null,
+                startAt,
+                endAt,
+                pageSize,
+                page));
+  }
+
+  public Pagination<HistOrdersResponse> getKucoinHistOrders(
+      String symbol, int page, int pageSize, Long startAt, Long endAt) throws IOException {
+    checkAuthenticated();
+    return classifyingExceptions(
+        () ->
+            histOrdersApi.queryHistOrders(
+                apiKey,
+                digest,
+                nonceFactory,
+                passphrase,
+                symbol,
                 null,
-                null,
+                startAt,
+                endAt,
                 pageSize,
                 page));
   }

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/HistOrdersResponse.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/HistOrdersResponse.java
@@ -2,11 +2,10 @@ package org.knowm.xchange.kucoin.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
-import lombok.ToString;
-
 import java.math.BigDecimal;
 import java.util.Date;
+import lombok.Data;
+import lombok.ToString;
 
 @Data
 @ToString

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/HistOrdersResponse.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/HistOrdersResponse.java
@@ -2,10 +2,11 @@ package org.knowm.xchange.kucoin.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.math.BigDecimal;
-import java.util.Date;
 import lombok.Data;
 import lombok.ToString;
+
+import java.math.BigDecimal;
+import java.util.Date;
 
 @Data
 @ToString
@@ -23,6 +24,7 @@ public class HistOrdersResponse {
   @JsonProperty("dealPrice")
   private BigDecimal price;
 
+  // price * amount (i.e. volume of this trade in counter ccy)
   @JsonProperty("dealValue")
   private BigDecimal value;
 

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/HistOrdersResponse.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/HistOrdersResponse.java
@@ -1,0 +1,41 @@
+package org.knowm.xchange.kucoin.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.util.Date;
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HistOrdersResponse {
+
+  private String symbol;
+
+  private String side;
+
+  public String getSide() {
+    return this.side == null ? null : this.side.toLowerCase();
+  }
+
+  @JsonProperty("dealPrice")
+  private BigDecimal price;
+
+  @JsonProperty("dealValue")
+  private BigDecimal value;
+
+  private BigDecimal amount;
+
+  private BigDecimal fee;
+
+  @JsonProperty("createdAt")
+  private long createdAtSeconds;
+
+  public Date getTradeCreatedAt() {
+    return new Date(createdAtSeconds * 1000);
+  }
+
+  private String id;
+}

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/HistOrdersAPI.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/HistOrdersAPI.java
@@ -1,0 +1,42 @@
+package org.knowm.xchange.kucoin.service;
+
+import java.io.IOException;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import org.knowm.xchange.kucoin.dto.response.HistOrdersResponse;
+import org.knowm.xchange.kucoin.dto.response.KucoinResponse;
+import org.knowm.xchange.kucoin.dto.response.Pagination;
+import si.mazi.rescu.ParamsDigest;
+import si.mazi.rescu.SynchronizedValueFactory;
+
+@Path("/api/v1/hist-orders")
+@Produces(MediaType.APPLICATION_JSON)
+public interface HistOrdersAPI {
+
+  /**
+   * Get a list of recent fills.
+   *
+   * @param symbol [optional] Limit list of fills to this orderId
+   * @param side [optional] buy or sell
+   * @param startAt [optional] Start time. unix timestamp calculated in milliseconds, the creation
+   *     time queried shall posterior to the start time.
+   * @param endAt [optional] End time. unix timestamp calculated in milliseconds, the creation time
+   *     queried shall prior to the end time.
+   * @param pageSize [optional] The page size.
+   * @param currentPage [optional] The page to select.
+   * @return Trades.
+   */
+  @GET
+  KucoinResponse<Pagination<HistOrdersResponse>> queryHistOrders(
+      @HeaderParam(APIConstants.API_HEADER_KEY) String apiKey,
+      @HeaderParam(APIConstants.API_HEADER_SIGN) ParamsDigest signature,
+      @HeaderParam(APIConstants.API_HEADER_TIMESTAMP) SynchronizedValueFactory<Long> nonce,
+      @HeaderParam(APIConstants.API_HEADER_PASSPHRASE) String apiPassphrase,
+      @QueryParam("symbol") String symbol,
+      @QueryParam("side") String side,
+      @QueryParam("startAt") Long startAt,
+      @QueryParam("endAt") Long endAt,
+      @QueryParam("pageSize") int pageSize,
+      @QueryParam("currentPage") int currentPage)
+      throws IOException;
+}

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/HistOrdersAPI.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/HistOrdersAPI.java
@@ -17,13 +17,13 @@ public interface HistOrdersAPI {
   /**
    * Get a list of recent fills.
    *
-   * @param symbol      [optional] Limit list of fills to this orderId
-   * @param side        [optional] buy or sell
-   * @param startAt     [optional] Start time. unix timestamp calculated in milliseconds, the creation
-   *                    time queried shall posterior to the start time.
-   * @param endAt       [optional] End time. unix timestamp calculated in milliseconds, the creation time
-   *                    queried shall prior to the end time.
-   * @param pageSize    [optional] The page size.
+   * @param symbol [optional] Limit list of fills to this orderId
+   * @param side [optional] buy or sell
+   * @param startAt [optional] Start time. unix timestamp calculated in milliseconds, the creation
+   *     time queried shall posterior to the start time.
+   * @param endAt [optional] End time. unix timestamp calculated in milliseconds, the creation time
+   *     queried shall prior to the end time.
+   * @param pageSize [optional] The page size.
    * @param currentPage [optional] The page to select.
    * @return Trades.
    */

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/HistOrdersAPI.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/HistOrdersAPI.java
@@ -1,13 +1,14 @@
 package org.knowm.xchange.kucoin.service;
 
-import java.io.IOException;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
 import org.knowm.xchange.kucoin.dto.response.HistOrdersResponse;
 import org.knowm.xchange.kucoin.dto.response.KucoinResponse;
 import org.knowm.xchange.kucoin.dto.response.Pagination;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.SynchronizedValueFactory;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
 
 @Path("/api/v1/hist-orders")
 @Produces(MediaType.APPLICATION_JSON)
@@ -16,13 +17,13 @@ public interface HistOrdersAPI {
   /**
    * Get a list of recent fills.
    *
-   * @param symbol [optional] Limit list of fills to this orderId
-   * @param side [optional] buy or sell
-   * @param startAt [optional] Start time. unix timestamp calculated in milliseconds, the creation
-   *     time queried shall posterior to the start time.
-   * @param endAt [optional] End time. unix timestamp calculated in milliseconds, the creation time
-   *     queried shall prior to the end time.
-   * @param pageSize [optional] The page size.
+   * @param symbol      [optional] Limit list of fills to this orderId
+   * @param side        [optional] buy or sell
+   * @param startAt     [optional] Start time. unix timestamp calculated in milliseconds, the creation
+   *                    time queried shall posterior to the start time.
+   * @param endAt       [optional] End time. unix timestamp calculated in milliseconds, the creation time
+   *                    queried shall prior to the end time.
+   * @param pageSize    [optional] The page size.
    * @param currentPage [optional] The page to select.
    * @return Trades.
    */

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/HistOrdersAPI.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/HistOrdersAPI.java
@@ -1,14 +1,13 @@
 package org.knowm.xchange.kucoin.service;
 
+import java.io.IOException;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
 import org.knowm.xchange.kucoin.dto.response.HistOrdersResponse;
 import org.knowm.xchange.kucoin.dto.response.KucoinResponse;
 import org.knowm.xchange.kucoin.dto.response.Pagination;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.SynchronizedValueFactory;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import java.io.IOException;
 
 @Path("/api/v1/hist-orders")
 @Produces(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
KuCoin changed their system/API on 28th Feb 2019 and trades executed before that date do not show up in the regular trade history.

This fix automatically uses the **hist-orders** API endpoint when a date range before the 28th Feb 2019 is specified and the **fills** endpoint for dates after in tradeService.getTradeHistory(...) calls. It also checks if the date range specified complies with KuCoin API restrictions and adjusts if necessary.

Fixes #3377