### PR TITLE
[CoinEgg] Fix region when requesting market depth

### DIFF
--- a/xchange-coinegg/src/main/java/org/knowm/xchange/coinegg/CoinEgg.java
+++ b/xchange-coinegg/src/main/java/org/knowm/xchange/coinegg/CoinEgg.java
@@ -23,6 +23,7 @@ public interface CoinEgg {
   CoinEggTrade[] getTrades(@PathParam("symbol") String symbol) throws IOException;
 
   @GET
-  @Path("depth?coin={symbol}")
-  CoinEggOrders getOrders(@PathParam("symbol") String symbol) throws IOException;
+  @Path("depth/region/{region}?coin={symbol}")
+  CoinEggOrders getOrders(@PathParam("region") String region, @PathParam("symbol") String symbol)
+      throws IOException;
 }

--- a/xchange-coinegg/src/main/java/org/knowm/xchange/coinegg/service/CoinEggMarketDataService.java
+++ b/xchange-coinegg/src/main/java/org/knowm/xchange/coinegg/service/CoinEggMarketDataService.java
@@ -25,7 +25,10 @@ public class CoinEggMarketDataService extends CoinEggMarketDataServiceRaw
   @Override
   public OrderBook getOrderBook(CurrencyPair currencyPair, Object... args) throws IOException {
     return CoinEggAdapters.adaptOrders(
-        getCoinEggOrders(currencyPair.base.getCurrencyCode().toLowerCase()), currencyPair);
+        getCoinEggOrders(
+            currencyPair.counter.getCurrencyCode().toLowerCase(),
+            currencyPair.base.getCurrencyCode().toLowerCase()),
+        currencyPair);
   }
 
   @Override

--- a/xchange-coinegg/src/main/java/org/knowm/xchange/coinegg/service/CoinEggMarketDataServiceRaw.java
+++ b/xchange-coinegg/src/main/java/org/knowm/xchange/coinegg/service/CoinEggMarketDataServiceRaw.java
@@ -23,7 +23,7 @@ public class CoinEggMarketDataServiceRaw extends CoinEggBaseService {
   }
 
   // TODO: Exception Handling - See Bitfinex
-  public CoinEggOrders getCoinEggOrders(String coin) throws IOException {
-    return coinEgg.getOrders(coin);
+  public CoinEggOrders getCoinEggOrders(String region, String coin) throws IOException {
+    return coinEgg.getOrders(region, coin);
   }
 }

--- a/xchange-coinegg/src/test/java/org/knowm/xchange/coinegg/service/marketdata/CoinEggOrdersFetchIntegration.java
+++ b/xchange-coinegg/src/test/java/org/knowm/xchange/coinegg/service/marketdata/CoinEggOrdersFetchIntegration.java
@@ -22,4 +22,15 @@ public class CoinEggOrdersFetchIntegration {
     // Verify Not Null Values
     assertThat(orders).isNotNull();
   }
+
+  @Test
+  public void ordersFetchTest_BTC_USDT() throws Exception {
+
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinEggExchange.class.getName());
+    MarketDataService marketDataService = exchange.getMarketDataService();
+    OrderBook orders = marketDataService.getOrderBook(CurrencyPair.BTC_USDT);
+
+    // Verify Not Null Values
+    assertThat(orders).isNotNull();
+  }
 }


### PR DESCRIPTION
The specification for CoinEgg REST service defines that the request URI should specify the region, or in fact the counter currency. The current implementation omits the region part of the URI, thus working only for */BTC pairs.

This pull request adds the necessary part of the URI path and also provides a test to verify that it's working.