### PR TITLE
[stream-core] [stream-wrapper] [WIP] Exchange -> StreamingExchange wrapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,7 @@
     <module>xchange-stream-service-pubnub</module>
     <module>xchange-stream-service-pusher</module>
     <module>xchange-stream-service-wamp</module>
+    <module>xchange-stream-wrapper</module>
 
   </modules>
 

--- a/xchange-simulated/src/main/java/org/knowm/xchange/simulated/MatchingEngine.java
+++ b/xchange-simulated/src/main/java/org/knowm/xchange/simulated/MatchingEngine.java
@@ -48,7 +48,7 @@ final class MatchingEngine {
   private final Deque<Trade> publicTrades = new ConcurrentLinkedDeque<>();
   private final Multimap<String, UserTrade> userTrades = LinkedListMultimap.create();
 
-  private volatile Ticker ticker = new Ticker.Builder().build();
+  private volatile Ticker ticker;
 
   MatchingEngine(
       AccountFactory accountFactory,
@@ -69,6 +69,7 @@ final class MatchingEngine {
     this.priceScale = priceScale;
     this.minimumAmount = minimumAmount;
     this.onFill = onFill;
+    this.ticker = new Ticker.Builder().currencyPair(currencyPair).build();
   }
 
   public synchronized LimitOrder postOrder(String apiKey, Order original) {
@@ -172,6 +173,7 @@ final class MatchingEngine {
 
   private Ticker.Builder newTickerFromBook() {
     return new Ticker.Builder()
+        .currencyPair(currencyPair)
         .ask(asks.isEmpty() ? null : asks.get(0).getPrice())
         .bid(bids.isEmpty() ? null : bids.get(0).getPrice());
   }

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingService.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingService.java
@@ -3,6 +3,7 @@ package info.bitrich.xchangestream.binance;
 import com.fasterxml.jackson.databind.JsonNode;
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.service.netty.JsonNettyStreamingService;
+import io.reactivex.Completable;
 import java.io.IOException;
 
 public class BinanceStreamingService extends JsonNettyStreamingService {
@@ -42,8 +43,9 @@ public class BinanceStreamingService extends JsonNettyStreamingService {
   }
 
   @Override
-  public void sendMessage(String message) {
+  public Completable sendMessage(String message) {
     // Subscriptions are made upon connection - no messages are sent.
+    return Completable.complete();
   }
 
   /**

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceUserDataStreamingService.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceUserDataStreamingService.java
@@ -3,6 +3,7 @@ package info.bitrich.xchangestream.binance;
 import com.fasterxml.jackson.databind.JsonNode;
 import info.bitrich.xchangestream.binance.dto.BaseBinanceWebSocketTransaction.BinanceWebSocketTypes;
 import info.bitrich.xchangestream.service.netty.JsonNettyStreamingService;
+import io.reactivex.Completable;
 import io.reactivex.Observable;
 import java.io.IOException;
 import org.slf4j.Logger;
@@ -60,7 +61,8 @@ public class BinanceUserDataStreamingService extends JsonNettyStreamingService {
   }
 
   @Override
-  public void sendMessage(String message) {
+  public Completable sendMessage(String message) {
     // Subscriptions are made upon connection - no messages are sent.
+    return Completable.complete();
   }
 }

--- a/xchange-stream-lgo/src/test/java/info/bitrich/xchangestream/lgo/LgoStreamingTradeServiceTest.java
+++ b/xchange-stream-lgo/src/test/java/info/bitrich/xchangestream/lgo/LgoStreamingTradeServiceTest.java
@@ -378,7 +378,7 @@ public class LgoStreamingTradeServiceTest {
     key.setValue(parsePublicKey(utf8));
     when(keyService.selectKey()).thenReturn(key);
     when(signatureService.signOrder(anyString())).thenReturn(new LgoOrderSignature("signed"));
-    doNothing().when(streamingService).sendMessage(anyString());
+    when(streamingService.sendMessage(anyString())).then(inv -> null);
 
     String ref = service.placeLimitOrder(limitOrder);
 

--- a/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/Loop.java
+++ b/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/Loop.java
@@ -1,0 +1,920 @@
+package org.knowm.xchange.stream.wrapper;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static java.time.LocalDateTime.now;
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static java.util.stream.Collectors.toSet;
+import static org.knowm.xchange.dto.Order.OrderType.ASK;
+import static org.knowm.xchange.dto.Order.OrderType.BID;
+import static org.knowm.xchange.stream.wrapper.MarketDataType.BALANCE;
+import static org.knowm.xchange.stream.wrapper.MarketDataType.PollBehaviour.POLL_ALWAYS;
+
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSet.Builder;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Streams;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import info.bitrich.xchangestream.core.ProductSubscription;
+import info.bitrich.xchangestream.core.ProductSubscription.ProductSubscriptionBuilder;
+import info.bitrich.xchangestream.core.StreamingExchange;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.subjects.PublishSubject;
+import java.io.IOException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.bitfinex.v1.dto.BitfinexExceptionV1;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.account.Balance;
+import org.knowm.xchange.dto.account.Wallet;
+import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.marketdata.Ticker;
+import org.knowm.xchange.dto.marketdata.Trade;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.dto.trade.OpenOrders;
+import org.knowm.xchange.dto.trade.UserTrade;
+import org.knowm.xchange.exceptions.ExchangeException;
+import org.knowm.xchange.exceptions.ExchangeSecurityException;
+import org.knowm.xchange.exceptions.ExchangeUnavailableException;
+import org.knowm.xchange.exceptions.FrequencyLimitExceededException;
+import org.knowm.xchange.exceptions.NonceException;
+import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
+import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
+import org.knowm.xchange.exceptions.RateLimitExceededException;
+import org.knowm.xchange.service.account.AccountService;
+import org.knowm.xchange.service.marketdata.MarketDataService;
+import org.knowm.xchange.service.trade.TradeService;
+import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
+import org.knowm.xchange.service.trade.params.TradeHistoryParamLimit;
+import org.knowm.xchange.service.trade.params.TradeHistoryParamPaging;
+import org.knowm.xchange.service.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.trade.params.orders.DefaultOpenOrdersParamCurrencyPair;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamCurrencyPair;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
+import si.mazi.rescu.HttpStatusIOException;
+
+/**
+ * Handles the market data polling and subscription cycle for an exchange. Publishes raw events as they occur with no
+ * attempt at deduplication or cleanup.
+ *
+ * @author Graham Crockford
+ */
+@Slf4j
+final class Loop extends AbstractExecutionThreadService {
+
+  private static final int MAX_TRADES = 20;
+  private static final int ORDERBOOK_DEPTH = 20;
+  private static final int MINUTES_BETWEEN_EXCEPTION_NOTIFICATIONS = 15;
+  private static final int DEFAULT_BLOCK_ON_ERROR_MS = 10000;
+
+  @Getter
+  private final PublishSubject<TickerEvent> tickers = PublishSubject.create();
+  @Getter
+  private final PublishSubject<OrderBookEvent> orderBooks = PublishSubject.create();
+  @Getter
+  private final PublishSubject<TradeEvent> trades = PublishSubject.create();
+  @Getter
+  private final PublishSubject<UserTradeEvent> userTrades = PublishSubject.create();
+  @Getter
+  private final PublishSubject<OrderEvent> orders = PublishSubject.create();
+  @Getter
+  private final PublishSubject<BalanceEvent> balances = PublishSubject.create();
+
+  private final String exchangeName;
+  private final Exchange exchange;
+  private final StreamingExchange streamingExchange;
+  private final RateController rateController;
+  private final long blockOnErrorMs;
+  private final boolean authenticated;
+  private final Phaser phaser = new Phaser(1);
+  private LoopListener lifecycleListener = new LoopListener() {
+  };
+  private AccountService accountService;
+  private MarketDataService marketDataService;
+  private TradeService tradeService;
+  private int phase;
+  private boolean subscriptionsFailed;
+  private Exception lastPollException;
+  private LocalDateTime lastPollErrorNotificationTime;
+
+  private AtomicReference<Set<Subscription>> nextSubscriptions = new AtomicReference<>();
+  private Set<Subscription> subscriptions = ImmutableSet.of();
+  private Set<Subscription> polls = ImmutableSet.of();
+  private Collection<Disposable> disposables = ImmutableList.of();
+  private Set<Subscription> unavailableSubscriptions = new HashSet<>();
+
+  Loop(String exchangeName, Exchange exchange, RateController rateController,
+      long blockOnErrorMs, boolean authenticated) {
+    this.exchangeName = exchangeName;
+    this.exchange = exchange;
+    this.streamingExchange =
+        exchange instanceof StreamingExchange
+            ? (StreamingExchange) exchange
+            : null;
+    this.rateController = rateController;
+    this.blockOnErrorMs = blockOnErrorMs;
+    this.authenticated = authenticated;
+  }
+
+  void setLifecycleListener(LoopListener lifecycleListener) {
+    this.lifecycleListener = lifecycleListener;
+  }
+
+  String getExchangeName() {
+    return exchangeName;
+  }
+
+  void updateSubscriptions(Iterable<Subscription> subscriptions) {
+    log.debug("Requesting update of subscriptions for {} to {}", exchangeName, subscriptions);
+    nextSubscriptions.set(ImmutableSet.copyOf(subscriptions));
+    wake();
+  }
+
+  @Override
+  protected void run() {
+    Thread.currentThread().setName("poll-loop[" + exchangeName + "]");
+    log.info("{} starting", exchangeName);
+    try {
+      initialise();
+      while (!phaser.isTerminated()) {
+
+        // Before we check for the presence of polls, determine which phase
+        // we are going to wait for if there's no work to do - i.e. the
+        // next wakeup.
+        phase = phaser.getPhase();
+        if (phase == -1) {
+          break;
+        }
+
+        loop();
+      }
+      log.info("{} shutting down due to termination", exchangeName);
+    } catch (InterruptedException e) {
+      log.info("{} shutting down due to interrupt", exchangeName);
+      Thread.currentThread().interrupt();
+    } catch (Exception e) {
+      log.error("{} shutting down due to uncaught exception", exchangeName, e);
+    } finally {
+      log.debug("{} sending shutdown event", exchangeName);
+      lifecycleListener.onStop();
+    }
+  }
+
+  @Override
+  protected void triggerShutdown() {
+    log.debug("Triggering shut down of {} poll loop", exchangeName);
+    phaser.arriveAndDeregister();
+    phaser.forceTermination();
+  }
+
+  /**
+   * This may fail when the exchange is not available, so keep trying.
+   *
+   * @throws InterruptedException If interrupted while sleeping.
+   */
+  private void initialise() throws InterruptedException {
+    while (!phaser.isTerminated()) {
+      try {
+        if (Thread.interrupted()) {
+          throw new InterruptedException();
+        }
+        this.accountService = exchange.getAccountService();
+        this.marketDataService = exchange.getMarketDataService();
+        this.tradeService = exchange.getTradeService();
+        break;
+      } catch (InterruptedException e) {
+        throw e;
+      } catch (Exception e) {
+        log.error(exchangeName + " - failing initialising. Will retry in one minute.", e);
+        Thread.sleep(60000);
+      }
+    }
+  }
+
+  private void loop() throws InterruptedException {
+
+    // Check if there is a queued subscription change.  If so, apply it
+    doSubscriptionChanges();
+
+    // Check if we have any polling to do. If not, go to sleep until awoken
+    // by a subscription change, unless we failed to process subscriptions,
+    // in which case wake ourselves up in a few seconds to try again
+    Set<Subscription> polls = activePolls();
+    if (polls.isEmpty()) {
+      suspend(phase, subscriptionsFailed);
+      return;
+    }
+
+    log.debug("{} - start poll", exchangeName);
+    Set<Currency> balanceCurrencies = new HashSet<>();
+    for (Subscription subscription : polls) {
+      if (phaser.isTerminated()) {
+        break;
+      }
+      if (subscription.type().equals(BALANCE)) {
+        // Rather than fetching balances currency-by-currency, we can fetch them all at once
+        // by requesting the wallet below.
+        balanceCurrencies.add(subscription.currency());
+      } else {
+        fetchAndBroadcast(subscription);
+      }
+    }
+
+    if (phaser.isTerminated()) {
+      return;
+    }
+
+    if (!balanceCurrencies.isEmpty()) {
+      manageExchangeExceptions(
+          "Balances",
+          () -> {
+            Instant requestInstant = Instant.now();
+            fetchBalances(balanceCurrencies)
+                .forEach(balance -> balances.onNext(BalanceEvent.of(balance, requestInstant)));
+          },
+          () -> FluentIterable.from(polls).filter(s -> s.type().equals(BALANCE)),
+          e -> balanceCurrencies.forEach(currency -> balances.onNext(BalanceEvent.of(currency, e))));
+    }
+  }
+
+  private void suspend(int phase, boolean failed) throws InterruptedException {
+    log.debug("{} - poll going to sleep", exchangeName);
+    try {
+      if (failed) {
+        phaser.awaitAdvanceInterruptibly(phase, blockOnErrorMs, TimeUnit.MILLISECONDS);
+      } else {
+        log.debug("{} - sleeping until phase {}", exchangeName, phase);
+        lifecycleListener.onBlocked();
+        phaser.awaitAdvanceInterruptibly(phase);
+        log.debug("{} - poll woken up on request", exchangeName);
+      }
+    } catch (TimeoutException e) {
+      // fine
+    } catch (InterruptedException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("Failure in phaser wait for {}", exchangeName, e);
+    }
+  }
+
+  private void wake() {
+    int phase = phaser.arrive();
+    log.debug("Progressing to phase {}", phase);
+  }
+
+  private void manageExchangeExceptions(
+      String dataDescription,
+      ThrowingRunnable runnable,
+      Supplier<Iterable<Subscription>> toUnsubscribe,
+      Consumer<Throwable> onError)
+      throws InterruptedException {
+    try {
+      runnable.run();
+
+    } catch (InterruptedException e) {
+      throw e;
+
+    } catch (UnsupportedOperationException e) {
+
+      // Disable the feature since the exchange doesn't have support for it.
+      String message = String.format("%s not available: %s (%s)", dataDescription,
+          e.getClass().getSimpleName(),
+          exceptionMessage(e));
+      log.error(message);
+      onError.accept(new UnsupportedOperationException(message, e));
+      Iterables.addAll(unavailableSubscriptions, toUnsubscribe.get());
+
+    } catch (SocketTimeoutException
+        | SocketException
+        | ExchangeUnavailableException
+        | NonceException e) {
+
+      // Managed connectivity issues.
+      log.warn(
+          "Throttling {} - {} ({}) when fetching {}",
+          exchangeName,
+          e.getClass().getSimpleName(),
+          exceptionMessage(e),
+          dataDescription);
+      rateController.throttle();
+
+    } catch (HttpStatusIOException e) {
+
+      handleHttpStatusException(dataDescription, e);
+
+    } catch (RateLimitExceededException | FrequencyLimitExceededException e) {
+
+      log.warn(
+          "Getting rate limiting errors on {} when fetching {}. Pausing access and will resume at a lower rate.",
+          exchangeName, dataDescription);
+      rateController.backoff();
+      rateController.pause();
+
+    } catch (ExchangeException e) {
+      if (e.getCause() instanceof HttpStatusIOException) {
+        // TODO Bitmex is inappropriately wrapping these and should be fixed
+        // for consistency. In the meantime...
+        handleHttpStatusException(dataDescription, (HttpStatusIOException) e.getCause());
+      } else {
+        handleUnknownPollException(e);
+      }
+    } catch (BitfinexExceptionV1 e) {
+      handleUnknownPollException(
+          new ExchangeException(
+              "Bitfinex exception: " + exceptionMessage(e) + " (error code=" + e.getError() + ")",
+              e));
+    } catch (Exception e) {
+      handleUnknownPollException(e);
+    }
+  }
+
+  private void handleHttpStatusException(String dataDescription, HttpStatusIOException e) {
+    if (e.getHttpStatusCode() == 408
+        || e.getHttpStatusCode() == 502
+        || e.getHttpStatusCode() == 504
+        || e.getHttpStatusCode() == 521) {
+      // Usually these are rejections at CloudFlare (Coinbase Pro & Kraken being common cases) or
+      // connection timeouts.
+      if (log.isWarnEnabled()) {
+        log.warn(
+            "Throttling {} - failed at gateway ({} - {}) when fetching {}",
+            exchangeName,
+            e.getHttpStatusCode(),
+            exceptionMessage(e),
+            dataDescription);
+      }
+      rateController.throttle();
+    } else {
+      handleUnknownPollException(e);
+    }
+  }
+
+  private String exceptionMessage(Throwable e) {
+    if (e.getMessage() == null) {
+      if (e.getCause() == null) {
+        return "No description";
+      } else {
+        return exceptionMessage(e.getCause());
+      }
+    } else {
+      return e.getMessage();
+    }
+  }
+
+  private void handleUnknownPollException(Exception e) {
+    LocalDateTime now = now();
+    String exceptionMessage = exceptionMessage(e);
+    if (lastPollException == null
+        || !lastPollException.getClass().equals(e.getClass())
+        || !firstNonNull(exceptionMessage(lastPollException), "").equals(exceptionMessage)
+        || lastPollErrorNotificationTime.until(now, MINUTES)
+        > MINUTES_BETWEEN_EXCEPTION_NOTIFICATIONS) {
+      lastPollErrorNotificationTime = now;
+      log.error("Throttling access to {} due to server error ({} - {})", exchangeName, e.getClass().getSimpleName(),
+          exceptionMessage);
+    } else {
+      log.error("Repeated error fetching data for {} ({})", exchangeName, exceptionMessage);
+    }
+    lastPollException = e;
+    rateController.throttle();
+  }
+
+  /**
+   * Actually performs the subscription changes. Occurs synchronously in the poll loop.
+   */
+  private void doSubscriptionChanges() {
+    log.debug("{} - start subscription check", exchangeName);
+    subscriptionsFailed = false;
+
+    // Pull the subscription change off the queue. If there isn't one,
+    // we're done
+    Set<Subscription> newSubscriptions = nextSubscriptions.getAndSet(null);
+    if (newSubscriptions == null) {
+      return;
+    }
+
+    try {
+
+      // Get the current subscriptions
+      Set<Subscription> oldSubscriptions =
+          Streams.concat(subscriptions.stream(), polls.stream())
+              .collect(toSet());
+
+      // If there's no difference, we're good, done
+      if (newSubscriptions.equals(oldSubscriptions)) {
+        return;
+      }
+
+      // Otherwise, let's crack on
+      log.info(
+          "{} - updating subscriptions to: {} from {}",
+          exchangeName,
+          newSubscriptions,
+          oldSubscriptions);
+
+      // Disconnect any streaming exchanges where the tickers currently
+      // subscribed mismatch the ones we want.
+      if (!oldSubscriptions.isEmpty()) {
+        disconnect();
+      }
+
+      // Add new subscriptions if we have any
+      if (newSubscriptions.isEmpty()) {
+        polls = ImmutableSet.of();
+        log.debug("{} - polls cleared", exchangeName);
+      } else {
+        subscribe(newSubscriptions);
+      }
+    } catch (Exception e) {
+      subscriptionsFailed = true;
+      log.error("Error updating subscriptions", e);
+      if (nextSubscriptions.compareAndSet(null, newSubscriptions)) {
+        wake();
+      }
+      throw e;
+    }
+  }
+
+  private Set<Subscription> activePolls() {
+    return polls.stream()
+        .filter(s -> !unavailableSubscriptions.contains(s))
+        .collect(toSet());
+  }
+
+  private void disconnect() {
+    if (streamingExchange != null) {
+      SafelyDispose.of(disposables);
+      disposables = ImmutableSet.of();
+      try {
+        streamingExchange.disconnect().blockingAwait();
+      } catch (Exception e) {
+        log.error("Error disconnecting from " + exchangeName, e);
+      }
+    }
+  }
+
+  private void subscribe(Set<Subscription> newSubscriptions) {
+    Builder<Subscription> pollingBuilder = ImmutableSet.builder();
+    if (streamingExchange != null) {
+      Set<Subscription> remainingSubscriptions =
+          openSubscriptionsWherePossible(newSubscriptions);
+      pollingBuilder.addAll(remainingSubscriptions);
+    } else {
+      pollingBuilder.addAll(newSubscriptions);
+    }
+    polls = pollingBuilder.build();
+    log.debug("{} - polls now set to: {}", exchangeName, polls);
+  }
+
+  private Set<Subscription> openSubscriptionsWherePossible(Set<Subscription> newSubscriptions) {
+
+    connectExchange(newSubscriptions);
+
+    HashSet<Subscription> connected = new HashSet<>(newSubscriptions);
+    Builder<Subscription> remainder = ImmutableSet.builder();
+    List<Disposable> disposables = new ArrayList<>();
+
+    for (Subscription s : newSubscriptions) {
+      if (s.type().getPollBehaviour() == POLL_ALWAYS) {
+        remainder.add(s);
+      }
+      try {
+        disposables.add(connectSubscription(s));
+      } catch (UnsupportedOperationException | ExchangeSecurityException e) {
+        log.debug(
+            "Not subscribing to {} on socket due to {}: {}. Falling back to polling.",
+            s.key(),
+            e.getClass().getSimpleName(),
+            e.getMessage());
+        remainder.add(s);
+        connected.remove(s);
+      }
+    }
+
+    this.subscriptions = Collections.unmodifiableSet(connected);
+    this.disposables = disposables;
+    return remainder.build();
+  }
+
+  private Disposable connectSubscription(Subscription sub) {
+    switch (sub.type()) {
+      case ORDERBOOK:
+        return streamingExchange
+            .getStreamingMarketDataService()
+            .getOrderBook(sub.currencyPair())
+            .map(ob -> OrderBookEvent.of(sub.currencyPair(), ob))
+            .subscribe(orderBooks::onNext, e -> orderBooks.onNext(OrderBookEvent.of(sub.currencyPair(), e)));
+      case TICKER:
+        return streamingExchange
+            .getStreamingMarketDataService()
+            .getTicker(sub.currencyPair())
+            .map(TickerEvent::of)
+            .subscribe(tickers::onNext, e -> tickers.onNext(TickerEvent.of(sub.currencyPair(), e)));
+      case TRADES:
+        return streamingExchange
+            .getStreamingMarketDataService()
+            .getTrades(sub.currencyPair())
+            .map(this::convertBinanceOrderType)
+            .map(TradeEvent::of)
+            .subscribe(trades::onNext, e -> trades.onNext(TradeEvent.of(sub.currencyPair(), e)));
+      case USER_TRADE:
+        return streamingExchange
+            .getStreamingTradeService()
+            .getUserTrades(sub.currencyPair())
+            .map(UserTradeEvent::of)
+            .subscribe(userTrades::onNext, e -> userTrades.onNext(UserTradeEvent.of(sub.currencyPair(), e)));
+      case ORDER:
+        return streamingExchange
+            .getStreamingTradeService()
+            .getOrderChanges(sub.currencyPair())
+            .map(o -> OrderEvent.of(o, Instant.now()))
+            .subscribe(orders::onNext, e -> orders.onNext(OrderEvent.of(sub.currencyPair(), e)));
+      case BALANCE:
+        return streamingExchange
+            .getStreamingAccountService()
+            .getBalanceChanges(sub.currency(), "exchange") // TODO bitfinex walletId.
+            .map(b -> BalanceEvent.of(b, Instant.now()))
+            .subscribe(balances::onNext, e -> balances.onNext(BalanceEvent.of(sub.currency(), e)));
+      default:
+        throw new NotAvailableFromExchangeException();
+    }
+  }
+
+  /**
+   * TODO Temporary fix for https://github.com/knowm/XChange/issues/2468#issuecomment-441440035
+   */
+  private Trade convertBinanceOrderType(Trade t) {
+    if (exchangeName.equalsIgnoreCase("binance")) {
+      return Trade.Builder.from(t).type(t.getType() == BID ? ASK : BID).build();
+    } else {
+      return t;
+    }
+  }
+
+  private void connectExchange(Collection<Subscription> subscriptionsForExchange) {
+    if (subscriptionsForExchange.isEmpty()) {
+      return;
+    }
+    log.info("Connecting to exchange: {}", exchangeName);
+    ProductSubscriptionBuilder builder = ProductSubscription.create();
+    subscriptionsForExchange.forEach(
+        s -> {
+          switch (s.type()) {
+            case TICKER:
+              builder.addTicker(s.currencyPair());
+              break;
+            case ORDERBOOK:
+              builder.addOrderbook(s.currencyPair());
+              break;
+            case TRADES:
+              builder.addTrades(s.currencyPair());
+              break;
+            case ORDER:
+              if (authenticated) {
+                builder.addOrders(s.currencyPair());
+              }
+              break;
+            case USER_TRADE:
+              if (authenticated) {
+                builder.addUserTrades(s.currencyPair());
+              }
+              break;
+            case BALANCE:
+              if (authenticated) {
+                builder.addBalances(s.currency());
+              }
+              break;
+            default:
+              // Not available from socket
+          }
+        });
+    rateController.acquire();
+    streamingExchange.connect(builder.build()).blockingAwait();
+    log.info("Connected to exchange: {}", exchangeName);
+  }
+
+  private Iterable<Balance> fetchBalances(Collection<Currency> currencies) throws IOException {
+    log.debug("Fetching balances for {}", currencies);
+    Map<Currency, Balance> result = new HashMap<>();
+    currencies.forEach(currency -> result.put(currency, Balance.zero(currency)));
+    wallet().getBalances().values().stream()
+        .filter(balance -> currencies.contains(balance.getCurrency()))
+        .forEach(balance -> result.put(balance.getCurrency(), balance));
+    return result.values();
+  }
+
+  private Wallet wallet() throws IOException {
+    rateController.acquire();
+    Wallet wallet;
+    // TODO make these exchanges consistently return the main trading wallet if you just ask for .getWallet().
+    if (exchangeName.equalsIgnoreCase("bitfinex")) {
+      wallet = accountService.getAccountInfo().getWallet("exchange");
+    } else if (exchangeName.equals("kucoin")) {
+      wallet = accountService.getAccountInfo().getWallet("trade");
+      if (wallet == null) {
+        wallet = accountService.getAccountInfo().getWallet();
+      }
+    } else {
+      wallet = accountService.getAccountInfo().getWallet();
+    }
+    if (wallet == null) {
+      throw new IllegalStateException("No wallet returned");
+    }
+    return wallet;
+  }
+
+  private void fetchAndBroadcast(Subscription subscription)
+      throws InterruptedException {
+    rateController.acquire();
+    manageExchangeExceptions(
+        subscription.key(),
+        () -> {
+          switch (subscription.type()) {
+            case TICKER:
+              pollAndEmitTicker(subscription.currencyPair());
+              break;
+            case ORDERBOOK:
+              pollAndEmitOrderbook(subscription.currencyPair());
+              break;
+            case TRADES:
+              pollAndEmitTrades(subscription.currencyPair());
+              break;
+            case USER_TRADE:
+              pollAndEmitUserTradeHistory(subscription.currencyPair());
+              break;
+            case ORDER:
+              pollAndEmitOpenOrders(subscription.currencyPair());
+              break;
+            default:
+              throw new IllegalStateException(
+                  "Market data type " + subscription.type() + " not supported in this way");
+          }
+        },
+        () -> ImmutableList.of(subscription),
+        e -> {
+          switch (subscription.type()) {
+            case TICKER:
+              tickers.onNext(TickerEvent.of(subscription.currencyPair(), e));
+              break;
+            case ORDERBOOK:
+              orderBooks.onNext(OrderBookEvent.of(subscription.currencyPair(), e));
+              break;
+            case TRADES:
+              trades.onNext(TradeEvent.of(subscription.currencyPair(), e));
+              break;
+            case USER_TRADE:
+              userTrades.onNext(UserTradeEvent.of(subscription.currencyPair(), e));
+              break;
+            case ORDER:
+              orders.onNext(OrderEvent.of(subscription.currencyPair(), e));
+              break;
+            case BALANCE:
+              balances.onNext(BalanceEvent.of(subscription.currency(), e));
+              break;
+            default:
+              throw new IllegalStateException(
+                  "Market data type " + subscription.type() + " not supported in this way");
+          }
+        });
+  }
+
+  private void pollAndEmitUserTradeHistory(CurrencyPair currencyPair) throws IOException {
+    TradeHistoryParams tradeHistoryParams = tradeHistoryParams(currencyPair);
+    tradeService
+        .getTradeHistory(tradeHistoryParams)
+        .getUserTrades()
+        .forEach(t -> userTrades.onNext(UserTradeEvent.of(t)));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void pollAndEmitOpenOrders(CurrencyPair currencyPair) throws IOException {
+    OpenOrdersParams openOrdersParams = openOrdersParams(currencyPair);
+
+    Date originatingTimestamp = new Date();
+    OpenOrders fetched = tradeService.getOpenOrders(openOrdersParams);
+
+    // TODO GDAX PR required
+    if (exchangeName.equalsIgnoreCase("coinbasepro") || exchangeName.equalsIgnoreCase("gdax")) {
+      List<LimitOrder> filteredOpen =
+          fetched.getOpenOrders().stream().filter(openOrdersParams::accept)
+              .collect(Collectors.toList());
+      List<? extends Order> filteredHidden = new ArrayList<>(fetched.getHiddenOrders());
+      fetched = new OpenOrders(filteredOpen, (List<Order>) filteredHidden);
+    }
+
+    fetched.getAllOpenOrders()
+        .forEach(o -> orders.onNext(OrderEvent.of(o, originatingTimestamp.toInstant())));
+  }
+
+  private void pollAndEmitTrades(CurrencyPair currencyPair) throws IOException {
+    marketDataService
+        .getTrades(currencyPair)
+        .getTrades()
+        .forEach(t -> trades.onNext(TradeEvent.of(t)));
+  }
+
+  private void pollAndEmitOrderbook(CurrencyPair currencyPair) throws IOException {
+    OrderBook orderBook =
+        marketDataService.getOrderBook(currencyPair, exchangeOrderbookArgs());
+    orderBooks.onNext(OrderBookEvent.of(currencyPair, orderBook));
+  }
+
+  private Object[] exchangeOrderbookArgs() {
+    // TODO
+    if (exchangeName.equals("bitmex")) {
+      return new Object[]{};
+    } else {
+      return new Object[]{ORDERBOOK_DEPTH, ORDERBOOK_DEPTH};
+    }
+  }
+
+  private void pollAndEmitTicker(CurrencyPair currencyPair) throws IOException {
+    tickers.onNext(TickerEvent.of(marketDataService.getTicker(currencyPair)));
+  }
+
+  private TradeHistoryParams tradeHistoryParams(CurrencyPair currencyPair) {
+    TradeHistoryParams params;
+
+    // TODO fix with pull requests
+    if (exchangeName.equals("bitmex") || exchangeName.equals("coinbasepro") || exchangeName
+        .equals("gdax")) {
+      params =
+          new TradeHistoryParamCurrencyPair() {
+
+            private CurrencyPair pair;
+
+            @Override
+            public CurrencyPair getCurrencyPair() {
+              return pair;
+            }
+
+            @Override
+            public void setCurrencyPair(CurrencyPair pair) {
+              this.pair = pair;
+            }
+          };
+    } else {
+      params = tradeService.createTradeHistoryParams();
+    }
+
+    if (params instanceof TradeHistoryParamCurrencyPair) {
+      ((TradeHistoryParamCurrencyPair) params)
+          .setCurrencyPair(currencyPair);
+    } else {
+      throw new UnsupportedOperationException(
+          "Don't know how to read user trades on this exchange: "
+              + exchangeName);
+    }
+    if (params instanceof TradeHistoryParamLimit) {
+      ((TradeHistoryParamLimit) params).setLimit(MAX_TRADES);
+    }
+    if (params instanceof TradeHistoryParamPaging) {
+      ((TradeHistoryParamPaging) params).setPageLength(MAX_TRADES);
+      ((TradeHistoryParamPaging) params).setPageNumber(0);
+    }
+    return params;
+  }
+
+  private OpenOrdersParams openOrdersParams(CurrencyPair currencyPair) {
+    OpenOrdersParams params = null;
+    try {
+      params = tradeService.createOpenOrdersParams();
+    } catch (NotYetImplementedForExchangeException e) {
+      // Fiiiiine Bitmex
+    }
+    if (params == null) {
+      // Bitfinex & Bitmex
+      params = new DefaultOpenOrdersParamCurrencyPair(currencyPair);
+    } else if (params instanceof OpenOrdersParamCurrencyPair) {
+      ((OpenOrdersParamCurrencyPair) params).setCurrencyPair(currencyPair);
+    } else {
+      throw new UnsupportedOperationException(
+          "Don't know how to read open orders on this exchange: "
+              + exchangeName);
+    }
+    return params;
+  }
+
+  @Value
+  static final class TickerEvent {
+
+    static TickerEvent of(Ticker ticker) {
+      return new TickerEvent(ticker.getCurrencyPair(), ticker, null);
+    }
+
+    static TickerEvent of(CurrencyPair currencyPair, Throwable error) {
+      return new TickerEvent(currencyPair, null, error);
+    }
+
+    CurrencyPair currencyPair;
+    Ticker ticker;
+    Throwable error;
+  }
+
+  @Value
+  static final class OrderBookEvent {
+
+    static OrderBookEvent of(CurrencyPair currencyPair, OrderBook orderBook) {
+      return new OrderBookEvent(currencyPair, orderBook, null);
+    }
+
+    static OrderBookEvent of(CurrencyPair currencyPair, Throwable error) {
+      return new OrderBookEvent(currencyPair, null, error);
+    }
+
+    CurrencyPair currencyPair;
+    OrderBook orderBook;
+    Throwable error;
+  }
+
+  @Value
+  static final class TradeEvent {
+
+    static TradeEvent of(Trade trade) {
+      return new TradeEvent(trade.getCurrencyPair(), trade, null);
+    }
+
+    static TradeEvent of(CurrencyPair currencyPair, Throwable error) {
+      return new TradeEvent(currencyPair, null, error);
+    }
+
+    CurrencyPair currencyPair;
+    Trade trade;
+    Throwable error;
+  }
+
+  @Value
+  static final class UserTradeEvent {
+
+    static UserTradeEvent of(UserTrade trade) {
+      return new UserTradeEvent(trade.getCurrencyPair(), trade, null);
+    }
+
+    static UserTradeEvent of(CurrencyPair currencyPair, Throwable error) {
+      return new UserTradeEvent(currencyPair, null, error);
+    }
+
+    CurrencyPair currencyPair;
+    UserTrade trade;
+    Throwable error;
+  }
+
+  @Value
+  static final class BalanceEvent {
+
+    static BalanceEvent of(Balance balance, Instant instant) {
+      return new BalanceEvent(balance.getCurrency(), balance, instant, null);
+    }
+
+    static BalanceEvent of(Currency currency, Throwable error) {
+      return new BalanceEvent(currency, null, null, error);
+    }
+
+    Currency currency;
+    Balance balance;
+    Instant instant;
+    Throwable error;
+  }
+
+  @Value
+  static final class OrderEvent {
+
+    static OrderEvent of(Order order, Instant instant) {
+      return new OrderEvent(order.getCurrencyPair(), order, instant, null);
+    }
+
+    static OrderEvent of(CurrencyPair currencyPair, Throwable error) {
+      return new OrderEvent(currencyPair, null, null, error);
+    }
+
+    CurrencyPair currencyPair;
+    Order order;
+    Instant instant;
+    Throwable error;
+  }
+}

--- a/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/LoopListener.java
+++ b/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/LoopListener.java
@@ -1,0 +1,14 @@
+package org.knowm.xchange.stream.wrapper;
+
+import com.google.common.annotations.VisibleForTesting;
+
+@VisibleForTesting
+interface LoopListener {
+
+  default void onBlocked() {
+  }
+
+  default void onStop() {
+  }
+
+}

--- a/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/MarketDataType.java
+++ b/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/MarketDataType.java
@@ -1,0 +1,27 @@
+package org.knowm.xchange.stream.wrapper;
+
+import lombok.Getter;
+
+enum MarketDataType {
+
+  TICKER(PollBehaviour.POLL_AS_FALLBACK),
+  ORDERBOOK(PollBehaviour.POLL_AS_FALLBACK),
+  TRADES(PollBehaviour.POLL_AS_FALLBACK),
+  ORDER(PollBehaviour.POLL_ALWAYS),
+  USER_TRADE(PollBehaviour.POLL_ALWAYS),
+  BALANCE(PollBehaviour.POLL_ALWAYS);
+
+  @Getter
+  private final PollBehaviour pollBehaviour;
+
+  MarketDataType(PollBehaviour pollBehaviour) {
+    this.pollBehaviour = pollBehaviour;
+  }
+
+  enum PollBehaviour {
+    POLL_ALWAYS,
+    POLL_AS_FALLBACK
+  }
+
+}
+

--- a/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/PollingStreamingExchangeWrapper.java
+++ b/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/PollingStreamingExchangeWrapper.java
@@ -1,0 +1,496 @@
+package org.knowm.xchange.stream.wrapper;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import info.bitrich.xchangestream.core.ProductSubscription;
+import info.bitrich.xchangestream.core.StreamingAccountService;
+import info.bitrich.xchangestream.core.StreamingExchange;
+import info.bitrich.xchangestream.core.StreamingMarketDataService;
+import info.bitrich.xchangestream.core.StreamingTradeService;
+import info.bitrich.xchangestream.service.exception.NotConnectedException;
+import io.reactivex.Completable;
+import io.reactivex.Observable;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subjects.Subject;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.account.Balance;
+import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.marketdata.Ticker;
+import org.knowm.xchange.dto.marketdata.Trade;
+import org.knowm.xchange.dto.meta.ExchangeMetaData;
+import org.knowm.xchange.dto.trade.UserTrade;
+import org.knowm.xchange.exceptions.ExchangeException;
+import org.knowm.xchange.service.account.AccountService;
+import org.knowm.xchange.service.marketdata.MarketDataService;
+import org.knowm.xchange.service.trade.TradeService;
+import org.knowm.xchange.stream.wrapper.Loop.BalanceEvent;
+import org.knowm.xchange.stream.wrapper.Loop.OrderBookEvent;
+import org.knowm.xchange.stream.wrapper.Loop.OrderEvent;
+import org.knowm.xchange.stream.wrapper.Loop.TickerEvent;
+import org.knowm.xchange.stream.wrapper.Loop.TradeEvent;
+import org.knowm.xchange.stream.wrapper.Loop.UserTradeEvent;
+import si.mazi.rescu.SynchronizedValueFactory;
+
+/**
+ * A wrapper for {@link Exchange} instances that performs several roles:
+ *
+ * <ul>
+ *   <li>Adds {@link StreamingExchange} capability to non-streaming {@link Exchange} implementations, allowing
+ *   them to be used in a non-blocking way like any other {@link StreamingExchange}. This avoids the complexity
+ *   of having to mix-and-match client code when using a variety of different exchanges in the same application.
+ *   Just use a {@link PollingStreamingExchangeWrapper} for every exchange and treat them all as RX sources.</li>
+ *   <li>In doing so, migrates all blocking code into dedicated threads, allowing you to ensure that computation
+ *   threads remain fully active and can therefore be predictably sized (e.g. to the number of cores).</li>
+ *   <li>Avoids the need for client code to implement any resilience handling. Most common temporary exchange
+ *   issues are automatically detected and logged, and exponential backoff is used to stop spamming failing
+ *   endpoints. Dramatically reduces production failures requiring intervention.</li>
+ *   <li>Allows graceful fallback where exchanges partially implement the {@link StreamingExchange} API,
+ *   detecting this and using polling instead for only those endpoints.</li>
+ *   <li>Attempts to commonise variations in exchange implementations so that every exchange can be addressed
+ *   using the same API. Mostly these will be migrated into the individual exchanges over time to ensure consistency,
+ *   but this works as a temporary stopgap while the difficulties of changing existing exchange implementations
+ *   can be discussed.  However, in some cases, such variations are unlikely to ever be resolved (such as Binance
+ *   requiring all subscriptions to be made up-front via a {@link ProductSubscription}) and this removes the need
+ *   to worry about that: the websocket is automatically disconnected and reconnected transparently without
+ *   requiring {@link Observable}s to be recycled.</li>
+ * </ul>
+ *
+ * <p>Usage:</p>
+ *
+ * <blockquote><pre>// Create the wrapper
+ * StreamingExchange exchange = new PollingStreamingExchangeWrapper("binance", binanceExchange,
+ * rateController, 1000, true);
+ * // Start the background worker
+ * exchange.connect().blockingAwait();
+ * // Use like any normal StreamingExchange
+ * // Shut down
+ * exchange.disconnect().blockingAwait();</pre></blockquote>
+ */
+@Slf4j
+public final class PollingStreamingExchangeWrapper implements StreamingExchange {
+
+  private final Exchange exchange;
+  private final Supplier<Connection> connectionFactory;
+
+  private volatile boolean alive;
+  private Connection connection;
+
+  public PollingStreamingExchangeWrapper(String exchangeName,
+      Exchange exchange,
+      RateController rateController,
+      long blockOnErrorMs,
+      boolean authenticated) {
+    this.exchange = exchange;
+    this.connectionFactory = () -> new Connection(new Loop(
+        exchangeName,
+        exchange,
+        rateController,
+        blockOnErrorMs,
+        authenticated));
+  }
+
+  @Override
+  public Completable connect(ProductSubscription... args) {
+    if (alive) {
+      return Completable.error(new IllegalStateException("Already connected"));
+    }
+    synchronized (PollingStreamingExchangeWrapper.this) {
+      if (alive) {
+        return Completable.error(new IllegalStateException("Already connected"));
+      }
+      this.alive = true;
+      this.connection = connectionFactory.get();
+      return connection.connect();
+    }
+  }
+
+  @Override
+  public boolean isAlive() {
+    return alive;
+  }
+
+  @Override
+  public Completable disconnect() {
+    if (!alive) {
+      return Completable.error(new IllegalStateException("Not connected"));
+    }
+    synchronized (PollingStreamingExchangeWrapper.this) {
+      if (!alive) {
+        return Completable.error(new IllegalStateException("Not connected"));
+      }
+      this.alive = false;
+      Connection connection = this.connection;
+      this.connection = null;
+      return connection.disconnect();
+    }
+  }
+
+  @Override
+  public StreamingMarketDataService getStreamingMarketDataService() {
+    if (!alive) {
+      throw new NotConnectedException();
+    }
+    return connection;
+  }
+
+  @Override
+  public StreamingAccountService getStreamingAccountService() {
+    if (!alive) {
+      throw new NotConnectedException();
+    }
+    return connection;
+  }
+
+  @Override
+  public StreamingTradeService getStreamingTradeService() {
+    if (!alive) {
+      throw new NotConnectedException();
+    }
+    return connection;
+  }
+
+  @Override
+  public void useCompressedMessages(boolean compressedMessages) {
+    if (exchange instanceof StreamingExchange) {
+      ((StreamingExchange) exchange).useCompressedMessages(compressedMessages);
+    }
+  }
+
+  @Override
+  public ExchangeSpecification getExchangeSpecification() {
+    return exchange.getExchangeSpecification();
+  }
+
+  @Override
+  public ExchangeMetaData getExchangeMetaData() {
+    return exchange.getExchangeMetaData();
+  }
+
+  @Override
+  public List<CurrencyPair> getExchangeSymbols() {
+    return exchange.getExchangeSymbols();
+  }
+
+  @Override
+  public SynchronizedValueFactory<Long> getNonceFactory() {
+    return exchange.getNonceFactory();
+  }
+
+  @Override
+  public ExchangeSpecification getDefaultExchangeSpecification() {
+    return exchange.getDefaultExchangeSpecification();
+  }
+
+  @Override
+  public void applySpecification(ExchangeSpecification exchangeSpecification) {
+    exchange.applySpecification(exchangeSpecification);
+  }
+
+  @Override
+  public MarketDataService getMarketDataService() {
+    return exchange.getMarketDataService();
+  }
+
+  @Override
+  public TradeService getTradeService() {
+    return exchange.getTradeService();
+  }
+
+  @Override
+  public AccountService getAccountService() {
+    return exchange.getAccountService();
+  }
+
+  @Override
+  public void remoteInit() throws IOException, ExchangeException {
+    exchange.remoteInit();
+  }
+
+  /**
+   * Everything that's scoped to a single connection.
+   */
+  private static class Connection implements StreamingMarketDataService,
+      StreamingTradeService, StreamingAccountService {
+
+    private final RxServiceWrapper<Loop> loop;
+
+    private final ConcurrentMap<Subscription, AtomicInteger> refCounts = Maps.newConcurrentMap();
+
+    private final ConcurrentMap<CurrencyPair, SharedSubject<Ticker>> tickerSubjects = Maps.newConcurrentMap();
+    private final ConcurrentMap<CurrencyPair, SharedSubject<OrderBook>> orderBookSubjects = Maps.newConcurrentMap();
+    private final ConcurrentMap<CurrencyPair, SharedSubject<Trade>> tradeSubjects = Maps.newConcurrentMap();
+    private final ConcurrentMap<CurrencyPair, SharedSubject<UserTrade>> userTradeSubjects = Maps.newConcurrentMap();
+    private final ConcurrentMap<Currency, SharedSubject<Timestamped<Balance>>> balanceSubjects = Maps
+        .newConcurrentMap();
+    private final ConcurrentMap<CurrencyPair, SharedSubject<Timestamped<Order>>> orderSubjects = Maps
+        .newConcurrentMap();
+
+    Connection(Loop loop) {
+      this.loop = new RxServiceWrapper<>(loop);
+      this.loop.getDelegate().getTickers().subscribe(this::emitTicker);
+      this.loop.getDelegate().getBalances().subscribe(this::emitBalance);
+      this.loop.getDelegate().getOrderBooks().subscribe(this::emitOrderBook);
+      this.loop.getDelegate().getOrders().subscribe(this::emitOrder);
+      this.loop.getDelegate().getTrades().subscribe(this::emitTrade);
+      this.loop.getDelegate().getUserTrades().subscribe(this::emitUserTrade);
+    }
+
+    Completable connect() {
+      return loop.start();
+    }
+
+    Completable disconnect() {
+      return loop.stop();
+    }
+
+    void setListener(LoopListener loopListener) {
+      loop.getDelegate().setLifecycleListener(loopListener);
+    }
+
+    @Override
+    public Observable<Ticker> getTicker(CurrencyPair currencyPair, Object... args) {
+      SharedSubject<Ticker> subject = tickerSubjects.computeIfAbsent(currencyPair, pair -> newBehaviourSubject());
+      Subscription subscription = new Subscription(currencyPair, MarketDataType.TICKER);
+      subscribe(subscription);
+      return subject.observe().doOnDispose(() -> unsubscribe(subscription));
+    }
+
+    private void emitTicker(TickerEvent event) {
+      SharedSubject<Ticker> subject = tickerSubjects.get(event.getCurrencyPair());
+      if (subject != null) {
+        if (event.getError() == null) {
+          subject.onNext(event.getTicker());
+        } else {
+          subject.onError(event.getError());
+        }
+      }
+    }
+
+    @Override
+    public Observable<OrderBook> getOrderBook(CurrencyPair currencyPair, Object... args) {
+      SharedSubject<OrderBook> subject = orderBookSubjects.computeIfAbsent(currencyPair, pair -> newBehaviourSubject());
+      Subscription subscription = new Subscription(currencyPair, MarketDataType.ORDERBOOK);
+      subscribe(subscription);
+      return subject.observe().doOnDispose(() -> unsubscribe(subscription));
+    }
+
+    private void emitOrderBook(OrderBookEvent event) {
+      SharedSubject<OrderBook> subject = orderBookSubjects.get(event.getCurrencyPair());
+      if (subject != null) {
+        if (event.getError() == null) {
+          subject.onNext(event.getOrderBook());
+        } else {
+          subject.onError(event.getError());
+        }
+      }
+    }
+
+    @Override
+    public Observable<Trade> getTrades(CurrencyPair currencyPair, Object... args) {
+      SharedSubject<Trade> subject = tradeSubjects.computeIfAbsent(currencyPair, pair -> newPublishSubject());
+      Subscription subscription = new Subscription(currencyPair, MarketDataType.TRADES);
+      subscribe(subscription);
+      return subject.observe().doOnDispose(() -> unsubscribe(subscription));
+    }
+
+    private void emitTrade(TradeEvent event) {
+      SharedSubject<Trade> subject = tradeSubjects.get(event.getCurrencyPair());
+      if (subject != null) {
+        if (event.getError() == null) {
+          subject.onNext(event.getTrade());
+        } else {
+          subject.onError(event.getError());
+        }
+      }
+    }
+
+    @Override
+    public Observable<UserTrade> getUserTrades(CurrencyPair currencyPair, Object... args) {
+      SharedSubject<UserTrade> subject = userTradeSubjects.computeIfAbsent(currencyPair, pair -> newPublishSubject());
+      Subscription subscription = new Subscription(currencyPair, MarketDataType.USER_TRADE);
+      subscribe(subscription);
+      Set<String> sent = Sets.newConcurrentHashSet();
+      return subject.observe()
+          .filter(t -> sent.add(t.getId()))
+          .doOnDispose(() -> unsubscribe(subscription));
+    }
+
+    private void emitUserTrade(UserTradeEvent event) {
+      SharedSubject<UserTrade> subject = userTradeSubjects.get(event.getCurrencyPair());
+      if (subject != null) {
+        if (event.getError() == null) {
+          subject.onNext(event.getTrade());
+        } else {
+          subject.onError(event.getError());
+        }
+      }
+    }
+
+    @Override
+    public Observable<Balance> getBalanceChanges(Currency currency, Object... args) {
+      SharedSubject<Timestamped<Balance>> subject = balanceSubjects
+          .computeIfAbsent(currency, pair -> newBehaviourSubject());
+      Subscription subscription = new Subscription(currency, MarketDataType.BALANCE);
+      subscribe(subscription);
+      AtomicReference<Instant> mostRecent = new AtomicReference<>(Instant.EPOCH);
+      return subject.observe()
+          .filter(b -> {
+            if (mostRecent.getAndUpdate(prev -> prev.isBefore(b.getInstant()) ? b.getInstant() : prev)
+                .isBefore(b.getInstant())) {
+              return true;
+            } else {
+              log.debug("Filtered out {} (old)", b);
+              return false;
+            }
+          })
+          .map(Timestamped::getItem)
+          .doOnDispose(() -> unsubscribe(subscription));
+    }
+
+    private void emitBalance(BalanceEvent event) {
+      log.debug("Got balance: {}", event);
+      SharedSubject<Timestamped<Balance>> subject = balanceSubjects.get(event.getCurrency());
+      if (subject != null) {
+        if (event.getError() == null) {
+          subject.onNext(new Timestamped<>(event.getBalance(), event.getInstant()));
+        } else {
+          subject.onError(event.getError());
+        }
+      }
+    }
+
+    @Override
+    public Observable<Order> getOrderChanges(CurrencyPair currencyPair, Object... args) {
+      SharedSubject<Timestamped<Order>> subject = orderSubjects
+          .computeIfAbsent(currencyPair, pair -> newPublishSubject());
+      Subscription subscription = new Subscription(currencyPair, MarketDataType.ORDER);
+      subscribe(subscription);
+      ConcurrentMap<String, Instant> mostRecentByOrderId = Maps.newConcurrentMap();
+      return subject.observe()
+          .filter(
+              o -> mostRecentByOrderId.merge(o.getItem().getId(), o.getInstant(), (ov, nv) -> ov.isBefore(nv) ? nv : ov)
+                  .equals(o.getInstant()))
+          .map(Timestamped::getItem)
+          .doOnDispose(() -> unsubscribe(subscription));
+    }
+
+    private void emitOrder(OrderEvent event) {
+      SharedSubject<Timestamped<Order>> subject = orderSubjects.get(event.getCurrencyPair());
+      if (subject != null) {
+        if (event.getError() == null) {
+          subject.onNext(new Timestamped<>(event.getOrder(), event.getInstant()));
+        } else {
+          subject.onError(event.getError());
+        }
+      }
+    }
+
+    private <T> SharedSubject<T> newBehaviourSubject() {
+      return new SharedSubject<>(BehaviorSubject.create());
+    }
+
+    private <T> SharedSubject<T> newPublishSubject() {
+      return new SharedSubject<>(PublishSubject.create());
+    }
+
+    private <K, T> void pushIfNew(
+        Map<K, Instant> times, Subject<T> subject, T item, K key, Instant thisTiming) {
+      times.compute(
+          key,
+          (k, previousTiming) -> {
+            Instant newMostRecent = previousTiming;
+            if (previousTiming == null) {
+              newMostRecent = thisTiming;
+            } else if (thisTiming.isAfter(previousTiming)) {
+              newMostRecent = thisTiming;
+              subject.onNext(item);
+            }
+            return newMostRecent;
+          });
+    }
+
+    private boolean subscribe(Subscription subscription) {
+      log.debug("... subscribing {}", subscription);
+      boolean changeSubscriptions =
+          refCounts
+              .computeIfAbsent(subscription, s -> new AtomicInteger(0))
+              .incrementAndGet()
+              == 1;
+      if (changeSubscriptions) {
+        log.debug("   ... new subscriptions");
+        loop.getDelegate().updateSubscriptions(refCounts.keySet());
+      }
+      return changeSubscriptions;
+    }
+
+    private boolean unsubscribe(Subscription subscription) {
+      log.debug("... unsubscribing {}", subscription);
+      AtomicInteger refCount = refCounts.get(subscription);
+      if (refCount == null) {
+        log.warn("   ... Refcount is unset for live subscription: {}", subscription);
+        return true;
+      }
+      int newRefCount = refCount.decrementAndGet();
+      log.debug("   ... refcount set to {}", newRefCount);
+      if (newRefCount == 0) {
+        log.debug("   ... removing subscription");
+        refCounts.remove(subscription);
+        loop.getDelegate().updateSubscriptions(refCounts.keySet());
+        return true;
+      } else {
+        log.debug("   ... other subscribers still holding it open");
+      }
+      return false;
+    }
+  }
+
+  @Value
+  private static final class Timestamped<T> {
+
+    T item;
+    Instant instant;
+  }
+
+  private static final class SharedSubject<T> {
+
+    private final Subject<T> subject;
+    private final Observable<T> observable;
+
+    SharedSubject(Subject<T> subject) {
+      this.subject = subject;
+      this.observable = subject
+          .serialize()
+          .share()
+          .observeOn(Schedulers.computation());
+    }
+
+    void onNext(T t) {
+      subject.onNext(t);
+    }
+
+    void onError(Throwable e) {
+      subject.onError(e);
+    }
+
+    Observable<T> observe() {
+      return observable;
+    }
+  }
+}

--- a/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/RateController.java
+++ b/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/RateController.java
@@ -1,0 +1,32 @@
+package org.knowm.xchange.stream.wrapper;
+
+/**
+ * TODO at the moment this is an abstract concept which needs to be combined with the {@link
+ * org.knowm.xchange.ExchangeSpecification.ResilienceSpecification} work and fall back to {@link
+ * org.knowm.xchange.dto.meta.ExchangeMetaData} if no resilience support is built into the exchange. No concrete
+ * implementation yet.
+ */
+public interface RateController {
+
+  /**
+   * Blocks until the operation can succeed. TODO this is currently fairly dumb, but needs combining with the resilience
+   * work
+   */
+  void acquire();
+
+  /**
+   * Cuts the throughput rate significantly on a temporary basis. This throttle will expire after a period of time.
+   */
+  void throttle();
+
+  /**
+   * Slightly reduces the throughput permanently. Use on encountering rate limiting errors to reduce the likelihood of
+   * hitting it again.
+   */
+  void backoff();
+
+  /**
+   * Blocks any further processing for a period of time. Intended to be used on detection of a rate ban.
+   */
+  void pause();
+}

--- a/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/RxServiceWrapper.java
+++ b/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/RxServiceWrapper.java
@@ -1,0 +1,80 @@
+package org.knowm.xchange.stream.wrapper;
+
+import com.google.common.util.concurrent.Service;
+import com.google.common.util.concurrent.Service.Listener;
+import com.google.common.util.concurrent.Service.State;
+import io.reactivex.Completable;
+import io.reactivex.CompletableEmitter;
+import io.reactivex.schedulers.Schedulers;
+import java.util.Optional;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * RX wrapper for {@link Service} which ensures that confirmation of start and shut down can be obtained on a
+ * non-blocking basis.
+ *
+ * @param <T> The service type.
+ */
+class RxServiceWrapper<T extends Service> {
+
+  private final T service;
+
+  private final BlockingQueue<CompletableEmitter> statusEmitters = new ArrayBlockingQueue<>(1);
+
+  RxServiceWrapper(T service) {
+    this.service = service;
+    service.addListener(new Listener() {
+      @Override
+      public void running() {
+        Optional.ofNullable(statusEmitters.poll())
+            .ifPresent(CompletableEmitter::onComplete);
+      }
+
+      @Override
+      public void terminated(State from) {
+        Optional.ofNullable(statusEmitters.poll())
+            .ifPresent(CompletableEmitter::onComplete);
+      }
+
+      @Override
+      public void failed(State from, Throwable failure) {
+        Optional.ofNullable(statusEmitters.poll())
+            .ifPresent(emitter -> emitter.onError(failure));
+      }
+    }, Schedulers.computation()::scheduleDirect);
+  }
+
+  Completable start() {
+    return Completable.create(emitter -> {
+      statusEmitters.put(emitter); // Implicit block as 1-length queue, for safety
+      if (isRunning()) {
+        emitter.onComplete();
+        statusEmitters.clear();
+      } else {
+        service.startAsync();
+      }
+    });
+  }
+
+  Completable stop() {
+    return Completable.create(emitter -> {
+      statusEmitters.put(emitter); // Implicit block as 1-length queue, for safety
+      if (!isRunning()) {
+        emitter.onComplete();
+        statusEmitters.clear();
+      } else {
+        service.stopAsync();
+      }
+    });
+  }
+
+  private boolean isRunning() {
+    return service.isRunning();
+  }
+
+  T getDelegate() {
+    return service;
+  }
+
+}

--- a/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/Safely.java
+++ b/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/Safely.java
@@ -1,0 +1,23 @@
+package org.knowm.xchange.stream.wrapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class Safely {
+
+  private Safely() {
+    // Not instantiatable
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(Safely.class);
+
+  static boolean run(String gerund, ThrowingRunnable runnable) {
+    try {
+      runnable.run();
+      return true;
+    } catch (Exception e) {
+      LOGGER.error("Error when {}", gerund, e);
+      return false;
+    }
+  }
+}

--- a/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/SafelyDispose.java
+++ b/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/SafelyDispose.java
@@ -1,0 +1,29 @@
+package org.knowm.xchange.stream.wrapper;
+
+import io.reactivex.disposables.Disposable;
+import java.util.Arrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class SafelyDispose {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SafelyDispose.class);
+
+  private SafelyDispose() {
+    // Not instantiatable
+  }
+
+  static void of(Disposable... disposables) {
+    of(Arrays.asList(disposables));
+  }
+
+  static void of(Iterable<Disposable> disposables) {
+    disposables.forEach(
+        d -> {
+          if (d == null) {
+            return;
+          }
+          Safely.run("disposing of subscription", d::dispose);
+        });
+  }
+}

--- a/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/Subscription.java
+++ b/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/Subscription.java
@@ -1,0 +1,39 @@
+package org.knowm.xchange.stream.wrapper;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+
+@Getter
+@EqualsAndHashCode
+@Accessors(fluent = true)
+class Subscription {
+
+  private final CurrencyPair currencyPair;
+  private final Currency currency;
+  private final MarketDataType type;
+
+  Subscription(CurrencyPair currencyPair, MarketDataType type) {
+    this.currencyPair = currencyPair;
+    this.currency = null;
+    this.type = type;
+  }
+
+  Subscription(Currency currency, MarketDataType type) {
+    this.currency = currency;
+    this.currencyPair = null;
+    this.type = type;
+  }
+
+  final String key() {
+    return (currencyPair == null ? currency : currencyPair) + "/" + type;
+  }
+
+  @Override
+  public final String toString() {
+    return key();
+  }
+
+}

--- a/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/ThrowingRunnable.java
+++ b/xchange-stream-wrapper/src/main/java/org/knowm/xchange/stream/wrapper/ThrowingRunnable.java
@@ -1,0 +1,6 @@
+package org.knowm.xchange.stream.wrapper;
+
+interface ThrowingRunnable {
+
+  void run() throws Exception;
+}

--- a/xchange-stream-wrapper/src/test/java/org/knowm/xchange/stream/wrapper/LoopTest.java
+++ b/xchange-stream-wrapper/src/test/java/org/knowm/xchange/stream/wrapper/LoopTest.java
@@ -1,0 +1,64 @@
+package org.knowm.xchange.stream.wrapper;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.google.common.collect.Sets;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Before;
+import org.junit.Test;
+import org.knowm.xchange.Exchange;
+import org.mockito.Mock;
+
+@Slf4j
+public class LoopTest {
+
+  @Mock private Exchange exchange;
+
+  private final CountDownLatch blocked = new CountDownLatch(1);
+  private final CountDownLatch shutdown = new CountDownLatch(1);
+
+  private final Set<Thread> threads = Sets.newConcurrentHashSet();
+
+  private RxServiceWrapper<Loop> loop;
+
+  @Before
+  public void setup() {
+    initMocks(this);
+    loop = new RxServiceWrapper<>(new Loop("test", exchange, mock(RateController.class), 100, true));
+    loop.getDelegate().setLifecycleListener(new LoopListener() {
+      @Override
+      public void onBlocked() {
+        threads.add(Thread.currentThread());
+        blocked.countDown();
+      }
+
+      @Override
+      public void onStop() {
+        shutdown.countDown();
+      }
+    });
+  }
+
+  @Test
+  public void testImmediateStartupShutdown() throws InterruptedException {
+    assertTrue(loop.start().blockingAwait(2, SECONDS));
+    assertTrue(blocked.await(2, SECONDS));
+    assertFalse(shutdown.await(2, SECONDS));
+    assertTrue(loop.stop().blockingAwait(2, SECONDS));
+    assertTrue(shutdown.await(2, SECONDS));
+  }
+
+  @Test
+  public void testInterrupt() throws InterruptedException {
+    assertTrue(loop.start().blockingAwait(2, SECONDS));
+    assertTrue(blocked.await(2, SECONDS));
+    threads.forEach(Thread::interrupt);
+    assertTrue(shutdown.await(2, SECONDS));
+  }
+}

--- a/xchange-stream-wrapper/src/test/java/org/knowm/xchange/stream/wrapper/PollingStreamingExchangeWrapperMockTest.java
+++ b/xchange-stream-wrapper/src/test/java/org/knowm/xchange/stream/wrapper/PollingStreamingExchangeWrapperMockTest.java
@@ -1,0 +1,166 @@
+package org.knowm.xchange.stream.wrapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import io.reactivex.Observable;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.Action;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Before;
+import org.junit.Test;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.marketdata.Ticker;
+import org.knowm.xchange.exceptions.RateLimitExceededException;
+import org.slf4j.LoggerFactory;
+import si.mazi.rescu.HttpStatusIOException;
+import si.mazi.rescu.InvocationResult;
+
+@Slf4j
+public class PollingStreamingExchangeWrapperMockTest {
+
+  private Exchange exchange;
+  private PollingStreamingExchangeWrapper singleWrapped;
+  private PollingStreamingExchangeWrapper doubleWrapped;
+  private RateController rateController;
+
+  @Before
+  public void setup() {
+
+    // Use INFO level logging for this test otherwise the logging is overwhelming
+    ((ch.qos.logback.classic.Logger)
+        LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME))
+        .setLevel(Level.INFO);
+
+    exchange = mock(Exchange.class, RETURNS_DEEP_STUBS);
+
+    rateController = mock(RateController.class);
+    doAnswer(inv -> {
+      Thread.sleep(200);
+      return null;
+    }).when(rateController).acquire();
+
+    // Wrap the exchange once (to test ability to poll)
+    singleWrapped = new PollingStreamingExchangeWrapper(
+        "simulated",
+        exchange,
+        rateController,
+        1000, true);
+
+    // Wrap that again to test that we can connect streams too
+    doubleWrapped = new PollingStreamingExchangeWrapper(
+        "wrapped",
+        singleWrapped,
+        rateController,
+        1000, true);
+  }
+
+  @Test
+  public void testPollExceptionUnknown() throws Exception {
+    failThreeTimes(() -> new RuntimeException("DELIBERATE"));
+    withSingleWrapped(
+        () -> assertReceiving(() -> singleWrapped.getStreamingMarketDataService().getTicker(CurrencyPair.BTC_USD)));
+    verify(rateController, times(3)).throttle();
+    verify(rateController, times(0)).backoff();
+    verify(rateController, times(0)).pause();
+  }
+
+  @Test
+  public void testPollExceptionHttpStatus() throws Exception {
+    failThreeTimes(() -> new HttpStatusIOException("DELIBERATE", new InvocationResult("Foo", 502)));
+    withSingleWrapped(
+        () -> assertReceiving(() -> singleWrapped.getStreamingMarketDataService().getTicker(CurrencyPair.BTC_USD)));
+    verify(rateController, times(3)).throttle();
+    verify(rateController, times(0)).backoff();
+    verify(rateController, times(0)).pause();
+  }
+
+  @Test
+  public void testRateLimitExceeded() throws Exception {
+    failThreeTimes(() -> new RateLimitExceededException("DELIBERATE"));
+    withSingleWrapped(
+        () -> assertReceiving(() -> singleWrapped.getStreamingMarketDataService().getTicker(CurrencyPair.BTC_USD)));
+    verify(rateController, times(0)).throttle();
+    verify(rateController, times(3)).backoff();
+    verify(rateController, times(3)).pause();
+  }
+
+  @Test
+  public void testUnsupportedOperation() throws Exception {
+    AtomicInteger attemptCount = new AtomicInteger(0);
+    when(exchange.getMarketDataService().getTicker(CurrencyPair.BTC_USD)).then(inv -> {
+      if (attemptCount.getAndIncrement() > 2) {
+        return new Ticker.Builder().currencyPair(CurrencyPair.BTC_USD).build();
+      } else {
+        throw new UnsupportedOperationException("DELIBERATE");
+      }
+    });
+    withSingleWrapped(() -> assertThatThrownBy(
+        () -> singleWrapped.getStreamingMarketDataService().getTicker(CurrencyPair.BTC_USD).blockingSubscribe())
+        .isInstanceOf(UnsupportedOperationException.class));
+    verify(rateController, times(0)).throttle();
+    verify(rateController, times(0)).backoff();
+    verify(rateController, times(0)).pause();
+  }
+
+  private void withSingleWrapped(Action action) throws Exception {
+    assertThat(singleWrapped.connect().blockingAwait(5, TimeUnit.SECONDS)).isTrue();
+    try {
+      action.run();
+    } finally {
+      assertThat(singleWrapped.disconnect().blockingAwait(5, TimeUnit.SECONDS)).isTrue();
+    }
+  }
+
+  private void withDoubleWrapped(Action action) throws Exception {
+    assertThat(doubleWrapped.connect().blockingAwait(5, TimeUnit.SECONDS)).isTrue();
+    try {
+      action.run();
+    } finally {
+      assertThat(doubleWrapped.disconnect().blockingAwait(5, TimeUnit.SECONDS)).isTrue();
+    }
+  }
+
+  private <T> void assertReceiving(Supplier<Observable<T>> rx) throws InterruptedException {
+    CountDownLatch gotTwo1 = new CountDownLatch(2);
+    CountDownLatch gotTwo2 = new CountDownLatch(2);
+    Disposable disposable1 = rx.get().subscribe(t -> {
+      log.info("Got (1): {}", t);
+      gotTwo1.countDown();
+    });
+    Disposable disposable2 = rx.get().subscribe(t -> {
+      log.info("Got (2): {}", t);
+      gotTwo2.countDown();
+    });
+    try {
+      assertThat(gotTwo1.await(30, TimeUnit.SECONDS)).isTrue();
+      assertThat(gotTwo2.await(30, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      SafelyDispose.of(disposable1, disposable2);
+    }
+  }
+
+  private void failThreeTimes(Supplier<Exception> exceptionSupplier) throws IOException {
+    AtomicInteger attemptCount = new AtomicInteger(0);
+    when(exchange.getMarketDataService().getTicker(CurrencyPair.BTC_USD)).then(inv -> {
+      if (attemptCount.getAndIncrement() > 2) {
+        return new Ticker.Builder().currencyPair(CurrencyPair.BTC_USD).build();
+      } else {
+        throw exceptionSupplier.get();
+      }
+    });
+  }
+}

--- a/xchange-stream-wrapper/src/test/java/org/knowm/xchange/stream/wrapper/PollingStreamingExchangeWrapperStackTest.java
+++ b/xchange-stream-wrapper/src/test/java/org/knowm/xchange/stream/wrapper/PollingStreamingExchangeWrapperStackTest.java
@@ -1,0 +1,216 @@
+package org.knowm.xchange.stream.wrapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.knowm.xchange.simulated.SimulatedExchange.ACCOUNT_FACTORY_PARAM;
+import static org.knowm.xchange.simulated.SimulatedExchange.ENGINE_FACTORY_PARAM;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import ch.qos.logback.classic.Level;
+import com.google.common.util.concurrent.Service;
+import io.reactivex.Observable;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.Action;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.simulated.AccountFactory;
+import org.knowm.xchange.simulated.MatchingEngineFactory;
+import org.knowm.xchange.simulated.SimulatedExchange;
+import org.slf4j.LoggerFactory;
+
+@Slf4j
+public class PollingStreamingExchangeWrapperStackTest {
+
+  private Exchange exchange;
+  private Service simulatedActivity;
+  private PollingStreamingExchangeWrapper singleWrapped;
+  private PollingStreamingExchangeWrapper doubleWrapped;
+
+  @Before
+  public void setup() {
+
+    // Use INFO level logging for this test otherwise the logging is overwhelming
+    ((ch.qos.logback.classic.Logger)
+        LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME))
+        .setLevel(Level.INFO);
+
+    // Set up a simulated exchange in the background with randomised trading activity
+    AccountFactory accountFactory = new AccountFactory();
+    MatchingEngineFactory matchingEngineFactory = new MatchingEngineFactory(accountFactory);
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(SimulatedExchange.class);
+    exchangeSpecification.setApiKey("MarketMakers");
+    exchangeSpecification.setExchangeSpecificParametersItem(ENGINE_FACTORY_PARAM, matchingEngineFactory);
+    exchangeSpecification.setExchangeSpecificParametersItem(ACCOUNT_FACTORY_PARAM, accountFactory);
+    exchange = ExchangeFactory.INSTANCE.createExchange(exchangeSpecification);
+    simulatedActivity = new SimulatedOrderBookActivity(accountFactory, matchingEngineFactory);
+    simulatedActivity.startAsync();
+
+    RateController rateController = mock(RateController.class);
+    doAnswer(inv -> {
+      Thread.sleep(200);
+      return null;
+    }).when(rateController).acquire();
+
+    // Wrap the exchange once (to test ability to poll)
+    singleWrapped = new PollingStreamingExchangeWrapper(
+        "simulated",
+        exchange,
+        rateController,
+        1000, true);
+
+    // Wrap that again to test that we can connect streams too
+    doubleWrapped = new PollingStreamingExchangeWrapper(
+        "wrapped",
+        singleWrapped,
+        rateController,
+        1000, true);
+  }
+
+  @After
+  public void tearDown() {
+    simulatedActivity.stopAsync();
+  }
+
+  @Test
+  public void testPollingTickers() throws Exception {
+    withSingleWrapped(
+        () -> assertReceiving(() -> singleWrapped.getStreamingMarketDataService().getTicker(CurrencyPair.BTC_USD)));
+  }
+
+  @Test
+  public void testStreamingTickers() throws Exception {
+    withDoubleWrapped(
+        () -> assertReceiving(() -> doubleWrapped.getStreamingMarketDataService().getTicker(CurrencyPair.BTC_USD)));
+  }
+
+  @Test
+  public void testPollingOrderBooks() throws Exception {
+    withSingleWrapped(
+        () -> assertReceiving(() -> singleWrapped.getStreamingMarketDataService().getOrderBook(CurrencyPair.BTC_USD)));
+  }
+
+  @Test
+  public void testStreamingOrderBooks() throws Exception {
+    withDoubleWrapped(
+        () -> assertReceiving(() -> doubleWrapped.getStreamingMarketDataService().getOrderBook(CurrencyPair.BTC_USD)));
+  }
+
+  @Test
+  public void testPollingTrades() throws Exception {
+    withSingleWrapped(
+        () -> assertReceiving(() -> singleWrapped.getStreamingMarketDataService().getTrades(CurrencyPair.BTC_USD)));
+  }
+
+  @Test
+  public void testStreamingTrades() throws Exception {
+    withDoubleWrapped(
+        () -> assertReceiving(() -> doubleWrapped.getStreamingMarketDataService().getTrades(CurrencyPair.BTC_USD)));
+  }
+
+  @Test
+  public void testPollingBalances() throws Exception {
+    withSingleWrapped(() -> {
+      assertReceiving(() -> singleWrapped.getStreamingAccountService().getBalanceChanges(Currency.BTC));
+      assertReceiving(() -> singleWrapped.getStreamingAccountService().getBalanceChanges(Currency.USD));
+    });
+  }
+
+  @Test
+  public void testStreamingBalances() throws Exception {
+    withDoubleWrapped(() -> {
+      assertReceiving(() -> doubleWrapped.getStreamingAccountService().getBalanceChanges(Currency.BTC));
+      assertReceiving(() -> doubleWrapped.getStreamingAccountService().getBalanceChanges(Currency.USD));
+    });
+  }
+
+  @Test
+  public void testPollingOrders() throws Exception {
+    withSingleWrapped(
+        () -> assertReceiving(() -> singleWrapped.getStreamingTradeService().getOrderChanges(CurrencyPair.BTC_USD)));
+  }
+
+  @Test
+  public void testStreamingOrders() throws Exception {
+    withDoubleWrapped(
+        () -> assertReceiving(() -> doubleWrapped.getStreamingTradeService().getOrderChanges(CurrencyPair.BTC_USD)));
+  }
+
+  @Test
+  public void testPollingUserTrades() throws Exception {
+    withSingleWrapped(
+        () -> assertReceiving(() -> singleWrapped.getStreamingTradeService().getUserTrades(CurrencyPair.BTC_USD)));
+  }
+
+  @Test
+  public void testStreamingUserTrades() throws Exception {
+    withDoubleWrapped(
+        () -> assertReceiving(() -> doubleWrapped.getStreamingTradeService().getUserTrades(CurrencyPair.BTC_USD)));
+  }
+
+  @Test
+  public void testChangeSubscriptions() throws Exception {
+    AtomicReference<CountDownLatch> tickers = new AtomicReference<>(new CountDownLatch(3));
+    AtomicReference<CountDownLatch> orderBooks = new AtomicReference<>(new CountDownLatch(3));
+    withSingleWrapped(() -> {
+      Disposable d1 = singleWrapped.getStreamingMarketDataService().getTicker(CurrencyPair.BTC_USD)
+          .subscribe(it -> tickers.get().countDown());
+      Thread.sleep(2000);
+      Disposable d2 = singleWrapped.getStreamingMarketDataService().getOrderBook(CurrencyPair.BTC_USD)
+          .subscribe(it -> orderBooks.get().countDown());
+      Thread.sleep(2000);
+      tickers.set(new CountDownLatch(3));
+      orderBooks.set(new CountDownLatch(3));
+      assertThat(tickers.get().await(30, TimeUnit.SECONDS)).isTrue();
+      assertThat(orderBooks.get().await(30, TimeUnit.SECONDS)).isTrue();
+      SafelyDispose.of(d1, d2);
+    });
+  }
+
+  private <T> void assertReceiving(Supplier<Observable<T>> rx) throws InterruptedException {
+    CountDownLatch gotTwo1 = new CountDownLatch(2);
+    CountDownLatch gotTwo2 = new CountDownLatch(2);
+    Disposable disposable1 = rx.get().subscribe(t -> {
+      log.info("Got (1): {}", t);
+      gotTwo1.countDown();
+    });
+    Disposable disposable2 = rx.get().subscribe(t -> {
+      log.info("Got (2): {}", t);
+      gotTwo2.countDown();
+    });
+    try {
+      assertThat(gotTwo1.await(30, TimeUnit.SECONDS)).isTrue();
+      assertThat(gotTwo2.await(30, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      SafelyDispose.of(disposable1, disposable2);
+    }
+  }
+
+  private void withSingleWrapped(Action action) throws Exception {
+    assertThat(singleWrapped.connect().blockingAwait(5, TimeUnit.SECONDS)).isTrue();
+    try {
+      action.run();
+    } finally {
+      assertThat(singleWrapped.disconnect().blockingAwait(5, TimeUnit.SECONDS)).isTrue();
+    }
+  }
+
+  private void withDoubleWrapped(Action action) throws Exception {
+    assertThat(doubleWrapped.connect().blockingAwait(5, TimeUnit.SECONDS)).isTrue();
+    try {
+      action.run();
+    } finally {
+      assertThat(doubleWrapped.disconnect().blockingAwait(5, TimeUnit.SECONDS)).isTrue();
+    }
+  }
+}

--- a/xchange-stream-wrapper/src/test/java/org/knowm/xchange/stream/wrapper/SimulatedOrderBookActivity.java
+++ b/xchange-stream-wrapper/src/test/java/org/knowm/xchange/stream/wrapper/SimulatedOrderBookActivity.java
@@ -1,0 +1,141 @@
+package org.knowm.xchange.stream.wrapper;
+
+import static java.math.RoundingMode.HALF_UP;
+import static org.knowm.xchange.currency.Currency.BTC;
+import static org.knowm.xchange.currency.Currency.USD;
+import static org.knowm.xchange.currency.CurrencyPair.BTC_USD;
+import static org.knowm.xchange.dto.Order.OrderType.ASK;
+import static org.knowm.xchange.dto.Order.OrderType.BID;
+import static org.knowm.xchange.simulated.SimulatedExchange.ACCOUNT_FACTORY_PARAM;
+import static org.knowm.xchange.simulated.SimulatedExchange.ENGINE_FACTORY_PARAM;
+
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Random;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.dto.Order.OrderType;
+import org.knowm.xchange.dto.marketdata.Ticker;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.dto.trade.MarketOrder;
+import org.knowm.xchange.simulated.AccountFactory;
+import org.knowm.xchange.simulated.MatchingEngineFactory;
+import org.knowm.xchange.simulated.SimulatedExchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class SimulatedOrderBookActivity extends AbstractExecutionThreadService {
+
+  private static final BigDecimal MIN_PRICE = new BigDecimal("0.01");
+  private static final Logger LOGGER = LoggerFactory.getLogger(SimulatedOrderBookActivity.class);
+  private static final BigDecimal THOUSAND = new BigDecimal(1000);
+  private static final BigDecimal HUNDRED = new BigDecimal(100);
+
+  private final SimulatedExchange marketMakerExchange;
+  private final Random random;
+
+  SimulatedOrderBookActivity(AccountFactory accountFactory, MatchingEngineFactory matchingEngineFactory) {
+    ExchangeSpecification exchangeSpecification =
+        new ExchangeSpecification(SimulatedExchange.class);
+    exchangeSpecification.setApiKey("MarketMakers");
+    exchangeSpecification.setExchangeSpecificParametersItem(
+        ENGINE_FACTORY_PARAM, matchingEngineFactory);
+    exchangeSpecification.setExchangeSpecificParametersItem(ACCOUNT_FACTORY_PARAM, accountFactory);
+    marketMakerExchange =
+        (SimulatedExchange) ExchangeFactory.INSTANCE.createExchange(exchangeSpecification);
+    random = new Random();
+  }
+
+  @Override
+  protected void run() {
+    LOGGER.info("Starting market data simulator...");
+
+    try {
+      mockMarket();
+      LOGGER.info("Prepared mock order book");
+
+      while (isRunning() && !Thread.interrupted()) {
+
+        // Wait a random amount of time, up to 2 seconds
+        Thread.sleep(500L + random.nextInt(1499));
+
+        // Randomly add a bit to the book and then execute a market order on the opposite side
+        OrderType orderType = random.nextBoolean() ? ASK : BID;
+        placeLimitOrder(orderType, randomPrice(orderType), randomAmount(2));
+        placeMarketOrder(orderType.equals(ASK) ? BID : ASK, randomAmount(2));
+      }
+    } catch (Exception e) {
+      LOGGER.error("Simulator failed.", e);
+    }
+  }
+
+  private BigDecimal randomAmount(int max) {
+    // 0.001 - max BTC
+    return new BigDecimal(1 + random.nextInt(max * 1000 - 1)).divide(THOUSAND, 4, HALF_UP);
+  }
+
+  private BigDecimal randomPrice(OrderType orderType) throws IOException {
+    // 0 - 50 USD from the current price
+    Ticker ticker = marketMakerExchange.getMarketDataService().getTicker(BTC_USD);
+    BigDecimal diff = new BigDecimal(random.nextInt(5000)).divide(HUNDRED, 2, HALF_UP);
+    if (orderType == BID) {
+      BigDecimal result = ticker.getBid().subtract(diff);
+      return result.compareTo(MIN_PRICE) <= 0 ? MIN_PRICE : result;
+    } else {
+      return ticker.getAsk().add(diff);
+    }
+  }
+
+  private void mockMarket() {
+    marketMakerExchange.getAccountService().deposit(USD, new BigDecimal("99999999999999999"));
+    marketMakerExchange.getAccountService().deposit(BTC, new BigDecimal("99999999999999999"));
+    BigDecimal startPrice = new BigDecimal(5000);
+    BigDecimal startAmount = new BigDecimal("2");
+    BigDecimal range = new BigDecimal(4000);
+    BigDecimal seedIncrement = new BigDecimal("0.1");
+    BigDecimal multiplicator = new BigDecimal("1.3");
+
+    BigDecimal diff = seedIncrement;
+    BigDecimal amount = startAmount;
+    while (diff.compareTo(range) < 0) {
+      LOGGER.debug("Building order book, price diff {}", diff);
+      marketMakerOrder(
+          ASK, startPrice.add(diff).setScale(2, HALF_UP), amount.add(randomAmount(10)));
+      marketMakerOrder(
+          BID, startPrice.subtract(diff).setScale(2, HALF_UP), amount.add(randomAmount(10)));
+      diff = diff.multiply(multiplicator).setScale(2, HALF_UP);
+      amount = amount.divide(multiplicator, 2, HALF_UP);
+    }
+  }
+
+  private void placeLimitOrder(OrderType orderType, BigDecimal price, BigDecimal amount)
+      throws IOException {
+    LOGGER.debug("Simulated limit order: {} {} @ {}", orderType, amount, price);
+    marketMakerExchange
+        .getTradeService()
+        .placeLimitOrder(
+            new LimitOrder.Builder(orderType, BTC_USD)
+                .limitPrice(price)
+                .originalAmount(amount)
+                .build());
+  }
+
+  private void placeMarketOrder(OrderType orderType, BigDecimal amount) throws IOException {
+    LOGGER.debug("Simulated market order: {} {}", orderType, amount);
+    marketMakerExchange
+        .getTradeService()
+        .placeMarketOrder(
+            new MarketOrder.Builder(orderType, BTC_USD).originalAmount(amount).build());
+  }
+
+  private void marketMakerOrder(OrderType orderType, BigDecimal price, BigDecimal amount) {
+    marketMakerExchange
+        .getTradeService()
+        .placeLimitOrderUnrestricted(
+            new LimitOrder.Builder(orderType, BTC_USD)
+                .limitPrice(price)
+                .originalAmount(amount)
+                .build());
+  }
+}


### PR DESCRIPTION
**Definitely work in progress. Posted for comment.**

**Rolls up #3518**

Introduces `PollingExchangeWrapper`, a wrapper for `Exchange` instances that performs several roles:

 - Adds `StreamingExchange` capability to non-streaming `Exchange` implementations, allowing them to be used in a non-blocking way like any other `StreamingExchange`. This avoids the complexity of having to mix-and-match client code when using a variety of different exchanges in the same application. Just use a `PollingStreamingExchangeWrapper` for every exchange and treat them all as RX sources.
 - In doing so, migrates all blocking code into dedicated threads, allowing you to ensure that computation threads remain fully active and can therefore be predictably sized (e.g. to the number of cores).
 - Avoids the need for client code to implement any resilience handling. Most common temporary exchange issues are automatically detected and logged, and exponential backoff is used to stop spamming failing endpoints. Dramatically reduces production failures requiring intervention.
 - Allows graceful fallback where exchanges partially implement the `StreamingExchange` API, detecting this and using polling instead for only those endpoints.
 - Attempts to commonise variations in exchange implementations so that every exchange can be addressed using the same API. Mostly these will be migrated into the individual exchanges over time to ensure consistency, but this works as a temporary stopgap while the difficulties of changing existing exchange implementations can be discussed. However, in some cases, such variations are unlikely to ever be resolved (such as Binance requiring all subscriptions to be made up-front via a `ProductSubscription`) and this removes the need to worry about that: the websocket is automatically disconnected and reconnected transparently without requiring Observables to be recycled.

Usage:

```java
   // Create the Exchange
   Exchange binanceExchange = ExchangeFactory.createExchange(BinanceExchange.class);
   // Create the wrapper
   StreamingExchange exchange = new PollingStreamingExchangeWrapper(
     "binance", binanceExchange, rateController, 1000, true);
   // Start the background worker
   exchange.connect().blockingAwait();
   // Use like any normal StreamingExchange
   // Shut down
   exchange.disconnect().blockingAwait();
```