### PR TITLE
[Kraken Stream] Added Support for OHLC web socket subscription.

### DIFF
--- a/xchange-stream-kraken/src/test/java/info/bitrich/xchangestream/kraken/KrakenManualExample.java
+++ b/xchange-stream-kraken/src/test/java/info/bitrich/xchangestream/kraken/KrakenManualExample.java
@@ -81,13 +81,26 @@ public class KrakenManualExample {
                 throwable -> {
                   LOG.error("Fail to get trade {}", throwable.getMessage(), throwable);
                 });
+
     TimeUnit.SECONDS.sleep(5);
 
     btcEurOrderBookDis.dispose();
     btcUsdOrderBookDis.dispose();
     tickerDis.dispose();
     tradeDis.dispose();
-
+      Disposable ohlcDis = ((KrakenStreamingMarketDataService)
+              krakenExchange
+                      .getStreamingMarketDataService()).getOHLC(CurrencyPair.BTC_USD, 1)
+              .subscribe(
+                      s -> {
+                          LOG.info("Received {}", s);
+                      },
+                      e -> {
+                          LOG.error("Fail to get OHLC {}", e.getMessage(), e);
+                      }
+              );
+      TimeUnit.SECONDS.sleep(120);
+    ohlcDis.dispose();
     krakenExchange.disconnect().subscribe(() -> LOG.info("Disconnected"));
   }
 }


### PR DESCRIPTION
This PR adds support for subscribing and acting on the OHLC web socket feed from Kraken. I know personally, this is incredibly useful functionality as many traders have to manage our own candles and this emitter when the next candle is over simplifies the strategy process immensely. 

Slightly related to [Issue #3559](https://github.com/knowm/XChange/issues/3559).


```java
Disposable ohlcDis = ((KrakenStreamingMarketDataService) krakenExchange
// 1 corresponds to the candle period you'd like to subscribe to, multiple subscriptions work.
                .getStreamingMarketDataService()).getOHLC(CurrencyPair.BTC_USD, 1)
                .subscribe(
                        s -> {
                            LOG.info("Latest Candle is Here for Period 1m {}", s);
                        },
                        e -> {
                            LOG.error("Fail to get Candle {}", e.getMessage(), e);
                        }
                );
```