### PR TITLE
[Bittrex] Deprecated methods with confusing names

### DIFF
--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/BittrexUtils.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/BittrexUtils.java
@@ -4,6 +4,9 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.exceptions.ExchangeException;
 
@@ -14,25 +17,64 @@ public final class BittrexUtils {
   private static final String DATE_FORMAT_NO_MILLIS = "yyyy-MM-dd'T'HH:mm:ss";
 
   private static final TimeZone TIME_ZONE = TimeZone.getTimeZone("UTC");
+  protected static final String MARKET_NAME_SEPARATOR = "-";
 
   /** private Constructor */
   private BittrexUtils() {}
 
+  /**
+   * @deprecated Name if confusing (no api version specification), use a toPairString with a version
+   *     specifier since Bittrex changed the market names order.
+   *     <p>use {@link #toPairString(CurrencyPair, boolean)} ()} instead
+   */
+  @Deprecated
   public static String toPairString(CurrencyPair currencyPair) {
     return currencyPair.counter.getCurrencyCode().toUpperCase()
         + "-"
         + currencyPair.base.getCurrencyCode().toUpperCase();
   }
 
-  // Bittrex reversed the symbols in V3...
-  public static String toPairStringV3(CurrencyPair currencyPair) {
-    return currencyPair.base.getCurrencyCode().toUpperCase()
-        + "-"
-        + currencyPair.counter.getCurrencyCode().toUpperCase();
+  /**
+   * The market names format is reversed starting api version 3.
+   *
+   * @param currencyPair the market name
+   * @param apiVersion3 true if api version is 3 or more
+   * @return the market name string representation
+   */
+  public static String toPairString(CurrencyPair currencyPair, boolean apiVersion3) {
+    Stream<Currency> currencies =
+        apiVersion3
+            ? Stream.of(currencyPair.base, currencyPair.counter)
+            : Stream.of(currencyPair.counter, currencyPair.base);
+    return currencies
+        .map(Currency::getCurrencyCode)
+        .collect(Collectors.joining(MARKET_NAME_SEPARATOR))
+        .toUpperCase();
   }
 
+  /**
+   * The market names format is reversed starting api version 3.
+   *
+   * @param pairString the Bittrex string representation of a market
+   * @param apiVersion3 true if api version is 3 or more
+   * @return the corresponding CurrencyPair
+   */
+  public static CurrencyPair toCurrencyPair(String pairString, boolean apiVersion3) {
+    String[] pairStringSplit = pairString.split(MARKET_NAME_SEPARATOR);
+    if (apiVersion3) {
+      return new CurrencyPair(pairStringSplit[0], pairStringSplit[1]);
+    }
+    return new CurrencyPair(pairStringSplit[1], pairStringSplit[0]);
+  }
+
+  /**
+   * @deprecated Name if confusing (no api version specification), use a toPairString with a version
+   *     specifier since Bittrex changed the market names order.
+   *     <p>use {@link #toCurrencyPair(String, boolean)} ()} instead
+   */
+  @Deprecated
   public static CurrencyPair toCurrencyPair(String pairString) {
-    String[] pairStringSplit = pairString.split("-");
+    String[] pairStringSplit = pairString.split(MARKET_NAME_SEPARATOR);
     return new CurrencyPair(pairStringSplit[1], pairStringSplit[0]);
   }
 

--- a/xchange-bittrex/src/test/java/org/knowm/xchange/bittrex/BittrexUtilsTest.java
+++ b/xchange-bittrex/src/test/java/org/knowm/xchange/bittrex/BittrexUtilsTest.java
@@ -1,0 +1,33 @@
+package org.knowm.xchange.bittrex;
+
+import static org.knowm.xchange.bittrex.BittrexUtils.MARKET_NAME_SEPARATOR;
+import static org.knowm.xchange.bittrex.BittrexUtils.toCurrencyPair;
+import static org.knowm.xchange.bittrex.BittrexUtils.toPairString;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Test;
+import org.knowm.xchange.currency.CurrencyPair;
+
+public class BittrexUtilsTest extends TestCase {
+
+  @Test
+  public void testToPairString() {
+    CurrencyPair market = CurrencyPair.ETH_BTC;
+    String oldApiVersionPairString = market.counter + MARKET_NAME_SEPARATOR + market.base;
+    String v3ApiVersionPairString = market.base + MARKET_NAME_SEPARATOR + market.counter;
+
+    Assert.assertEquals(v3ApiVersionPairString, toPairString(market, true));
+    Assert.assertEquals(oldApiVersionPairString, toPairString(market, false));
+  }
+
+  @Test
+  public void testToCurrencyPair() {
+    CurrencyPair market = CurrencyPair.ETH_BTC;
+    String marketOldVersionString = "BTC-ETH";
+    String marketV3ApiString = "ETH-BTC";
+
+    Assert.assertEquals(market, toCurrencyPair(marketV3ApiString, true));
+    Assert.assertEquals(market, toCurrencyPair(marketOldVersionString, false));
+  }
+}


### PR DESCRIPTION

Bittrex reversed the market names order with version 3