### PR TITLE
Fix remove a single order from the order book

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/OrderBook.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/OrderBook.java
@@ -150,9 +150,12 @@ public final class OrderBook implements Serializable {
     int idx = Collections.binarySearch(asks, limitOrder);
     if (idx >= 0) {
       asks.remove(idx);
-      asks.add(idx, limitOrder);
     } else {
-      asks.add(-idx - 1, limitOrder);
+      idx = -idx - 1;
+    }
+
+    if (limitOrder.getRemainingAmount().compareTo(BigDecimal.ZERO) != 0) {
+      asks.add(idx, limitOrder);
     }
   }
 

--- a/xchange-core/src/test/java/org/knowm/xchange/OrderBookTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/OrderBookTest.java
@@ -11,6 +11,7 @@ import java.util.Date;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
+import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.marketdata.OrderBook;
@@ -78,6 +79,20 @@ public class OrderBookTest {
             timeStamp,
             BigDecimal.ZERO);
     orderBook.update(lowerBidUpdate);
+    assertThat(orderBook.getBids().size()).isEqualTo(0);
+  }
+
+  @Test
+  public void testUpdateRemoveSingleOrder() {
+
+    Date timeStamp = new Date(0);
+    LimitOrder limitOrder = new LimitOrder.Builder(OrderType.BID, CurrencyPair.BTC_USD)
+        .originalAmount(BigDecimal.ONE)
+        .limitPrice(BigDecimal.TEN)
+        .timestamp(timeStamp)
+        .cumulativeAmount(BigDecimal.ONE) // remaining amount is now 0
+        .build();
+    orderBook.update(limitOrder);
     assertThat(orderBook.getBids().size()).isEqualTo(0);
   }
 

--- a/xchange-core/src/test/java/org/knowm/xchange/OrderBookTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/OrderBookTest.java
@@ -11,7 +11,6 @@ import java.util.Date;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
-import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.marketdata.OrderBook;


### PR DESCRIPTION
The contract for market updates (order books) specifies that when the amount for a given limit price is 0 (zero), then this bid/ask has been fulfilled and has to be removed from the order book. 

This is implemented in the `update(List<LimitOrder> asks, LimitOrder limitOrder)` and `update(OrderBookUpdate orderBookUpdate)` methods, but not in the `update(LimitOrder limitOrder)` method. The latter is not used at all in the project and there are no test cases for it. I assume that's the reason the issue was not caught earlier.

Also added a new test case to verify.