### PR TITLE
[stream-core] Improve consistency of use of non-blocking calls

### DIFF
--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingService.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingService.java
@@ -3,6 +3,7 @@ package info.bitrich.xchangestream.binance;
 import com.fasterxml.jackson.databind.JsonNode;
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.service.netty.JsonNettyStreamingService;
+import io.reactivex.Completable;
 import java.io.IOException;
 
 public class BinanceStreamingService extends JsonNettyStreamingService {
@@ -42,8 +43,9 @@ public class BinanceStreamingService extends JsonNettyStreamingService {
   }
 
   @Override
-  public void sendMessage(String message) {
+  public Completable sendMessage(String message) {
     // Subscriptions are made upon connection - no messages are sent.
+    return Completable.complete();
   }
 
   /**

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceUserDataStreamingService.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceUserDataStreamingService.java
@@ -3,6 +3,7 @@ package info.bitrich.xchangestream.binance;
 import com.fasterxml.jackson.databind.JsonNode;
 import info.bitrich.xchangestream.binance.dto.BaseBinanceWebSocketTransaction.BinanceWebSocketTypes;
 import info.bitrich.xchangestream.service.netty.JsonNettyStreamingService;
+import io.reactivex.Completable;
 import io.reactivex.Observable;
 import java.io.IOException;
 import org.slf4j.Logger;
@@ -60,7 +61,8 @@ public class BinanceUserDataStreamingService extends JsonNettyStreamingService {
   }
 
   @Override
-  public void sendMessage(String message) {
+  public Completable sendMessage(String message) {
     // Subscriptions are made upon connection - no messages are sent.
+    return Completable.complete();
   }
 }

--- a/xchange-stream-lgo/src/test/java/info/bitrich/xchangestream/lgo/LgoStreamingTradeServiceTest.java
+++ b/xchange-stream-lgo/src/test/java/info/bitrich/xchangestream/lgo/LgoStreamingTradeServiceTest.java
@@ -378,7 +378,7 @@ public class LgoStreamingTradeServiceTest {
     key.setValue(parsePublicKey(utf8));
     when(keyService.selectKey()).thenReturn(key);
     when(signatureService.signOrder(anyString())).thenReturn(new LgoOrderSignature("signed"));
-    doNothing().when(streamingService).sendMessage(anyString());
+    when(streamingService.sendMessage(anyString())).then(inv -> null);
 
     String ref = service.placeLimitOrder(limitOrder);
 


### PR DESCRIPTION
A few improvements to use of RX in the core streaming API.

 * Support non-blocking rate limit acquisition
 * Allow callers to hook into completion of the (already non-blocking) sending of socket messages.
 * Fix (unobserved) bug where connection emitters were fired before the socket was ready

Still being tested. Presented as draft for comment.