### PR TITLE
[simulated] - Implemented additional cancel/getOrder functions 

### DIFF
--- a/xchange-simulated/src/main/java/org/knowm/xchange/simulated/MatchingEngine.java
+++ b/xchange-simulated/src/main/java/org/knowm/xchange/simulated/MatchingEngine.java
@@ -380,6 +380,17 @@ final class MatchingEngine {
     onFill.accept(fill);
   }
 
+  public void cancelOrder(String orderId) {
+    asks.stream()
+        .forEach(
+            bookLevel ->
+                bookLevel.getOrders().removeIf(bookOrder -> bookOrder.getId().equals(orderId)));
+    bids.stream()
+        .forEach(
+            bookLevel ->
+                bookLevel.getOrders().removeIf(bookOrder -> bookOrder.getId().equals(orderId)));
+  }
+
   public void cancelOrder(String orderId, Order.OrderType type) {
 
     switch (type) {

--- a/xchange-simulated/src/main/java/org/knowm/xchange/simulated/MatchingEngine.java
+++ b/xchange-simulated/src/main/java/org/knowm/xchange/simulated/MatchingEngine.java
@@ -380,35 +380,35 @@ final class MatchingEngine {
     onFill.accept(fill);
   }
 
-  public void cancelOrder(String orderId) {
-    asks.stream()
-        .forEach(
-            bookLevel ->
-                bookLevel.getOrders().removeIf(bookOrder -> bookOrder.getId().equals(orderId)));
-    bids.stream()
-        .forEach(
-            bookLevel ->
-                bookLevel.getOrders().removeIf(bookOrder -> bookOrder.getId().equals(orderId)));
+  public void cancelOrder(String apiKey, String orderId) {
+    cancelOrder(apiKey, orderId, BID);
+    cancelOrder(apiKey, orderId, ASK);
   }
 
-  public void cancelOrder(String orderId, Order.OrderType type) {
-
+  public void cancelOrder(String apiKey, String orderId, OrderType type) {
+    Account account = accountFactory.get(apiKey);
+    Stream<BookLevel> bookLevelStream;
     switch (type) {
       case ASK:
-        asks.stream()
-            .forEach(
-                bookLevel ->
-                    bookLevel.getOrders().removeIf(bookOrder -> bookOrder.getId().equals(orderId)));
+        bookLevelStream = asks.stream();
         break;
       case BID:
-        bids.stream()
-            .forEach(
-                bookLevel ->
-                    bookLevel.getOrders().removeIf(bookOrder -> bookOrder.getId().equals(orderId)));
-
+        bookLevelStream = bids.stream();
         break;
       default:
         throw new ExchangeException("Unsupported order type: " + type);
     }
+    bookLevelStream.forEach(
+        bookLevel ->
+            bookLevel
+                .getOrders()
+                .removeIf(
+                    bookOrder -> {
+                      final boolean remove = bookOrder.getId().equals(orderId);
+                      if (remove) {
+                        account.release(bookOrder.toOrder(currencyPair));
+                      }
+                      return remove;
+                    }));
   }
 }

--- a/xchange-simulated/src/main/java/org/knowm/xchange/simulated/MatchingEngineFactory.java
+++ b/xchange-simulated/src/main/java/org/knowm/xchange/simulated/MatchingEngineFactory.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.simulated;
 
 import java.math.BigDecimal;
+import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
@@ -35,5 +36,9 @@ public class MatchingEngineFactory {
   MatchingEngine create(CurrencyPair currencyPair, int priceScale, BigDecimal minimumAmount) {
     return engines.computeIfAbsent(
         currencyPair, pair -> new MatchingEngine(accountFactory, pair, priceScale, minimumAmount));
+  }
+
+  Collection<MatchingEngine> engines() {
+    return engines.values();
   }
 }

--- a/xchange-simulated/src/main/java/org/knowm/xchange/simulated/SimulatedExchange.java
+++ b/xchange-simulated/src/main/java/org/knowm/xchange/simulated/SimulatedExchange.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.simulated;
 import static java.math.BigDecimal.ZERO;
 
 import java.io.IOException;
+import java.util.Collection;
 import org.apache.commons.lang3.StringUtils;
 import org.knowm.xchange.BaseExchange;
 import org.knowm.xchange.ExchangeSpecification;
@@ -114,6 +115,10 @@ public class SimulatedExchange extends BaseExchange {
 
   void maybeThrow() throws IOException {
     exceptionThrower.onSimulatedExchangeOperation();
+  }
+
+  Collection<MatchingEngine> getEngines() {
+    return engineFactory.engines();
   }
 
   MatchingEngine getEngine(CurrencyPair currencyPair) {

--- a/xchange-simulated/src/main/java/org/knowm/xchange/simulated/SimulatedTradeService.java
+++ b/xchange-simulated/src/main/java/org/knowm/xchange/simulated/SimulatedTradeService.java
@@ -107,13 +107,13 @@ public class SimulatedTradeService extends BaseExchangeService<SimulatedExchange
         String orderId = ((CancelOrderByIdParams) orderParams).getOrderId();
         Order.OrderType type = ((CancelOrderByOrderTypeParams) orderParams).getOrderType();
 
-        engine.cancelOrder(orderId, type);
+        engine.cancelOrder(orderId, getApiKey(), type);
 
         return true;
       }
     } else if (orderParams instanceof DefaultCancelOrderParamId) {
       String orderId = ((CancelOrderByIdParams) orderParams).getOrderId();
-      exchange.getEngines().forEach(engine -> engine.cancelOrder(orderId));
+      exchange.getEngines().forEach(engine -> engine.cancelOrder(getApiKey(), orderId));
       return true;
     }
 

--- a/xchange-simulated/src/main/java/org/knowm/xchange/simulated/SimulatedTradeService.java
+++ b/xchange-simulated/src/main/java/org/knowm/xchange/simulated/SimulatedTradeService.java
@@ -1,10 +1,7 @@
 package org.knowm.xchange.simulated;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.knowm.xchange.dto.Order;
@@ -56,13 +53,17 @@ public class SimulatedTradeService extends BaseExchangeService<SimulatedExchange
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws IOException {
-    if (!(params instanceof OpenOrdersParamCurrencyPair)) {
-      throw new ExchangeException("Currency pair required");
+    if (params instanceof OpenOrdersParamCurrencyPair) {
+      MatchingEngine engine =
+          exchange.getEngine(((OpenOrdersParamCurrencyPair) params).getCurrencyPair());
+      exchange.maybeThrow();
+      return new OpenOrders(engine.openOrders(getApiKey()));
+    } else {
+      return new OpenOrders(
+          exchange.getEngines().stream()
+              .flatMap(e -> e.openOrders(getApiKey()).stream())
+              .collect(Collectors.toList()));
     }
-    MatchingEngine engine =
-        exchange.getEngine(((OpenOrdersParamCurrencyPair) params).getCurrencyPair());
-    exchange.maybeThrow();
-    return new OpenOrders(engine.openOrders(getApiKey()));
   }
 
   @Override
@@ -110,29 +111,47 @@ public class SimulatedTradeService extends BaseExchangeService<SimulatedExchange
 
         return true;
       }
+    } else if (orderParams instanceof DefaultCancelOrderParamId) {
+      String orderId = ((CancelOrderByIdParams) orderParams).getOrderId();
+      exchange.getEngines().forEach(engine -> engine.cancelOrder(orderId));
+      return true;
     }
+
     throw new NotYetImplementedForExchangeException();
   }
 
   @Override
-  public Collection<Order> getOrder(OrderQueryParams... orderQueryParams) throws IOException {
+  public boolean cancelOrder(String orderId) throws IOException {
+    return cancelOrder(new DefaultCancelOrderParamId(orderId));
+  }
+
+  @Override
+  public Collection<Order> getOrder(OrderQueryParams... orderQueryParams) {
     return Arrays.stream(orderQueryParams)
-        .map(
+        .flatMap(
             p -> {
-              if (!(p instanceof OrderQueryParamCurrencyPair))
+              if (p instanceof OrderQueryParamCurrencyPair) {
+                return exchange.getEngine(((OrderQueryParamCurrencyPair) p).getCurrencyPair())
+                    .openOrders(getApiKey()).stream()
+                    .filter(o -> o.getId().equals(p.getOrderId()));
+              } else if (p instanceof DefaultQueryOrderParam) {
+                return exchange.getEngines().stream()
+                    .flatMap(e -> e.openOrders(getApiKey()).stream())
+                    .filter(o -> o.getId().equals(p.getOrderId()));
+              } else {
                 throw new NotYetImplementedForExchangeException();
-
-              MatchingEngine engine =
-                  exchange.getEngine(((OrderQueryParamCurrencyPair) p).getCurrencyPair());
-
-              Optional<LimitOrder> first =
-                  engine.openOrders(getApiKey()).stream()
-                      .filter(o -> o.getId().equals(p.getOrderId()))
-                      .findFirst();
-
-              return first.orElse(null);
+              }
             })
-        .filter(Objects::nonNull)
         .collect(Collectors.toList());
+  }
+
+  @Override
+  public Collection<Order> getOrder(String... orderIds) {
+    List<Order> openOrders = new ArrayList<>();
+
+    for (String orderId : orderIds) {
+      openOrders.addAll(getOrder(new DefaultQueryOrderParam(orderId)));
+    }
+    return openOrders;
   }
 }

--- a/xchange-simulated/src/test/java/org/knowm/xchange/simulated/TestSimulatedExchange.java
+++ b/xchange-simulated/src/test/java/org/knowm/xchange/simulated/TestSimulatedExchange.java
@@ -340,6 +340,26 @@ public class TestSimulatedExchange {
         .isEqualTo(INITIAL_BALANCE.subtract(expectedUsdCost).subtract(expectedUsdReserved));
   }
 
+  @Test
+  public void testBalanceIsReleasedOnCancel() throws IOException {
+    // When
+    String orderId =
+        exchange
+            .getTradeService()
+            .placeLimitOrder(
+                new LimitOrder.Builder(BID, BTC_USD)
+                    .limitPrice(new BigDecimal(10))
+                    .originalAmount(new BigDecimal("0.7"))
+                    .build());
+    exchange.getTradeService().cancelOrder(orderId);
+    Balance baseBalance = exchange.getAccountService().getAccountInfo().getWallet().getBalance(BTC);
+
+    // THen
+    assertThat(baseBalance.getTotal()).isEqualTo(INITIAL_BALANCE);
+    assertThat(baseBalance.getFrozen()).isEqualTo(ZERO);
+    assertThat(baseBalance.getAvailable()).isEqualTo(INITIAL_BALANCE);
+  }
+
   private OpenOrders getOpenOrders() throws IOException {
     OpenOrdersParamCurrencyPair params = exchange.getTradeService().createOpenOrdersParams();
     params.setCurrencyPair(BTC_USD);


### PR DESCRIPTION
Implemented additional functions on the Simulated exchange to allow getOder and cancel calls without passing in the currency pairs.