### PR TITLE
[bitfinex] Added fee to FundingRecord

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
@@ -792,13 +792,19 @@ public final class BitfinexAdapters {
       }
 
       final BigDecimal fee = responseEntry.getFee() != null ? responseEntry.getFee().abs() : null;
+      BigDecimal amount = responseEntry.getAmount();
+      if(fee != null && responseEntry.getType().isOutflowing()){
+        //The amount reported form Bitfinex on a withdrawal is without the fee, so it has to be added to get the full amount withdrawn from the wallet
+        //Deposits don't seem to have fees, but I would assume that the reported is the full amount added to the wallet
+        amount = amount.add(fee);
+      }
 
       FundingRecord fundingRecordEntry =
           new FundingRecord(
               address,
               responseEntry.getTimestamp(),
               currency,
-              responseEntry.getAmount(),
+              amount,
               String.valueOf(responseEntry.getId()),
               txnId,
               responseEntry.getType(),

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
@@ -791,6 +791,8 @@ public final class BitfinexAdapters {
         }
       }
 
+      final BigDecimal fee = responseEntry.getFee() != null ? responseEntry.getFee().abs() : null;
+
       FundingRecord fundingRecordEntry =
           new FundingRecord(
               address,
@@ -802,7 +804,7 @@ public final class BitfinexAdapters {
               responseEntry.getType(),
               status,
               null,
-              null,
+              fee,
               description);
 
       fundingRecords.add(fundingRecordEntry);


### PR DESCRIPTION
The `FundingRecord` gets fee set from `BitfinexDepositWithdrawalHistoryResponse` entity, which was already present