### PR TITLE
[bitfinex] extended status for derivatives pairs

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/Status.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/Status.java
@@ -1,8 +1,10 @@
 package org.knowm.xchange.bitfinex.v2.dto.marketdata;
 
+import java.math.BigDecimal;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import java.math.BigDecimal;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -14,6 +16,7 @@ import lombok.ToString;
 @ToString
 
 /** see https://docs.bitfinex.com/v2/reference#status */
+/** see https://docs.bitfinex.com/reference#rest-public-status */
 public class Status {
 
   private String symbol;
@@ -38,4 +41,14 @@ public class Status {
   private Object placeHolder4;
   /** Funding applied in the current 8h period */
   private BigDecimal currentFunding;
+  
+  private Object placeHolder5;
+  private Object placeHolder6;
+  /** Price based on the BFX Composite Index */
+  private BigDecimal markPrice;
+  private Object placeHolder7;
+  private Object placeHolder8;
+  /** Total number of outstanding derivative contracts */
+  private BigDecimal openInterest;
+  
 }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/Status.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/Status.java
@@ -15,7 +15,6 @@ import lombok.ToString;
 @Getter
 @ToString
 
-/** see https://docs.bitfinex.com/v2/reference#status */
 /** see https://docs.bitfinex.com/reference#rest-public-status */
 public class Status {
 

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/Status.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/Status.java
@@ -40,11 +40,12 @@ public class Status {
   private Object placeHolder4;
   /** Funding applied in the current 8h period */
   private BigDecimal currentFunding;
-  
+
   private Object placeHolder5;
   private Object placeHolder6;
   /** Price based on the BFX Composite Index */
   private BigDecimal markPrice;
+
   private Object placeHolder7;
   private Object placeHolder8;
   /** Total number of outstanding derivative contracts */

--- a/xchange-bitfinex/src/test/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexStatusJSONTest.java
+++ b/xchange-bitfinex/src/test/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexStatusJSONTest.java
@@ -34,5 +34,7 @@ public class BitfinexStatusJSONTest {
     assertThat(s0.getPlaceHolder1()).isNull();
     assertThat(s0.getInsuranceFundBalance()).isEqualByComparingTo("402688.36164408");
     assertThat(s0.getPlaceHolder2()).isNull();
+    assertThat(s0.getMarkPrice()).isEqualByComparingTo("8413.376666666667");
+    assertThat(s0.getOpenInterest()).isEqualByComparingTo("862.33402476");
   }
 }


### PR DESCRIPTION
Extended the Status bean to handle additional fields:
 - MARK_PRICE
 - OPEN_INTEREST