### PR TITLE
UserTrade missing field "original volume"

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/trade/BinanceTrade.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/trade/BinanceTrade.java
@@ -10,6 +10,7 @@ public final class BinanceTrade {
   public final long orderId;
   public final BigDecimal price;
   public final BigDecimal qty;
+  public final BigDecimal quoteQty;
   public final BigDecimal commission;
   public final String commissionAsset;
   public final long time;
@@ -22,6 +23,7 @@ public final class BinanceTrade {
       @JsonProperty("orderId") long orderId,
       @JsonProperty("price") BigDecimal price,
       @JsonProperty("qty") BigDecimal qty,
+      @JsonProperty("quoteQty") BigDecimal quoteQty,
       @JsonProperty("commission") BigDecimal commission,
       @JsonProperty("commissionAsset") String commissionAsset,
       @JsonProperty("time") long time,
@@ -32,6 +34,7 @@ public final class BinanceTrade {
     this.orderId = orderId;
     this.price = price;
     this.qty = qty;
+    this.quoteQty = quoteQty;
     this.commission = commission;
     this.commissionAsset = commissionAsset;
     this.time = time;

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/trade/BinanceUserTrade.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/trade/BinanceUserTrade.java
@@ -1,0 +1,180 @@
+package org.knowm.xchange.binance.dto.trade;
+
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.Objects;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.trade.UserTrade;
+
+public class BinanceUserTrade extends UserTrade {
+
+  private BigDecimal originalVolume;
+
+  public BinanceUserTrade(
+      final Order.OrderType type,
+      final BigDecimal originalAmount,
+      final BigDecimal originalVolume,
+      final CurrencyPair currencyPair,
+      final BigDecimal price,
+      final Date timestamp,
+      final String id,
+      final String orderId,
+      final BigDecimal feeAmount,
+      final Currency feeCurrency,
+      final String orderUserReference) {
+    super(
+        type,
+        originalAmount,
+        currencyPair,
+        price,
+        timestamp,
+        id,
+        orderId,
+        feeAmount,
+        feeCurrency,
+        orderUserReference);
+    this.originalVolume = originalVolume;
+  }
+
+  public BigDecimal getOriginalVolume() {
+    return originalVolume;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    final BinanceUserTrade that = (BinanceUserTrade) o;
+    return Objects.equals(originalVolume, that.originalVolume);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), originalVolume);
+  }
+
+  @Override
+  public String toString() {
+    return "BinanceUserTrade[type="
+        + type
+        + ", originalAmount="
+        + originalAmount
+        + ", originalVolume="
+        + originalVolume
+        + ", currencyPair="
+        + currencyPair
+        + ", price="
+        + price
+        + ", timestamp="
+        + timestamp
+        + ", id="
+        + id
+        + ", orderId='"
+        + getOrderId()
+        + '\''
+        + ", feeAmount="
+        + getFeeAmount()
+        + ", feeCurrency='"
+        + getFeeCurrency()
+        + '\''
+        + ", orderUserReference='"
+        + getOrderUserReference()
+        + '\''
+        + "]";
+  }
+
+  @JsonPOJOBuilder(withPrefix = "")
+  public static class Builder extends UserTrade.Builder {
+    protected BigDecimal originalVolume;
+
+    public static Builder from(BinanceUserTrade trade) {
+      return new Builder()
+          .type(trade.getType())
+          .originalAmount(trade.getOriginalAmount())
+          .originalVolume(trade.getOriginalVolume())
+          .currencyPair(trade.getCurrencyPair())
+          .price(trade.getPrice())
+          .timestamp(trade.getTimestamp())
+          .id(trade.getId())
+          .orderId(trade.getOrderId())
+          .feeAmount(trade.getFeeAmount())
+          .feeCurrency(trade.getFeeCurrency())
+          .orderUserReference(trade.getOrderUserReference());
+    }
+
+    @Override
+    public Builder type(Order.OrderType type) {
+      return (Builder) super.type(type);
+    }
+
+    @Override
+    public Builder originalAmount(BigDecimal originalAmount) {
+      return (Builder) super.originalAmount(originalAmount);
+    }
+
+    public Builder originalVolume(final BigDecimal originalVolume) {
+      this.originalVolume = originalVolume;
+      return this;
+    }
+
+    @Override
+    public Builder currencyPair(CurrencyPair currencyPair) {
+      return (Builder) super.currencyPair(currencyPair);
+    }
+
+    @Override
+    public Builder price(BigDecimal price) {
+      return (Builder) super.price(price);
+    }
+
+    @Override
+    public Builder timestamp(Date timestamp) {
+      return (Builder) super.timestamp(timestamp);
+    }
+
+    @Override
+    public Builder id(String id) {
+      return (Builder) super.id(id);
+    }
+
+    @Override
+    public Builder orderId(String orderId) {
+      return (Builder) super.orderId(orderId);
+    }
+
+    @Override
+    public Builder feeAmount(BigDecimal feeAmount) {
+      return (Builder) super.feeAmount(feeAmount);
+    }
+
+    @Override
+    public Builder feeCurrency(Currency feeCurrency) {
+      return (Builder) super.feeCurrency(feeCurrency);
+    }
+
+    @Override
+    public Builder orderUserReference(String orderUserReference) {
+      return (Builder) super.orderUserReference(orderUserReference);
+    }
+
+    @Override
+    public BinanceUserTrade build() {
+      return new BinanceUserTrade(
+          type,
+          originalAmount,
+          originalVolume,
+          currencyPair,
+          price,
+          timestamp,
+          id,
+          orderId,
+          feeAmount,
+          feeCurrency,
+          orderUserReference);
+    }
+  }
+}

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeService.java
@@ -12,11 +12,7 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.binance.BinanceAdapters;
 import org.knowm.xchange.binance.BinanceErrorAdapter;
 import org.knowm.xchange.binance.dto.BinanceException;
-import org.knowm.xchange.binance.dto.trade.BinanceNewOrder;
-import org.knowm.xchange.binance.dto.trade.BinanceOrder;
-import org.knowm.xchange.binance.dto.trade.BinanceTrade;
-import org.knowm.xchange.binance.dto.trade.OrderType;
-import org.knowm.xchange.binance.dto.trade.TimeInForce;
+import org.knowm.xchange.binance.dto.trade.*;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
@@ -280,9 +276,10 @@ public class BinanceTradeService extends BinanceTradeServiceRaw implements Trade
           binanceTrades.stream()
               .map(
                   t ->
-                      new UserTrade.Builder()
+                      new BinanceUserTrade.Builder()
                           .type(BinanceAdapters.convertType(t.isBuyer))
                           .originalAmount(t.qty)
+                          .originalVolume(t.quoteQty)
                           .currencyPair(pair)
                           .price(t.price)
                           .timestamp(t.getTime())

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAdapters.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAdapters.java
@@ -15,10 +15,7 @@ import org.knowm.xchange.bitstamp.dto.marketdata.BitstampOrderBook;
 import org.knowm.xchange.bitstamp.dto.marketdata.BitstampPairInfo;
 import org.knowm.xchange.bitstamp.dto.marketdata.BitstampTicker;
 import org.knowm.xchange.bitstamp.dto.marketdata.BitstampTransaction;
-import org.knowm.xchange.bitstamp.dto.trade.BitstampOrderStatus;
-import org.knowm.xchange.bitstamp.dto.trade.BitstampOrderStatusResponse;
-import org.knowm.xchange.bitstamp.dto.trade.BitstampOrderTransaction;
-import org.knowm.xchange.bitstamp.dto.trade.BitstampUserTransaction;
+import org.knowm.xchange.bitstamp.dto.trade.*;
 import org.knowm.xchange.bitstamp.order.dto.BitstampGenericOrder;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -232,9 +229,10 @@ public final class BitstampAdapters {
       final CurrencyPair pair =
           new CurrencyPair(t.getBaseCurrency().toUpperCase(), t.getCounterCurrency().toUpperCase());
       UserTrade trade =
-          new UserTrade.Builder()
+          new BitstampUserTrade.Builder()
               .type(orderType)
               .originalAmount(t.getBaseAmount().abs())
+              .originalVolume(t.getCounterAmount().abs())
               .currencyPair(pair)
               .price(t.getPrice().abs())
               .timestamp(t.getDatetime())

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/trade/BitstampUserTrade.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/trade/BitstampUserTrade.java
@@ -1,0 +1,180 @@
+package org.knowm.xchange.bitstamp.dto.trade;
+
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.Objects;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.trade.UserTrade;
+
+public class BitstampUserTrade extends UserTrade {
+
+  private BigDecimal originalVolume;
+
+  public BitstampUserTrade(
+      final Order.OrderType type,
+      final BigDecimal originalAmount,
+      final BigDecimal originalVolume,
+      final CurrencyPair currencyPair,
+      final BigDecimal price,
+      final Date timestamp,
+      final String id,
+      final String orderId,
+      final BigDecimal feeAmount,
+      final Currency feeCurrency,
+      final String orderUserReference) {
+    super(
+        type,
+        originalAmount,
+        currencyPair,
+        price,
+        timestamp,
+        id,
+        orderId,
+        feeAmount,
+        feeCurrency,
+        orderUserReference);
+    this.originalVolume = originalVolume;
+  }
+
+  public BigDecimal getOriginalVolume() {
+    return originalVolume;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    final BitstampUserTrade that = (BitstampUserTrade) o;
+    return Objects.equals(originalVolume, that.originalVolume);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), originalVolume);
+  }
+
+  @Override
+  public String toString() {
+    return "BitstampUserTrade[type="
+        + type
+        + ", originalAmount="
+        + originalAmount
+        + ", originalVolume="
+        + originalVolume
+        + ", currencyPair="
+        + currencyPair
+        + ", price="
+        + price
+        + ", timestamp="
+        + timestamp
+        + ", id="
+        + id
+        + ", orderId='"
+        + getOrderId()
+        + '\''
+        + ", feeAmount="
+        + getFeeAmount()
+        + ", feeCurrency='"
+        + getFeeCurrency()
+        + '\''
+        + ", orderUserReference='"
+        + getOrderUserReference()
+        + '\''
+        + "]";
+  }
+
+  @JsonPOJOBuilder(withPrefix = "")
+  public static class Builder extends UserTrade.Builder {
+    protected BigDecimal originalVolume;
+
+    public static Builder from(BitstampUserTrade trade) {
+      return new Builder()
+          .type(trade.getType())
+          .originalAmount(trade.getOriginalAmount())
+          .originalVolume(trade.getOriginalVolume())
+          .currencyPair(trade.getCurrencyPair())
+          .price(trade.getPrice())
+          .timestamp(trade.getTimestamp())
+          .id(trade.getId())
+          .orderId(trade.getOrderId())
+          .feeAmount(trade.getFeeAmount())
+          .feeCurrency(trade.getFeeCurrency())
+          .orderUserReference(trade.getOrderUserReference());
+    }
+
+    @Override
+    public Builder type(Order.OrderType type) {
+      return (Builder) super.type(type);
+    }
+
+    @Override
+    public Builder originalAmount(BigDecimal originalAmount) {
+      return (Builder) super.originalAmount(originalAmount);
+    }
+
+    public Builder originalVolume(final BigDecimal originalVolume) {
+      this.originalVolume = originalVolume;
+      return this;
+    }
+
+    @Override
+    public Builder currencyPair(CurrencyPair currencyPair) {
+      return (Builder) super.currencyPair(currencyPair);
+    }
+
+    @Override
+    public Builder price(BigDecimal price) {
+      return (Builder) super.price(price);
+    }
+
+    @Override
+    public Builder timestamp(Date timestamp) {
+      return (Builder) super.timestamp(timestamp);
+    }
+
+    @Override
+    public Builder id(String id) {
+      return (Builder) super.id(id);
+    }
+
+    @Override
+    public Builder orderId(String orderId) {
+      return (Builder) super.orderId(orderId);
+    }
+
+    @Override
+    public Builder feeAmount(BigDecimal feeAmount) {
+      return (Builder) super.feeAmount(feeAmount);
+    }
+
+    @Override
+    public Builder feeCurrency(Currency feeCurrency) {
+      return (Builder) super.feeCurrency(feeCurrency);
+    }
+
+    @Override
+    public Builder orderUserReference(String orderUserReference) {
+      return (Builder) super.orderUserReference(orderUserReference);
+    }
+
+    @Override
+    public BitstampUserTrade build() {
+      return new BitstampUserTrade(
+          type,
+          originalAmount,
+          originalVolume,
+          currencyPair,
+          price,
+          timestamp,
+          id,
+          orderId,
+          feeAmount,
+          feeCurrency,
+          orderUserReference);
+    }
+  }
+}

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAuthenticated.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAuthenticated.java
@@ -24,8 +24,8 @@ import org.knowm.xchange.poloniex.dto.trade.PoloniexMarginAccountResponse;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexMarginPostionResponse;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexMoveResponse;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexOpenOrder;
+import org.knowm.xchange.poloniex.dto.trade.PoloniexTrade;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexTradeResponse;
-import org.knowm.xchange.poloniex.dto.trade.PoloniexUserTrade;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.SynchronizedValueFactory;
 
@@ -80,7 +80,7 @@ public interface PoloniexAuthenticated {
 
   @POST
   @FormParam("command")
-  PoloniexUserTrade[] returnOrderTrades(
+  PoloniexTrade[] returnOrderTrades(
       @HeaderParam("Key") String apiKey,
       @HeaderParam("Sign") ParamsDigest signature,
       @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
@@ -98,7 +98,7 @@ public interface PoloniexAuthenticated {
 
   @POST
   @FormParam("command")
-  PoloniexUserTrade[] returnTradeHistory(
+  PoloniexTrade[] returnTradeHistory(
       @HeaderParam("Key") String apiKey,
       @HeaderParam("Sign") ParamsDigest signature,
       @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
@@ -136,7 +136,7 @@ public interface PoloniexAuthenticated {
 
   @POST
   @FormParam("command")
-  HashMap<String, PoloniexUserTrade[]> returnTradeHistory(
+  HashMap<String, PoloniexTrade[]> returnTradeHistory(
       @HeaderParam("Key") String apiKey,
       @HeaderParam("Sign") ParamsDigest signature,
       @FormParam("nonce") SynchronizedValueFactory<Long> nonce,

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/trade/PoloniexTrade.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/trade/PoloniexTrade.java
@@ -1,0 +1,176 @@
+package org.knowm.xchange.poloniex.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({"tradeId", "date", "rate", "amount", "total", "fee", "orderNumber", "type"})
+public class PoloniexTrade {
+
+  @JsonProperty("tradeID")
+  private String tradeID;
+
+  @JsonProperty("date")
+  private String date;
+
+  @JsonProperty("rate")
+  private BigDecimal rate;
+
+  @JsonProperty("amount")
+  private BigDecimal amount;
+
+  @JsonProperty("total")
+  private BigDecimal total;
+
+  @JsonProperty("fee")
+  private BigDecimal fee;
+
+  @JsonProperty("orderNumber")
+  private String orderNumber;
+
+  @JsonProperty("type")
+  private String type;
+
+  @JsonIgnore private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+  @JsonProperty("tradeID")
+  public String getTradeID() {
+
+    return tradeID;
+  }
+
+  @JsonProperty("tradeID")
+  public void setTradeID(String tradeID) {
+
+    this.tradeID = tradeID;
+  }
+
+  @JsonProperty("date")
+  public String getDate() {
+
+    return date;
+  }
+
+  @JsonProperty("date")
+  public void setDate(String date) {
+
+    this.date = date;
+  }
+
+  @JsonProperty("rate")
+  public BigDecimal getRate() {
+
+    return rate;
+  }
+
+  @JsonProperty("rate")
+  public void setRate(BigDecimal rate) {
+
+    this.rate = rate;
+  }
+
+  @JsonProperty("amount")
+  public BigDecimal getAmount() {
+
+    return amount;
+  }
+
+  @JsonProperty("amount")
+  public void setAmount(BigDecimal amount) {
+
+    this.amount = amount;
+  }
+
+  @JsonProperty("total")
+  public BigDecimal getTotal() {
+
+    return total;
+  }
+
+  @JsonProperty("total")
+  public void setTotal(BigDecimal total) {
+
+    this.total = total;
+  }
+
+  @JsonProperty("fee")
+  public BigDecimal getFee() {
+
+    return fee;
+  }
+
+  @JsonProperty("fee")
+  public void setFee(BigDecimal fee) {
+
+    this.fee = fee;
+  }
+
+  @JsonProperty("orderNumber")
+  public String getOrderNumber() {
+
+    return orderNumber;
+  }
+
+  @JsonProperty("orderNumber")
+  public void setOrderNumber(String orderNumber) {
+
+    this.orderNumber = orderNumber;
+  }
+
+  @JsonProperty("type")
+  public String getType() {
+
+    return type;
+  }
+
+  @JsonProperty("type")
+  public void setType(String type) {
+
+    this.type = type;
+  }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+
+    return this.additionalProperties;
+  }
+
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+
+    this.additionalProperties.put(name, value);
+  }
+
+  @Override
+  public String toString() {
+
+    return "PoloniexUserTrade [tradeID= "
+        + tradeID
+        + ", date="
+        + date
+        + ", rate="
+        + rate
+        + ", amount="
+        + amount
+        + ", total="
+        + total
+        + ", fee="
+        + fee
+        + ", orderNumber="
+        + orderNumber
+        + ", type="
+        + type
+        + ", additionalProperties="
+        + additionalProperties
+        + "]";
+  }
+}

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/trade/PoloniexUserTrade.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/trade/PoloniexUserTrade.java
@@ -1,176 +1,180 @@
 package org.knowm.xchange.poloniex.dto.trade;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.Map;
-import javax.annotation.Generated;
+import java.util.Date;
+import java.util.Objects;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.trade.UserTrade;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
-@Generated("org.jsonschema2pojo")
-@JsonPropertyOrder({"tradeId", "date", "rate", "amount", "total", "fee", "orderNumber", "type"})
-public class PoloniexUserTrade {
+public class PoloniexUserTrade extends UserTrade {
 
-  @JsonProperty("tradeID")
-  private String tradeID;
+  private BigDecimal originalVolume;
 
-  @JsonProperty("date")
-  private String date;
-
-  @JsonProperty("rate")
-  private BigDecimal rate;
-
-  @JsonProperty("amount")
-  private BigDecimal amount;
-
-  @JsonProperty("total")
-  private BigDecimal total;
-
-  @JsonProperty("fee")
-  private BigDecimal fee;
-
-  @JsonProperty("orderNumber")
-  private String orderNumber;
-
-  @JsonProperty("type")
-  private String type;
-
-  @JsonIgnore private Map<String, Object> additionalProperties = new HashMap<String, Object>();
-
-  @JsonProperty("tradeID")
-  public String getTradeID() {
-
-    return tradeID;
+  public PoloniexUserTrade(
+      final Order.OrderType type,
+      final BigDecimal originalAmount,
+      final BigDecimal originalVolume,
+      final CurrencyPair currencyPair,
+      final BigDecimal price,
+      final Date timestamp,
+      final String id,
+      final String orderId,
+      final BigDecimal feeAmount,
+      final Currency feeCurrency,
+      final String orderUserReference) {
+    super(
+        type,
+        originalAmount,
+        currencyPair,
+        price,
+        timestamp,
+        id,
+        orderId,
+        feeAmount,
+        feeCurrency,
+        orderUserReference);
+    this.originalVolume = originalVolume;
   }
 
-  @JsonProperty("tradeID")
-  public void setTradeID(String tradeID) {
-
-    this.tradeID = tradeID;
+  public BigDecimal getOriginalVolume() {
+    return originalVolume;
   }
 
-  @JsonProperty("date")
-  public String getDate() {
-
-    return date;
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    final PoloniexUserTrade that = (PoloniexUserTrade) o;
+    return Objects.equals(originalVolume, that.originalVolume);
   }
 
-  @JsonProperty("date")
-  public void setDate(String date) {
-
-    this.date = date;
-  }
-
-  @JsonProperty("rate")
-  public BigDecimal getRate() {
-
-    return rate;
-  }
-
-  @JsonProperty("rate")
-  public void setRate(BigDecimal rate) {
-
-    this.rate = rate;
-  }
-
-  @JsonProperty("amount")
-  public BigDecimal getAmount() {
-
-    return amount;
-  }
-
-  @JsonProperty("amount")
-  public void setAmount(BigDecimal amount) {
-
-    this.amount = amount;
-  }
-
-  @JsonProperty("total")
-  public BigDecimal getTotal() {
-
-    return total;
-  }
-
-  @JsonProperty("total")
-  public void setTotal(BigDecimal total) {
-
-    this.total = total;
-  }
-
-  @JsonProperty("fee")
-  public BigDecimal getFee() {
-
-    return fee;
-  }
-
-  @JsonProperty("fee")
-  public void setFee(BigDecimal fee) {
-
-    this.fee = fee;
-  }
-
-  @JsonProperty("orderNumber")
-  public String getOrderNumber() {
-
-    return orderNumber;
-  }
-
-  @JsonProperty("orderNumber")
-  public void setOrderNumber(String orderNumber) {
-
-    this.orderNumber = orderNumber;
-  }
-
-  @JsonProperty("type")
-  public String getType() {
-
-    return type;
-  }
-
-  @JsonProperty("type")
-  public void setType(String type) {
-
-    this.type = type;
-  }
-
-  @JsonAnyGetter
-  public Map<String, Object> getAdditionalProperties() {
-
-    return this.additionalProperties;
-  }
-
-  @JsonAnySetter
-  public void setAdditionalProperty(String name, Object value) {
-
-    this.additionalProperties.put(name, value);
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), originalVolume);
   }
 
   @Override
   public String toString() {
-
-    return "PoloniexUserTrade [tradeID= "
-        + tradeID
-        + ", date="
-        + date
-        + ", rate="
-        + rate
-        + ", amount="
-        + amount
-        + ", total="
-        + total
-        + ", fee="
-        + fee
-        + ", orderNumber="
-        + orderNumber
-        + ", type="
+    return "PoloniexUserTrade[type="
         + type
-        + ", additionalProperties="
-        + additionalProperties
+        + ", originalAmount="
+        + originalAmount
+        + ", originalVolume="
+        + originalVolume
+        + ", currencyPair="
+        + currencyPair
+        + ", price="
+        + price
+        + ", timestamp="
+        + timestamp
+        + ", id="
+        + id
+        + ", orderId='"
+        + getOrderId()
+        + '\''
+        + ", feeAmount="
+        + getFeeAmount()
+        + ", feeCurrency='"
+        + getFeeCurrency()
+        + '\''
+        + ", orderUserReference='"
+        + getOrderUserReference()
+        + '\''
         + "]";
+  }
+
+  @JsonPOJOBuilder(withPrefix = "")
+  public static class Builder extends UserTrade.Builder {
+    protected BigDecimal originalVolume;
+
+    public static Builder from(PoloniexUserTrade trade) {
+      return new Builder()
+          .type(trade.getType())
+          .originalAmount(trade.getOriginalAmount())
+          .originalVolume(trade.getOriginalVolume())
+          .currencyPair(trade.getCurrencyPair())
+          .price(trade.getPrice())
+          .timestamp(trade.getTimestamp())
+          .id(trade.getId())
+          .orderId(trade.getOrderId())
+          .feeAmount(trade.getFeeAmount())
+          .feeCurrency(trade.getFeeCurrency())
+          .orderUserReference(trade.getOrderUserReference());
+    }
+
+    @Override
+    public Builder type(Order.OrderType type) {
+      return (Builder) super.type(type);
+    }
+
+    @Override
+    public Builder originalAmount(BigDecimal originalAmount) {
+      return (Builder) super.originalAmount(originalAmount);
+    }
+
+    public Builder originalVolume(final BigDecimal originalVolume) {
+      this.originalVolume = originalVolume;
+      return this;
+    }
+
+    @Override
+    public Builder currencyPair(CurrencyPair currencyPair) {
+      return (Builder) super.currencyPair(currencyPair);
+    }
+
+    @Override
+    public Builder price(BigDecimal price) {
+      return (Builder) super.price(price);
+    }
+
+    @Override
+    public Builder timestamp(Date timestamp) {
+      return (Builder) super.timestamp(timestamp);
+    }
+
+    @Override
+    public Builder id(String id) {
+      return (Builder) super.id(id);
+    }
+
+    @Override
+    public Builder orderId(String orderId) {
+      return (Builder) super.orderId(orderId);
+    }
+
+    @Override
+    public Builder feeAmount(BigDecimal feeAmount) {
+      return (Builder) super.feeAmount(feeAmount);
+    }
+
+    @Override
+    public Builder feeCurrency(Currency feeCurrency) {
+      return (Builder) super.feeCurrency(feeCurrency);
+    }
+
+    @Override
+    public Builder orderUserReference(String orderUserReference) {
+      return (Builder) super.orderUserReference(orderUserReference);
+    }
+
+    @Override
+    public PoloniexUserTrade build() {
+      return new PoloniexUserTrade(
+          type,
+          originalAmount,
+          originalVolume,
+          currencyPair,
+          price,
+          timestamp,
+          id,
+          orderId,
+          feeAmount,
+          feeCurrency,
+          orderUserReference);
+    }
   }
 }

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexTradeService.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexTradeService.java
@@ -28,8 +28,8 @@ import org.knowm.xchange.poloniex.PoloniexUtils;
 import org.knowm.xchange.poloniex.dto.PoloniexException;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexLimitOrder;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexOpenOrder;
+import org.knowm.xchange.poloniex.dto.trade.PoloniexTrade;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexTradeResponse;
-import org.knowm.xchange.poloniex.dto.trade.PoloniexUserTrade;
 import org.knowm.xchange.service.trade.TradeService;
 import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
 import org.knowm.xchange.service.trade.params.CancelOrderParams;
@@ -199,22 +199,22 @@ public class PoloniexTradeService extends PoloniexTradeServiceRaw implements Tra
     try {
       List<UserTrade> trades = new ArrayList<>();
       if (currencyPair == null) {
-        HashMap<String, PoloniexUserTrade[]> poloniexUserTrades =
+        HashMap<String, PoloniexTrade[]> poloniexUserTrades =
             returnTradeHistory(startTime, endTime, limit);
         if (poloniexUserTrades != null) {
-          for (Map.Entry<String, PoloniexUserTrade[]> mapEntry : poloniexUserTrades.entrySet()) {
+          for (Map.Entry<String, PoloniexTrade[]> mapEntry : poloniexUserTrades.entrySet()) {
             currencyPair = PoloniexUtils.toCurrencyPair(mapEntry.getKey());
-            for (PoloniexUserTrade poloniexUserTrade : mapEntry.getValue()) {
-              trades.add(PoloniexAdapters.adaptPoloniexUserTrade(poloniexUserTrade, currencyPair));
+            for (PoloniexTrade poloniexTrade : mapEntry.getValue()) {
+              trades.add(PoloniexAdapters.adaptPoloniexUserTrade(poloniexTrade, currencyPair));
             }
           }
         }
       } else {
-        PoloniexUserTrade[] poloniexUserTrades =
+        PoloniexTrade[] poloniexTrades =
             returnTradeHistory(currencyPair, startTime, endTime, limit);
-        if (poloniexUserTrades != null) {
-          for (PoloniexUserTrade poloniexUserTrade : poloniexUserTrades) {
-            trades.add(PoloniexAdapters.adaptPoloniexUserTrade(poloniexUserTrade, currencyPair));
+        if (poloniexTrades != null) {
+          for (PoloniexTrade poloniexTrade : poloniexTrades) {
+            trades.add(PoloniexAdapters.adaptPoloniexUserTrade(poloniexTrade, currencyPair));
           }
         }
       }
@@ -279,11 +279,11 @@ public class PoloniexTradeService extends PoloniexTradeServiceRaw implements Tra
     try {
       List<UserTrade> trades = new ArrayList<>();
 
-      PoloniexUserTrade[] poloniexUserTrades = returnOrderTrades(orderId);
-      if (poloniexUserTrades != null) {
-        for (PoloniexUserTrade poloniexUserTrade : poloniexUserTrades) {
-          poloniexUserTrade.setOrderNumber(orderId); // returnOrderTrades doesn't fill in orderId
-          trades.add(PoloniexAdapters.adaptPoloniexUserTrade(poloniexUserTrade, currencyPair));
+      PoloniexTrade[] poloniexTrades = returnOrderTrades(orderId);
+      if (poloniexTrades != null) {
+        for (PoloniexTrade poloniexTrade : poloniexTrades) {
+          poloniexTrade.setOrderNumber(orderId); // returnOrderTrades doesn't fill in orderId
+          trades.add(PoloniexAdapters.adaptPoloniexUserTrade(poloniexTrade, currencyPair));
         }
       }
 

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexTradeServiceRaw.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexTradeServiceRaw.java
@@ -16,8 +16,8 @@ import org.knowm.xchange.poloniex.dto.trade.PoloniexMarginPostionResponse;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexMoveResponse;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexOpenOrder;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexOrderFlags;
+import org.knowm.xchange.poloniex.dto.trade.PoloniexTrade;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexTradeResponse;
-import org.knowm.xchange.poloniex.dto.trade.PoloniexUserTrade;
 
 /** @author Zach Holmes */
 public class PoloniexTradeServiceRaw extends PoloniexBaseService {
@@ -32,7 +32,7 @@ public class PoloniexTradeServiceRaw extends PoloniexBaseService {
         apiKey, signatureCreator, exchange.getNonceFactory(), PoloniexAuthenticated.AllPairs.all);
   }
 
-  PoloniexUserTrade[] returnOrderTrades(String orderId) throws IOException {
+  PoloniexTrade[] returnOrderTrades(String orderId) throws IOException {
     return poloniexAuthenticated.returnOrderTrades(
         apiKey, signatureCreator, exchange.getNonceFactory(), orderId);
   }
@@ -45,7 +45,7 @@ public class PoloniexTradeServiceRaw extends PoloniexBaseService {
         PoloniexUtils.toPairString(currencyPair));
   }
 
-  public PoloniexUserTrade[] returnTradeHistory(
+  public PoloniexTrade[] returnTradeHistory(
       CurrencyPair currencyPair, Long startTime, Long endTime, Integer limit) throws IOException {
 
     return poloniexAuthenticated.returnTradeHistory(
@@ -58,7 +58,7 @@ public class PoloniexTradeServiceRaw extends PoloniexBaseService {
         limit);
   }
 
-  public HashMap<String, PoloniexUserTrade[]> returnTradeHistory(
+  public HashMap<String, PoloniexTrade[]> returnTradeHistory(
       Long startTime, Long endTime, Integer limit) throws IOException {
 
     String ignore = null; // only used so PoloniexAuthenticated.returnTradeHistory can be overloaded

--- a/xchange-poloniex/src/test/java/org/knowm/xchange/poloniex/PoloniexAdapterTest.java
+++ b/xchange-poloniex/src/test/java/org/knowm/xchange/poloniex/PoloniexAdapterTest.java
@@ -21,7 +21,7 @@ import org.knowm.xchange.dto.account.FundingRecord.Type;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.poloniex.dto.marketdata.PoloniexLoansDataTest;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexDepositsWithdrawalsResponse;
-import org.knowm.xchange.poloniex.dto.trade.PoloniexUserTrade;
+import org.knowm.xchange.poloniex.dto.trade.PoloniexTrade;
 
 public class PoloniexAdapterTest {
 
@@ -29,13 +29,13 @@ public class PoloniexAdapterTest {
   public void testTradeHistory() throws IOException {
 
     final InputStream is =
-        PoloniexUserTrade.class.getResourceAsStream(
+        PoloniexTrade.class.getResourceAsStream(
             "/org/knowm/xchange/poloniex/dto/trade/adapter-trade-history.json");
 
     final ObjectMapper mapper = new ObjectMapper();
-    final JavaType tradeArray = mapper.getTypeFactory().constructArrayType(PoloniexUserTrade.class);
+    final JavaType tradeArray = mapper.getTypeFactory().constructArrayType(PoloniexTrade.class);
 
-    PoloniexUserTrade[] tradeHistory = mapper.readValue(is, tradeArray);
+    PoloniexTrade[] tradeHistory = mapper.readValue(is, tradeArray);
 
     LimitOrder result = PoloniexAdapters.adaptUserTradesToOrderStatus("102", tradeHistory);
 

--- a/xchange-poloniex/src/test/java/org/knowm/xchange/poloniex/dto/trade/PoloniexTradeTest.java
+++ b/xchange-poloniex/src/test/java/org/knowm/xchange/poloniex/dto/trade/PoloniexTradeTest.java
@@ -14,23 +14,23 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 
-public class PoloniexUserTradeTest {
+public class PoloniexTradeTest {
 
   @Test
   public void testTradeHistoryMultiPair()
       throws JsonParseException, JsonMappingException, IOException {
 
     final InputStream is =
-        PoloniexUserTrade.class.getResourceAsStream(
+        PoloniexTrade.class.getResourceAsStream(
             "/org/knowm/xchange/poloniex/dto/trade/trade-history-multi-pair.json");
 
     final ObjectMapper mapper = new ObjectMapper();
     final JavaType stringType = mapper.getTypeFactory().constructType(String.class, String.class);
-    final JavaType tradeArray = mapper.getTypeFactory().constructArrayType(PoloniexUserTrade.class);
+    final JavaType tradeArray = mapper.getTypeFactory().constructArrayType(PoloniexTrade.class);
     final JavaType multiPairTradeType =
         mapper.getTypeFactory().constructMapType(HashMap.class, stringType, tradeArray);
 
-    final Map<String, PoloniexUserTrade[]> tradeHistory = mapper.readValue(is, multiPairTradeType);
+    final Map<String, PoloniexTrade[]> tradeHistory = mapper.readValue(is, multiPairTradeType);
     assertThat(tradeHistory).hasSize(2);
 
     assertThat(tradeHistory).containsKey("BTC_LTC");
@@ -39,7 +39,7 @@ public class PoloniexUserTradeTest {
     assertThat(tradeHistory).containsKey("BTC_DRK");
     assertThat(tradeHistory.get("BTC_DRK")).hasSize(1);
 
-    PoloniexUserTrade trade = tradeHistory.get("BTC_DRK")[0];
+    PoloniexTrade trade = tradeHistory.get("BTC_DRK")[0];
     assertThat(trade.getTradeID()).isEqualTo("296610");
     assertThat(trade.getDate()).isEqualTo("2014-09-14 04:54:57");
     assertThat(trade.getRate()).isEqualTo("0.00583818");
@@ -55,16 +55,16 @@ public class PoloniexUserTradeTest {
       throws JsonParseException, JsonMappingException, IOException {
 
     final InputStream is =
-        PoloniexUserTrade.class.getResourceAsStream(
+        PoloniexTrade.class.getResourceAsStream(
             "/org/knowm/xchange/poloniex/dto/trade/trade-history-single-pair.json");
 
     final ObjectMapper mapper = new ObjectMapper();
-    final JavaType tradeArray = mapper.getTypeFactory().constructArrayType(PoloniexUserTrade.class);
+    final JavaType tradeArray = mapper.getTypeFactory().constructArrayType(PoloniexTrade.class);
 
-    PoloniexUserTrade[] tradeHistory = mapper.readValue(is, tradeArray);
+    PoloniexTrade[] tradeHistory = mapper.readValue(is, tradeArray);
     assertThat(tradeHistory).hasSize(3);
 
-    PoloniexUserTrade trade = tradeHistory[0];
+    PoloniexTrade trade = tradeHistory[0];
     assertThat(trade.getTradeID()).isEqualTo("267356");
     assertThat(trade.getDate()).isEqualTo("2014-09-12 00:22:32");
     assertThat(trade.getRate()).isEqualTo("0.01026896");


### PR DESCRIPTION
As I mentioned in my issue  #3269 some exchanges offer a "original volume" value, similar to OriginalAmount, which is missing from UserTrade.
The argument "[the value] can easily be calculated" is not entirly true as following example of a binace trade shows:
{"symbol":"ETHBTC","id":15919****,"orderId":59246****,"orderListId":-1,"price":"0.01938500","qty":"0.00700000","quoteQty":"0.00013569","commission":"0.00005069","commissionAsset":"BNB","time":15801309*****,"isBuyer":true,"isMaker":false,"isBestMatch":true}

The "CurrencyPairMetaData" defines the scale to 6 digitis which would result in a volume of 0.007 * 0.019385 = 0.000136 insteadt of "quoteQty = 0.00013569".

To compromise between not poluting the UserTrade object and returning the correct value I duplicated the behaviour of the KrakenTradeService, which return the KrakenUserTrade with an additional cost field.
I implemented UserTrade subclasses for Binace, Bitstamp and Poloniex.