### PR TITLE
[bitcoinde] Upgraded API to version 4 and added TradeService (partially)

### DIFF
--- a/xchange-bitcoinde/pom.xml
+++ b/xchange-bitcoinde/pom.xml
@@ -30,6 +30,9 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
     </dependencies>
-
 </project>

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/BitcoindeUtils.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/BitcoindeUtils.java
@@ -1,10 +1,15 @@
 package org.knowm.xchange.bitcoinde;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
 
 public class BitcoindeUtils {
+
+  private static final DateFormat DATE_FORMATTER = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
 
   private BitcoindeUtils() {}
 
@@ -21,6 +26,9 @@ public class BitcoindeUtils {
     return type.equals(OrderType.ASK) ? "sell" : "buy";
   }
 
+  public static String rfc3339Timestamp(Date date) {
+    return DATE_FORMATTER.format(date);
+  }
 
   public static Integer createBitcoindeBoolean(Boolean value) {
     return Boolean.TRUE.equals(value) ? 1 : 0;

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/BitcoindeUtils.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/BitcoindeUtils.java
@@ -1,12 +1,28 @@
 package org.knowm.xchange.bitcoinde;
 
+import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order.OrderType;
 
 public class BitcoindeUtils {
 
-  public static String createBitcoindePair(CurrencyPair currencyPair) {
+  private BitcoindeUtils() {}
 
-    return currencyPair.base.getCurrencyCode().toLowerCase()
-        + currencyPair.counter.getCurrencyCode().toLowerCase();
+  public static String createBitcoindePair(CurrencyPair currencyPair) {
+    return createBitcoindeCurrency(currencyPair.base)
+        + createBitcoindeCurrency(currencyPair.counter);
+  }
+
+  public static String createBitcoindeCurrency(Currency currency) {
+    return currency.getCurrencyCode().toLowerCase();
+  }
+
+  public static String createBitcoindeType(OrderType type) {
+    return type.equals(OrderType.ASK) ? "sell" : "buy";
+  }
+
+
+  public static Integer createBitcoindeBoolean(Boolean value) {
+    return Boolean.TRUE.equals(value) ? 1 : 0;
   }
 }

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/Bitcoinde.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/Bitcoinde.java
@@ -7,6 +7,7 @@ import javax.ws.rs.core.MediaType;
 import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeException;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeCompactOrderbookWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeOrderbookWrapper;
+import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeTradesWrapper;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.SynchronizedValueFactory;
 
@@ -34,5 +35,15 @@ public interface Bitcoinde {
       @QueryParam("order_requirements_fullfilled") Integer orderRequirementsFullfilled,
       @QueryParam("only_kyc_full") Integer onlyKycFull,
       @QueryParam("only_express_orders") Integer onlyExpressOrders)
+      throws IOException, BitcoindeException;
+
+  @GET
+  @Path("{trading_pair}/trades/history")
+  BitcoindeTradesWrapper getTrades(
+      @HeaderParam("X-API-KEY") String apiKey,
+      @HeaderParam("X-API-NONCE") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-API-SIGNATURE") ParamsDigest paramsDigest,
+      @PathParam("trading_pair") String tradingPair,
+      @QueryParam("since_tid") Integer since)
       throws IOException, BitcoindeException;
 }

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/Bitcoinde.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/Bitcoinde.java
@@ -1,11 +1,38 @@
 package org.knowm.xchange.bitcoinde.v4;
 
-import javax.ws.rs.Path;
+import java.io.IOException;
 import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeException;
+import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeCompactOrderbookWrapper;
+import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeOrderbookWrapper;
+import si.mazi.rescu.ParamsDigest;
+import si.mazi.rescu.SynchronizedValueFactory;
 
 @Path("v4")
 @Produces(MediaType.APPLICATION_JSON)
 public interface Bitcoinde {
     
+  @GET
+  @Path("{trading_pair}/orderbook/compact")
+  BitcoindeCompactOrderbookWrapper getCompactOrderBook(
+      @HeaderParam("X-API-KEY") String apiKey,
+      @HeaderParam("X-API-NONCE") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-API-SIGNATURE") ParamsDigest paramsDigest,
+      @PathParam("trading_pair") String tradingPair)
+      throws IOException, BitcoindeException;
+
+  @GET
+  @Path("{trading_pair}/orderbook")
+  BitcoindeOrderbookWrapper getOrderBook(
+      @HeaderParam("X-API-KEY") String apiKey,
+      @HeaderParam("X-API-NONCE") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-API-SIGNATURE") ParamsDigest paramsDigest,
+      @PathParam("trading_pair") String tradingPair,
+      @QueryParam("type") String type,
+      @QueryParam("order_requirements_fullfilled") Integer orderRequirementsFullfilled,
+      @QueryParam("only_kyc_full") Integer onlyKycFull,
+      @QueryParam("only_express_orders") Integer onlyExpressOrders)
+      throws IOException, BitcoindeException;
 }

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/Bitcoinde.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/Bitcoinde.java
@@ -5,6 +5,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeException;
+import org.knowm.xchange.bitcoinde.v4.dto.account.BitcoindeAccountWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeCompactOrderbookWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeOrderbookWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeTradesWrapper;
@@ -45,5 +46,13 @@ public interface Bitcoinde {
       @HeaderParam("X-API-SIGNATURE") ParamsDigest paramsDigest,
       @PathParam("trading_pair") String tradingPair,
       @QueryParam("since_tid") Integer since)
+      throws IOException, BitcoindeException;
+
+  @GET
+  @Path("account")
+  BitcoindeAccountWrapper getAccount(
+      @HeaderParam("X-API-KEY") String apiKey,
+      @HeaderParam("X-API-NONCE") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-API-SIGNATURE") ParamsDigest paramsDigest)
       throws IOException, BitcoindeException;
 }

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/Bitcoinde.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/Bitcoinde.java
@@ -5,6 +5,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeException;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeResponse;
 import org.knowm.xchange.bitcoinde.v4.dto.account.BitcoindeAccountLedgerWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.account.BitcoindeAccountWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeCompactOrderbookWrapper;
@@ -98,4 +99,14 @@ public interface Bitcoinde {
       @QueryParam("page") Integer page)
       throws IOException, BitcoindeException;
 
+
+  @DELETE
+  @Path("{trading_pair}/orders/{order_id}")
+  BitcoindeResponse deleteOrder(
+      @HeaderParam("X-API-KEY") String apiKey,
+      @HeaderParam("X-API-NONCE") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-API-SIGNATURE") ParamsDigest paramsDigest,
+      @PathParam("order_id") String orderId,
+      @PathParam("trading_pair") String tradingPair)
+      throws IOException, BitcoindeException;
 }

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/Bitcoinde.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/Bitcoinde.java
@@ -1,7 +1,7 @@
 package org.knowm.xchange.bitcoinde.v4;
 
 import java.io.IOException;
-import javax.ws.rs.Produces;
+import java.math.BigDecimal;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeException;
@@ -11,6 +11,7 @@ import org.knowm.xchange.bitcoinde.v4.dto.account.BitcoindeAccountWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeCompactOrderbookWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeOrderbookWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeTradesWrapper;
+import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeIdResponse;
 import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeMyOrdersWrapper;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.SynchronizedValueFactory;
@@ -99,6 +100,17 @@ public interface Bitcoinde {
       @QueryParam("page") Integer page)
       throws IOException, BitcoindeException;
 
+  @POST
+  @Path("{trading_pair}/orders")
+  BitcoindeIdResponse createOrder(
+      @HeaderParam("X-API-KEY") String apiKey,
+      @HeaderParam("X-API-NONCE") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-API-SIGNATURE") ParamsDigest paramsDigest,
+      @FormParam("max_amount_currency_to_trade") BigDecimal maxAmount,
+      @FormParam("price") BigDecimal price,
+      @PathParam("trading_pair") String tradingPair,
+      @FormParam("type") String type)
+      throws IOException, BitcoindeException;
 
   @DELETE
   @Path("{trading_pair}/orders/{order_id}")

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/Bitcoinde.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/Bitcoinde.java
@@ -1,0 +1,11 @@
+package org.knowm.xchange.bitcoinde.v4;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("v4")
+@Produces(MediaType.APPLICATION_JSON)
+public interface Bitcoinde {
+    
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/Bitcoinde.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/Bitcoinde.java
@@ -10,6 +10,7 @@ import org.knowm.xchange.bitcoinde.v4.dto.account.BitcoindeAccountWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeCompactOrderbookWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeOrderbookWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeTradesWrapper;
+import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeMyOrdersWrapper;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.SynchronizedValueFactory;
 
@@ -69,4 +70,32 @@ public interface Bitcoinde {
       @QueryParam("datetime_end") String datetimeEnd,
       @QueryParam("page") Integer page)
       throws IOException, BitcoindeException;
+
+  @GET
+  @Path("orders")
+  BitcoindeMyOrdersWrapper getMyOrders(
+      @HeaderParam("X-API-KEY") String apiKey,
+      @HeaderParam("X-API-NONCE") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-API-SIGNATURE") ParamsDigest paramsDigest,
+      @QueryParam("type") String type,
+      @QueryParam("state") Integer state,
+      @QueryParam("date_start") String start,
+      @QueryParam("date_end") String end,
+      @QueryParam("page") Integer page)
+      throws IOException, BitcoindeException;
+
+  @GET
+  @Path("{trading_pair}/orders")
+  BitcoindeMyOrdersWrapper getMyOrders(
+      @HeaderParam("X-API-KEY") String apiKey,
+      @HeaderParam("X-API-NONCE") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-API-SIGNATURE") ParamsDigest paramsDigest,
+      @PathParam("trading_pair") String tradingPair,
+      @QueryParam("type") String type,
+      @QueryParam("state") Integer state,
+      @QueryParam("date_start") String start,
+      @QueryParam("date_end") String end,
+      @QueryParam("page") Integer page)
+      throws IOException, BitcoindeException;
+
 }

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/Bitcoinde.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/Bitcoinde.java
@@ -13,13 +13,14 @@ import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeOrderbookWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeTradesWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeIdResponse;
 import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeMyOrdersWrapper;
+import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeMyTradesWrapper;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 @Path("v4")
 @Produces(MediaType.APPLICATION_JSON)
 public interface Bitcoinde {
-    
+
   @GET
   @Path("{trading_pair}/orderbook/compact")
   BitcoindeCompactOrderbookWrapper getCompactOrderBook(
@@ -120,5 +121,38 @@ public interface Bitcoinde {
       @HeaderParam("X-API-SIGNATURE") ParamsDigest paramsDigest,
       @PathParam("order_id") String orderId,
       @PathParam("trading_pair") String tradingPair)
+      throws IOException, BitcoindeException;
+
+  @GET
+  @Path("trades")
+  BitcoindeMyTradesWrapper getMyTrades(
+      @HeaderParam("X-API-KEY") String apiKey,
+      @HeaderParam("X-API-NONCE") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-API-SIGNATURE") ParamsDigest paramsDigest,
+      @QueryParam("type") String type,
+      @QueryParam("state") Integer state,
+      @QueryParam("only_trades_with_action_for_payment_or_transfer_required")
+          Integer onlyTradesWithActionForPaymentOrTransferRequired,
+      @QueryParam("payment_method") Integer paymentMethod,
+      @QueryParam("date_start") String dateStart,
+      @QueryParam("date_end") String dateEnd,
+      @QueryParam("page") Integer page)
+      throws IOException, BitcoindeException;
+
+  @GET
+  @Path("{trading_pair}/trades")
+  BitcoindeMyTradesWrapper getMyTrades(
+      @HeaderParam("X-API-KEY") String apiKey,
+      @HeaderParam("X-API-NONCE") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-API-SIGNATURE") ParamsDigest paramsDigest,
+      @PathParam("trading_pair") String tradingPair,
+      @QueryParam("type") String type,
+      @QueryParam("state") Integer state,
+      @QueryParam("only_trades_with_action_for_payment_or_transfer_required")
+          Integer onlyTradesWithActionForPaymentOrTransferRequired,
+      @QueryParam("payment_method") Integer paymentMethod,
+      @QueryParam("date_start") String dateStart,
+      @QueryParam("date_end") String dateEnd,
+      @QueryParam("page") Integer page)
       throws IOException, BitcoindeException;
 }

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/Bitcoinde.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/Bitcoinde.java
@@ -5,6 +5,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeException;
+import org.knowm.xchange.bitcoinde.v4.dto.account.BitcoindeAccountLedgerWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.account.BitcoindeAccountWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeCompactOrderbookWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeOrderbookWrapper;
@@ -54,5 +55,18 @@ public interface Bitcoinde {
       @HeaderParam("X-API-KEY") String apiKey,
       @HeaderParam("X-API-NONCE") SynchronizedValueFactory<Long> nonce,
       @HeaderParam("X-API-SIGNATURE") ParamsDigest paramsDigest)
+      throws IOException, BitcoindeException;
+
+  @GET
+  @Path("{currency}/account/ledger")
+  BitcoindeAccountLedgerWrapper getAccountLedger(
+      @HeaderParam("X-API-KEY") String apiKey,
+      @HeaderParam("X-API-NONCE") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-API-SIGNATURE") ParamsDigest paramsDigest,
+      @PathParam("currency") String currency,
+      @QueryParam("type") String type,
+      @QueryParam("datetime_start") String datetimeStart,
+      @QueryParam("datetime_end") String datetimeEnd,
+      @QueryParam("page") Integer page)
       throws IOException, BitcoindeException;
 }

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeAdapters.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeAdapters.java
@@ -1,0 +1,9 @@
+package org.knowm.xchange.bitcoinde.v4;
+
+public final class BitcoindeAdapters {
+
+  /** Private constructor. */
+  private BitcoindeAdapters() {}
+
+  
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeAdapters.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeAdapters.java
@@ -10,6 +10,9 @@ import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderStatus;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.marketdata.Trade;
+import org.knowm.xchange.dto.marketdata.Trades;
+import org.knowm.xchange.dto.marketdata.Trades.TradeSortType;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
 public final class BitcoindeAdapters {
@@ -128,4 +131,36 @@ public final class BitcoindeAdapters {
         requirements.getSeatOfBank(),
         requirements.getPaymentOption());
   }
+
+  /**
+   * Adapt a org.knowm.xchange.bitcoinde.dto.marketdata.BitcoindeTrade[] object to a Trades object.
+   *
+   * @param bitcoindeTradesWrapper Exchange specific trades
+   * @param currencyPair (e.g. BTC/USD)
+   * @return The XChange Trades
+   */
+  public static Trades adaptTrades(
+          BitcoindeTradesWrapper bitcoindeTradesWrapper, CurrencyPair currencyPair) {
+    final List<Trade> trades = new ArrayList<>();
+    long lastTradeId = 0;
+
+    for (BitcoindeTrade bitcoindeTrade : bitcoindeTradesWrapper.getTrades()) {
+      final long tid = bitcoindeTrade.getTid();
+
+      if (tid > lastTradeId) {
+        lastTradeId = tid;
+      }
+      trades.add(
+              new Trade.Builder()
+                      .originalAmount(bitcoindeTrade.getAmount())
+                      .currencyPair(currencyPair)
+                      .price(bitcoindeTrade.getPrice())
+                      .timestamp(bitcoindeTrade.getDate())
+                      .id(String.valueOf(tid))
+                      .build());
+    }
+
+    return new Trades(trades, lastTradeId, TradeSortType.SortByID);
+  }
+
 }

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeAdapters.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeAdapters.java
@@ -1,9 +1,131 @@
 package org.knowm.xchange.bitcoinde.v4;
 
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.knowm.xchange.bitcoinde.v4.dto.*;
+import org.knowm.xchange.bitcoinde.v4.dto.marketdata.*;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order.OrderStatus;
+import org.knowm.xchange.dto.Order.OrderType;
+import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.dto.trade.OpenOrders;
 public final class BitcoindeAdapters {
 
   /** Private constructor. */
   private BitcoindeAdapters() {}
 
-  
+  /**
+   * Adapt a org.knowm.xchange.bitcoinde.dto.marketdata.BitcoindeOrderBook object to an OrderBook
+   * object.
+   *
+   * @param bitcoindeOrderbookWrapper the exchange specific OrderBook object
+   * @param currencyPair (e.g. BTC/USD)
+   * @return The XChange OrderBook
+   */
+  public static OrderBook adaptCompactOrderBook(
+      BitcoindeCompactOrderbookWrapper bitcoindeOrderbookWrapper, CurrencyPair currencyPair) {
+    final List<LimitOrder> asks =
+        createCompactOrders(
+            currencyPair, OrderType.ASK, bitcoindeOrderbookWrapper.getBitcoindeOrders().getAsks());
+    final List<LimitOrder> bids =
+        createCompactOrders(
+            currencyPair, OrderType.BID, bitcoindeOrderbookWrapper.getBitcoindeOrders().getBids());
+
+    Collections.sort(asks);
+    Collections.sort(bids);
+
+    return new OrderBook(null, asks, bids);
+  }
+
+  public static OrderBook adaptOrderBook(
+      BitcoindeOrderbookWrapper asksWrapper,
+      BitcoindeOrderbookWrapper bidsWrapper,
+      CurrencyPair currencyPair) {
+    final List<LimitOrder> asks =
+        createOrders(currencyPair, OrderType.ASK, asksWrapper.getBitcoindeOrders());
+    final List<LimitOrder> bids =
+        createOrders(currencyPair, OrderType.BID, bidsWrapper.getBitcoindeOrders());
+
+    Collections.sort(asks);
+    Collections.sort(bids);
+
+    return new OrderBook(null, asks, bids);
+  }
+
+  /** Create a list of orders from a list of asks or bids. */
+  public static List<LimitOrder> createCompactOrders(
+      CurrencyPair currencyPair, OrderType orderType, BitcoindeCompactOrder[] orders) {
+    final List<LimitOrder> limitOrders = new ArrayList<>();
+
+    for (BitcoindeCompactOrder order : orders) {
+      limitOrders.add(
+          new LimitOrder(orderType, order.getAmount(), currencyPair, null, null, order.getPrice()));
+    }
+
+    return limitOrders;
+  }
+
+  private static List<LimitOrder> createOrders(
+      CurrencyPair currencyPair, OrderType orderType, BitcoindeOrder[] orders) {
+    final List<LimitOrder> limitOrders = new ArrayList<>();
+
+    for (BitcoindeOrder order : orders) {
+      limitOrders.add(createOrder(currencyPair, order, orderType, order.getOrderId(), null));
+    }
+
+    return limitOrders;
+  }
+
+  /** Create an individual order. */
+  public static LimitOrder createOrder(
+      CurrencyPair currencyPair,
+      BitcoindeOrder bitcoindeOrder,
+      OrderType orderType,
+      String orderId,
+      Date timeStamp) {
+    final LimitOrder.Builder limitOrder =
+        new LimitOrder.Builder(orderType, currencyPair)
+            .id(orderId)
+            .timestamp(timeStamp)
+            .originalAmount(bitcoindeOrder.getMaxAmount())
+            .limitPrice(bitcoindeOrder.getPrice())
+            .orderStatus(OrderStatus.NEW);
+
+    limitOrder.flag(
+        new BitcoindeOrderFlagsOrderQuantities(
+            bitcoindeOrder.getMinAmount(),
+            bitcoindeOrder.getMaxAmount(),
+            bitcoindeOrder.getMinVolume(),
+            bitcoindeOrder.getMaxVolume()));
+    if (bitcoindeOrder.getTradingPartnerInformation() != null) {
+      final BitcoindeOrderFlagsTradingPartnerInformation tpi =
+          new BitcoindeOrderFlagsTradingPartnerInformation(
+              bitcoindeOrder.getTradingPartnerInformation().getUserName(),
+              bitcoindeOrder.getTradingPartnerInformation().getKycFull(),
+              bitcoindeOrder.getTradingPartnerInformation().getTrustLevel());
+      tpi.setBankName(bitcoindeOrder.getTradingPartnerInformation().getBankName());
+      tpi.setBic(bitcoindeOrder.getTradingPartnerInformation().getBic());
+      tpi.setSeatOfBank(bitcoindeOrder.getTradingPartnerInformation().getSeatOfBank());
+      tpi.setRating(bitcoindeOrder.getTradingPartnerInformation().getRating());
+      tpi.setNumberOfTrades(bitcoindeOrder.getTradingPartnerInformation().getAmountTrades());
+      limitOrder.flag(tpi);
+    }
+    if (bitcoindeOrder.getOrderRequirements() != null) {
+      limitOrder.flag(adaptOrderRequirements(bitcoindeOrder.getOrderRequirements()));
+    }
+
+    return limitOrder.build();
+  }
+
+  private static BitcoindeOrderFlagsOrderRequirements adaptOrderRequirements(
+      BitcoindeOrderRequirements requirements) {
+    return new BitcoindeOrderFlagsOrderRequirements(
+        requirements.getMinTrustLevel(),
+        requirements.getOnlyKycFull(),
+        requirements.getSeatOfBank(),
+        requirements.getPaymentOption());
+  }
 }

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeErrorAdapter.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeErrorAdapter.java
@@ -1,0 +1,94 @@
+package org.knowm.xchange.bitcoinde.v4;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeError;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeException;
+import org.knowm.xchange.exceptions.*;
+
+public final class BitcoindeErrorAdapter {
+
+  private static final List<ExceptionTranslation> TRANSLATIONS = new LinkedList<>();
+
+  static {
+    TRANSLATIONS.add(
+        new ExceptionTranslation(
+            (error, exception) ->
+                new NonceException(error.toString() + ", Last Nonce: " + exception.getNonce()),
+            4));
+
+    TRANSLATIONS.add(
+        new ExceptionTranslation(
+            (error, exception) ->
+                new RateLimitExceededException(
+                    error.toString() + ", Credits: " + exception.getCredits()),
+            6));
+
+    TRANSLATIONS.add(
+        new ExceptionTranslation(
+            (error, exception) -> new ExchangeSecurityException(error.toString()),
+            2, // Inactive api key
+            3, // Invalid api key
+            5, // Invalid signature
+            9, // Additional agreement not accepted
+            10, //	No 2 factor authentication
+            11, //	No beta group user
+            14, // No action permission for api key
+            32, //	Api key banned
+            33, //	Ip banned
+            94 //	Ip access restricted
+            ));
+
+    TRANSLATIONS.add(
+        new ExceptionTranslation(
+            (error, exception) -> new NotAvailableFromExchangeException(error.toString()),
+            7, // Invalid route
+            8 // Unkown api action
+            ));
+  }
+
+  private BitcoindeErrorAdapter() {}
+
+  public static RuntimeException adaptBitcoindeException(final BitcoindeException exception) {
+    for (ExceptionTranslation translation : TRANSLATIONS) {
+      final Optional<BitcoindeError> error =
+          getErrorCode(exception.getErrors(), translation.getErrorCodes());
+      if (error.isPresent()) {
+        return translation.provider.provide(error.get(), exception);
+      }
+    }
+
+    return new ExchangeException(exception.getMessage(), exception);
+  }
+
+  private static Optional<BitcoindeError> getErrorCode(
+      final BitcoindeError[] errors, final int[] errorCodes) {
+    return Arrays.stream(errors)
+        .filter(
+            error -> Arrays.stream(errorCodes).anyMatch(errorCode -> error.getCode() == errorCode))
+        .findFirst();
+  }
+
+  @Getter
+  @EqualsAndHashCode
+  @ToString
+  private static final class ExceptionTranslation {
+    private final ExceptionProvider provider;
+    private final int[] errorCodes;
+
+    public ExceptionTranslation(final ExceptionProvider provider, final int... errorCodes) {
+      this.provider = provider;
+      this.errorCodes = errorCodes;
+    }
+  }
+
+  @FunctionalInterface
+  private interface ExceptionProvider {
+    RuntimeException provide(BitcoindeError error, BitcoindeException exception);
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeExchange.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeExchange.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.bitcoinde.v4;
 import org.knowm.xchange.BaseExchange;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.bitcoinde.v4.service.BitcoindeMarketDataService;
 import org.knowm.xchange.utils.nonce.CurrentTimeNonceFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
@@ -26,7 +27,7 @@ public class BitcoindeExchange extends BaseExchange implements Exchange {
 
   @Override
   protected void initServices() {
-    
+    this.marketDataService = new BitcoindeMarketDataService(this);
   }
 
   @Override

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeExchange.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeExchange.java
@@ -1,0 +1,36 @@
+package org.knowm.xchange.bitcoinde.v4;
+
+import org.knowm.xchange.BaseExchange;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.utils.nonce.CurrentTimeNonceFactory;
+import si.mazi.rescu.SynchronizedValueFactory;
+
+public class BitcoindeExchange extends BaseExchange implements Exchange {
+
+  private SynchronizedValueFactory<Long> nonceFactory = new CurrentTimeNonceFactory();
+
+  @Override
+  public ExchangeSpecification getDefaultExchangeSpecification() {
+    final ExchangeSpecification exchangeSpecification =
+        new ExchangeSpecification(this.getClass().getCanonicalName());
+    exchangeSpecification.setSslUri("https://api.bitcoin.de/");
+    exchangeSpecification.setHost("bitcoin.de");
+    exchangeSpecification.setPort(80);
+    exchangeSpecification.setExchangeName("Bitcoin.de");
+    exchangeSpecification.setExchangeDescription(
+        "Bitcoin.de is the largest bitcoin marketplace in Europe. All servers are located in Germany.");
+
+    return exchangeSpecification;
+  }
+
+  @Override
+  protected void initServices() {
+    
+  }
+
+  @Override
+  public SynchronizedValueFactory<Long> getNonceFactory() {
+    return nonceFactory;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeExchange.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeExchange.java
@@ -5,6 +5,7 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.bitcoinde.v4.service.BitcoindeAccountService;
 import org.knowm.xchange.bitcoinde.v4.service.BitcoindeMarketDataService;
+import org.knowm.xchange.bitcoinde.v4.service.BitcoindeTradeService;
 import org.knowm.xchange.utils.nonce.CurrentTimeNonceFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
@@ -29,6 +30,7 @@ public class BitcoindeExchange extends BaseExchange implements Exchange {
   @Override
   protected void initServices() {
     this.marketDataService = new BitcoindeMarketDataService(this);
+    this.tradeService = new BitcoindeTradeService(this);
     this.accountService = new BitcoindeAccountService(this);
   }
 

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeExchange.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeExchange.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.bitcoinde.v4;
 import org.knowm.xchange.BaseExchange;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.bitcoinde.v4.service.BitcoindeAccountService;
 import org.knowm.xchange.bitcoinde.v4.service.BitcoindeMarketDataService;
 import org.knowm.xchange.utils.nonce.CurrentTimeNonceFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
@@ -28,6 +29,7 @@ public class BitcoindeExchange extends BaseExchange implements Exchange {
   @Override
   protected void initServices() {
     this.marketDataService = new BitcoindeMarketDataService(this);
+    this.accountService = new BitcoindeAccountService(this);
   }
 
   @Override

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeAccountLedgerType.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeAccountLedgerType.java
@@ -1,0 +1,29 @@
+package org.knowm.xchange.bitcoinde.v4.dto;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum BitcoindeAccountLedgerType {
+  ALL("all"),
+  BUY("buy"),
+  SELL("sell"),
+  INPAYMENT("inpayment"),
+  PAYOUT("payout"),
+  AFFILIATE("affiliate"),
+  WELCOME_BTC("welcome_btc"),
+  BUY_YUBIKEY("buy_yubikey"),
+  BUY_GOLDSHOP("buy_goldshop"),
+  BUY_DIAMONDSHOP("buy_diamondshop"),
+  KICKBACK("kickback"),
+  OUTGOING_FEE_VOLUNTARY("outgoing_fee_voluntary");
+
+  private final String value;
+
+  BitcoindeAccountLedgerType(final String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeError.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeError.java
@@ -1,0 +1,37 @@
+package org.knowm.xchange.bitcoinde.v4.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Value;
+import org.apache.commons.lang3.StringUtils;
+
+@Value
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeError {
+
+  String message;
+  Integer code;
+  String field;
+
+  @JsonCreator
+  public BitcoindeError(
+      @JsonProperty("message") String message,
+      @JsonProperty("code") Integer code,
+      @JsonProperty("field") String field) {
+    this.message = message;
+    this.code = code;
+    this.field = field;
+  }
+
+  /** Customized {@code toString()} methode for better usage in {@link BitcoindeException} */
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("Error ").append(code).append(": ").append(message);
+
+    if (StringUtils.isNotBlank(this.field)) {
+      sb.append(" (Field: ").append(this.field).append(")");
+    }
+    return sb.toString();
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeException.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeException.java
@@ -1,0 +1,39 @@
+package org.knowm.xchange.bitcoinde.v4.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeException extends RuntimeException {
+
+  Integer credits;
+  BitcoindeError[] errors;
+  BitcoindeMaintenance maintenance;
+  Long nonce;
+
+  @JsonCreator
+  public BitcoindeException(
+      @JsonProperty("credits") Integer credits,
+      @JsonProperty("errors") BitcoindeError[] errors,
+      @JsonProperty("maintenance") BitcoindeMaintenance maintenance,
+      @JsonProperty("nonce") Long nonce) {
+    this.credits = credits;
+    this.errors = errors;
+    this.maintenance = maintenance;
+    this.nonce = nonce;
+  }
+
+  @Override
+  public String getMessage() {
+    return Arrays.stream(this.errors)
+        .map(BitcoindeError::toString)
+        .collect(Collectors.joining(", "));
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeMaintenance.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeMaintenance.java
@@ -1,0 +1,26 @@
+package org.knowm.xchange.bitcoinde.v4.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Date;
+import lombok.Value;
+
+@Value
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class BitcoindeMaintenance {
+
+  String message;
+  Date start;
+  Date end;
+
+  @JsonCreator
+  public BitcoindeMaintenance(
+      @JsonProperty("message") String message,
+      @JsonProperty("start") Date start,
+      @JsonProperty("end") Date end) {
+    this.message = message;
+    this.start = start;
+    this.end = end;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeOrderFlagsOrderQuantities.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeOrderFlagsOrderQuantities.java
@@ -1,0 +1,42 @@
+package org.knowm.xchange.bitcoinde.v4.dto;
+
+import java.math.BigDecimal;
+import lombok.Value;
+import org.knowm.xchange.dto.Order.IOrderFlags;
+import org.knowm.xchange.dto.trade.LimitOrder;
+
+@Value
+public class BitcoindeOrderFlagsOrderQuantities implements IOrderFlags {
+
+  BigDecimal minAmountToTrade;
+  BigDecimal maxAmountToTrade;
+  BigDecimal minVolumeToPay;
+  BigDecimal maxVolumeToPay;
+
+  /**
+   * Returns a hash code value for the class itself. This ensure that {@link
+   * LimitOrder#getOrderFlags()} can only contain a single instance of {@code
+   * BitcoindeOrderFlagsOrderQuantities}.
+   *
+   * @return a hash code value for this object.
+   * @see java.lang.Object#equals(java.lang.Object)
+   */
+  @Override
+  public int hashCode() {
+    return BitcoindeOrderFlagsOrderQuantities.class.hashCode();
+  }
+
+  /**
+   * Indicates whether some other object is "equal to" this one by checking whether this is an
+   * instance of {@code BitcoindeOrderFlagsOrderQuantities} to comply with #hashCode()
+   *
+   * @param obj the reference object with which to compare.
+   * @return {@code true} if the obj argument is {@code instanceof
+   *     BitcoindeOrderFlagsOrderQuantities}; {@code false} otherwise.
+   * @see #hashCode()
+   */
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof BitcoindeOrderFlagsOrderQuantities;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeOrderFlagsOrderRequirements.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeOrderFlagsOrderRequirements.java
@@ -1,0 +1,45 @@
+package org.knowm.xchange.bitcoinde.v4.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.knowm.xchange.dto.Order.IOrderFlags;
+import org.knowm.xchange.dto.trade.LimitOrder;
+
+@Data
+@RequiredArgsConstructor
+@AllArgsConstructor
+public final class BitcoindeOrderFlagsOrderRequirements implements IOrderFlags {
+
+  private final BitcoindeTrustLevel minTrustLevel;
+  private Boolean onlyKYCFull;
+  private String[] seatsOfBank;
+  private BitcoindePaymentOption paymentOption;
+
+  /**
+   * Returns a hash code value for the class itself. This ensure that {@link
+   * LimitOrder#getOrderFlags()} can only contain a single instance of {@code
+   * BitcoindeOrderRequirements}.
+   *
+   * @return a hash code value for this object.
+   * @see java.lang.Object#equals(java.lang.Object)
+   */
+  @Override
+  public int hashCode() {
+    return BitcoindeOrderFlagsOrderRequirements.class.hashCode();
+  }
+
+  /**
+   * Indicates whether some other object is "equal to" this one by checking whether this is an
+   * instance of {@code BitcoindeOrderRequirements} to comply with #hashCode()
+   *
+   * @param obj the reference object with which to compare.
+   * @return {@code true} if the obj argument is {@code instanceof BitcoindeOrderRequirements};
+   *     {@code false} otherwise.
+   * @see #hashCode()
+   */
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof BitcoindeOrderFlagsOrderRequirements;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeOrderFlagsTradingPartnerInformation.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeOrderFlagsTradingPartnerInformation.java
@@ -1,0 +1,49 @@
+package org.knowm.xchange.bitcoinde.v4.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.knowm.xchange.dto.Order.IOrderFlags;
+import org.knowm.xchange.dto.trade.LimitOrder;
+
+@Data
+@RequiredArgsConstructor
+@AllArgsConstructor
+public final class BitcoindeOrderFlagsTradingPartnerInformation implements IOrderFlags {
+
+  private final String userName;
+  private final boolean kycFull;
+  private final BitcoindeTrustLevel trustLevel;
+  private String bankName;
+  private String bic;
+  private String seatOfBank;
+  private Integer rating;
+  private Integer numberOfTrades;
+
+  /**
+   * Returns a hash code value for the class itself. This ensure that {@link
+   * LimitOrder#getOrderFlags()} can only contain a single instance of {@code
+   * BitcoindeOrderFlagsTradingPartnerInformation}.
+   *
+   * @return a hash code value for this object.
+   * @see java.lang.Object#equals(java.lang.Object)
+   */
+  @Override
+  public int hashCode() {
+    return BitcoindeOrderFlagsTradingPartnerInformation.class.hashCode();
+  }
+
+  /**
+   * Indicates whether some other object is "equal to" this one by checking whether this is an
+   * instance of {@code BitcoindeOrderFlagsTradingPartnerInformation} to comply with #hashCode()
+   *
+   * @param obj the reference object with which to compare.
+   * @return {@code true} if the obj argument is {@code instanceof
+   *     BitcoindeOrderFlagsTradingPartnerInformation}; {@code false} otherwise.
+   * @see #hashCode()
+   */
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof BitcoindeOrderFlagsTradingPartnerInformation;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeOrderRequirements.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeOrderRequirements.java
@@ -1,0 +1,28 @@
+package org.knowm.xchange.bitcoinde.v4.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Value;
+
+@Value
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeOrderRequirements {
+
+  BitcoindeTrustLevel minTrustLevel;
+  Boolean onlyKycFull;
+  String[] seatOfBank;
+  BitcoindePaymentOption paymentOption;
+
+  @JsonCreator
+  public BitcoindeOrderRequirements(
+      @JsonProperty("min_trust_level") BitcoindeTrustLevel minTrustLevel,
+      @JsonProperty("only_kyc_full") Boolean onlyKycFull,
+      @JsonProperty("seat_of_bank") String[] seatOfBank,
+      @JsonProperty("payment_option") BitcoindePaymentOption paymentOption) {
+    this.minTrustLevel = minTrustLevel;
+    this.onlyKycFull = onlyKycFull;
+    this.seatOfBank = seatOfBank;
+    this.paymentOption = paymentOption;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeOrderState.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeOrderState.java
@@ -1,0 +1,32 @@
+package org.knowm.xchange.bitcoinde.v4.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum BitcoindeOrderState {
+  EXPIRED(-2),
+  CANCELLED(-1),
+  PENDING(0);
+
+  private final int value;
+
+  BitcoindeOrderState(final int value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public int getValue() {
+    return value;
+  }
+
+  @JsonCreator
+  public static BitcoindeOrderState fromValue(final int value) {
+    for (BitcoindeOrderState bitcoindeOrderState : BitcoindeOrderState.values()) {
+      if (value == bitcoindeOrderState.getValue()) {
+        return bitcoindeOrderState;
+      }
+    }
+
+    throw new IllegalArgumentException("Unknown OrderState value: " + value);
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindePage.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindePage.java
@@ -1,0 +1,21 @@
+package org.knowm.xchange.bitcoinde.v4.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Value;
+
+@Value
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindePage {
+
+  Integer current;
+  Integer last;
+
+  @JsonCreator
+  public BitcoindePage(
+      @JsonProperty("current") Integer current, @JsonProperty("last") Integer last) {
+    this.current = current;
+    this.last = last;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindePagedResponse.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindePagedResponse.java
@@ -1,0 +1,27 @@
+package org.knowm.xchange.bitcoinde.v4.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@EqualsAndHashCode(callSuper = true)
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindePagedResponse extends BitcoindeResponse {
+
+  @Getter private final BitcoindePage page;
+
+  @JsonCreator
+  public BitcoindePagedResponse(
+      @JsonProperty("page") BitcoindePage page,
+      @JsonProperty("credits") Integer credits,
+      @JsonProperty("errors") BitcoindeError[] errors,
+      @JsonProperty("maintenance") BitcoindeMaintenance maintenance,
+      @JsonProperty("nonce") Long nonce) {
+    super(credits, errors, maintenance, nonce);
+    this.page = page;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindePaymentOption.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindePaymentOption.java
@@ -1,0 +1,32 @@
+package org.knowm.xchange.bitcoinde.v4.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum BitcoindePaymentOption {
+  EXPRESS_ONLY(1),
+  SEPA_ONLY(2),
+  EXPRESS_SEPA(3);
+
+  private final int value;
+
+  BitcoindePaymentOption(final int value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public int getValue() {
+    return value;
+  }
+
+  @JsonCreator
+  public static BitcoindePaymentOption fromValue(final int value) {
+    for (BitcoindePaymentOption paymentOption : BitcoindePaymentOption.values()) {
+      if (value == paymentOption.getValue()) {
+        return paymentOption;
+      }
+    }
+
+    throw new IllegalArgumentException("Unknown PaymentOption value: " + value);
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeResponse.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeResponse.java
@@ -1,0 +1,28 @@
+package org.knowm.xchange.bitcoinde.v4.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeResponse {
+
+  private final Integer credits;
+  private final BitcoindeError[] errors;
+  private final BitcoindeMaintenance maintenance;
+  private final Long nonce;
+
+  @JsonCreator
+  public BitcoindeResponse(
+      @JsonProperty("credits") Integer credits,
+      @JsonProperty("errors") BitcoindeError[] errors,
+      @JsonProperty("maintenance") BitcoindeMaintenance maintenance,
+      @JsonProperty("nonce") Long nonce) {
+    this.credits = credits;
+    this.errors = errors;
+    this.maintenance = maintenance;
+    this.nonce = nonce;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeTradingPartnerInformation.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeTradingPartnerInformation.java
@@ -1,0 +1,46 @@
+package org.knowm.xchange.bitcoinde.v4.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Value;
+
+@Value
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeTradingPartnerInformation {
+
+  String userName;
+  Boolean kycFull;
+  BitcoindeTrustLevel trustLevel;
+  String depositor;
+  String iban;
+  String bankName;
+  String bic;
+  String seatOfBank;
+  Integer rating;
+  Integer amountTrades;
+
+  @JsonCreator
+  public BitcoindeTradingPartnerInformation(
+      @JsonProperty("username") String userName,
+      @JsonProperty("is_kyc_full") Boolean kycFull,
+      @JsonProperty("trust_level") BitcoindeTrustLevel trustLevel,
+      @JsonProperty("depositor") String depositor,
+      @JsonProperty("iban") String iban,
+      @JsonProperty("bank_name") String bankName,
+      @JsonProperty("bic") String bic,
+      @JsonProperty("seat_of_bank") String seatOfBank,
+      @JsonProperty("rating") Integer rating,
+      @JsonProperty("amount_trades") Integer amountTrades) {
+    this.userName = userName;
+    this.kycFull = kycFull;
+    this.trustLevel = trustLevel;
+    this.depositor = depositor;
+    this.iban = iban;
+    this.bankName = bankName;
+    this.bic = bic;
+    this.seatOfBank = seatOfBank;
+    this.rating = rating;
+    this.amountTrades = amountTrades;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeTrustLevel.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeTrustLevel.java
@@ -1,0 +1,21 @@
+package org.knowm.xchange.bitcoinde.v4.dto;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum BitcoindeTrustLevel {
+  BRONZE("bronze"),
+  SILVER("silver"),
+  GOLD("gold"),
+  PLATIN("platin");
+
+  private final String value;
+
+  BitcoindeTrustLevel(final String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeType.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeType.java
@@ -1,0 +1,19 @@
+package org.knowm.xchange.bitcoinde.v4.dto;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum BitcoindeType {
+  BUY("buy"),
+  SELL("sell");
+
+  private final String value;
+
+  BitcoindeType(final String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeAccountLedger.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeAccountLedger.java
@@ -1,0 +1,89 @@
+package org.knowm.xchange.bitcoinde.v4.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.math.BigDecimal;
+import java.util.Date;
+import lombok.Value;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeAccountLedgerType;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.utils.jackson.CurrencyPairDeserializer;
+
+@Value
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeAccountLedger {
+
+  Date date;
+  BitcoindeAccountLedgerType type;
+  String reference;
+  BigDecimal cashflow;
+  BigDecimal balance;
+  BitcoindeAccountLedgerTrade trade;
+
+  @JsonCreator
+  public BitcoindeAccountLedger(
+      @JsonProperty("date") Date date,
+      @JsonProperty("type") BitcoindeAccountLedgerType type,
+      @JsonProperty("reference") String reference,
+      @JsonProperty("cashflow") BigDecimal cashflow,
+      @JsonProperty("balance") BigDecimal balance,
+      @JsonProperty("trade") BitcoindeAccountLedgerTrade trade) {
+    this.date = date;
+    this.type = type;
+    this.reference = reference;
+    this.cashflow = cashflow;
+    this.balance = balance;
+    this.trade = trade;
+  }
+
+  @Value
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class BitcoindeAccountLedgerTrade {
+
+    String tradeId;
+    CurrencyPair tradingPair;
+    BigDecimal price;
+    Boolean isExternalWalletTrade;
+    BitcoindeAccountLedgerTradingAmount currencyToTrade;
+    BitcoindeAccountLedgerTradingAmount currencyToPay;
+
+    @JsonCreator
+    public BitcoindeAccountLedgerTrade(
+        @JsonProperty("trade_id") String tradeId,
+        @JsonProperty("trading_pair") @JsonDeserialize(using = CurrencyPairDeserializer.class)
+            CurrencyPair tradingPair,
+        @JsonProperty("price") BigDecimal price,
+        @JsonProperty("is_external_wallet_trade") Boolean isExternalWalletTrade,
+        @JsonProperty("currency_to_trade") BitcoindeAccountLedgerTradingAmount currencyToTrade,
+        @JsonProperty("currency_to_pay") BitcoindeAccountLedgerTradingAmount currencyToPay) {
+      this.tradeId = tradeId;
+      this.tradingPair = tradingPair;
+      this.price = price;
+      this.isExternalWalletTrade = isExternalWalletTrade;
+      this.currencyToTrade = currencyToTrade;
+      this.currencyToPay = currencyToPay;
+    }
+  }
+
+  @Value
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class BitcoindeAccountLedgerTradingAmount {
+
+    Currency currency;
+    BigDecimal beforeFee;
+    BigDecimal afterFee;
+
+    @JsonCreator
+    public BitcoindeAccountLedgerTradingAmount(
+        @JsonProperty("currency") Currency currency,
+        @JsonProperty("before_fee") BigDecimal beforeFee,
+        @JsonProperty("after_fee") BigDecimal afterFee) {
+      this.currency = currency;
+      this.beforeFee = beforeFee;
+      this.afterFee = afterFee;
+    }
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeAccountLedgerWrapper.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeAccountLedgerWrapper.java
@@ -1,0 +1,32 @@
+package org.knowm.xchange.bitcoinde.v4.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeError;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeMaintenance;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindePage;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindePagedResponse;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeAccountLedgerWrapper extends BitcoindePagedResponse {
+
+  List<BitcoindeAccountLedger> accountLedgers;
+
+  @JsonCreator
+  public BitcoindeAccountLedgerWrapper(
+      @JsonProperty("account_ledger") List<BitcoindeAccountLedger> accountLedgers,
+      @JsonProperty("page") BitcoindePage page,
+      @JsonProperty("credits") Integer credits,
+      @JsonProperty("errors") BitcoindeError[] errors,
+      @JsonProperty("maintenance") BitcoindeMaintenance maintenance,
+      @JsonProperty("nonce") Long nonce) {
+    super(page, credits, errors, maintenance, nonce);
+    this.accountLedgers = accountLedgers;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeAccountWrapper.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeAccountWrapper.java
@@ -1,0 +1,29 @@
+package org.knowm.xchange.bitcoinde.v4.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeError;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeMaintenance;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeResponse;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeAccountWrapper extends BitcoindeResponse {
+
+  BitcoindeData data;
+
+  @JsonCreator
+  public BitcoindeAccountWrapper(
+      @JsonProperty("data") BitcoindeData data,
+      @JsonProperty("credits") Integer credits,
+      @JsonProperty("errors") BitcoindeError[] errors,
+      @JsonProperty("maintenance") BitcoindeMaintenance maintenance,
+      @JsonProperty("nonce") Long nonce) {
+    super(credits, errors, maintenance, nonce);
+    this.data = data;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeAllocation.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeAllocation.java
@@ -1,0 +1,26 @@
+package org.knowm.xchange.bitcoinde.v4.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import lombok.Value;
+
+@Value
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeAllocation {
+
+  BigDecimal percent;
+  BigDecimal maxEurVolume;
+  BigDecimal eurVolumeOpenOrders;
+
+  @JsonCreator
+  public BitcoindeAllocation(
+      @JsonProperty("percent") BigDecimal percent,
+      @JsonProperty("max_eur_volume") BigDecimal maxEurVolume,
+      @JsonProperty("eur_volume_open_orders") BigDecimal eurVolumeOpenOrders) {
+    this.percent = percent;
+    this.maxEurVolume = maxEurVolume;
+    this.eurVolumeOpenOrders = eurVolumeOpenOrders;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeBalance.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeBalance.java
@@ -1,0 +1,26 @@
+package org.knowm.xchange.bitcoinde.v4.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import lombok.Value;
+
+@Value
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeBalance {
+
+  BigDecimal availableAmount;
+  BigDecimal reservedAmount;
+  BigDecimal totalAmount;
+
+  @JsonCreator
+  public BitcoindeBalance(
+      @JsonProperty("available_amount") BigDecimal availableAmount,
+      @JsonProperty("reserved_amount") BigDecimal reservedAmount,
+      @JsonProperty("total_amount") BigDecimal totalAmount) {
+    this.availableAmount = availableAmount;
+    this.reservedAmount = reservedAmount;
+    this.totalAmount = totalAmount;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeData.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeData.java
@@ -1,0 +1,26 @@
+package org.knowm.xchange.bitcoinde.v4.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+import lombok.Value;
+
+@Value
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeData {
+
+  Map<String, BitcoindeBalance> balances;
+  BitcoindeFidorReservation fidorReservation;
+  BitcoindeEncryptedInformation encryptedInformation;
+
+  @JsonCreator
+  public BitcoindeData(
+      @JsonProperty("balances") Map<String, BitcoindeBalance> btcBalances,
+      @JsonProperty("fidor_reservation") BitcoindeFidorReservation fidorReservation,
+      @JsonProperty("encrypted_information") BitcoindeEncryptedInformation encryptedInformation) {
+    this.balances = btcBalances;
+    this.fidorReservation = fidorReservation;
+    this.encryptedInformation = encryptedInformation;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeEncryptedInformation.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeEncryptedInformation.java
@@ -1,0 +1,25 @@
+package org.knowm.xchange.bitcoinde.v4.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Value;
+
+@Value
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeEncryptedInformation {
+
+  String bicShort;
+  String bicFull;
+  String uid;
+
+  @JsonCreator
+  public BitcoindeEncryptedInformation(
+      @JsonProperty("bic_short") String bicShort,
+      @JsonProperty("bic_full") String bicFull,
+      @JsonProperty("uid") String uid) {
+    this.bicShort = bicShort;
+    this.bicFull = bicFull;
+    this.uid = uid;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeFidorReservation.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeFidorReservation.java
@@ -1,0 +1,33 @@
+package org.knowm.xchange.bitcoinde.v4.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.util.Map;
+import lombok.Value;
+
+@Value
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeFidorReservation {
+
+  BigDecimal totalAmount;
+  BigDecimal availableAmount;
+  String reservedAt;
+  String validUntil;
+  Map<String, BitcoindeAllocation> allocation;
+
+  @JsonCreator
+  public BitcoindeFidorReservation(
+      @JsonProperty("total_amount") BigDecimal totalAmount,
+      @JsonProperty("available_amount") BigDecimal availableAmount,
+      @JsonProperty("reserved_at") String reservedAt,
+      @JsonProperty("valid_until") String validUntil,
+      @JsonProperty("allocation") Map<String, BitcoindeAllocation> allocation) {
+    this.totalAmount = totalAmount;
+    this.availableAmount = availableAmount;
+    this.reservedAt = reservedAt;
+    this.validUntil = validUntil;
+    this.allocation = allocation;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeCompactOrder.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeCompactOrder.java
@@ -1,0 +1,23 @@
+package org.knowm.xchange.bitcoinde.v4.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import lombok.Value;
+
+@Value
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeCompactOrder {
+
+  BigDecimal price;
+  BigDecimal amount;
+
+  @JsonCreator
+  public BitcoindeCompactOrder(
+      @JsonProperty("price") BigDecimal price,
+      @JsonProperty("amount_currency_to_trade") BigDecimal amount) {
+    this.price = price;
+    this.amount = amount;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeCompactOrderbookWrapper.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeCompactOrderbookWrapper.java
@@ -1,0 +1,36 @@
+package org.knowm.xchange.bitcoinde.v4.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeError;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeMaintenance;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeResponse;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.utils.jackson.CurrencyPairDeserializer;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeCompactOrderbookWrapper extends BitcoindeResponse {
+
+  CurrencyPair tradingPair;
+  BitcoindeCompactOrders bitcoindeOrders;
+
+  @JsonCreator
+  public BitcoindeCompactOrderbookWrapper(
+      @JsonProperty("trading_pair") @JsonDeserialize(using = CurrencyPairDeserializer.class)
+          CurrencyPair tradingPair,
+      @JsonProperty("orders") BitcoindeCompactOrders bitcoindeOrders,
+      @JsonProperty("credits") Integer credits,
+      @JsonProperty("errors") BitcoindeError[] errors,
+      @JsonProperty("maintenance") BitcoindeMaintenance maintenance,
+      @JsonProperty("nonce") Long nonce) {
+    super(credits, errors, maintenance, nonce);
+    this.tradingPair = tradingPair;
+    this.bitcoindeOrders = bitcoindeOrders;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeCompactOrders.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeCompactOrders.java
@@ -1,0 +1,22 @@
+package org.knowm.xchange.bitcoinde.v4.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Value;
+
+@Value
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeCompactOrders {
+
+  BitcoindeCompactOrder[] bids;
+  BitcoindeCompactOrder[] asks;
+
+  @JsonCreator
+  public BitcoindeCompactOrders(
+      @JsonProperty("bids") BitcoindeCompactOrder[] bids,
+      @JsonProperty("asks") BitcoindeCompactOrder[] asks) {
+    this.bids = bids;
+    this.asks = asks;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeOrder.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeOrder.java
@@ -1,0 +1,61 @@
+package org.knowm.xchange.bitcoinde.v4.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.math.BigDecimal;
+import lombok.Value;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeOrderRequirements;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeTradingPartnerInformation;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeType;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.utils.jackson.CurrencyPairDeserializer;
+
+@Value
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeOrder {
+
+  String orderId;
+  CurrencyPair tradingPair;
+  Boolean externalWalletOrder;
+  BitcoindeType type;
+  BigDecimal maxAmount;
+  BigDecimal minAmount;
+  BigDecimal price;
+  BigDecimal maxVolume;
+  BigDecimal minVolume;
+  Boolean requirementsFullfilled;
+  BitcoindeTradingPartnerInformation tradingPartnerInformation;
+  BitcoindeOrderRequirements orderRequirements;
+
+  @JsonCreator
+  public BitcoindeOrder(
+      @JsonProperty("order_id") String orderId,
+      @JsonProperty("trading_pair") @JsonDeserialize(using = CurrencyPairDeserializer.class)
+          CurrencyPair tradingPair,
+      @JsonProperty("is_external_wallet_order") Boolean externalWalletOrder,
+      @JsonProperty("type") BitcoindeType type,
+      @JsonProperty("max_amount_currency_to_trade") BigDecimal maxAmount,
+      @JsonProperty("min_amount_currency_to_trade") BigDecimal minAmount,
+      @JsonProperty("price") BigDecimal price,
+      @JsonProperty("max_volume_currency_to_pay") BigDecimal maxVolume,
+      @JsonProperty("min_volume_currency_to_pay") BigDecimal minVolume,
+      @JsonProperty("order_requirements_fullfilled") Boolean requirementsFullfilled,
+      @JsonProperty("trading_partner_information")
+          BitcoindeTradingPartnerInformation tradingPartnerInformation,
+      @JsonProperty("order_requirements") BitcoindeOrderRequirements orderRequirements) {
+    this.orderId = orderId;
+    this.tradingPair = tradingPair;
+    this.externalWalletOrder = externalWalletOrder;
+    this.type = type;
+    this.maxAmount = maxAmount;
+    this.minAmount = minAmount;
+    this.price = price;
+    this.maxVolume = maxVolume;
+    this.minVolume = minVolume;
+    this.requirementsFullfilled = requirementsFullfilled;
+    this.tradingPartnerInformation = tradingPartnerInformation;
+    this.orderRequirements = orderRequirements;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeOrderbookWrapper.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeOrderbookWrapper.java
@@ -1,0 +1,29 @@
+package org.knowm.xchange.bitcoinde.v4.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeError;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeMaintenance;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeResponse;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeOrderbookWrapper extends BitcoindeResponse {
+
+  BitcoindeOrder[] bitcoindeOrders;
+
+  @JsonCreator
+  public BitcoindeOrderbookWrapper(
+      @JsonProperty("orders") BitcoindeOrder[] bitcoindeOrders,
+      @JsonProperty("credits") Integer credits,
+      @JsonProperty("errors") BitcoindeError[] errors,
+      @JsonProperty("maintenance") BitcoindeMaintenance maintenance,
+      @JsonProperty("nonce") Long nonce) {
+    super(credits, errors, maintenance, nonce);
+    this.bitcoindeOrders = bitcoindeOrders;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeTrade.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeTrade.java
@@ -1,0 +1,32 @@
+package org.knowm.xchange.bitcoinde.v4.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.math.BigDecimal;
+import java.util.Date;
+import lombok.Value;
+import org.knowm.xchange.utils.jackson.UnixTimestampDeserializer;
+
+@Value
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeTrade {
+
+  Date date;
+  BigDecimal price;
+  BigDecimal amount;
+  Long tid;
+
+  @JsonCreator
+  public BitcoindeTrade(
+      @JsonProperty("date") @JsonDeserialize(using = UnixTimestampDeserializer.class) Date date,
+      @JsonProperty("price") BigDecimal price,
+      @JsonProperty("amount_currency_to_trade") BigDecimal amount,
+      @JsonProperty("tid") Long tid) {
+    this.date = date;
+    this.price = price;
+    this.amount = amount;
+    this.tid = tid;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeTradesWrapper.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeTradesWrapper.java
@@ -1,0 +1,36 @@
+package org.knowm.xchange.bitcoinde.v4.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeError;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeMaintenance;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeResponse;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.utils.jackson.CurrencyPairDeserializer;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeTradesWrapper extends BitcoindeResponse {
+
+  CurrencyPair tradingPair;
+  BitcoindeTrade[] trades;
+
+  @JsonCreator
+  public BitcoindeTradesWrapper(
+      @JsonProperty("trading_pair") @JsonDeserialize(using = CurrencyPairDeserializer.class)
+          CurrencyPair tradingPair,
+      @JsonProperty("trades") BitcoindeTrade[] trades,
+      @JsonProperty("credits") Integer credits,
+      @JsonProperty("errors") BitcoindeError[] errors,
+      @JsonProperty("maintenance") BitcoindeMaintenance maintenance,
+      @JsonProperty("nonce") Long nonce) {
+    super(credits, errors, maintenance, nonce);
+    this.tradingPair = tradingPair;
+    this.trades = trades;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/trade/BitcoindeIdResponse.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/trade/BitcoindeIdResponse.java
@@ -1,0 +1,29 @@
+package org.knowm.xchange.bitcoinde.v4.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeError;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeMaintenance;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeResponse;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeIdResponse extends BitcoindeResponse {
+
+  String id;
+
+  @JsonCreator
+  public BitcoindeIdResponse(
+      @JsonProperty("order_id") String id,
+      @JsonProperty("credits") Integer credits,
+      @JsonProperty("errors") BitcoindeError[] errors,
+      @JsonProperty("maintenance") BitcoindeMaintenance maintenance,
+      @JsonProperty("nonce") Long nonce) {
+    super(credits, errors, maintenance, nonce);
+    this.id = id;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/trade/BitcoindeMyOrder.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/trade/BitcoindeMyOrder.java
@@ -1,0 +1,67 @@
+package org.knowm.xchange.bitcoinde.v4.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.math.BigDecimal;
+import java.util.Date;
+import lombok.Value;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeOrderRequirements;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeOrderState;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeType;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.utils.jackson.CurrencyPairDeserializer;
+
+@Value
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeMyOrder {
+
+  String orderId;
+  CurrencyPair tradingPair;
+  Boolean externalWalletOrder;
+  BitcoindeType type;
+  BigDecimal maxAmount;
+  BigDecimal minAmount;
+  BigDecimal price;
+  BigDecimal maxVolume;
+  BigDecimal minVolume;
+  Date endDatetime;
+  Boolean newOrderForRemainingAmount;
+  BitcoindeOrderState state;
+  BitcoindeOrderRequirements orderRequirements;
+  Date createdAt;
+
+  @JsonCreator
+  public BitcoindeMyOrder(
+      @JsonProperty("order_id") String orderId,
+      @JsonProperty("trading_pair") @JsonDeserialize(using = CurrencyPairDeserializer.class)
+          CurrencyPair tradingPair,
+      @JsonProperty("is_external_wallet_order") Boolean externalWalletOrder,
+      @JsonProperty("type") BitcoindeType type,
+      @JsonProperty("max_amount_currency_to_trade") BigDecimal maxAmount,
+      @JsonProperty("min_amount_currency_to_trade") BigDecimal minAmount,
+      @JsonProperty("price") BigDecimal price,
+      @JsonProperty("max_volume_currency_to_pay") BigDecimal maxVolume,
+      @JsonProperty("min_volume_currency_to_pay") BigDecimal minVolume,
+      @JsonProperty("end_datetime") Date endDatetime,
+      @JsonProperty("new_order_for_remaining_amount") Boolean newOrderForRemainingAmount,
+      @JsonProperty("state") BitcoindeOrderState state,
+      @JsonProperty("order_requirements") BitcoindeOrderRequirements orderRequirements,
+      @JsonProperty("created_at") Date createdAt) {
+    this.orderId = orderId;
+    this.tradingPair = tradingPair;
+    this.externalWalletOrder = externalWalletOrder;
+    this.type = type;
+    this.maxAmount = maxAmount;
+    this.minAmount = minAmount;
+    this.price = price;
+    this.maxVolume = maxVolume;
+    this.minVolume = minVolume;
+    this.endDatetime = endDatetime;
+    this.newOrderForRemainingAmount = newOrderForRemainingAmount;
+    this.state = state;
+    this.orderRequirements = orderRequirements;
+    this.createdAt = createdAt;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/trade/BitcoindeMyOrdersWrapper.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/trade/BitcoindeMyOrdersWrapper.java
@@ -1,0 +1,32 @@
+package org.knowm.xchange.bitcoinde.v4.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeError;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeMaintenance;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindePage;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindePagedResponse;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeMyOrdersWrapper extends BitcoindePagedResponse {
+
+  List<BitcoindeMyOrder> orders;
+
+  @JsonCreator
+  public BitcoindeMyOrdersWrapper(
+      @JsonProperty("orders") List<BitcoindeMyOrder> orders,
+      @JsonProperty("page") BitcoindePage page,
+      @JsonProperty("credits") Integer credits,
+      @JsonProperty("errors") BitcoindeError[] errors,
+      @JsonProperty("maintenance") BitcoindeMaintenance maintenance,
+      @JsonProperty("nonce") Long nonce) {
+    super(page, credits, errors, maintenance, nonce);
+    this.orders = orders;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/trade/BitcoindeMyTrade.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/trade/BitcoindeMyTrade.java
@@ -1,0 +1,162 @@
+package org.knowm.xchange.bitcoinde.v4.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.math.BigDecimal;
+import java.util.Date;
+import lombok.Value;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeTradingPartnerInformation;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeType;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.utils.jackson.CurrencyPairDeserializer;
+
+@Value
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeMyTrade {
+
+  String tradeId;
+  Boolean isExternalWalletTrade;
+  CurrencyPair tradingPair;
+  BitcoindeType type;
+  BigDecimal amountCurrencyToTrade;
+  BigDecimal amountCurrencyToTradeAfterFee;
+  BigDecimal price;
+  BigDecimal volumeCurrencyToPay;
+  BigDecimal volumeCurrencyToPayAfterFee;
+  BigDecimal feeCurrencyToPay;
+  BigDecimal feeCurrencyToTrade;
+  String newOrderIdForRemainingAmount;
+  State state;
+  Boolean isTradeMarkedAsPaid;
+  Date tradeMarkedAsPaidAt;
+  Rating myRatingForTradingPartner;
+  BitcoindeTradingPartnerInformation tradingPartnerInformation;
+  Date createdAt;
+  Date successfullyFinishedAt;
+  Date cancelledAt;
+  PaymentMethod payment_method;
+
+  @JsonCreator
+  public BitcoindeMyTrade(
+      @JsonProperty("trade_id") String tradeId,
+      @JsonProperty("is_external_wallet_trade") Boolean isExternalWalletTrade,
+      @JsonProperty("trading_pair") @JsonDeserialize(using = CurrencyPairDeserializer.class)
+          CurrencyPair tradingPair,
+      @JsonProperty("type") BitcoindeType type,
+      @JsonProperty("amount_currency_to_trade") BigDecimal amountCurrencyToTrade,
+      @JsonProperty("amount_currency_to_trade_after_fee") BigDecimal amountCurrencyToTradeAfterFee,
+      @JsonProperty("price") BigDecimal price,
+      @JsonProperty("volume_currency_to_pay") BigDecimal volumeCurrencyToPay,
+      @JsonProperty("volume_currency_to_pay_after_fee") BigDecimal volumeCurrencyToPayAfterFee,
+      @JsonProperty("fee_currency_to_pay") BigDecimal feeCurrencyToPay,
+      @JsonProperty("fee_currency_to_trade") BigDecimal feeCurrencyToTrade,
+      @JsonProperty("new_order_id_for_remaining_amount") String newOrderIdForRemainingAmount,
+      @JsonProperty("state") State state,
+      @JsonProperty("is_trade_marked_as_paid") Boolean isTradeMarkedAsPaid,
+      @JsonProperty("trade_marked_as_paid_at") Date tradeMarkedAsPaidAt,
+      @JsonProperty("my_rating_for_trading_partner") Rating myRatingForTradingPartner,
+      @JsonProperty("trading_partner_information")
+          BitcoindeTradingPartnerInformation tradingPartnerInformation,
+      @JsonProperty("created_at") Date createdAt,
+      @JsonProperty("successfully_finished_at") Date successfullyFinishedAt,
+      @JsonProperty("cancelled_at") Date cancelledAt,
+      @JsonProperty("payment_method") PaymentMethod payment_method) {
+    this.tradeId = tradeId;
+    this.isExternalWalletTrade = isExternalWalletTrade;
+    this.tradingPair = tradingPair;
+    this.type = type;
+    this.amountCurrencyToTrade = amountCurrencyToTrade;
+    this.price = price;
+    this.volumeCurrencyToPay = volumeCurrencyToPay;
+    this.volumeCurrencyToPayAfterFee = volumeCurrencyToPayAfterFee;
+    this.amountCurrencyToTradeAfterFee = amountCurrencyToTradeAfterFee;
+    this.feeCurrencyToPay = feeCurrencyToPay;
+    this.feeCurrencyToTrade = feeCurrencyToTrade;
+    this.newOrderIdForRemainingAmount = newOrderIdForRemainingAmount;
+    this.state = state;
+    this.isTradeMarkedAsPaid = isTradeMarkedAsPaid;
+    this.tradeMarkedAsPaidAt = tradeMarkedAsPaidAt;
+    this.myRatingForTradingPartner = myRatingForTradingPartner;
+    this.tradingPartnerInformation = tradingPartnerInformation;
+    this.createdAt = createdAt;
+    this.successfullyFinishedAt = successfullyFinishedAt;
+    this.cancelledAt = cancelledAt;
+    this.payment_method = payment_method;
+  }
+
+  public enum State {
+    CANCELLED(-1),
+    PENDING(0),
+    SUCCESSFUL(1);
+
+    private final int value;
+
+    State(int value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public int getValue() {
+      return value;
+    }
+
+    @JsonCreator
+    public static State fromValue(final int value) {
+      for (State state : State.values()) {
+        if (value == state.getValue()) {
+          return state;
+        }
+      }
+
+      throw new IllegalArgumentException("Unknown BitcoindeMyTrade.State value: " + value);
+    }
+  }
+
+  public enum PaymentMethod {
+    SEPA(1),
+    EXPRESS(2);
+
+    private final int value;
+
+    PaymentMethod(int value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public int getValue() {
+      return value;
+    }
+
+    @JsonCreator
+    public static PaymentMethod fromValue(final int value) {
+      for (PaymentMethod paymentMethod : PaymentMethod.values()) {
+        if (value == paymentMethod.getValue()) {
+          return paymentMethod;
+        }
+      }
+
+      throw new IllegalArgumentException("Unknown BitcoindeMyTrade.PaymentMethod value: " + value);
+    }
+  }
+
+  public enum Rating {
+    PENDING("pending"),
+    NEGATIVE("negative"),
+    NEUTRAL("neutral"),
+    POSITIVE("positive");
+
+    private final String value;
+
+    Rating(String value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+      return value;
+    }
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/trade/BitcoindeMyTradesWrapper.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/dto/trade/BitcoindeMyTradesWrapper.java
@@ -1,0 +1,32 @@
+package org.knowm.xchange.bitcoinde.v4.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeError;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeMaintenance;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindePage;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindePagedResponse;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitcoindeMyTradesWrapper extends BitcoindePagedResponse {
+
+  List<BitcoindeMyTrade> trades;
+
+  @JsonCreator
+  public BitcoindeMyTradesWrapper(
+      @JsonProperty("trades") List<BitcoindeMyTrade> trades,
+      @JsonProperty("page") BitcoindePage page,
+      @JsonProperty("credits") Integer credits,
+      @JsonProperty("errors") BitcoindeError[] errors,
+      @JsonProperty("maintenance") BitcoindeMaintenance maintenance,
+      @JsonProperty("nonce") Long nonce) {
+    super(page, credits, errors, maintenance, nonce);
+    this.trades = trades;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeAccountService.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeAccountService.java
@@ -1,0 +1,20 @@
+package org.knowm.xchange.bitcoinde.v4.service;
+
+import org.knowm.xchange.bitcoinde.v4.BitcoindeAdapters;
+import org.knowm.xchange.bitcoinde.v4.BitcoindeExchange;
+import org.knowm.xchange.dto.account.AccountInfo;
+import org.knowm.xchange.service.account.AccountService;
+
+import java.io.IOException;
+
+public class BitcoindeAccountService extends BitcoindeAccountServiceRaw implements AccountService {
+
+  public BitcoindeAccountService(BitcoindeExchange exchange) {
+    super(exchange);
+  }
+
+  @Override
+  public AccountInfo getAccountInfo() throws IOException {
+    return BitcoindeAdapters.adaptAccountInfo(getBitcoindeAccount());
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeAccountService.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeAccountService.java
@@ -2,10 +2,21 @@ package org.knowm.xchange.bitcoinde.v4.service;
 
 import org.knowm.xchange.bitcoinde.v4.BitcoindeAdapters;
 import org.knowm.xchange.bitcoinde.v4.BitcoindeExchange;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeAccountLedgerType;
+import org.knowm.xchange.bitcoinde.v4.dto.account.BitcoindeAccountLedger;
+import org.knowm.xchange.bitcoinde.v4.dto.account.BitcoindeAccountLedgerWrapper;
+import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.dto.account.AccountInfo;
+import org.knowm.xchange.dto.account.FundingRecord;
 import org.knowm.xchange.service.account.AccountService;
+import org.knowm.xchange.service.trade.params.*;
+import org.knowm.xchange.utils.Assert;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
 
 public class BitcoindeAccountService extends BitcoindeAccountServiceRaw implements AccountService {
 
@@ -16,5 +27,146 @@ public class BitcoindeAccountService extends BitcoindeAccountServiceRaw implemen
   @Override
   public AccountInfo getAccountInfo() throws IOException {
     return BitcoindeAdapters.adaptAccountInfo(getBitcoindeAccount());
+  }
+
+  @Override
+  public TradeHistoryParams createFundingHistoryParams() {
+    return new BitcoindeFundingHistoryParams();
+  }
+
+  @Override
+  public List<FundingRecord> getFundingHistory(TradeHistoryParams params) throws IOException {
+    Assert.isTrue(
+        params instanceof TradeHistoryParamCurrency,
+        "You need to provide a currency to retrieve the funding history.");
+
+    if (((TradeHistoryParamCurrency) params).getCurrency() == null) {
+      throw new IllegalArgumentException("Currency has to be specified");
+    }
+
+    if (params instanceof BitcoindeFundingHistoryParams
+        && ((BitcoindeFundingHistoryParams) params).getType() != null
+        && ((BitcoindeFundingHistoryParams) params).getCustomType() != null) {
+      throw new IllegalArgumentException("Only one type can be specified");
+    }
+
+    Currency currency = ((TradeHistoryParamCurrency) params).getCurrency();
+    BitcoindeAccountLedgerType customType = null;
+    boolean leaveFeesSeperate = false;
+    Date start = null;
+    Date end = null;
+    Integer pageNumber = null;
+
+    if (params instanceof HistoryParamsFundingType) {
+      if (((HistoryParamsFundingType) params).getType() != null) {
+        switch (((HistoryParamsFundingType) params).getType()) {
+          case WITHDRAWAL:
+            customType = BitcoindeAccountLedgerType.PAYOUT;
+            break;
+          case DEPOSIT:
+            customType = BitcoindeAccountLedgerType.INPAYMENT;
+            break;
+          default:
+            throw new IllegalArgumentException(
+                "Unsupported FundingRecord.Type: "
+                    + ((HistoryParamsFundingType) params).getType()
+                    + ". For Bitcoin.de specific types use BitcoindeFundingHistoryParams#customType");
+        }
+      }
+    }
+
+    if (params instanceof BitcoindeFundingHistoryParams) {
+      customType = ((BitcoindeFundingHistoryParams) params).getCustomType();
+      leaveFeesSeperate = ((BitcoindeFundingHistoryParams) params).isLeaveFeesSeperate();
+    }
+
+    if (params instanceof TradeHistoryParamsTimeSpan) {
+      start = ((TradeHistoryParamsTimeSpan) params).getStartTime();
+      end = ((TradeHistoryParamsTimeSpan) params).getEndTime();
+    }
+
+    if (params instanceof TradeHistoryParamPaging) {
+      pageNumber = ((TradeHistoryParamPaging) params).getPageNumber();
+    }
+
+    BitcoindeAccountLedgerWrapper result =
+        getAccountLedger(currency, customType, start, end, pageNumber);
+
+    List<BitcoindeAccountLedger> ledger = result.getAccountLedgers();
+    if (!leaveFeesSeperate && !ledger.isEmpty()) {
+      ledger.addAll(
+          checkForAndQueryAdditionalFees(ledger, currency, customType, start, end, pageNumber));
+    }
+
+    // Report back paging information to user to enable efficient paging
+    if (params instanceof BitcoindeFundingHistoryParams) {
+      ((BitcoindeFundingHistoryParams) params).setPageNumber(result.getPage().getCurrent());
+      ((BitcoindeFundingHistoryParams) params).setLastPageNumber(result.getPage().getLast());
+    }
+
+    return BitcoindeAdapters.adaptFundingHistory(currency, ledger, leaveFeesSeperate);
+  }
+
+  private List<BitcoindeAccountLedger> checkForAndQueryAdditionalFees(
+      final List<BitcoindeAccountLedger> ledgers,
+      final Currency currency,
+      final BitcoindeAccountLedgerType customType,
+      final Date start,
+      final Date end,
+      final Integer page)
+      throws IOException {
+
+    /*
+        Only PAYOUTs can have fees, so there is not need for additional checking if there
+        are no PAYOUTs in the ledger list
+    */
+    if (customType != null
+        && BitcoindeAccountLedgerType.PAYOUT != customType
+        && BitcoindeAccountLedgerType.ALL != customType) {
+      return Collections.emptyList();
+    }
+
+    // If only PAYOUTs were requested, this get the same "page" of OUTGOING_FEE_VOLUNTARYs
+    if (BitcoindeAccountLedgerType.PAYOUT == customType) {
+      return getAccountLedger(
+              currency, BitcoindeAccountLedgerType.OUTGOING_FEE_VOLUNTARY, start, end, page)
+          .getAccountLedgers();
+    }
+
+    /*
+        PAYOUTs and OUTGOING_FEE_VOLUNTARYs always have the same reference and date.
+        If the ledger list ends on an uneven ratio between PAYOUTs and OUTGOING_FEE_VOLUNTARYs
+        then it's missing OUTGOING_FEE_VOLUNTARYs.
+        In that case the following page is requested and filtered for the starting
+        OUTGOING_FEE_VOLUNTARY ledger entries.
+    */
+    int feeCount = 0;
+    for (int i = ledgers.size() - 1; i >= 0; i--) {
+      if (BitcoindeAccountLedgerType.OUTGOING_FEE_VOLUNTARY == ledgers.get(i).getType()) {
+        feeCount++;
+      } else if (BitcoindeAccountLedgerType.PAYOUT == ledgers.get(i).getType()) {
+        feeCount--;
+      } else {
+        break;
+      }
+    }
+
+    if (feeCount < 0) {
+      List<BitcoindeAccountLedger> feeLedgers = new ArrayList<>();
+      List<BitcoindeAccountLedger> feeResult =
+          getAccountLedger(currency, customType, start, end, page + 1).getAccountLedgers();
+
+      for (BitcoindeAccountLedger ledger : feeResult) {
+        if (BitcoindeAccountLedgerType.OUTGOING_FEE_VOLUNTARY == ledger.getType()) {
+          feeLedgers.add(ledger);
+        } else {
+          break;
+        }
+      }
+
+      return feeLedgers;
+    }
+
+    return Collections.emptyList();
   }
 }

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeAccountServiceRaw.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeAccountServiceRaw.java
@@ -1,0 +1,26 @@
+package org.knowm.xchange.bitcoinde.v4.service;
+
+import org.knowm.xchange.bitcoinde.v4.BitcoindeExchange;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeException;
+import org.knowm.xchange.bitcoinde.v4.dto.account.BitcoindeAccountWrapper;
+import si.mazi.rescu.SynchronizedValueFactory;
+
+import java.io.IOException;
+
+public class BitcoindeAccountServiceRaw extends BitcoindeBaseService {
+
+  private final SynchronizedValueFactory<Long> nonceFactory;
+
+  protected BitcoindeAccountServiceRaw(BitcoindeExchange exchange) {
+    super(exchange);
+    this.nonceFactory = exchange.getNonceFactory();
+  }
+
+  public BitcoindeAccountWrapper getBitcoindeAccount() throws IOException {
+    try {
+      return bitcoinde.getAccount(apiKey, nonceFactory, signatureCreator);
+    } catch (BitcoindeException e) {
+      throw handleError(e);
+    }
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeAccountServiceRaw.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeAccountServiceRaw.java
@@ -1,11 +1,17 @@
 package org.knowm.xchange.bitcoinde.v4.service;
 
-import org.knowm.xchange.bitcoinde.v4.BitcoindeExchange;
-import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeException;
-import org.knowm.xchange.bitcoinde.v4.dto.account.BitcoindeAccountWrapper;
-import si.mazi.rescu.SynchronizedValueFactory;
+import static org.knowm.xchange.bitcoinde.BitcoindeUtils.rfc3339Timestamp;
 
 import java.io.IOException;
+import java.util.Date;
+import org.knowm.xchange.bitcoinde.BitcoindeUtils;
+import org.knowm.xchange.bitcoinde.v4.BitcoindeExchange;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeAccountLedgerType;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeException;
+import org.knowm.xchange.bitcoinde.v4.dto.account.BitcoindeAccountLedgerWrapper;
+import org.knowm.xchange.bitcoinde.v4.dto.account.BitcoindeAccountWrapper;
+import org.knowm.xchange.currency.Currency;
+import si.mazi.rescu.SynchronizedValueFactory;
 
 public class BitcoindeAccountServiceRaw extends BitcoindeBaseService {
 
@@ -19,6 +25,40 @@ public class BitcoindeAccountServiceRaw extends BitcoindeBaseService {
   public BitcoindeAccountWrapper getBitcoindeAccount() throws IOException {
     try {
       return bitcoinde.getAccount(apiKey, nonceFactory, signatureCreator);
+    } catch (BitcoindeException e) {
+      throw handleError(e);
+    }
+  }
+
+  /**
+   * Calls the API function Bitcoinde.getAccountLedger().
+   *
+   * @param currency mandatory
+   * @param type optional (default: all)
+   * @param start optional (default: 10 days ago)
+   * @param end optional (default: yesterday)
+   * @param page optional (default: 1)
+   * @return BitcoindeAccountLedgerWrapper
+   * @throws IOException
+   */
+  public BitcoindeAccountLedgerWrapper getAccountLedger(
+      Currency currency, BitcoindeAccountLedgerType type, Date start, Date end, Integer page)
+      throws IOException {
+
+    String typeAsString = type != null ? type.getValue() : null;
+    String startAsString = start != null ? rfc3339Timestamp(start) : null;
+    String endAsString = end != null ? rfc3339Timestamp(end) : null;
+
+    try {
+      return bitcoinde.getAccountLedger(
+          apiKey,
+          nonceFactory,
+          signatureCreator,
+          BitcoindeUtils.createBitcoindeCurrency(currency),
+          typeAsString,
+          startAsString,
+          endAsString,
+          page);
     } catch (BitcoindeException e) {
       throw handleError(e);
     }

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeBaseService.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeBaseService.java
@@ -1,0 +1,34 @@
+package org.knowm.xchange.bitcoinde.v4.service;
+
+import org.knowm.xchange.bitcoinde.v4.Bitcoinde;
+import org.knowm.xchange.bitcoinde.v4.BitcoindeErrorAdapter;
+import org.knowm.xchange.bitcoinde.v4.BitcoindeExchange;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeException;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
+import org.knowm.xchange.service.BaseExchangeService;
+import org.knowm.xchange.service.BaseService;
+import si.mazi.rescu.RestProxyFactory;
+
+public class BitcoindeBaseService extends BaseExchangeService<BitcoindeExchange>
+    implements BaseService {
+
+  protected final Bitcoinde bitcoinde;
+  protected final String apiKey;
+  protected final BitcoindeDigest signatureCreator;
+
+  protected BitcoindeBaseService(BitcoindeExchange exchange) {
+    super(exchange);
+    this.bitcoinde =
+        RestProxyFactory.createProxy(
+            Bitcoinde.class,
+            exchange.getExchangeSpecification().getSslUri(),
+            ExchangeRestProxyBuilder.createClientConfig(exchange.getExchangeSpecification()));
+    this.apiKey = exchange.getExchangeSpecification().getApiKey();
+    this.signatureCreator =
+        BitcoindeDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(), apiKey);
+  }
+
+  protected RuntimeException handleError(BitcoindeException exception) {
+    return BitcoindeErrorAdapter.adaptBitcoindeException(exception);
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeCancelOrderByIdAndCurrencyPair.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeCancelOrderByIdAndCurrencyPair.java
@@ -1,0 +1,11 @@
+package org.knowm.xchange.bitcoinde.v4.service;
+
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.service.trade.params.CancelOrderParams;
+
+public interface BitcoindeCancelOrderByIdAndCurrencyPair extends CancelOrderParams {
+
+  CurrencyPair getCurrencyPair();
+
+  String getId();
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeDigest.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeDigest.java
@@ -1,0 +1,77 @@
+package org.knowm.xchange.bitcoinde.v4.service;
+
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.Mac;
+import org.knowm.xchange.service.BaseParamsDigest;
+import si.mazi.rescu.RestInvocation;
+
+/** @author kaiserfr */
+public class BitcoindeDigest extends BaseParamsDigest {
+  private final String apiKey;
+
+  /**
+   * Constructor
+   *
+   * @param secretKeyBase64
+   * @param apiKey
+   * @throws IllegalArgumentException if key is invalid (cannot be base-64-decoded or the decoded
+   *     key is invalid).
+   */
+  private BitcoindeDigest(String secretKeyBase64, String apiKey) {
+    super(secretKeyBase64, HMAC_SHA_256);
+    this.apiKey = apiKey;
+  }
+
+  public static BitcoindeDigest createInstance(String secretKeyBase64, String apiKey) {
+
+    return secretKeyBase64 == null ? null : new BitcoindeDigest(secretKeyBase64, apiKey);
+  }
+
+  @Override
+  public String digestParams(RestInvocation restInvocation) {
+
+    // Step 1: concatenate URL with query string
+    String completeURL = restInvocation.getInvocationUrl();
+
+    // Step 2: create md5-Hash of the POST-Parameters for the HMAC-data
+    String httpMethod = restInvocation.getHttpMethod();
+    String requestBody = restInvocation.getRequestBody();
+
+    String md5;
+    if ("POST".equals(httpMethod)) {
+      md5 = getMD5(requestBody);
+    } else {
+      md5 = "d41d8cd98f00b204e9800998ecf8427e"; // no post params for GET methods
+    }
+
+    // Step 3: concat HMAC-input
+
+    // http_method+'#'+uri+'#'+api_key+'#'+nonce+'#'+post_parameter_md5_hashed_url_encoded_query_string
+    String nonce = restInvocation.getHttpHeadersFromParams().get("X-API-NONCE");
+    String hmac_data = String.format("%s#%s#%s#%s#%s", httpMethod, completeURL, apiKey, nonce, md5);
+
+    // Step 3: Create actual sha256-HMAC
+    Mac mac256 = getMac();
+    mac256.update(hmac_data.getBytes());
+
+    return String.format("%064x", new BigInteger(1, mac256.doFinal()));
+  }
+
+  private String getMD5(String original) {
+    MessageDigest md = null;
+    try {
+      md = MessageDigest.getInstance("MD5");
+    } catch (NoSuchAlgorithmException e) {
+      e.printStackTrace();
+    }
+    md.update(original.getBytes());
+    byte[] digest = md.digest();
+    StringBuffer sb = new StringBuffer();
+    for (byte b : digest) {
+      sb.append(String.format("%02x", b & 0xff));
+    }
+    return sb.toString();
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeFundingHistoryParams.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeFundingHistoryParams.java
@@ -1,0 +1,73 @@
+package org.knowm.xchange.bitcoinde.v4.service;
+
+import java.util.Date;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeAccountLedgerType;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.dto.account.FundingRecord;
+import org.knowm.xchange.service.trade.params.*;
+
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class BitcoindeFundingHistoryParams extends DefaultTradeHistoryParamsTimeSpan
+    implements TradeHistoryParamCurrency, HistoryParamsFundingType, TradeHistoryParamPaging {
+
+  private Currency currency;
+  private FundingRecord.Type type;
+  private BitcoindeAccountLedgerType customType;
+  private boolean leaveFeesSeperate = false;
+  private Integer pageNumber;
+  // This is used to report back the number of pages available
+  private Integer lastPageNumber;
+
+  public BitcoindeFundingHistoryParams(
+      final Currency currency,
+      final FundingRecord.Type type,
+      final Date startTime,
+      final Date endTime,
+      final Integer pageNumber) {
+    super(startTime, endTime);
+    this.currency = currency;
+    this.type = type;
+    this.pageNumber = pageNumber;
+  }
+
+  public BitcoindeFundingHistoryParams(
+      final Currency currency,
+      final BitcoindeAccountLedgerType customType,
+      final Date startTime,
+      final Date endTime,
+      final Integer pageNumber) {
+    super(startTime, endTime);
+    this.currency = currency;
+    this.customType = customType;
+
+    this.pageNumber = pageNumber;
+  }
+
+  /**
+   * Copy constructor
+   *
+   * @param other
+   */
+  public BitcoindeFundingHistoryParams(BitcoindeFundingHistoryParams other) {
+    super(other.getStartTime(), other.getEndTime());
+    this.currency = other.currency;
+    this.type = other.type;
+    this.customType = other.customType;
+    this.leaveFeesSeperate = other.leaveFeesSeperate;
+    this.pageNumber = other.pageNumber;
+  }
+
+  // Only include to fulfill TradeHistoryParamPaging interface, can't be changed and isn't used
+  @Override
+  public Integer getPageLength() {
+    return null;
+  }
+
+  @Override
+  public void setPageLength(final Integer pageLength) {}
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeMarketDataService.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeMarketDataService.java
@@ -1,15 +1,14 @@
 package org.knowm.xchange.bitcoinde.v4.service;
 
+import static org.knowm.xchange.bitcoinde.v4.BitcoindeAdapters.*;
+
+import java.io.IOException;
 import org.knowm.xchange.bitcoinde.v4.BitcoindeExchange;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.service.marketdata.MarketDataService;
-
-import java.io.IOException;
-
-import static org.knowm.xchange.bitcoinde.v4.BitcoindeAdapters.adaptCompactOrderBook;
-import static org.knowm.xchange.bitcoinde.v4.BitcoindeAdapters.adaptOrderBook;
 
 public class BitcoindeMarketDataService extends BitcoindeMarketDataServiceRaw
     implements MarketDataService {
@@ -35,5 +34,21 @@ public class BitcoindeMarketDataService extends BitcoindeMarketDataServiceRaw
         String.format(
             "Only support %s as an argument",
             BitcoindeOrderbookOrdersParams.class.getSimpleName()));
+  }
+
+  @Override
+  public Trades getTrades(CurrencyPair currencyPair, Object... args) throws IOException {
+    Integer since = null; // all trades possible
+    if (args != null && args.length > 0) {
+      // parameter 1, if present, is the since param
+      if (args[0] instanceof Integer) {
+        since = (Integer) args[0];
+      } else {
+        throw new IllegalArgumentException(
+            "Extra argument #1,  'since', must be an int (was " + args[0].getClass() + ")");
+      }
+    }
+
+    return adaptTrades(getBitcoindeTrades(currencyPair, since), currencyPair);
   }
 }

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeMarketDataService.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeMarketDataService.java
@@ -1,0 +1,39 @@
+package org.knowm.xchange.bitcoinde.v4.service;
+
+import org.knowm.xchange.bitcoinde.v4.BitcoindeExchange;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order.OrderType;
+import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.service.marketdata.MarketDataService;
+
+import java.io.IOException;
+
+import static org.knowm.xchange.bitcoinde.v4.BitcoindeAdapters.adaptCompactOrderBook;
+import static org.knowm.xchange.bitcoinde.v4.BitcoindeAdapters.adaptOrderBook;
+
+public class BitcoindeMarketDataService extends BitcoindeMarketDataServiceRaw
+    implements MarketDataService {
+
+  public BitcoindeMarketDataService(BitcoindeExchange exchange) {
+    super(exchange);
+  }
+
+  @Override
+  public OrderBook getOrderBook(CurrencyPair currencyPair, Object... args) throws IOException {
+    if (args == null || args.length == 0) {
+      return adaptCompactOrderBook(getBitcoindeCompactOrderBook(currencyPair), currencyPair);
+    } else if (args[0] instanceof BitcoindeOrderbookOrdersParams) {
+      final BitcoindeOrderbookOrdersParams params = (BitcoindeOrderbookOrdersParams) args[0];
+
+      return adaptOrderBook(
+          getBitcoindeOrderBook(currencyPair, OrderType.BID, params),
+          getBitcoindeOrderBook(currencyPair, OrderType.ASK, params),
+          currencyPair);
+    }
+
+    throw new IllegalArgumentException(
+        String.format(
+            "Only support %s as an argument",
+            BitcoindeOrderbookOrdersParams.class.getSimpleName()));
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeMarketDataServiceRaw.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeMarketDataServiceRaw.java
@@ -1,16 +1,16 @@
 package org.knowm.xchange.bitcoinde.v4.service;
 
+import static org.knowm.xchange.bitcoinde.BitcoindeUtils.*;
+
+import java.io.IOException;
 import org.knowm.xchange.bitcoinde.v4.BitcoindeExchange;
 import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeException;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeCompactOrderbookWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeOrderbookWrapper;
+import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeTradesWrapper;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
 import si.mazi.rescu.SynchronizedValueFactory;
-
-import java.io.IOException;
-
-import static org.knowm.xchange.bitcoinde.BitcoindeUtils.*;
 
 public class BitcoindeMarketDataServiceRaw extends BitcoindeBaseService {
 
@@ -44,6 +44,16 @@ public class BitcoindeMarketDataServiceRaw extends BitcoindeBaseService {
           createBitcoindeBoolean(params.onlyOrdersWithRequirementsFullfilled()),
           createBitcoindeBoolean(params.onlyFromFullyIdentifiedUsers()),
           createBitcoindeBoolean(params.onlyExpressOrders()));
+    } catch (BitcoindeException e) {
+      throw handleError(e);
+    }
+  }
+
+  public BitcoindeTradesWrapper getBitcoindeTrades(CurrencyPair currencyPair, Integer since)
+      throws IOException {
+    try {
+      return bitcoinde.getTrades(
+          apiKey, nonceFactory, signatureCreator, createBitcoindePair(currencyPair), since);
     } catch (BitcoindeException e) {
       throw handleError(e);
     }

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeMarketDataServiceRaw.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeMarketDataServiceRaw.java
@@ -1,0 +1,51 @@
+package org.knowm.xchange.bitcoinde.v4.service;
+
+import org.knowm.xchange.bitcoinde.v4.BitcoindeExchange;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeException;
+import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeCompactOrderbookWrapper;
+import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeOrderbookWrapper;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order.OrderType;
+import si.mazi.rescu.SynchronizedValueFactory;
+
+import java.io.IOException;
+
+import static org.knowm.xchange.bitcoinde.BitcoindeUtils.*;
+
+public class BitcoindeMarketDataServiceRaw extends BitcoindeBaseService {
+
+  private final SynchronizedValueFactory<Long> nonceFactory;
+
+  public BitcoindeMarketDataServiceRaw(BitcoindeExchange exchange) {
+    super(exchange);
+    this.nonceFactory = exchange.getNonceFactory();
+  }
+
+  public BitcoindeCompactOrderbookWrapper getBitcoindeCompactOrderBook(CurrencyPair currencyPair)
+      throws IOException {
+    try {
+      return bitcoinde.getCompactOrderBook(
+          apiKey, nonceFactory, signatureCreator, createBitcoindePair(currencyPair));
+    } catch (BitcoindeException e) {
+      throw handleError(e);
+    }
+  }
+
+  public BitcoindeOrderbookWrapper getBitcoindeOrderBook(
+      CurrencyPair currencyPair, OrderType type, BitcoindeOrderbookOrdersParams params)
+      throws IOException {
+    try {
+      return bitcoinde.getOrderBook(
+          apiKey,
+          nonceFactory,
+          signatureCreator,
+          createBitcoindePair(currencyPair),
+          createBitcoindeType(type),
+          createBitcoindeBoolean(params.onlyOrdersWithRequirementsFullfilled()),
+          createBitcoindeBoolean(params.onlyFromFullyIdentifiedUsers()),
+          createBitcoindeBoolean(params.onlyExpressOrders()));
+    } catch (BitcoindeException e) {
+      throw handleError(e);
+    }
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeOpenOrdersParams.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeOpenOrdersParams.java
@@ -1,0 +1,47 @@
+package org.knowm.xchange.bitcoinde.v4.service;
+
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.knowm.xchange.bitcoinde.v4.BitcoindeAdapters;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeOrderState;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeType;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamCurrencyPair;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamOffset;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BitcoindeOpenOrdersParams
+    implements OpenOrdersParamCurrencyPair, OpenOrdersParamOffset {
+
+  private CurrencyPair currencyPair;
+  private BitcoindeType type;
+  private BitcoindeOrderState state;
+  private Date start;
+  private Date end;
+  private Integer offset;
+
+  public BitcoindeOpenOrdersParams(final BitcoindeOrderState state) {
+    this.state = state;
+  }
+
+  @Override
+  public boolean accept(final LimitOrder order) {
+    return accept((Order) order);
+  }
+
+  @Override
+  public boolean accept(final Order order) {
+    return order != null
+        && order.getInstrument().equals(currencyPair)
+        && order.getType() == BitcoindeAdapters.adaptOrderType(this.type)
+        && order.getStatus() == BitcoindeAdapters.adaptOrderStatus(this.state)
+        && !order.getTimestamp().before(this.start)
+        && !order.getTimestamp().after(this.end);
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeOrderbookOrdersParams.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeOrderbookOrdersParams.java
@@ -1,0 +1,35 @@
+package org.knowm.xchange.bitcoinde.v4.service;
+
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindePaymentOption;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
+
+public interface BitcoindeOrderbookOrdersParams extends OpenOrdersParams {
+
+  default boolean onlyOrdersWithRequirementsFullfilled() {
+    return false;
+  }
+
+  default boolean onlyFromFullyIdentifiedUsers() {
+    return false;
+  }
+
+  default boolean onlyExpressOrders() {
+    return true;
+  }
+
+  default boolean onlyOrdersWithSameBankGroup() {
+    return false;
+  }
+
+  default boolean onlyOrdersWithSameBIC() {
+    return false;
+  }
+
+  default String[] onlyOrdersWithSeatOfBank() {
+    return new String[0];
+  }
+
+  default BitcoindePaymentOption onlyOrdersWithPaymentOption() {
+    return null;
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeTradeHistoryParams.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeTradeHistoryParams.java
@@ -1,0 +1,74 @@
+package org.knowm.xchange.bitcoinde.v4.service;
+
+import java.util.Date;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeMyTrade;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.service.trade.params.DefaultTradeHistoryParamsTimeSpan;
+import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
+import org.knowm.xchange.service.trade.params.TradeHistoryParamPaging;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+public class BitcoindeTradeHistoryParams extends DefaultTradeHistoryParamsTimeSpan
+    implements TradeHistoryParamCurrencyPair, TradeHistoryParamPaging {
+
+  private CurrencyPair currencyPair;
+  private Order.OrderType type;
+  private BitcoindeMyTrade.State state;
+  private Boolean onlyTradesWithActionForPaymentOrTransferRequired;
+  private BitcoindeMyTrade.PaymentMethod paymentMethod;
+  private Integer pageNumber;
+  // This is used to report back the number of pages available
+  private Integer lastPageNumber;
+
+  public BitcoindeTradeHistoryParams(
+      final CurrencyPair currencyPair,
+      final Order.OrderType type,
+      final Date startTime,
+      final Date endTime,
+      final BitcoindeMyTrade.State state,
+      final Boolean onlyTradesWithActionForPaymentOrTransferRequired,
+      final BitcoindeMyTrade.PaymentMethod paymentMethod,
+      final Integer pageNumber) {
+
+    super(startTime, endTime);
+    this.currencyPair = currencyPair;
+    this.type = type;
+    this.state = state;
+    this.onlyTradesWithActionForPaymentOrTransferRequired =
+        onlyTradesWithActionForPaymentOrTransferRequired;
+    this.paymentMethod = paymentMethod;
+    this.pageNumber = pageNumber;
+  }
+
+  /**
+   * Copy constructor
+   *
+   * @param other
+   */
+  public BitcoindeTradeHistoryParams(BitcoindeTradeHistoryParams other) {
+    this(
+        other.currencyPair,
+        other.type,
+        other.getStartTime(),
+        other.getEndTime(),
+        other.state,
+        other.onlyTradesWithActionForPaymentOrTransferRequired,
+        other.paymentMethod,
+        other.getPageNumber());
+  }
+
+  // Only include to fulfill TradeHistoryParamPaging interface, can't be changed and isn't used
+  @Override
+  public Integer getPageLength() {
+    return null;
+  }
+
+  @Override
+  public void setPageLength(final Integer pageLength) {}
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeTradeService.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeTradeService.java
@@ -4,7 +4,9 @@ import org.knowm.xchange.bitcoinde.v4.BitcoindeAdapters;
 import org.knowm.xchange.bitcoinde.v4.BitcoindeExchange;
 import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeOrderState;
 import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeType;
+import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeIdResponse;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.service.trade.TradeService;
 import org.knowm.xchange.service.trade.params.*;
@@ -57,6 +59,12 @@ public class BitcoindeTradeService extends BitcoindeTradeServiceRaw implements T
 
     return BitcoindeAdapters.adaptOpenOrders(
         getBitcoindeMyOrders(currencyPair, type, state, start, end, offset));
+  }
+
+  @Override
+  public String placeLimitOrder(LimitOrder limitOrder) throws IOException {
+    BitcoindeIdResponse response = bitcoindePlaceLimitOrder(limitOrder);
+    return response.getId();
   }
 
   @Override

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeTradeService.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeTradeService.java
@@ -1,0 +1,60 @@
+package org.knowm.xchange.bitcoinde.v4.service;
+
+import org.knowm.xchange.bitcoinde.v4.BitcoindeAdapters;
+import org.knowm.xchange.bitcoinde.v4.BitcoindeExchange;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeOrderState;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeType;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.trade.OpenOrders;
+import org.knowm.xchange.service.trade.TradeService;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamCurrencyPair;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamOffset;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
+
+import java.io.IOException;
+import java.util.Date;
+
+public class BitcoindeTradeService extends BitcoindeTradeServiceRaw implements TradeService {
+
+  public BitcoindeTradeService(BitcoindeExchange exchange) {
+    super(exchange);
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return new BitcoindeOpenOrdersParams(BitcoindeOrderState.PENDING);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders() throws IOException {
+    return getOpenOrders(createOpenOrdersParams());
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(final OpenOrdersParams params) throws IOException {
+    CurrencyPair currencyPair = null;
+    BitcoindeType type = null;
+    BitcoindeOrderState state = null;
+    Date start = null;
+    Date end = null;
+    Integer offset = null;
+
+    if (params instanceof OpenOrdersParamCurrencyPair) {
+      currencyPair = ((OpenOrdersParamCurrencyPair) params).getCurrencyPair();
+    }
+
+    if (params instanceof BitcoindeOpenOrdersParams) {
+      type = ((BitcoindeOpenOrdersParams) params).getType();
+      state = ((BitcoindeOpenOrdersParams) params).getState();
+      start = ((BitcoindeOpenOrdersParams) params).getStart();
+      end = ((BitcoindeOpenOrdersParams) params).getEnd();
+    }
+
+    if (params instanceof OpenOrdersParamOffset) {
+      offset = ((OpenOrdersParamOffset) params).getOffset();
+    }
+
+    return BitcoindeAdapters.adaptOpenOrders(
+        getBitcoindeMyOrders(currencyPair, type, state, start, end, offset));
+  }
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeTradeService.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeTradeService.java
@@ -1,21 +1,23 @@
 package org.knowm.xchange.bitcoinde.v4.service;
 
+import java.io.IOException;
+import java.util.Date;
 import org.knowm.xchange.bitcoinde.v4.BitcoindeAdapters;
 import org.knowm.xchange.bitcoinde.v4.BitcoindeExchange;
 import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeOrderState;
 import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeType;
 import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeIdResponse;
+import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeMyTrade;
+import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeMyTradesWrapper;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
+import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.service.trade.TradeService;
 import org.knowm.xchange.service.trade.params.*;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamOffset;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
-
-import java.io.IOException;
-import java.util.Date;
 
 public class BitcoindeTradeService extends BitcoindeTradeServiceRaw implements TradeService {
 
@@ -76,5 +78,84 @@ public class BitcoindeTradeService extends BitcoindeTradeServiceRaw implements T
     }
 
     return true;
+  }
+
+  /**
+   * Create trade history parameters with state specified to "Successful"
+   *
+   * @return tradeHistoryParams
+   */
+  @Override
+  public TradeHistoryParams createTradeHistoryParams() {
+    BitcoindeTradeHistoryParams params = new BitcoindeTradeHistoryParams();
+    params.setState(BitcoindeMyTrade.State.SUCCESSFUL);
+
+    return params;
+  }
+
+  @Override
+  public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
+    CurrencyPair currencyPair = null;
+    BitcoindeType type = null;
+    BitcoindeMyTrade.State state = null;
+    Boolean onlyTradesWithActionForPaymentOrTransferRequired = null;
+    BitcoindeMyTrade.PaymentMethod paymentMethod = null;
+    Date start = null;
+    Date end = null;
+    Integer pageNumber = null;
+
+    if (params instanceof TradeHistoryParamCurrencyPair) {
+      currencyPair = ((TradeHistoryParamCurrencyPair) params).getCurrencyPair();
+    }
+
+    if (params instanceof BitcoindeTradeHistoryParams) {
+      if (((BitcoindeTradeHistoryParams) params).getType() != null) {
+        switch (((BitcoindeTradeHistoryParams) params).getType()) {
+          case BID:
+            type = BitcoindeType.BUY;
+            break;
+          case ASK:
+            type = BitcoindeType.SELL;
+            break;
+          default:
+            throw new IllegalArgumentException(
+                "Unsupported Order.OrderType: " + ((BitcoindeTradeHistoryParams) params).getType());
+        }
+      }
+
+      state = ((BitcoindeTradeHistoryParams) params).getState();
+      onlyTradesWithActionForPaymentOrTransferRequired =
+          ((BitcoindeTradeHistoryParams) params)
+              .getOnlyTradesWithActionForPaymentOrTransferRequired();
+      paymentMethod = ((BitcoindeTradeHistoryParams) params).getPaymentMethod();
+    }
+
+    if (params instanceof TradeHistoryParamsTimeSpan) {
+      start = ((TradeHistoryParamsTimeSpan) params).getStartTime();
+      end = ((TradeHistoryParamsTimeSpan) params).getEndTime();
+    }
+
+    if (params instanceof TradeHistoryParamPaging) {
+      pageNumber = ((TradeHistoryParamPaging) params).getPageNumber();
+    }
+
+    BitcoindeMyTradesWrapper result =
+        getBitcoindeMyTrades(
+            currencyPair,
+            type,
+            state,
+            onlyTradesWithActionForPaymentOrTransferRequired,
+            paymentMethod,
+            start,
+            end,
+            pageNumber);
+
+    // Report back paging information to user to enable efficient paging
+    if (params instanceof BitcoindeTradeHistoryParams) {
+      ((BitcoindeTradeHistoryParams) params).setPageNumber(result.getPage().getCurrent());
+      ((BitcoindeTradeHistoryParams) params).setLastPageNumber(result.getPage().getLast());
+    }
+
+    return BitcoindeAdapters.adaptTradeHistory(result);
   }
 }

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeTradeService.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeTradeService.java
@@ -7,6 +7,7 @@ import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeType;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.service.trade.TradeService;
+import org.knowm.xchange.service.trade.params.*;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamOffset;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
@@ -56,5 +57,16 @@ public class BitcoindeTradeService extends BitcoindeTradeServiceRaw implements T
 
     return BitcoindeAdapters.adaptOpenOrders(
         getBitcoindeMyOrders(currencyPair, type, state, start, end, offset));
+  }
+
+  @Override
+  public boolean cancelOrder(CancelOrderParams orderParams) throws IOException {
+    if (orderParams instanceof BitcoindeCancelOrderByIdAndCurrencyPair) {
+      BitcoindeCancelOrderByIdAndCurrencyPair cob =
+          (BitcoindeCancelOrderByIdAndCurrencyPair) orderParams;
+      bitcoindeCancelOrders(cob.getId(), cob.getCurrencyPair());
+    }
+
+    return true;
   }
 }

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeTradeServiceRaw.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeTradeServiceRaw.java
@@ -1,0 +1,68 @@
+package org.knowm.xchange.bitcoinde.v4.service;
+
+import org.knowm.xchange.bitcoinde.v4.BitcoindeExchange;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeException;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeOrderState;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeType;
+import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeMyOrdersWrapper;
+import org.knowm.xchange.currency.CurrencyPair;
+import si.mazi.rescu.SynchronizedValueFactory;
+
+import java.io.IOException;
+import java.util.Date;
+
+import static org.knowm.xchange.bitcoinde.BitcoindeUtils.createBitcoindePair;
+import static org.knowm.xchange.bitcoinde.BitcoindeUtils.rfc3339Timestamp;
+
+public class BitcoindeTradeServiceRaw extends BitcoindeBaseService {
+
+  private final SynchronizedValueFactory<Long> nonceFactory;
+
+  protected BitcoindeTradeServiceRaw(BitcoindeExchange exchange) {
+    super(exchange);
+    this.nonceFactory = exchange.getNonceFactory();
+  }
+
+  public BitcoindeMyOrdersWrapper getBitcoindeMyOrders(
+      CurrencyPair currencyPair,
+      BitcoindeType type,
+      BitcoindeOrderState state,
+      Date start,
+      Date end,
+      Integer page)
+      throws IOException {
+    try {
+      String typeAsString = type != null ? type.getValue() : null;
+      Integer stateAsInteger = state != null ? state.getValue() : null;
+      String startAsString = start != null ? rfc3339Timestamp(start) : null;
+      String endAsString = end != null ? rfc3339Timestamp(end) : null;
+
+      if (currencyPair == null) {
+        return bitcoinde.getMyOrders(
+            apiKey,
+            nonceFactory,
+            signatureCreator,
+            typeAsString,
+            stateAsInteger,
+            startAsString,
+            endAsString,
+            page);
+      }
+
+      return bitcoinde.getMyOrders(
+          apiKey,
+          nonceFactory,
+          signatureCreator,
+          createBitcoindePair(currencyPair),
+          typeAsString,
+          stateAsInteger,
+          startAsString,
+          endAsString,
+          page);
+    } catch (BitcoindeException e) {
+      throw handleError(e);
+    }
+  }
+
+  
+}

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeTradeServiceRaw.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeTradeServiceRaw.java
@@ -1,12 +1,15 @@
 package org.knowm.xchange.bitcoinde.v4.service;
 
+import static org.knowm.xchange.bitcoinde.BitcoindeUtils.*;
 import org.knowm.xchange.bitcoinde.v4.BitcoindeExchange;
 import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeException;
 import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeOrderState;
 import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeResponse;
 import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeType;
+import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeIdResponse;
 import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeMyOrdersWrapper;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.trade.LimitOrder;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 import java.io.IOException;
@@ -76,4 +79,21 @@ public class BitcoindeTradeServiceRaw extends BitcoindeBaseService {
     }
   }
   
+  public BitcoindeIdResponse bitcoindePlaceLimitOrder(LimitOrder order) throws IOException {
+    try {
+      String side = createBitcoindeType(order.getType());
+      String bitcoindeCurrencyPair = createBitcoindePair(order.getCurrencyPair());
+
+      return bitcoinde.createOrder(
+          apiKey,
+          nonceFactory,
+          signatureCreator,
+          order.getOriginalAmount(),
+          order.getLimitPrice(),
+          bitcoindeCurrencyPair,
+          side);
+    } catch (BitcoindeException e) {
+      throw handleError(e);
+    }
+  }
 }

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeTradeServiceRaw.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeTradeServiceRaw.java
@@ -8,6 +8,8 @@ import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeResponse;
 import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeType;
 import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeIdResponse;
 import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeMyOrdersWrapper;
+import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeMyTrade;
+import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeMyTradesWrapper;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import si.mazi.rescu.SynchronizedValueFactory;
@@ -78,7 +80,7 @@ public class BitcoindeTradeServiceRaw extends BitcoindeBaseService {
       throw handleError(e);
     }
   }
-  
+
   public BitcoindeIdResponse bitcoindePlaceLimitOrder(LimitOrder order) throws IOException {
     try {
       String side = createBitcoindeType(order.getType());
@@ -92,6 +94,71 @@ public class BitcoindeTradeServiceRaw extends BitcoindeBaseService {
           order.getLimitPrice(),
           bitcoindeCurrencyPair,
           side);
+    } catch (BitcoindeException e) {
+      throw handleError(e);
+    }
+  }
+
+  /**
+   * Calls the API function Bitcoinde.getMyTrades().
+   *
+   * @param tradingPair optional (default: all)
+   * @param type optional (default: all)
+   * @param state optional (default: all)
+   * @param actionRequired (default: all)
+   * @param paymentMethod (default: all)
+   * @param start optional (default: 10 days ago)
+   * @param end optional (default: yesterday)
+   * @param page optional (default: 1)
+   * @return BitcoindeAccountLedgerWrapper
+   * @throws IOException
+   */
+  public BitcoindeMyTradesWrapper getBitcoindeMyTrades(
+      CurrencyPair tradingPair,
+      BitcoindeType type,
+      BitcoindeMyTrade.State state,
+      Boolean actionRequired,
+      BitcoindeMyTrade.PaymentMethod paymentMethod,
+      Date start,
+      Date end,
+      Integer page)
+      throws IOException {
+
+    String typeAsString = type != null ? type.getValue() : null;
+    Integer stateAsInteger = state != null ? state.getValue() : null;
+    Integer actionRequiredAsInteger =
+        actionRequired != null ? createBitcoindeBoolean(actionRequired) : null;
+    Integer paymentMethodeAsInteger = paymentMethod != null ? paymentMethod.getValue() : null;
+    String startAsString = start != null ? rfc3339Timestamp(start) : null;
+    String endAsString = end != null ? rfc3339Timestamp(end) : null;
+
+    try {
+      if (tradingPair == null) {
+        return bitcoinde.getMyTrades(
+            apiKey,
+            nonceFactory,
+            signatureCreator,
+            typeAsString,
+            stateAsInteger,
+            actionRequiredAsInteger,
+            paymentMethodeAsInteger,
+            startAsString,
+            endAsString,
+            page);
+      }
+
+      return bitcoinde.getMyTrades(
+          apiKey,
+          nonceFactory,
+          signatureCreator,
+          createBitcoindePair(tradingPair),
+          typeAsString,
+          stateAsInteger,
+          actionRequiredAsInteger,
+          paymentMethodeAsInteger,
+          startAsString,
+          endAsString,
+          page);
     } catch (BitcoindeException e) {
       throw handleError(e);
     }

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeTradeServiceRaw.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeTradeServiceRaw.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.bitcoinde.v4.service;
 import org.knowm.xchange.bitcoinde.v4.BitcoindeExchange;
 import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeException;
 import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeOrderState;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeResponse;
 import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeType;
 import org.knowm.xchange.bitcoinde.v4.dto.trade.BitcoindeMyOrdersWrapper;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -64,5 +65,15 @@ public class BitcoindeTradeServiceRaw extends BitcoindeBaseService {
     }
   }
 
+  public BitcoindeResponse bitcoindeCancelOrders(String orderId, CurrencyPair currencyPair)
+      throws IOException {
+    try {
+      String currPair = createBitcoindePair(currencyPair);
+
+      return bitcoinde.deleteOrder(apiKey, nonceFactory, signatureCreator, orderId, currPair);
+    } catch (BitcoindeException e) {
+      throw handleError(e);
+    }
+  }
   
 }

--- a/xchange-bitcoinde/src/main/resources/bitcoinde.json
+++ b/xchange-bitcoinde/src/main/resources/bitcoinde.json
@@ -1,19 +1,41 @@
 {
   "currency_pairs": {
     "BTC/EUR": {
-      "price_scale": 2,
-      "trading_fee": 0.5
+      "price_scale": 2
     },
     "BCH/EUR": {
-      "price_scale": 2,
-      "trading_fee": 0.5
+      "price_scale": 2
+    },
+    "BTG/EUR": {
+      "price_scale": 2
     },
     "ETH/EUR": {
-      "price_scale": 2,
-      "trading_fee": 0.5
+      "price_scale": 2
+    },
+    "BSV/EUR": {
+      "price_scale": 2
     }
   },
-  "currencies": {},
+  "currencies": {
+    "BTC": {
+      "scale": 8
+    },
+    "BCH": {
+      "scale": 8
+    },
+    "BTG": {
+      "scale": 8
+    },
+    "ETH": {
+      "scale": 8
+    },
+    "BSV": {
+      "scale": 8
+    },
+    "EUR": {
+      "scale": 2
+    }
+  },
   "public_rate_limits": [
     {
       "calls": 2,

--- a/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/BitcoindeAdapterTest.java
+++ b/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/BitcoindeAdapterTest.java
@@ -39,7 +39,7 @@ public class BitcoindeAdapterTest {
     assertThat(orderBook.getBids().get(0).getLimitPrice().toString()).isEqualTo("2406.11");
     assertThat(orderBook.getBids().get(0).getType()).isEqualTo(OrderType.BID);
     assertThat(orderBook.getBids().get(0).getOriginalAmount()).isEqualTo(new BigDecimal("1.745"));
-    assertThat(orderBook.getBids().get(0).getCurrencyPair()).isEqualTo(CurrencyPair.BTC_EUR);
+    assertThat(orderBook.getBids().get(0).getInstrument()).isEqualTo(CurrencyPair.BTC_EUR);
   }
 
   @Test

--- a/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/BitcoindeAdaptersTest.java
+++ b/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/BitcoindeAdaptersTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.junit.Test;
 import org.knowm.xchange.bitcoinde.v4.dto.*;
+import org.knowm.xchange.bitcoinde.v4.dto.account.BitcoindeAccountLedgerWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.account.BitcoindeAccountWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeCompactOrderbookWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeOrderbookWrapper;
@@ -20,6 +21,7 @@ import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderStatus;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.account.AccountInfo;
+import org.knowm.xchange.dto.account.FundingRecord;
 import org.knowm.xchange.dto.account.Wallet;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Trade;
@@ -163,6 +165,7 @@ public class BitcoindeAdaptersTest {
     assertThat(firstTrade.getCurrencyPair()).isEqualTo(CurrencyPair.BTC_EUR);
     assertThat(firstTrade.getTimestamp()).isEqualTo(new Date(1500717160L * 1000));
   }
+
   @Test
   public void testAccountInfoAdapter() throws IOException {
     // Read in the JSON from the example resources
@@ -229,5 +232,48 @@ public class BitcoindeAdaptersTest {
     assertThat(ethWallet.getBalances().get(Currency.EUR).getAvailable()).isEqualByComparingTo("0");
     assertThat(ethWallet.getBalances().get(Currency.EUR).getFrozen()).isEqualByComparingTo("0");
     assertThat(ethWallet.getBalances().get(Currency.EUR).getTotal()).isEqualByComparingTo("0");
+  }
+
+  @Test
+  public void testFundingHistoryAdapter() throws IOException {
+    final InputStream is =
+            BitcoindeAdaptersTest.class.getResourceAsStream(
+                    "/org/knowm/xchange/bitcoinde/v4/dto/account_ledger.json");
+
+    // Use Jackson to parse it
+    final ObjectMapper mapper = new ObjectMapper();
+    BitcoindeAccountLedgerWrapper accountLedgerWrapper = mapper.readValue(is, BitcoindeAccountLedgerWrapper.class);
+
+    final List<FundingRecord> fundingRecords = BitcoindeAdapters.adaptFundingHistory(Currency.BTC, accountLedgerWrapper.getAccountLedgers(), false);
+
+    // Make sure trade values are correct
+    assertThat(fundingRecords).isNotEmpty();
+    assertThat(fundingRecords.size()).isEqualTo(2);
+
+    assertThat(fundingRecords.get(0).getAddress()).isNull();
+    assertThat(fundingRecords.get(0).getAddressTag()).isNull();
+    assertThat(fundingRecords.get(0).getDate()).isEqualTo("2015-08-12T13:05:02+02:00");
+    assertThat(fundingRecords.get(0).getCurrency()).isEqualByComparingTo(Currency.BTC);
+    assertThat(fundingRecords.get(0).getAmount()).isEqualByComparingTo("0.10000000");
+    assertThat(fundingRecords.get(0).getInternalId()).isNull();
+    assertThat(fundingRecords.get(0).getBlockchainTransactionHash()).isEqualTo("dqwdqwdwqwq4dqw4d5qd45qd45qwd4qw5df45g4r5g4trh4r5j5j4tz5j4tbc");
+    assertThat(fundingRecords.get(0).getType()).isEqualByComparingTo(FundingRecord.Type.WITHDRAWAL);
+    assertThat(fundingRecords.get(0).getBalance()).isEqualByComparingTo("4.71619794");
+    assertThat(fundingRecords.get(0).getStatus()).isEqualByComparingTo(FundingRecord.Status.COMPLETE);
+    assertThat(fundingRecords.get(0).getFee()).isNull();
+    assertThat(fundingRecords.get(0).getDescription()).isEqualTo(BitcoindeAccountLedgerType.PAYOUT.getValue());
+
+    assertThat(fundingRecords.get(1).getAddress()).isNull();
+    assertThat(fundingRecords.get(1).getAddressTag()).isNull();
+    assertThat(fundingRecords.get(1).getDate()).isEqualTo("2015-08-12T12:30:01+02:00");
+    assertThat(fundingRecords.get(1).getCurrency()).isEqualByComparingTo(Currency.BTC);
+    assertThat(fundingRecords.get(1).getAmount()).isEqualByComparingTo("1.91894200");
+    assertThat(fundingRecords.get(1).getInternalId()).isNull();
+    assertThat(fundingRecords.get(1).getBlockchainTransactionHash()).isEqualTo("bdgwflwguwgr884t34g4g555h4zr5j4fh5j48rg4s5bx2nt4jr5jr45j4r5j4");
+    assertThat(fundingRecords.get(1).getType()).isEqualByComparingTo(FundingRecord.Type.WITHDRAWAL);
+    assertThat(fundingRecords.get(1).getBalance()).isEqualByComparingTo("4.81619794");
+    assertThat(fundingRecords.get(1).getStatus()).isEqualByComparingTo(FundingRecord.Status.COMPLETE);
+    assertThat(fundingRecords.get(1).getFee()).isNull();
+    assertThat(fundingRecords.get(1).getDescription()).isEqualTo(BitcoindeAccountLedgerType.PAYOUT.getValue());
   }
 }

--- a/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/BitcoindeAdaptersTest.java
+++ b/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/BitcoindeAdaptersTest.java
@@ -1,7 +1,131 @@
 package org.knowm.xchange.bitcoinde.v4;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Test;
+import org.knowm.xchange.bitcoinde.v4.dto.*;
+import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeCompactOrderbookWrapper;
+import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeOrderbookWrapper;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order.OrderStatus;
+import org.knowm.xchange.dto.Order.OrderType;
+import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.trade.LimitOrder;
 /** @author matthewdowney */
 public class BitcoindeAdaptersTest {
 
+  @Test
+  public void testCompactOrderBookAdapter() throws IOException {
+    // Read in the JSON from the example resources
+    final InputStream is =
+        BitcoindeAdaptersTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitcoinde/v4/dto/compact_orderbook.json");
+
+    // Use Jackson to parse it
+    final ObjectMapper mapper = new ObjectMapper();
+    final BitcoindeCompactOrderbookWrapper bitcoindeOrderBook =
+        mapper.readValue(is, BitcoindeCompactOrderbookWrapper.class);
+
+    // Create a generic OrderBook object from a Bitcoinde specific OrderBook
+    final OrderBook orderBook =
+        BitcoindeAdapters.adaptCompactOrderBook(bitcoindeOrderBook, CurrencyPair.BTC_EUR);
+    final LimitOrder firstBid = orderBook.getBids().get(0);
+
+    // verify all fields are filled correctly
+    assertThat(firstBid.getLimitPrice()).isEqualByComparingTo("2406.11");
+    assertThat(firstBid.getType()).isEqualTo(OrderType.BID);
+    assertThat(firstBid.getOriginalAmount()).isEqualByComparingTo("1.745");
+    assertThat(firstBid.getInstrument()).isEqualTo(CurrencyPair.BTC_EUR);
+  }
+
+  @Test
+  public void testOrderBookAdapter() throws IOException {
+    // Read in the JSON from the example resources
+    final InputStream is =
+        BitcoindeAdaptersTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitcoinde/v4/dto/orderbook.json");
+
+    // Use Jackson to parse it
+    final ObjectMapper mapper = new ObjectMapper();
+    final BitcoindeOrderbookWrapper bitcoindeOrderBook =
+        mapper.readValue(is, BitcoindeOrderbookWrapper.class);
+
+    // Create a generic OrderBook object from a Bitcoinde specific OrderBook
+    final OrderBook orderBook =
+        BitcoindeAdapters.adaptOrderBook(
+            bitcoindeOrderBook, bitcoindeOrderBook, CurrencyPair.BCH_EUR);
+    final LimitOrder firstBid = orderBook.getBids().get(0);
+    final BitcoindeOrderFlagsTradingPartnerInformation tpi =
+        new BitcoindeOrderFlagsTradingPartnerInformation("bla", true, BitcoindeTrustLevel.GOLD);
+    final BitcoindeOrderFlagsOrderRequirements or =
+        new BitcoindeOrderFlagsOrderRequirements(BitcoindeTrustLevel.GOLD);
+    final BitcoindeOrderFlagsOrderQuantities oqty =
+        new BitcoindeOrderFlagsOrderQuantities(
+            new BigDecimal("0.1"),
+            new BigDecimal("0.5"),
+            new BigDecimal("23.06"),
+            new BigDecimal("115.28"));
+
+    // verify all fields are filled correctly
+    assertThat(firstBid.getLimitPrice()).isEqualByComparingTo("230.55");
+    assertThat(firstBid.getType()).isEqualTo(OrderType.BID);
+    assertThat(firstBid.getOriginalAmount()).isEqualByComparingTo("0.5");
+    assertThat(firstBid.getInstrument()).isEqualTo(CurrencyPair.BCH_EUR);
+    assertThat(firstBid.hasFlag(tpi)).isEqualTo(true);
+    assertThat(firstBid.hasFlag(or)).isEqualTo(true);
+    assertThat(firstBid.hasFlag(oqty)).isEqualTo(true);
+    testTradingPartnerInformation(firstBid, tpi);
+    testOrderRequirements(firstBid, or);
+    testOrderQuantities(firstBid, oqty);
+  }
+
+  private void testTradingPartnerInformation(
+      LimitOrder order, BitcoindeOrderFlagsTradingPartnerInformation tpi) {
+    order.getOrderFlags().stream()
+        .filter(flag -> flag instanceof BitcoindeOrderFlagsTradingPartnerInformation)
+        .forEach(
+            flag -> {
+              assertThat(((BitcoindeOrderFlagsTradingPartnerInformation) flag).getUserName())
+                  .isEqualTo(tpi.getUserName());
+              assertThat(((BitcoindeOrderFlagsTradingPartnerInformation) flag).isKycFull())
+                  .isEqualTo(tpi.isKycFull());
+              assertThat(((BitcoindeOrderFlagsTradingPartnerInformation) flag).getTrustLevel())
+                  .isEqualByComparingTo(tpi.getTrustLevel());
+            });
+  }
+
+  private void testOrderRequirements(LimitOrder order, BitcoindeOrderFlagsOrderRequirements or) {
+    order.getOrderFlags().stream()
+        .filter(flag -> flag instanceof BitcoindeOrderFlagsOrderRequirements)
+        .forEach(
+            flag -> {
+              assertThat(((BitcoindeOrderFlagsOrderRequirements) flag).getMinTrustLevel())
+                  .isEqualByComparingTo(or.getMinTrustLevel());
+            });
+  }
+
+  private void testOrderQuantities(LimitOrder order, BitcoindeOrderFlagsOrderQuantities qty) {
+    order.getOrderFlags().stream()
+        .filter(flag -> flag instanceof BitcoindeOrderFlagsOrderQuantities)
+        .forEach(
+            flag -> {
+              assertThat(((BitcoindeOrderFlagsOrderQuantities) flag).getMinAmountToTrade())
+                  .isEqualByComparingTo(qty.getMinAmountToTrade());
+              assertThat(((BitcoindeOrderFlagsOrderQuantities) flag).getMaxAmountToTrade())
+                  .isEqualByComparingTo(qty.getMaxAmountToTrade());
+              assertThat(((BitcoindeOrderFlagsOrderQuantities) flag).getMinVolumeToPay())
+                  .isEqualByComparingTo(qty.getMinVolumeToPay());
+              assertThat(((BitcoindeOrderFlagsOrderQuantities) flag).getMaxVolumeToPay())
+                  .isEqualByComparingTo(qty.getMaxVolumeToPay());
+            });
+  }
     
 }

--- a/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/BitcoindeAdaptersTest.java
+++ b/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/BitcoindeAdaptersTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.junit.Test;
 import org.knowm.xchange.bitcoinde.v4.dto.*;
+import org.knowm.xchange.bitcoinde.v4.dto.account.BitcoindeAccountWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeCompactOrderbookWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeOrderbookWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeTradesWrapper;
@@ -18,6 +19,8 @@ import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderStatus;
 import org.knowm.xchange.dto.Order.OrderType;
+import org.knowm.xchange.dto.account.AccountInfo;
+import org.knowm.xchange.dto.account.Wallet;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Trade;
 import org.knowm.xchange.dto.marketdata.Trades;
@@ -159,5 +162,72 @@ public class BitcoindeAdaptersTest {
     assertThat(firstTrade.getOriginalAmount()).isEqualTo(new BigDecimal("0.08064516"));
     assertThat(firstTrade.getCurrencyPair()).isEqualTo(CurrencyPair.BTC_EUR);
     assertThat(firstTrade.getTimestamp()).isEqualTo(new Date(1500717160L * 1000));
+  }
+  @Test
+  public void testAccountInfoAdapter() throws IOException {
+    // Read in the JSON from the example resources
+    final InputStream is =
+        BitcoindeAdaptersTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitcoinde/v4/dto/account.json");
+
+    // Use Jackson to parse it
+    final ObjectMapper mapper = new ObjectMapper();
+    final BitcoindeAccountWrapper bitcoindeTradesWrapper =
+        mapper.readValue(is, BitcoindeAccountWrapper.class);
+
+    // Use our adapter to get a generic AccountInfo object from a BitcoindeData object
+    final AccountInfo accountInfo = BitcoindeAdapters.adaptAccountInfo(bitcoindeTradesWrapper);
+    assertThat(accountInfo.getWallets()).containsOnlyKeys("BTC", "BCH", "BTG", "BSV", "ETH");
+
+    final Wallet btcWallet = accountInfo.getWallet("BTC");
+    assertThat(btcWallet.getBalances()).containsOnlyKeys(Currency.BTC, Currency.EUR);
+    assertThat(btcWallet.getBalances().get(Currency.BTC).getAvailable())
+        .isEqualByComparingTo("0.009");
+    assertThat(btcWallet.getBalances().get(Currency.BTC).getFrozen()).isEqualByComparingTo("0");
+    assertThat(btcWallet.getBalances().get(Currency.BTC).getTotal()).isEqualByComparingTo("0.009");
+    assertThat(btcWallet.getBalances().get(Currency.EUR).getAvailable())
+        .isEqualByComparingTo("2000");
+    assertThat(btcWallet.getBalances().get(Currency.EUR).getFrozen()).isEqualByComparingTo("0");
+    assertThat(btcWallet.getBalances().get(Currency.EUR).getTotal()).isEqualByComparingTo("2000");
+
+    final Wallet bchWallet = accountInfo.getWallet("BCH");
+    assertThat(bchWallet.getBalances()).containsOnlyKeys(Currency.BCH, Currency.EUR);
+    assertThat(bchWallet.getBalances().get(Currency.BCH).getAvailable())
+        .isEqualByComparingTo("0.008");
+    assertThat(bchWallet.getBalances().get(Currency.BCH).getFrozen()).isEqualByComparingTo("0");
+    assertThat(bchWallet.getBalances().get(Currency.BCH).getTotal()).isEqualByComparingTo("0.008");
+    assertThat(bchWallet.getBalances().get(Currency.EUR).getAvailable()).isEqualByComparingTo("0");
+    assertThat(bchWallet.getBalances().get(Currency.EUR).getFrozen()).isEqualByComparingTo("0");
+    assertThat(bchWallet.getBalances().get(Currency.EUR).getTotal()).isEqualByComparingTo("0");
+
+    final Wallet btgWallet = accountInfo.getWallet("BTG");
+    assertThat(btgWallet.getBalances()).containsOnlyKeys(Currency.BTG, Currency.EUR);
+    assertThat(btgWallet.getBalances().get(Currency.BTG).getAvailable())
+        .isEqualByComparingTo("0.007");
+    assertThat(btgWallet.getBalances().get(Currency.BTG).getFrozen()).isEqualByComparingTo("0");
+    assertThat(btgWallet.getBalances().get(Currency.BTG).getTotal()).isEqualByComparingTo("0.007");
+    assertThat(btgWallet.getBalances().get(Currency.EUR).getAvailable()).isEqualByComparingTo("0");
+    assertThat(btgWallet.getBalances().get(Currency.EUR).getFrozen()).isEqualByComparingTo("0");
+    assertThat(btgWallet.getBalances().get(Currency.EUR).getTotal()).isEqualByComparingTo("0");
+
+    final Wallet bsvWallet = accountInfo.getWallet("BSV");
+    assertThat(bsvWallet.getBalances()).containsOnlyKeys(Currency.getInstance("BSV"));
+    assertThat(bsvWallet.getBalances().get(Currency.getInstance("BSV")).getAvailable())
+        .isEqualByComparingTo("0.006");
+    assertThat(bsvWallet.getBalances().get(Currency.getInstance("BSV")).getFrozen())
+        .isEqualByComparingTo("0");
+    assertThat(bsvWallet.getBalances().get(Currency.getInstance("BSV")).getTotal())
+        .isEqualByComparingTo("0.006");
+
+    final Wallet ethWallet = accountInfo.getWallet("ETH");
+    assertThat(ethWallet.getBalances()).containsOnlyKeys(Currency.ETH, Currency.EUR);
+    assertThat(ethWallet.getBalances().get(Currency.ETH).getAvailable())
+        .isEqualByComparingTo("0.06463044");
+    assertThat(ethWallet.getBalances().get(Currency.ETH).getFrozen()).isEqualByComparingTo("0");
+    assertThat(ethWallet.getBalances().get(Currency.ETH).getTotal())
+        .isEqualByComparingTo("0.06463044");
+    assertThat(ethWallet.getBalances().get(Currency.EUR).getAvailable()).isEqualByComparingTo("0");
+    assertThat(ethWallet.getBalances().get(Currency.EUR).getFrozen()).isEqualByComparingTo("0");
+    assertThat(ethWallet.getBalances().get(Currency.EUR).getTotal()).isEqualByComparingTo("0");
   }
 }

--- a/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/BitcoindeAdaptersTest.java
+++ b/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/BitcoindeAdaptersTest.java
@@ -13,11 +13,14 @@ import org.junit.Test;
 import org.knowm.xchange.bitcoinde.v4.dto.*;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeCompactOrderbookWrapper;
 import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeOrderbookWrapper;
+import org.knowm.xchange.bitcoinde.v4.dto.marketdata.BitcoindeTradesWrapper;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderStatus;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.marketdata.Trade;
+import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.dto.trade.LimitOrder;
 /** @author matthewdowney */
 public class BitcoindeAdaptersTest {
@@ -128,4 +131,33 @@ public class BitcoindeAdaptersTest {
             });
   }
     
+  @Test
+  public void testTradesAdapter() throws IOException {
+    // Read in the JSON from the example resources
+    final InputStream is =
+        BitcoindeAdaptersTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitcoinde/v4/dto/trades.json");
+
+    // Use Jackson to parse it
+    final ObjectMapper mapper = new ObjectMapper();
+    final BitcoindeTradesWrapper bitcoindeTradesWrapper =
+        mapper.readValue(is, BitcoindeTradesWrapper.class);
+
+    // Use our adapter to get a generic Trades object from a
+    // BitcoindeTrade[] object
+    final Trades trades =
+        BitcoindeAdapters.adaptTrades(bitcoindeTradesWrapper, CurrencyPair.BTC_EUR);
+    final Trade firstTrade = trades.getTrades().get(0);
+
+    // Make sure the adapter got all the data
+    assertThat(trades.getTrades().size()).isEqualTo(92);
+    assertThat(trades.getlastID()).isEqualTo(2844384);
+
+    // Verify that all fields are filled
+    assertThat(firstTrade.getId()).isEqualTo("2844111");
+    assertThat(firstTrade.getPrice()).isEqualTo(new BigDecimal("2395"));
+    assertThat(firstTrade.getOriginalAmount()).isEqualTo(new BigDecimal("0.08064516"));
+    assertThat(firstTrade.getCurrencyPair()).isEqualTo(CurrencyPair.BTC_EUR);
+    assertThat(firstTrade.getTimestamp()).isEqualTo(new Date(1500717160L * 1000));
+  }
 }

--- a/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/BitcoindeAdaptersTest.java
+++ b/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/BitcoindeAdaptersTest.java
@@ -1,0 +1,7 @@
+package org.knowm.xchange.bitcoinde.v4;
+
+/** @author matthewdowney */
+public class BitcoindeAdaptersTest {
+
+    
+}

--- a/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeErrorTest.java
+++ b/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeErrorTest.java
@@ -1,0 +1,35 @@
+package org.knowm.xchange.bitcoinde.v4.dto;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Test;
+
+public class BitcoindeErrorTest {
+
+  @Test
+  public void testBitcoindeError() throws IOException {
+
+    // Read in the JSON from the example resources
+    InputStream is =
+        BitcoindeErrorTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitcoinde/v4/dto/errors.json");
+
+    // Use Jackson to parse it
+    ObjectMapper mapper = new ObjectMapper();
+    BitcoindeException bitcoindeException = mapper.readValue(is, BitcoindeException.class);
+    assertThat(bitcoindeException.getMessage())
+        .isEqualTo("Error 13: Order not found (Field: order_id), Error 99: Made up Error");
+
+    assertThat(bitcoindeException.getCredits()).isEqualTo(-3);
+    assertThat(bitcoindeException.getErrors()).hasSize(2);
+    assertThat(bitcoindeException.getErrors()[0].getCode()).isEqualTo(13);
+    assertThat(bitcoindeException.getErrors()[0].getMessage()).isEqualTo("Order not found");
+    assertThat(bitcoindeException.getErrors()[0].getField()).isEqualTo("order_id");
+    assertThat(bitcoindeException.getErrors()[1].getCode()).isEqualTo(99);
+    assertThat(bitcoindeException.getErrors()[1].getMessage()).isEqualTo("Made up Error");
+    assertThat(bitcoindeException.getErrors()[1].getField()).isNull();
+  }
+}

--- a/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeMaintenanceTest.java
+++ b/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/dto/BitcoindeMaintenanceTest.java
@@ -1,0 +1,30 @@
+package org.knowm.xchange.bitcoinde.v4.dto;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Test;
+
+public class BitcoindeMaintenanceTest {
+
+  @Test
+  public void testBitcoindeMaintenance() throws IOException {
+
+    // Read in the JSON from the example resources
+    InputStream is =
+        BitcoindeMaintenanceTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitcoinde/v4/dto/maintenance.json");
+
+    // Use Jackson to parse it
+    ObjectMapper mapper = new ObjectMapper();
+    BitcoindeMaintenance bitcoindeMaintenance = mapper.readValue(is, BitcoindeMaintenance.class);
+    assertThat(bitcoindeMaintenance.getMessage())
+        .isEqualTo(
+            "*** Scheduled maintainance on 2018/01/26 at 04:00 am until approx. 06:00 am (CEST)*** Due to network infrastructure maintenance Bitcoin.de will be unavailable between 04:00 am and approx. 06:00 am (CEST). ***");
+
+    assertThat(bitcoindeMaintenance.getStart()).isEqualTo("2018-01-26T04:00:00+01:00");
+    assertThat(bitcoindeMaintenance.getEnd()).isEqualTo("2018-01-26T06:00:00+01:00");
+  }
+}

--- a/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeAccountLedgerWrapperTest.java
+++ b/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeAccountLedgerWrapperTest.java
@@ -1,0 +1,71 @@
+package org.knowm.xchange.bitcoinde.v4.dto.account;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Test;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeAccountLedgerType;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+
+public class BitcoindeAccountLedgerWrapperTest {
+
+  @Test
+  public void testBitcoindeAccountLedgerWrapper() throws IOException {
+    // Read in the JSON from the example resources
+    final InputStream is =
+        BitcoindeAccountLedgerWrapperTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitcoinde/v4/dto/account_ledger.json");
+
+    // Use Jackson to parse it
+    final ObjectMapper mapper = new ObjectMapper();
+    final BitcoindeAccountLedgerWrapper accountLedgerWrapper =
+        mapper.readValue(is, BitcoindeAccountLedgerWrapper.class);
+
+    // Make sure balance values are correct
+    assertThat(accountLedgerWrapper.getAccountLedgers()).isNotEmpty();
+    assertThat(accountLedgerWrapper.getAccountLedgers().size()).isEqualTo(3);
+
+    BitcoindeAccountLedger trade = accountLedgerWrapper.getAccountLedgers().get(0);
+    assertThat(trade.getDate()).isEqualTo("2015-08-13T10:20:27+02:00");
+    assertThat(trade.getType()).isEqualByComparingTo(BitcoindeAccountLedgerType.SELL);
+    assertThat(trade.getReference()).isEqualTo("NVP39U");
+    assertThat(trade.getTrade()).isNotNull();
+    assertThat(trade.getTrade().getTradeId()).isEqualTo("NVP39U");
+    assertThat(trade.getTrade().getTradingPair()).isEqualByComparingTo(CurrencyPair.BTC_EUR);
+    assertThat(trade.getTrade().getPrice()).isEqualByComparingTo("243.77");
+    assertThat(trade.getTrade().getCurrencyToTrade()).isNotNull();
+    assertThat(trade.getTrade().getCurrencyToTrade().getCurrency())
+        .isEqualByComparingTo(Currency.BTC);
+    assertThat(trade.getTrade().getCurrencyToTrade().getBeforeFee())
+        .isEqualByComparingTo("1.71600000");
+    assertThat(trade.getTrade().getCurrencyToTrade().getAfterFee())
+        .isEqualByComparingTo("1.69884000");
+    assertThat(trade.getTrade().getCurrencyToPay().getCurrency())
+        .isEqualByComparingTo(Currency.EUR);
+    assertThat(trade.getTrade().getCurrencyToPay().getBeforeFee()).isEqualByComparingTo("418.31");
+    assertThat(trade.getTrade().getCurrencyToPay().getAfterFee()).isEqualByComparingTo("414.13");
+    assertThat(trade.getCashflow()).isEqualByComparingTo("-1.71600000");
+    assertThat(trade.getBalance()).isEqualByComparingTo("3.00019794");
+
+    BitcoindeAccountLedger payout1 = accountLedgerWrapper.getAccountLedgers().get(1);
+    assertThat(payout1.getDate()).isEqualTo("2015-08-12T13:05:02+02:00");
+    assertThat(payout1.getType()).isEqualByComparingTo(BitcoindeAccountLedgerType.PAYOUT);
+    assertThat(payout1.getTrade()).isNull();
+    assertThat(payout1.getReference())
+        .isEqualTo("dqwdqwdwqwq4dqw4d5qd45qd45qwd4qw5df45g4r5g4trh4r5j5j4tz5j4tbc");
+    assertThat(payout1.getCashflow()).isEqualByComparingTo("-0.10000000");
+    assertThat(payout1.getBalance()).isEqualByComparingTo("4.71619794");
+
+    BitcoindeAccountLedger payout2 = accountLedgerWrapper.getAccountLedgers().get(2);
+    assertThat(payout2.getDate()).isEqualTo("2015-08-12T12:30:01+02:00");
+    assertThat(payout2.getType()).isEqualByComparingTo(BitcoindeAccountLedgerType.PAYOUT);
+    assertThat(payout2.getTrade()).isNull();
+    assertThat(payout2.getReference())
+        .isEqualTo("bdgwflwguwgr884t34g4g555h4zr5j4fh5j48rg4s5bx2nt4jr5jr45j4r5j4");
+    assertThat(payout2.getCashflow()).isEqualByComparingTo("-1.91894200");
+    assertThat(payout2.getBalance()).isEqualByComparingTo("4.81619794");
+  }
+}

--- a/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeAccountWrapperTest.java
+++ b/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/dto/account/BitcoindeAccountWrapperTest.java
@@ -1,0 +1,91 @@
+package org.knowm.xchange.bitcoinde.v4.dto.account;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import org.junit.Test;
+
+public class BitcoindeAccountWrapperTest {
+
+  @Test
+  public void testBitcoindeAccountWarpper() throws IOException {
+    // Read in the JSON from the example resources
+    final InputStream is =
+        BitcoindeAccountWrapperTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitcoinde/v4/dto/account.json");
+
+    // Use Jackson to parse it
+    final ObjectMapper mapper = new ObjectMapper();
+    final BitcoindeAccountWrapper bitcoindeAccountWrapper =
+        mapper.readValue(is, BitcoindeAccountWrapper.class);
+
+    // Make sure balance values are correct
+    assertThat(bitcoindeAccountWrapper.getData()).isNotNull();
+    assertThat(bitcoindeAccountWrapper.getData().getBalances()).isNotNull();
+
+    final Map<String, BitcoindeBalance> balances = bitcoindeAccountWrapper.getData().getBalances();
+    assertThat(balances).containsOnlyKeys("btc", "eth", "bch", "btg", "bsv");
+
+    final BitcoindeBalance btcBalance = balances.get("btc");
+    assertThat(btcBalance.getAvailableAmount()).isEqualByComparingTo("0.009");
+    assertThat(btcBalance.getReservedAmount()).isEqualByComparingTo("0");
+    assertThat(btcBalance.getTotalAmount()).isEqualByComparingTo("0.009");
+
+    final BitcoindeBalance ethBalance = balances.get("eth");
+    assertThat(ethBalance.getAvailableAmount()).isEqualByComparingTo("0.06463044");
+    assertThat(ethBalance.getReservedAmount()).isEqualByComparingTo("0");
+    assertThat(ethBalance.getTotalAmount()).isEqualByComparingTo("0.06463044");
+
+    final BitcoindeBalance bchBalance = balances.get("bch");
+    assertThat(bchBalance.getAvailableAmount()).isEqualByComparingTo("0.008");
+    assertThat(bchBalance.getReservedAmount()).isEqualByComparingTo("0");
+    assertThat(bchBalance.getTotalAmount()).isEqualByComparingTo("0.008");
+
+    final BitcoindeBalance btgBalance = balances.get("btg");
+    assertThat(btgBalance.getAvailableAmount()).isEqualByComparingTo("0.007");
+    assertThat(btgBalance.getReservedAmount()).isEqualByComparingTo("0");
+    assertThat(btgBalance.getTotalAmount()).isEqualByComparingTo("0.007");
+
+    final BitcoindeBalance bsvBalance = balances.get("bsv");
+    assertThat(bsvBalance.getAvailableAmount()).isEqualByComparingTo("0.006");
+    assertThat(bsvBalance.getReservedAmount()).isEqualByComparingTo("0");
+    assertThat(bsvBalance.getTotalAmount()).isEqualByComparingTo("0.006");
+
+    // Make sure balance fidor reservations are correct
+    final BitcoindeFidorReservation fidorReservation =
+        bitcoindeAccountWrapper.getData().getFidorReservation();
+
+    assertThat(fidorReservation).isNotNull();
+    assertThat(fidorReservation.getAllocation()).isNotNull();
+    assertThat(fidorReservation.getTotalAmount()).isEqualByComparingTo("2000");
+    assertThat(fidorReservation.getAvailableAmount()).isEqualByComparingTo("2000");
+    assertThat(fidorReservation.getReservedAt()).isEqualTo("2018-01-24T10:36:03+01:00");
+    assertThat(fidorReservation.getValidUntil()).isEqualTo("2018-01-31T10:36:02+01:00");
+
+    final Map<String, BitcoindeAllocation> allocations = fidorReservation.getAllocation();
+    assertThat(allocations).containsOnlyKeys("btc", "eth", "bch", "btg");
+
+    final BitcoindeAllocation btcAllocation = allocations.get("btc");
+    assertThat(btcAllocation.getPercent()).isEqualByComparingTo("100");
+    assertThat(btcAllocation.getMaxEurVolume()).isEqualByComparingTo("2000");
+    assertThat(btcAllocation.getEurVolumeOpenOrders()).isEqualByComparingTo("0");
+
+    final BitcoindeAllocation ethAllocation = allocations.get("eth");
+    assertThat(ethAllocation.getPercent()).isEqualByComparingTo("0");
+    assertThat(ethAllocation.getMaxEurVolume()).isEqualByComparingTo("0");
+    assertThat(ethAllocation.getEurVolumeOpenOrders()).isEqualByComparingTo("0");
+
+    final BitcoindeAllocation bchAllocation = allocations.get("bch");
+    assertThat(bchAllocation.getPercent()).isEqualByComparingTo("0");
+    assertThat(bchAllocation.getMaxEurVolume()).isEqualByComparingTo("0");
+    assertThat(bchAllocation.getEurVolumeOpenOrders()).isEqualByComparingTo("0");
+
+    final BitcoindeAllocation btgAllocation = allocations.get("btg");
+    assertThat(btgAllocation.getPercent()).isEqualByComparingTo("0");
+    assertThat(btgAllocation.getMaxEurVolume()).isEqualByComparingTo("0");
+    assertThat(btgAllocation.getEurVolumeOpenOrders()).isEqualByComparingTo("0");
+  }
+}

--- a/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeCompactOrderbookWrapperTest.java
+++ b/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeCompactOrderbookWrapperTest.java
@@ -1,0 +1,37 @@
+package org.knowm.xchange.bitcoinde.v4.dto.marketdata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Test;
+
+/** @author matthewdowney */
+public class BitcoindeCompactOrderbookWrapperTest {
+
+  @Test
+  public void testBitcoindeCompactOrderbookWrapper()
+      throws JsonParseException, JsonMappingException, IOException {
+    // Read in the JSON from the example resources
+    final InputStream is =
+        BitcoindeCompactOrderbookWrapperTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitcoinde/v4/dto/compact_orderbook.json");
+
+    // Use Jackson to parse it
+    final ObjectMapper mapper = new ObjectMapper();
+    final BitcoindeCompactOrderbookWrapper bitcoindeOrderBook =
+        mapper.readValue(is, BitcoindeCompactOrderbookWrapper.class);
+    final BitcoindeCompactOrders orders = bitcoindeOrderBook.getBitcoindeOrders();
+
+    // Make sure asks are correct
+    assertThat(orders.getAsks()[0].getPrice()).isEqualByComparingTo("2461.61");
+    assertThat(orders.getAsks()[0].getAmount()).isEqualByComparingTo("0.0406218");
+
+    // Make sure bids are correct
+    assertThat(orders.getBids()[0].getPrice()).isEqualByComparingTo("1200");
+    assertThat(orders.getBids()[0].getAmount()).isEqualByComparingTo("8.333");
+  }
+}

--- a/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeOrderbookWrapperTest.java
+++ b/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeOrderbookWrapperTest.java
@@ -1,0 +1,66 @@
+package org.knowm.xchange.bitcoinde.v4.dto.marketdata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Test;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindePaymentOption;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeTrustLevel;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeType;
+import org.knowm.xchange.currency.CurrencyPair;
+
+public class BitcoindeOrderbookWrapperTest {
+
+  @Test
+  public void testBitcoindeOrderbookWrapper()
+      throws JsonParseException, JsonMappingException, IOException {
+    // Read in the JSON from the example resources
+    final InputStream is =
+        BitcoindeOrderbookWrapperTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitcoinde/v4/dto/orderbook.json");
+
+    // Use Jackson to parse it
+    final ObjectMapper mapper = new ObjectMapper();
+    final BitcoindeOrderbookWrapper bitcoindeOrderBook =
+        mapper.readValue(is, BitcoindeOrderbookWrapper.class);
+    final BitcoindeOrder[] orders = bitcoindeOrderBook.getBitcoindeOrders();
+
+    assertThat(orders.length).isEqualTo(1);
+    assertThat(orders[0].getOrderId()).isEqualTo("A1B2D3");
+    assertThat(orders[0].getTradingPair()).isEqualByComparingTo(CurrencyPair.BTC_EUR);
+    assertThat(orders[0].getType()).isEqualByComparingTo(BitcoindeType.BUY);
+    assertThat(orders[0].getExternalWalletOrder()).isFalse();
+    assertThat(orders[0].getMinAmount()).isEqualByComparingTo("0.1");
+    assertThat(orders[0].getMaxAmount()).isEqualByComparingTo("0.5");
+    assertThat(orders[0].getPrice()).isEqualByComparingTo("230.55");
+    assertThat(orders[0].getMinVolume()).isEqualByComparingTo("23.06");
+    assertThat(orders[0].getMaxVolume()).isEqualByComparingTo("115.28");
+    assertThat(orders[0].getRequirementsFullfilled()).isTrue();
+    assertThat(orders[0].getTradingPartnerInformation()).isNotNull();
+    assertThat(orders[0].getTradingPartnerInformation().getUserName()).isEqualTo("bla");
+    assertThat(orders[0].getTradingPartnerInformation().getTrustLevel())
+        .isEqualByComparingTo(BitcoindeTrustLevel.GOLD);
+    assertThat(orders[0].getTradingPartnerInformation().getRating()).isEqualTo(99);
+    assertThat(orders[0].getTradingPartnerInformation().getKycFull()).isTrue();
+    assertThat(orders[0].getTradingPartnerInformation().getBankName()).isEqualTo("Sparkasse");
+    assertThat(orders[0].getTradingPartnerInformation().getBic()).isEqualTo("HASPDEHHXXX");
+    assertThat(orders[0].getTradingPartnerInformation().getSeatOfBank()).isEqualTo("DE");
+    assertThat(orders[0].getTradingPartnerInformation().getAmountTrades()).isEqualTo(52);
+    assertThat(orders[0].getOrderRequirements()).isNotNull();
+    assertThat(orders[0].getOrderRequirements().getMinTrustLevel())
+        .isEqualByComparingTo(BitcoindeTrustLevel.GOLD);
+    assertThat(orders[0].getOrderRequirements().getOnlyKycFull()).isTrue();
+    assertThat(orders[0].getOrderRequirements().getPaymentOption())
+        .isEqualByComparingTo(BitcoindePaymentOption.EXPRESS_ONLY);
+    assertThat(orders[0].getOrderRequirements().getSeatOfBank()).containsExactly("DE", "NL");
+
+    assertThat(bitcoindeOrderBook.getCredits()).isEqualTo(12);
+    assertThat(bitcoindeOrderBook.getErrors()).isEmpty();
+    assertThat(bitcoindeOrderBook.getMaintenance()).isNull();
+    assertThat(bitcoindeOrderBook.getNonce()).isNull();
+  }
+}

--- a/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeTradesWrapperTest.java
+++ b/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/dto/marketdata/BitcoindeTradesWrapperTest.java
@@ -1,0 +1,32 @@
+package org.knowm.xchange.bitcoinde.v4.dto.marketdata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Test;
+
+public class BitcoindeTradesWrapperTest {
+
+  @Test
+  public void testBitcoindeTradesWrapper() throws IOException {
+    // Read in the JSON from the example resources
+    final InputStream is =
+        BitcoindeTradesWrapperTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitcoinde/v4/dto/trades.json");
+
+    // Use Jackson to parse it
+    final ObjectMapper mapper = new ObjectMapper();
+    final BitcoindeTradesWrapper bitcoindeTradesWrapper =
+        mapper.readValue(is, BitcoindeTradesWrapper.class);
+
+    // Make sure trade values are correct
+    final BitcoindeTrade[] trades = bitcoindeTradesWrapper.getTrades();
+
+    assertThat(trades[0].getDate()).isEqualTo("2017-07-22T12:14:14+02:00");
+    assertThat(trades[0].getPrice()).isEqualByComparingTo("2391.48");
+    assertThat(trades[0].getAmount()).isEqualByComparingTo("0.90000000");
+    assertThat(trades[0].getTid()).isEqualTo(2844384L);
+  }
+}

--- a/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/dto/trade/BitcoindeMyOrdersWrapperTest.java
+++ b/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/dto/trade/BitcoindeMyOrdersWrapperTest.java
@@ -1,0 +1,64 @@
+package org.knowm.xchange.bitcoinde.v4.dto.trade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Test;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeOrderState;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindePage;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindePaymentOption;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeTrustLevel;
+import org.knowm.xchange.currency.CurrencyPair;
+
+public class BitcoindeMyOrdersWrapperTest {
+
+  @Test
+  public void testBitcoindeMyOrdersWrapper()
+      throws JsonParseException, JsonMappingException, IOException {
+    // Read in the JSON from the example resources
+    final InputStream is =
+        BitcoindeMyOrdersWrapperTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitcoinde/v4/dto/my_orders.json");
+
+    // Use Jackson to parse it
+    final ObjectMapper mapper = new ObjectMapper();
+    BitcoindeMyOrdersWrapper bitcoindeOpenOrdersWrapper =
+        mapper.readValue(is, BitcoindeMyOrdersWrapper.class);
+
+    // Make sure trade values are correct
+    assertThat(bitcoindeOpenOrdersWrapper.getOrders().size()).isEqualTo(1);
+
+    final BitcoindeMyOrder order = bitcoindeOpenOrdersWrapper.getOrders().get(0);
+    assertThat(order.getOrderId()).isEqualTo("VNSP86");
+    assertThat(order.getTradingPair()).isEqualTo(CurrencyPair.BTC_EUR);
+    assertThat(order.getExternalWalletOrder()).isFalse();
+    assertThat(order.getMaxAmount()).isEqualByComparingTo("0.01");
+    assertThat(order.getMinAmount()).isEqualByComparingTo("0.01");
+    assertThat(order.getPrice()).isEqualByComparingTo("6000");
+    assertThat(order.getMaxVolume()).isEqualByComparingTo("60");
+    assertThat(order.getMinVolume()).isEqualByComparingTo("60");
+
+    assertThat(order.getOrderRequirements()).isNotNull();
+    assertThat(order.getOrderRequirements().getMinTrustLevel())
+        .isEqualTo(BitcoindeTrustLevel.SILVER);
+    assertThat(order.getOrderRequirements().getOnlyKycFull()).isFalse();
+    assertThat(order.getOrderRequirements().getSeatOfBank())
+        .containsExactly(
+            "AT", "BE", "BG", "CH", "CY", "CZ", "DE", "DK", "EE", "ES", "FI", "FR", "GB", "GR",
+            "HR", "HU", "IE", "IS", "IT", "LI", "LT", "LU", "LV", "MQ", "MT", "NL", "NO", "PL",
+            "PT", "RO", "SE", "SI", "SK");
+    assertThat(order.getOrderRequirements().getPaymentOption())
+        .isEqualTo(BitcoindePaymentOption.EXPRESS_SEPA);
+
+    assertThat(order.getNewOrderForRemainingAmount()).isFalse();
+    assertThat(order.getState()).isEqualTo(BitcoindeOrderState.PENDING);
+    assertThat(order.getEndDatetime()).isEqualTo("2018-01-30T23:45:00+01:00");
+    assertThat(order.getCreatedAt()).isEqualTo("2018-01-25T17:35:19+01:00");
+
+    assertThat(bitcoindeOpenOrdersWrapper.getPage()).isEqualTo(new BitcoindePage(1, 1));
+  }
+}

--- a/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/dto/trade/BitcoindeMyTradesWrapperTest.java
+++ b/xchange-bitcoinde/src/test/java/org/knowm/xchange/bitcoinde/v4/dto/trade/BitcoindeMyTradesWrapperTest.java
@@ -1,0 +1,64 @@
+package org.knowm.xchange.bitcoinde.v4.dto.trade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Test;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeTrustLevel;
+import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeType;
+import org.knowm.xchange.currency.CurrencyPair;
+
+public class BitcoindeMyTradesWrapperTest {
+
+  @Test
+  public void testBitcoindeMyTradesWrapper() throws IOException {
+    // Read in the JSON from the example resources
+    final InputStream is =
+        BitcoindeMyTradesWrapperTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitcoinde/v4/dto/my_trades.json");
+
+    // Use Jackson to parse it
+    final ObjectMapper mapper = new ObjectMapper();
+    BitcoindeMyTradesWrapper myTradesWrapper = mapper.readValue(is, BitcoindeMyTradesWrapper.class);
+
+    // Make sure trade values are correct
+    assertThat(myTradesWrapper.getTrades()).isNotEmpty();
+    assertThat(myTradesWrapper.getTrades().size()).isEqualTo(1);
+
+    BitcoindeMyTrade trade = myTradesWrapper.getTrades().get(0);
+    assertThat(trade.getTradeId()).isEqualTo("2EDYNS");
+    assertThat(trade.getTradingPair()).isEqualByComparingTo(CurrencyPair.BTC_EUR);
+    assertThat(trade.getIsExternalWalletTrade()).isFalse();
+    assertThat(trade.getType()).isEqualByComparingTo(BitcoindeType.SELL);
+    assertThat(trade.getAmountCurrencyToTrade()).isEqualByComparingTo("0.5");
+    assertThat(trade.getAmountCurrencyToTradeAfterFee()).isEqualByComparingTo("0.4975");
+    assertThat(trade.getPrice()).isEqualByComparingTo("250.55");
+    assertThat(trade.getVolumeCurrencyToPay()).isEqualByComparingTo("125.28");
+    assertThat(trade.getVolumeCurrencyToPayAfterFee()).isEqualByComparingTo("124.68");
+    assertThat(trade.getFeeCurrencyToPay()).isEqualByComparingTo("0.6");
+    assertThat(trade.getFeeCurrencyToTrade()).isEqualByComparingTo("0.0025");
+    assertThat(trade.getNewOrderIdForRemainingAmount()).isEqualTo("C4Y8HD");
+    assertThat(trade.getState()).isEqualByComparingTo(BitcoindeMyTrade.State.SUCCESSFUL);
+    assertThat(trade.getIsTradeMarkedAsPaid()).isFalse();
+    assertThat(trade.getTradeMarkedAsPaidAt()).isNull();
+    assertThat(trade.getMyRatingForTradingPartner())
+        .isEqualByComparingTo(BitcoindeMyTrade.Rating.POSITIVE);
+    assertThat(trade.getTradingPartnerInformation()).isNotNull();
+    assertThat(trade.getTradingPartnerInformation().getUserName()).isEqualTo("testuser");
+    assertThat(trade.getTradingPartnerInformation().getKycFull()).isTrue();
+    assertThat(trade.getTradingPartnerInformation().getTrustLevel())
+        .isEqualByComparingTo(BitcoindeTrustLevel.GOLD);
+    assertThat(trade.getTradingPartnerInformation().getDepositor()).isEqualTo("Max Musterman");
+    assertThat(trade.getTradingPartnerInformation().getIban()).isEqualTo("DE02370501980001802057");
+    assertThat(trade.getTradingPartnerInformation().getBankName()).isEqualTo("sparkasse");
+    assertThat(trade.getTradingPartnerInformation().getBic()).isEqualTo("HASPDEHHXXX");
+    assertThat(trade.getTradingPartnerInformation().getRating()).isEqualTo(99);
+    assertThat(trade.getTradingPartnerInformation().getAmountTrades()).isEqualTo(42);
+    assertThat(trade.getTradingPartnerInformation().getSeatOfBank()).isEqualTo("DE");
+    assertThat(trade.getCreatedAt()).isEqualTo("2015-01-10T15:00:00+02:00");
+    assertThat(trade.getSuccessfullyFinishedAt()).isEqualTo("2015-01-10T15:00:00+02:00");
+    assertThat(trade.getPayment_method()).isEqualByComparingTo(BitcoindeMyTrade.PaymentMethod.SEPA);
+  }
+}

--- a/xchange-bitcoinde/src/test/resources/org/knowm/xchange/bitcoinde/v4/dto/account.json
+++ b/xchange-bitcoinde/src/test/resources/org/knowm/xchange/bitcoinde/v4/dto/account.json
@@ -1,0 +1,67 @@
+{
+	"data": {
+		"balances": {
+			"btc": {
+				"total_amount": "0.009",
+				"available_amount": "0.009",
+				"reserved_amount": "0"
+			},
+			"bch": {
+				"total_amount": "0.008",
+				"available_amount": "0.008",
+				"reserved_amount": "0"
+			},
+			"btg": {
+				"total_amount": "0.007",
+				"available_amount": "0.007",
+				"reserved_amount": "0"
+			},
+			"bsv": {
+				"total_amount": "0.006",
+				"available_amount": "0.006",
+				"reserved_amount": "0"
+			},
+			"eth": {
+				"total_amount": "0.06463044",
+				"available_amount": "0.06463044",
+				"reserved_amount": "0"
+			}
+		},
+		"fidor_reservation": {
+			"total_amount": 2000,
+			"available_amount": 2000,
+			"reserved_at": "2018-01-24T10:36:03+01:00",
+			"valid_until": "2018-01-31T10:36:02+01:00",
+			"allocation": {
+				"btc": {
+					"percent": 100,
+					"max_eur_volume": 2000,
+					"eur_volume_open_orders": 0
+				},
+				"bch": {
+					"percent": 0,
+					"max_eur_volume": 0,
+					"eur_volume_open_orders": 0
+				},
+				"btg": {
+					"percent": 0,
+					"max_eur_volume": 0,
+					"eur_volume_open_orders": 0
+				},
+				"eth": {
+					"percent": 0,
+					"max_eur_volume": 0,
+					"eur_volume_open_orders": 0
+				}
+			}
+		},
+		"encrypted_information": {
+			"uid": "0ywbQpgJkzkjYVE1",
+			"bic_short": "0yzjPeTwlzkig1B-",
+			"bic_full": "0yzjPeTw33DssfxIB4io2Mow-w.."
+		}
+	},
+	"errors": [
+	],
+	"credits": 13
+}

--- a/xchange-bitcoinde/src/test/resources/org/knowm/xchange/bitcoinde/v4/dto/account_ledger.json
+++ b/xchange-bitcoinde/src/test/resources/org/knowm/xchange/bitcoinde/v4/dto/account_ledger.json
@@ -1,0 +1,47 @@
+{
+  "account_ledger": [
+    {
+      "date": "2015-08-13T10:20:27+02:00",
+      "type": "sell",
+      "reference": "NVP39U",
+      "trade": {
+        "trade_id": "NVP39U",
+        "trading_pair": "btceur",
+        "price": "243.77",
+        "currency_to_trade": {
+          "currency": "btc",
+          "before_fee": "1.71600000",
+          "after_fee": "1.69884000"
+        },
+        "currency_to_pay": {
+          "currency": "eur",
+          "before_fee": "418.31",
+          "after_fee": "414.13"
+        }
+      },
+      "cashflow": "-1.71600000",
+      "balance": "3.00019794"
+    },
+    {
+      "date": "2015-08-12T13:05:02+02:00",
+      "type": "payout",
+      "reference": "dqwdqwdwqwq4dqw4d5qd45qd45qwd4qw5df45g4r5g4trh4r5j5j4tz5j4tbc",
+      "cashflow": "-0.10000000",
+      "balance": "4.71619794"
+    },
+    {
+      "date": "2015-08-12T12:30:01+02:00",
+      "type": "payout",
+      "reference": "bdgwflwguwgr884t34g4g555h4zr5j4fh5j48rg4s5bx2nt4jr5jr45j4r5j4",
+      "cashflow": "-1.91894200",
+      "balance": "4.81619794"
+    }
+  ],
+  "page": {
+    "current": 1,
+    "last": 1
+  },
+  "errors": [
+  ],
+  "credits": 9
+}

--- a/xchange-bitcoinde/src/test/resources/org/knowm/xchange/bitcoinde/v4/dto/compact_orderbook.json
+++ b/xchange-bitcoinde/src/test/resources/org/knowm/xchange/bitcoinde/v4/dto/compact_orderbook.json
@@ -1,0 +1,9111 @@
+{
+  "trading_pair":"btceur",
+  "orders": {
+    "asks": [
+      {
+        "price": 2461.61,
+        "amount_currency_to_trade": 0.0406218
+      },
+      {
+        "price": 2529.29,
+        "amount_currency_to_trade": 0.03953483
+      },
+      {
+        "price": 2545.45,
+        "amount_currency_to_trade": 0.03928383
+      },
+      {
+        "price": 2561.61,
+        "amount_currency_to_trade": 0.039036
+      },
+      {
+        "price": 2616.16,
+        "amount_currency_to_trade": 0.03822206
+      },
+      {
+        "price": 2632.32,
+        "amount_currency_to_trade": 0.03798741
+      },
+      {
+        "price": 2709.09,
+        "amount_currency_to_trade": 0.03691093
+      },
+      {
+        "price": 2981.81,
+        "amount_currency_to_trade": 0.0335351
+      },
+      {
+        "price": 2965.65,
+        "amount_currency_to_trade": 0.03371776
+      },
+      {
+        "price": 2948.48,
+        "amount_currency_to_trade": 0.03391409
+      },
+      {
+        "price": 2934.34,
+        "amount_currency_to_trade": 0.03407751
+      },
+      {
+        "price": 2908.08,
+        "amount_currency_to_trade": 0.03438525
+      },
+      {
+        "price": 2897.97,
+        "amount_currency_to_trade": 0.03450519
+      },
+      {
+        "price": 2869.69,
+        "amount_currency_to_trade": 0.03484525
+      },
+      {
+        "price": 2849.49,
+        "amount_currency_to_trade": 0.03509225
+      },
+      {
+        "price": 2834.34,
+        "amount_currency_to_trade": 0.03527982
+      },
+      {
+        "price": 2818.18,
+        "amount_currency_to_trade": 0.03548215
+      },
+      {
+        "price": 2785.85,
+        "amount_currency_to_trade": 0.0358939
+      },
+      {
+        "price": 2745.45,
+        "amount_currency_to_trade": 0.0364221
+      },
+      {
+        "price": 2734.34,
+        "amount_currency_to_trade": 0.0365701
+      },
+      {
+        "price": 2808.08,
+        "amount_currency_to_trade": 0.03560975
+      },
+      {
+        "price": 3029.29,
+        "amount_currency_to_trade": 0.03300939
+      },
+      {
+        "price": 3061.61,
+        "amount_currency_to_trade": 0.03266093
+      },
+      {
+        "price": 3093.93,
+        "amount_currency_to_trade": 0.03231974
+      },
+      {
+        "price": 3126.26,
+        "amount_currency_to_trade": 0.03198551
+      },
+      {
+        "price": 3158.58,
+        "amount_currency_to_trade": 0.03165822
+      },
+      {
+        "price": 3013.13,
+        "amount_currency_to_trade": 0.03318643
+      },
+      {
+        "price": 3045.45,
+        "amount_currency_to_trade": 0.03283423
+      },
+      {
+        "price": 3077.77,
+        "amount_currency_to_trade": 0.03248944
+      },
+      {
+        "price": 3142.42,
+        "amount_currency_to_trade": 0.03182102
+      },
+      {
+        "price": 3174.74,
+        "amount_currency_to_trade": 0.03149707
+      },
+      {
+        "price": 3195.95,
+        "amount_currency_to_trade": 0.03128804
+      },
+      {
+        "price": 3248.48,
+        "amount_currency_to_trade": 0.0307821
+      },
+      {
+        "price": 3296.96,
+        "amount_currency_to_trade": 0.03032947
+      },
+      {
+        "price": 3348.48,
+        "amount_currency_to_trade": 0.02986281
+      },
+      {
+        "price": 3397.97,
+        "amount_currency_to_trade": 0.02942787
+      },
+      {
+        "price": 3448.48,
+        "amount_currency_to_trade": 0.02899684
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 3337.87,
+        "amount_currency_to_trade": 0.051
+      },
+      {
+        "price": 2784,
+        "amount_currency_to_trade": 0.28215
+      },
+      {
+        "price": 2800,
+        "amount_currency_to_trade": 0.512864
+      },
+      {
+        "price": 2800,
+        "amount_currency_to_trade": 0.7
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.259
+      },
+      {
+        "price": 2800,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.2948
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.1839
+      },
+      {
+        "price": 2695,
+        "amount_currency_to_trade": 0.02227228
+      },
+      {
+        "price": 2498,
+        "amount_currency_to_trade": 9
+      },
+      {
+        "price": 2711.86,
+        "amount_currency_to_trade": 5.98535857
+      },
+      {
+        "price": 2737.7,
+        "amount_currency_to_trade": 0.0211
+      },
+      {
+        "price": 2568.98,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2690,
+        "amount_currency_to_trade": 0.743
+      },
+      {
+        "price": 2710,
+        "amount_currency_to_trade": 0.738
+      },
+      {
+        "price": 2570,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2680,
+        "amount_currency_to_trade": 0.7462
+      },
+      {
+        "price": 2970,
+        "amount_currency_to_trade": 0.6734
+      },
+      {
+        "price": 2960,
+        "amount_currency_to_trade": 0.2109
+      },
+      {
+        "price": 4025.85,
+        "amount_currency_to_trade": 0.056
+      },
+      {
+        "price": 3535.85,
+        "amount_currency_to_trade": 0.064
+      },
+      {
+        "price": 3337.85,
+        "amount_currency_to_trade": 0.051
+      },
+      {
+        "price": 3157.9,
+        "amount_currency_to_trade": 0.021
+      },
+      {
+        "price": 3000.01,
+        "amount_currency_to_trade": 0.024
+      },
+      {
+        "price": 2850,
+        "amount_currency_to_trade": 1.58
+      },
+      {
+        "price": 2799.99,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2970,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 3038,
+        "amount_currency_to_trade": 0.0198
+      },
+      {
+        "price": 2644.98,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 3795.85,
+        "amount_currency_to_trade": 0.045
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.02931801
+      },
+      {
+        "price": 3795.85,
+        "amount_currency_to_trade": 0.06
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.0682758
+      },
+      {
+        "price": 2465.99,
+        "amount_currency_to_trade": 0.027
+      },
+      {
+        "price": 3010,
+        "amount_currency_to_trade": 0.87296
+      },
+      {
+        "price": 2650,
+        "amount_currency_to_trade": 0.30143774
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.021
+      },
+      {
+        "price": 3999.9,
+        "amount_currency_to_trade": 0.015
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.13138966
+      },
+      {
+        "price": 2499.06,
+        "amount_currency_to_trade": 0.02400703
+      },
+      {
+        "price": 2548,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 2448.86,
+        "amount_currency_to_trade": 0.2282
+      },
+      {
+        "price": 2464.98,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2519.87,
+        "amount_currency_to_trade": 0.07100438
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 4200,
+        "amount_currency_to_trade": 0.01462343
+      },
+      {
+        "price": 2429.29,
+        "amount_currency_to_trade": 0.04116226
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.2727739
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2440.29,
+        "amount_currency_to_trade": 0.0245852
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2497.97,
+        "amount_currency_to_trade": 0.14651741
+      },
+      {
+        "price": 2475,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.02357056
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 2649.99,
+        "amount_currency_to_trade": 0.022
+      },
+      {
+        "price": 3250,
+        "amount_currency_to_trade": 0.30568825
+      },
+      {
+        "price": 2642,
+        "amount_currency_to_trade": 0.757
+      },
+      {
+        "price": 2690,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2790,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2890,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2990,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2695.9,
+        "amount_currency_to_trade": 0.0225
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.1984
+      },
+      {
+        "price": 2448.48,
+        "amount_currency_to_trade": 0.04083966
+      },
+      {
+        "price": 2750,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2900,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2650,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2800,
+        "amount_currency_to_trade": 0.07525
+      },
+      {
+        "price": 2492,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2499,
+        "amount_currency_to_trade": 0.7
+      },
+      {
+        "price": 2490,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 2590,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.025
+      },
+      {
+        "price": 2478.05,
+        "amount_currency_to_trade": 0.024
+      },
+      {
+        "price": 2749.95,
+        "amount_currency_to_trade": 0.021
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.1488
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 2485,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2800,
+        "amount_currency_to_trade": 6
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 3500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2708,
+        "amount_currency_to_trade": 0.02216
+      },
+      {
+        "price": 2511,
+        "amount_currency_to_trade": 0.84
+      },
+      {
+        "price": 4340,
+        "amount_currency_to_trade": 0.16418061
+      },
+      {
+        "price": 2478.95,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 2507.9,
+        "amount_currency_to_trade": 0.0235
+      },
+      {
+        "price": 4000,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 1.98
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 4400,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.11
+      },
+      {
+        "price": 2710,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 2444.44,
+        "amount_currency_to_trade": 0.024544
+      },
+      {
+        "price": 2488.99,
+        "amount_currency_to_trade": 0.024105
+      },
+      {
+        "price": 3000.01,
+        "amount_currency_to_trade": 0.019
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.992
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.0200001
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.399
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.399
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 2737.66,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2540,
+        "amount_currency_to_trade": 0.8925
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.12532023
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.2976
+      },
+      {
+        "price": 2550,
+        "amount_currency_to_trade": 0.3968
+      },
+      {
+        "price": 2998,
+        "amount_currency_to_trade": 0.125
+      },
+      {
+        "price": 2498,
+        "amount_currency_to_trade": 0.125
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.28215
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.12375
+      },
+      {
+        "price": 2502.29,
+        "amount_currency_to_trade": 0.08398907
+      },
+      {
+        "price": 2484.84,
+        "amount_currency_to_trade": 0.08457894
+      },
+      {
+        "price": 2467.51,
+        "amount_currency_to_trade": 0.0795954
+      },
+      {
+        "price": 2450.3,
+        "amount_currency_to_trade": 0.08577117
+      },
+      {
+        "price": 2433.21,
+        "amount_currency_to_trade": 0.17274706
+      },
+      {
+        "price": 2505.95,
+        "amount_currency_to_trade": 0.023
+      },
+      {
+        "price": 2505.87,
+        "amount_currency_to_trade": 0.092
+      },
+      {
+        "price": 2505.87,
+        "amount_currency_to_trade": 0.023
+      },
+      {
+        "price": 2609.87,
+        "amount_currency_to_trade": 0.022
+      },
+      {
+        "price": 2609.87,
+        "amount_currency_to_trade": 0.022
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.026
+      },
+      {
+        "price": 2635,
+        "amount_currency_to_trade": 0.02277
+      },
+      {
+        "price": 2630,
+        "amount_currency_to_trade": 0.393768
+      },
+      {
+        "price": 2735.85,
+        "amount_currency_to_trade": 0.021
+      },
+      {
+        "price": 2735.85,
+        "amount_currency_to_trade": 0.063
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.022
+      },
+      {
+        "price": 2700,
+        "amount_currency_to_trade": 0.7
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.09
+      },
+      {
+        "price": 2580,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 2999,
+        "amount_currency_to_trade": 0.0839718
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.055
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.022
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.024
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.027
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.6277
+      },
+      {
+        "price": 3200,
+        "amount_currency_to_trade": 0.24
+      },
+      {
+        "price": 2499,
+        "amount_currency_to_trade": 0.053
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.042
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.025
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2480,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2510,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2540,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2605,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2640,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2667,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 3500,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 2525,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2430,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2498.5,
+        "amount_currency_to_trade": 0.14
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.099
+      },
+      {
+        "price": 3500,
+        "amount_currency_to_trade": 0.01759899
+      },
+      {
+        "price": 2497,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2490,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2540,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2590,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2550,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2440,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 2430,
+        "amount_currency_to_trade": 0.279744
+      },
+      {
+        "price": 2560,
+        "amount_currency_to_trade": 0.02772
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.1985
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 3423,
+        "amount_currency_to_trade": 0.01761563
+      },
+      {
+        "price": 3769.96,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 2834,
+        "amount_currency_to_trade": 3.6
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.031
+      },
+      {
+        "price": 3500,
+        "amount_currency_to_trade": 0.0179
+      },
+      {
+        "price": 2900,
+        "amount_currency_to_trade": 0.020394
+      },
+      {
+        "price": 2649,
+        "amount_currency_to_trade": 2.5
+      },
+      {
+        "price": 2799.9,
+        "amount_currency_to_trade": 0.02143
+      },
+      {
+        "price": 2499,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2501,
+        "amount_currency_to_trade": 0.799
+      },
+      {
+        "price": 2599.99,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 3500,
+        "amount_currency_to_trade": 0.169504
+      },
+      {
+        "price": 2986,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2480,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2480,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2505.84,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2609.83,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2735.83,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 3500,
+        "amount_currency_to_trade": 0.198
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.8426
+      },
+      {
+        "price": 2550,
+        "amount_currency_to_trade": 0.099
+      },
+      {
+        "price": 2609.85,
+        "amount_currency_to_trade": 0.022
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.025
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.815
+      },
+      {
+        "price": 2750,
+        "amount_currency_to_trade": 0.63045818
+      },
+      {
+        "price": 2465,
+        "amount_currency_to_trade": 0.4926085
+      },
+      {
+        "price": 2899.98,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2999.98,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2849.98,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.026
+      },
+      {
+        "price": 3600,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 2800,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 3750,
+        "amount_currency_to_trade": 0.016
+      },
+      {
+        "price": 2505.85,
+        "amount_currency_to_trade": 0.0234
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 2857.5,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2857.2,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.059
+      },
+      {
+        "price": 3200,
+        "amount_currency_to_trade": 0.018
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.08
+      },
+      {
+        "price": 4444,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 4431,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 2470,
+        "amount_currency_to_trade": 0.992
+      },
+      {
+        "price": 2499.95,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.025
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.023
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.026
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.028
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.032
+      },
+      {
+        "price": 3799.9,
+        "amount_currency_to_trade": 0.015
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.198
+      },
+      {
+        "price": 2499.95,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 4400,
+        "amount_currency_to_trade": 0.013
+      },
+      {
+        "price": 3535.85,
+        "amount_currency_to_trade": 0.017
+      },
+      {
+        "price": 3749.95,
+        "amount_currency_to_trade": 0.016
+      },
+      {
+        "price": 4400,
+        "amount_currency_to_trade": 0.013
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.022
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.029
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.032
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.033
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 3109.09,
+        "amount_currency_to_trade": 0.03216215
+      },
+      {
+        "price": 2800,
+        "amount_currency_to_trade": 0.46993761
+      },
+      {
+        "price": 2499,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2816,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2735.82,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.023
+      },
+      {
+        "price": 3547.47,
+        "amount_currency_to_trade": 0.0281877
+      },
+      {
+        "price": 3648.48,
+        "amount_currency_to_trade": 0.02740731
+      },
+      {
+        "price": 3747.47,
+        "amount_currency_to_trade": 0.02668335
+      },
+      {
+        "price": 3848.48,
+        "amount_currency_to_trade": 0.025983
+      },
+      {
+        "price": 3948.48,
+        "amount_currency_to_trade": 0.02532495
+      },
+      {
+        "price": 4049.49,
+        "amount_currency_to_trade": 0.02469324
+      },
+      {
+        "price": 2498.99,
+        "amount_currency_to_trade": 1.49792
+      },
+      {
+        "price": 2431,
+        "amount_currency_to_trade": 2.2
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 2735.8,
+        "amount_currency_to_trade": 0.042
+      },
+      {
+        "price": 3224.24,
+        "amount_currency_to_trade": 0.03101352
+      },
+      {
+        "price": 3274.74,
+        "amount_currency_to_trade": 0.03053525
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.099
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 3462,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.028
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 2.71312
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.19751
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2657.1,
+        "amount_currency_to_trade": 1.8
+      },
+      {
+        "price": 2539,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 2850,
+        "amount_currency_to_trade": 0.022
+      },
+      {
+        "price": 2468.1,
+        "amount_currency_to_trade": 0.43
+      },
+      {
+        "price": 3769.93,
+        "amount_currency_to_trade": 0.015
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.028
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 2999.99,
+        "amount_currency_to_trade": 8.3
+      },
+      {
+        "price": 3495.95,
+        "amount_currency_to_trade": 0.0286031
+      },
+      {
+        "price": 3595.95,
+        "amount_currency_to_trade": 0.0278077
+      },
+      {
+        "price": 3696.96,
+        "amount_currency_to_trade": 0.02704792
+      },
+      {
+        "price": 4148.48,
+        "amount_currency_to_trade": 0.02410401
+      },
+      {
+        "price": 3324.24,
+        "amount_currency_to_trade": 0.03008056
+      },
+      {
+        "price": 3374.74,
+        "amount_currency_to_trade": 0.02963044
+      },
+      {
+        "price": 2889,
+        "amount_currency_to_trade": 0.02091721
+      },
+      {
+        "price": 2850,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2499.98,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.0222
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.49536497
+      },
+      {
+        "price": 3797.97,
+        "amount_currency_to_trade": 0.02632855
+      },
+      {
+        "price": 3898.98,
+        "amount_currency_to_trade": 0.02564646
+      },
+      {
+        "price": 3998.98,
+        "amount_currency_to_trade": 0.02500513
+      },
+      {
+        "price": 4098.98,
+        "amount_currency_to_trade": 0.0243951
+      },
+      {
+        "price": 4197.97,
+        "amount_currency_to_trade": 0.02381985
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2735.77,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.02574
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.027
+      },
+      {
+        "price": 2800,
+        "amount_currency_to_trade": 0.17791415
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2890,
+        "amount_currency_to_trade": 0.0208497
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 2732.99,
+        "amount_currency_to_trade": 0.063
+      },
+      {
+        "price": 2608.96,
+        "amount_currency_to_trade": 0.066
+      },
+      {
+        "price": 2502.95,
+        "amount_currency_to_trade": 0.069
+      },
+      {
+        "price": 3811,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2487.11,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 3157.9,
+        "amount_currency_to_trade": 0.022
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.06
+      },
+      {
+        "price": 2530,
+        "amount_currency_to_trade": 0.79
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.033
+      },
+      {
+        "price": 2510,
+        "amount_currency_to_trade": 2.5
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2700,
+        "amount_currency_to_trade": 0.0297
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.033
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.025
+      },
+      {
+        "price": 2498,
+        "amount_currency_to_trade": 0.516
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.08511543
+      },
+      {
+        "price": 3157.9,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.06811
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.021
+      },
+      {
+        "price": 2640,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2590,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2758,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2858,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2958,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2816.7,
+        "amount_currency_to_trade": 0.3218
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2510,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 2880,
+        "amount_currency_to_trade": 0.14135198
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.14799892
+      },
+      {
+        "price": 3157.9,
+        "amount_currency_to_trade": 0.018
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.43
+      },
+      {
+        "price": 2486,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 3000.01,
+        "amount_currency_to_trade": 0.019
+      },
+      {
+        "price": 3000.01,
+        "amount_currency_to_trade": 0.019
+      },
+      {
+        "price": 3535.82,
+        "amount_currency_to_trade": 0.016
+      },
+      {
+        "price": 3157.9,
+        "amount_currency_to_trade": 0.018
+      },
+      {
+        "price": 3000.01,
+        "amount_currency_to_trade": 0.019
+      },
+      {
+        "price": 2729.87,
+        "amount_currency_to_trade": 0.021
+      },
+      {
+        "price": 2729.87,
+        "amount_currency_to_trade": 0.021
+      },
+      {
+        "price": 3100,
+        "amount_currency_to_trade": 0.64511
+      },
+      {
+        "price": 3400,
+        "amount_currency_to_trade": 0.588
+      },
+      {
+        "price": 2999,
+        "amount_currency_to_trade": 0.11502001
+      },
+      {
+        "price": 2540,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.02376
+      },
+      {
+        "price": 2474,
+        "amount_currency_to_trade": 1.98
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2499,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.07124655
+      },
+      {
+        "price": 2725,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2728.74,
+        "amount_currency_to_trade": 0.042
+      },
+      {
+        "price": 2608.7,
+        "amount_currency_to_trade": 0.022
+      },
+      {
+        "price": 2500.99,
+        "amount_currency_to_trade": 0.023
+      },
+      {
+        "price": 2855,
+        "amount_currency_to_trade": 0.025
+      },
+      {
+        "price": 2750,
+        "amount_currency_to_trade": 0.0219
+      },
+      {
+        "price": 2665,
+        "amount_currency_to_trade": 0.106144
+      },
+      {
+        "price": 3535.8,
+        "amount_currency_to_trade": 0.017
+      },
+      {
+        "price": 3337.8,
+        "amount_currency_to_trade": 0.018
+      },
+      {
+        "price": 2640,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.0228
+      },
+      {
+        "price": 2499,
+        "amount_currency_to_trade": 0.7
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2700,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2597.87,
+        "amount_currency_to_trade": 0.48807616
+      },
+      {
+        "price": 2520,
+        "amount_currency_to_trade": 1.17454681
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 4000,
+        "amount_currency_to_trade": 0.992
+      },
+      {
+        "price": 4000,
+        "amount_currency_to_trade": 1.0912
+      },
+      {
+        "price": 4000,
+        "amount_currency_to_trade": 1.6751
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.09019354
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.099
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2490,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.024
+      },
+      {
+        "price": 2499,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.465
+      },
+      {
+        "price": 2555,
+        "amount_currency_to_trade": 0.9
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.197208
+      },
+      {
+        "price": 2498,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 2474,
+        "amount_currency_to_trade": 0.298
+      },
+      {
+        "price": 4125,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2499.95,
+        "amount_currency_to_trade": 0.025
+      },
+      {
+        "price": 2958,
+        "amount_currency_to_trade": 0.07919208
+      },
+      {
+        "price": 2543,
+        "amount_currency_to_trade": 0.112
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 3535.79,
+        "amount_currency_to_trade": 0.034
+      },
+      {
+        "price": 2590,
+        "amount_currency_to_trade": 0.042656
+      },
+      {
+        "price": 2650,
+        "amount_currency_to_trade": 0.92292602
+      },
+      {
+        "price": 3999.89,
+        "amount_currency_to_trade": 0.015
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.1522067
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.028
+      },
+      {
+        "price": 2700,
+        "amount_currency_to_trade": 0.156
+      },
+      {
+        "price": 2550,
+        "amount_currency_to_trade": 0.034672
+      },
+      {
+        "price": 2675,
+        "amount_currency_to_trade": 0.28648513
+      },
+      {
+        "price": 2594,
+        "amount_currency_to_trade": 0.33
+      },
+      {
+        "price": 2510,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 1.67
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 9.5
+      },
+      {
+        "price": 2555,
+        "amount_currency_to_trade": 0.782
+      },
+      {
+        "price": 2599.99,
+        "amount_currency_to_trade": 9.5
+      },
+      {
+        "price": 2600.01,
+        "amount_currency_to_trade": 5.07291263
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.666
+      },
+      {
+        "price": 2644,
+        "amount_currency_to_trade": 0.95
+      },
+      {
+        "price": 2550,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2530,
+        "amount_currency_to_trade": 0.79
+      },
+      {
+        "price": 2522.82,
+        "amount_currency_to_trade": 2.7171
+      },
+      {
+        "price": 2452,
+        "amount_currency_to_trade": 0.2475
+      },
+      {
+        "price": 3099.98,
+        "amount_currency_to_trade": 1.61911893
+      },
+      {
+        "price": 2499.98,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2700,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 2580,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2588.88,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 2499.97,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.247005
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 1.161
+      },
+      {
+        "price": 2444,
+        "amount_currency_to_trade": 1.25
+      },
+      {
+        "price": 2440,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2857.15,
+        "amount_currency_to_trade": 0.020999
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.02436056
+      },
+      {
+        "price": 2537,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2800,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2900,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 3100,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 3333,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 3200,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 3333,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 3500,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2400,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 2550,
+        "amount_currency_to_trade": 6.975
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 2570,
+        "amount_currency_to_trade": 1.77077786
+      },
+      {
+        "price": 4000,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2448,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2498,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2548,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2598,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2491,
+        "amount_currency_to_trade": 0.496
+      },
+      {
+        "price": 2534,
+        "amount_currency_to_trade": 2.1
+      },
+      {
+        "price": 2506,
+        "amount_currency_to_trade": 0.8432
+      },
+      {
+        "price": 2449.95,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2518.9,
+        "amount_currency_to_trade": 0.07
+      },
+      {
+        "price": 2650,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2451,
+        "amount_currency_to_trade": 0.51
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.769
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.085
+      },
+      {
+        "price": 2700,
+        "amount_currency_to_trade": 0.7
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2478.89,
+        "amount_currency_to_trade": 0.344
+      },
+      {
+        "price": 2550,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 2699,
+        "amount_currency_to_trade": 0.246016
+      },
+      {
+        "price": 2455,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2486,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2645,
+        "amount_currency_to_trade": 0.1946304
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.44
+      },
+      {
+        "price": 2510,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 10
+      },
+      {
+        "price": 2448,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 3500,
+        "amount_currency_to_trade": 0.198
+      },
+      {
+        "price": 2800,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2650,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2700,
+        "amount_currency_to_trade": 1.61135485
+      },
+      {
+        "price": 2480.1,
+        "amount_currency_to_trade": 0.20295
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2518.16,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2545.1,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2547.64,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 2540,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2497.97,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2497.96,
+        "amount_currency_to_trade": 0.6
+      },
+      {
+        "price": 2497.95,
+        "amount_currency_to_trade": 0.40017462
+      },
+      {
+        "price": 2649.5,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2550,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2750,
+        "amount_currency_to_trade": 0.23312
+      },
+      {
+        "price": 2477,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2446.99,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2440,
+        "amount_currency_to_trade": 0.3377
+      },
+      {
+        "price": 2498.1,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.594
+      },
+      {
+        "price": 2465,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 2499.99,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2514,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2584.1,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2700,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2800,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.59961379
+      },
+      {
+        "price": 2470,
+        "amount_currency_to_trade": 0.99
+      },
+      {
+        "price": 2528.55,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.06306362
+      },
+      {
+        "price": 2700,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2800,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2570,
+        "amount_currency_to_trade": 0.778
+      },
+      {
+        "price": 2474.89,
+        "amount_currency_to_trade": 0.79
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2450.99,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 4.95
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2489,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2940,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2460,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.13186606
+      },
+      {
+        "price": 2460,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2996,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2499.2,
+        "amount_currency_to_trade": 0.905
+      },
+      {
+        "price": 2418.66,
+        "amount_currency_to_trade": 0.19
+      },
+      {
+        "price": 2438.86,
+        "amount_currency_to_trade": 0.105804
+      },
+      {
+        "price": 2449,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2445,
+        "amount_currency_to_trade": 0.06965068
+      },
+      {
+        "price": 2449.99,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2576.43,
+        "amount_currency_to_trade": 1.067328
+      },
+      {
+        "price": 2627.32,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.223
+      },
+      {
+        "price": 2453.87,
+        "amount_currency_to_trade": 0.85200594
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.295
+      },
+      {
+        "price": 2445,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2432,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2449.99,
+        "amount_currency_to_trade": 0.082
+      },
+      {
+        "price": 2460,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.75
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.20999187
+      },
+      {
+        "price": 2589.9,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2489.25,
+        "amount_currency_to_trade": 0.34224
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.0495
+      },
+      {
+        "price": 2680,
+        "amount_currency_to_trade": 0.59932996
+      },
+      {
+        "price": 2575,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2439.9,
+        "amount_currency_to_trade": 0.025
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2749.92,
+        "amount_currency_to_trade": 8.35089391
+      },
+      {
+        "price": 2449,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 2470,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 3200,
+        "amount_currency_to_trade": 0.19
+      },
+      {
+        "price": 2646,
+        "amount_currency_to_trade": 3.0537472
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.157
+      },
+      {
+        "price": 2456,
+        "amount_currency_to_trade": 0.3071763
+      },
+      {
+        "price": 2715,
+        "amount_currency_to_trade": 1.65
+      },
+      {
+        "price": 2443,
+        "amount_currency_to_trade": 0.123008
+      },
+      {
+        "price": 2625,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2509.99,
+        "amount_currency_to_trade": 0.22608
+      },
+      {
+        "price": 2434.5,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2435,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2435,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2425,
+        "amount_currency_to_trade": 0.0396192
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.6
+      },
+      {
+        "price": 2455,
+        "amount_currency_to_trade": 0.68539977
+      },
+      {
+        "price": 2550,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2568,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 7.41024
+      },
+      {
+        "price": 3500,
+        "amount_currency_to_trade": 1.4
+      },
+      {
+        "price": 2454.08,
+        "amount_currency_to_trade": 0.11385
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.12563997
+      },
+      {
+        "price": 2498,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2510,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.049
+      },
+      {
+        "price": 2676,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2584,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2599,
+        "amount_currency_to_trade": 0.7
+      },
+      {
+        "price": 2459,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.2965
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.22
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.5445
+      },
+      {
+        "price": 2495,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2439.55,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 2439.55,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 2439.55,
+        "amount_currency_to_trade": 0.40079797
+      },
+      {
+        "price": 2488,
+        "amount_currency_to_trade": 0.675
+      },
+      {
+        "price": 2800,
+        "amount_currency_to_trade": 0.07486396
+      },
+      {
+        "price": 3124,
+        "amount_currency_to_trade": 0.081
+      },
+      {
+        "price": 2480,
+        "amount_currency_to_trade": 0.44
+      },
+      {
+        "price": 2480,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2567,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2650,
+        "amount_currency_to_trade": 6.24195
+      },
+      {
+        "price": 3157.9,
+        "amount_currency_to_trade": 0.05325
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.24213493
+      },
+      {
+        "price": 2510,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2550,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 2630,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 3500,
+        "amount_currency_to_trade": 0.0992
+      },
+      {
+        "price": 4248.48,
+        "amount_currency_to_trade": 0.02353666
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.198
+      },
+      {
+        "price": 2498,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2598,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2459.99,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2640,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2488.88,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2585,
+        "amount_currency_to_trade": 0.033
+      },
+      {
+        "price": 4444.44,
+        "amount_currency_to_trade": 0.0224989
+      },
+      {
+        "price": 4343.43,
+        "amount_currency_to_trade": 0.02302213
+      },
+      {
+        "price": 3998,
+        "amount_currency_to_trade": 0.094
+      },
+      {
+        "price": 4646.46,
+        "amount_currency_to_trade": 0.02152069
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2894,
+        "amount_currency_to_trade": 0.0207348
+      },
+      {
+        "price": 2449,
+        "amount_currency_to_trade": 0.143325
+      },
+      {
+        "price": 4298.98,
+        "amount_currency_to_trade": 0.02326017
+      },
+      {
+        "price": 4397.97,
+        "amount_currency_to_trade": 0.02273663
+      },
+      {
+        "price": 4177,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2700,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 4545.45,
+        "amount_currency_to_trade": 0.21999912
+      },
+      {
+        "price": 4498.98,
+        "amount_currency_to_trade": 0.02222615
+      },
+      {
+        "price": 4545.45,
+        "amount_currency_to_trade": 0.02199893
+      },
+      {
+        "price": 4597.97,
+        "amount_currency_to_trade": 0.02174765
+      },
+      {
+        "price": 4141.41,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 4545.45,
+        "amount_currency_to_trade": 0.06
+      },
+      {
+        "price": 3999.99,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 4400,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2800,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2900,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 4687.33,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.1456
+      },
+      {
+        "price": 2599.99,
+        "amount_currency_to_trade": 0.036
+      },
+      {
+        "price": 2449.98,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2459.98,
+        "amount_currency_to_trade": 0.18448
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.02
+      },
+      {
+        "price": 2599.27,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.024
+      },
+      {
+        "price": 2499.99,
+        "amount_currency_to_trade": 0.026
+      },
+      {
+        "price": 4444,
+        "amount_currency_to_trade": 0.028
+      },
+      {
+        "price": 2485.35,
+        "amount_currency_to_trade": 0.399
+      },
+      {
+        "price": 2513.65,
+        "amount_currency_to_trade": 0.67
+      },
+      {
+        "price": 2799.99,
+        "amount_currency_to_trade": 0.438624
+      },
+      {
+        "price": 2890,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.341248
+      },
+      {
+        "price": 2400,
+        "amount_currency_to_trade": 0.0259
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 1.9941431
+      },
+      {
+        "price": 2542.95,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2445,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2440,
+        "amount_currency_to_trade": 0.777
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.7936
+      },
+      {
+        "price": 4500,
+        "amount_currency_to_trade": 1.80477
+      },
+      {
+        "price": 2482,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2597.1,
+        "amount_currency_to_trade": 0.45
+      },
+      {
+        "price": 2499,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2425.3,
+        "amount_currency_to_trade": 0.07361321
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2449.99,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.035
+      },
+      {
+        "price": 2498.89,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 2498.89,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 2498.89,
+        "amount_currency_to_trade": 2.0300964
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.992
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.05952
+      },
+      {
+        "price": 2499.9,
+        "amount_currency_to_trade": 0.024
+      },
+      {
+        "price": 2999,
+        "amount_currency_to_trade": 0.07
+      },
+      {
+        "price": 2900,
+        "amount_currency_to_trade": 0.06961686
+      },
+      {
+        "price": 2461.47,
+        "amount_currency_to_trade": 0.71095839
+      },
+      {
+        "price": 2765,
+        "amount_currency_to_trade": 0.091264
+      },
+      {
+        "price": 2720,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 3600,
+        "amount_currency_to_trade": 2.07398906
+      },
+      {
+        "price": 2640,
+        "amount_currency_to_trade": 0.727
+      },
+      {
+        "price": 2489,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2503,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2440,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2543,
+        "amount_currency_to_trade": 0.22
+      },
+      {
+        "price": 2550,
+        "amount_currency_to_trade": 0.78
+      },
+      {
+        "price": 2514,
+        "amount_currency_to_trade": 0.79736119
+      },
+      {
+        "price": 2999.88,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2510,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2550,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 4285.5,
+        "amount_currency_to_trade": 0.014
+      },
+      {
+        "price": 2530,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2499.9,
+        "amount_currency_to_trade": 0.048
+      },
+      {
+        "price": 2486,
+        "amount_currency_to_trade": 0.21659328
+      },
+      {
+        "price": 2550,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 2490,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2499.97,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2699.98,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2467,
+        "amount_currency_to_trade": 0.17
+      },
+      {
+        "price": 2699.91,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 2430,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2430,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 4060,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2436,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2462,
+        "amount_currency_to_trade": 0.06039
+      },
+      {
+        "price": 2445,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2545,
+        "amount_currency_to_trade": 0.75
+      },
+      {
+        "price": 2645,
+        "amount_currency_to_trade": 0.75
+      },
+      {
+        "price": 2449.9,
+        "amount_currency_to_trade": 0.48
+      },
+      {
+        "price": 2700,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.258416
+      },
+      {
+        "price": 2800,
+        "amount_currency_to_trade": 0.022
+      },
+      {
+        "price": 2490,
+        "amount_currency_to_trade": 0.08152134
+      },
+      {
+        "price": 2469,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 2774,
+        "amount_currency_to_trade": 0.02163
+      },
+      {
+        "price": 2499.95,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2490,
+        "amount_currency_to_trade": 4.8
+      },
+      {
+        "price": 2800,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 1.77217044
+      },
+      {
+        "price": 2430,
+        "amount_currency_to_trade": 0.99
+      },
+      {
+        "price": 2435,
+        "amount_currency_to_trade": 0.193
+      },
+      {
+        "price": 2471.7,
+        "amount_currency_to_trade": 0.29959048
+      },
+      {
+        "price": 2699,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 2474.85,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2465,
+        "amount_currency_to_trade": 0.07300426
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 4.19616
+      },
+      {
+        "price": 2799.99,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 2460,
+        "amount_currency_to_trade": 0.49
+      },
+      {
+        "price": 4696.96,
+        "amount_currency_to_trade": 0.02128931
+      },
+      {
+        "price": 4726.26,
+        "amount_currency_to_trade": 0.02115733
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.2475
+      },
+      {
+        "price": 3000,
+        "amount_currency_to_trade": 0.02011341
+      },
+      {
+        "price": 2459.38,
+        "amount_currency_to_trade": 0.04554
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2448.5,
+        "amount_currency_to_trade": 3.2249448
+      },
+      {
+        "price": 2497,
+        "amount_currency_to_trade": 0.198
+      },
+      {
+        "price": 2650,
+        "amount_currency_to_trade": 0.49
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2544,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2756,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2469,
+        "amount_currency_to_trade": 0.1126
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 2.95485923
+      },
+      {
+        "price": 2800,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2500,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 2810,
+        "amount_currency_to_trade": 0.493344
+      },
+      {
+        "price": 2460,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2490,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2550,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2445,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 4756.98,
+        "amount_currency_to_trade": 0.06
+      },
+      {
+        "price": 2539.2,
+        "amount_currency_to_trade": 0.0992
+      },
+      {
+        "price": 4500,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 2440,
+        "amount_currency_to_trade": 0.048
+      },
+      {
+        "price": 4200,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2445,
+        "amount_currency_to_trade": 1.98
+      },
+      {
+        "price": 2539.2,
+        "amount_currency_to_trade": 0.496
+      },
+      {
+        "price": 2430,
+        "amount_currency_to_trade": 1.035
+      },
+      {
+        "price": 2420,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2444,
+        "amount_currency_to_trade": 0.616
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.99
+      },
+      {
+        "price": 2440,
+        "amount_currency_to_trade": 0.297
+      },
+      {
+        "price": 2484.99,
+        "amount_currency_to_trade": 4.26796
+      },
+      {
+        "price": 2460,
+        "amount_currency_to_trade": 0.99
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.98208
+      },
+      {
+        "price": 2550,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2449,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 0.82212755
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.17
+      },
+      {
+        "price": 2467,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2494.1,
+        "amount_currency_to_trade": 0.400946
+      },
+      {
+        "price": 2800,
+        "amount_currency_to_trade": 0.49
+      },
+      {
+        "price": 2428,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2459,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2444,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2750,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2430,
+        "amount_currency_to_trade": 10
+      },
+      {
+        "price": 2532.6,
+        "amount_currency_to_trade": 0.099
+      },
+      {
+        "price": 2450,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 2600,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2543.99,
+        "amount_currency_to_trade": 0.025
+      },
+      {
+        "price": 2458.71,
+        "amount_currency_to_trade": 0.052
+      },
+      {
+        "price": 2439.75,
+        "amount_currency_to_trade": 0.6222
+      },
+      {
+        "price": 2460.88,
+        "amount_currency_to_trade": 3.78
+      },
+      {
+        "price": 2461.13,
+        "amount_currency_to_trade": 1.6
+      },
+      {
+        "price": 2474.36,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 2430.22,
+        "amount_currency_to_trade": 0.05
+      }
+    ],
+    "bids": [
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 8.333
+      },
+      {
+        "price": 1208.5,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1250,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1203,
+        "amount_currency_to_trade": 1.6
+      },
+      {
+        "price": 1288.88,
+        "amount_currency_to_trade": 20
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1160,
+        "amount_currency_to_trade": 0.859
+      },
+      {
+        "price": 1177,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1100,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1060.4,
+        "amount_currency_to_trade": 0.056
+      },
+      {
+        "price": 1250,
+        "amount_currency_to_trade": 0.048
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 1420,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1040,
+        "amount_currency_to_trade": 0.7
+      },
+      {
+        "price": 1280,
+        "amount_currency_to_trade": 0.65
+      },
+      {
+        "price": 1055,
+        "amount_currency_to_trade": 0.9
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1411.11,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1100,
+        "amount_currency_to_trade": 0.08
+      },
+      {
+        "price": 1300,
+        "amount_currency_to_trade": 0.08
+      },
+      {
+        "price": 1057,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1250,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1027,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 1100,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1075,
+        "amount_currency_to_trade": 0.65
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1120,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1120,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1467.8,
+        "amount_currency_to_trade": 0.125
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1117,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1125,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1150,
+        "amount_currency_to_trade": 0.869
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.83
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1106,
+        "amount_currency_to_trade": 0.9
+      },
+      {
+        "price": 1125,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.34
+      },
+      {
+        "price": 1111,
+        "amount_currency_to_trade": 1.1
+      },
+      {
+        "price": 1090,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1090,
+        "amount_currency_to_trade": 0.45
+      },
+      {
+        "price": 1090,
+        "amount_currency_to_trade": 2.293578
+      },
+      {
+        "price": 1150,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1150,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 1.666
+      },
+      {
+        "price": 1170,
+        "amount_currency_to_trade": 0.85
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 1300,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1250,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 1245,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 1108,
+        "amount_currency_to_trade": 0.054
+      },
+      {
+        "price": 1122,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1198,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1102,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1379.4,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1502.6,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 1100,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1020,
+        "amount_currency_to_trade": 0.6
+      },
+      {
+        "price": 1012.75,
+        "amount_currency_to_trade": 1.974
+      },
+      {
+        "price": 1100,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1053.53,
+        "amount_currency_to_trade": 40
+      },
+      {
+        "price": 1100,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1100,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1050,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1051,
+        "amount_currency_to_trade": 1.2
+      },
+      {
+        "price": 1060,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1054,
+        "amount_currency_to_trade": 0.948
+      },
+      {
+        "price": 1051.51,
+        "amount_currency_to_trade": 500
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 1051,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1052,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1100,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 1033.33,
+        "amount_currency_to_trade": 999
+      },
+      {
+        "price": 1025,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.7
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1135,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1365,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1206,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 977.69,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1503,
+        "amount_currency_to_trade": 6
+      },
+      {
+        "price": 1517,
+        "amount_currency_to_trade": 6.591
+      },
+      {
+        "price": 1000,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1477,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1377,
+        "amount_currency_to_trade": 0.7
+      },
+      {
+        "price": 950,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.666
+      },
+      {
+        "price": 1000,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 1.2
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 1300,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 895,
+        "amount_currency_to_trade": 1.1
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1450,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1000,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 1510,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1000,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1520,
+        "amount_currency_to_trade": 0.35
+      },
+      {
+        "price": 1230,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1440,
+        "amount_currency_to_trade": 0.09
+      },
+      {
+        "price": 1505,
+        "amount_currency_to_trade": 1.2
+      },
+      {
+        "price": 1485,
+        "amount_currency_to_trade": 1.3
+      },
+      {
+        "price": 1500.06,
+        "amount_currency_to_trade": 0.21
+      },
+      {
+        "price": 1489,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1410,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1210,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1510,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1210,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 931,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1501,
+        "amount_currency_to_trade": 0.07
+      },
+      {
+        "price": 1310,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 999,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.125
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.125
+      },
+      {
+        "price": 1500.01,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1204,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 890,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 1530,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1350,
+        "amount_currency_to_trade": 1.1
+      },
+      {
+        "price": 1311,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.13
+      },
+      {
+        "price": 1522,
+        "amount_currency_to_trade": 0.181
+      },
+      {
+        "price": 1289,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1525,
+        "amount_currency_to_trade": 0.10644766
+      },
+      {
+        "price": 1495,
+        "amount_currency_to_trade": 0.12296927
+      },
+      {
+        "price": 1465,
+        "amount_currency_to_trade": 0.1421124
+      },
+      {
+        "price": 1435,
+        "amount_currency_to_trade": 0.16430453
+      },
+      {
+        "price": 1405,
+        "amount_currency_to_trade": 0.19004522
+      },
+      {
+        "price": 1375,
+        "amount_currency_to_trade": 0.21991883
+      },
+      {
+        "price": 1345,
+        "amount_currency_to_trade": 0.25460953
+      },
+      {
+        "price": 1315,
+        "amount_currency_to_trade": 0.29491919
+      },
+      {
+        "price": 1285,
+        "amount_currency_to_trade": 0.34178853
+      },
+      {
+        "price": 1255,
+        "amount_currency_to_trade": 0.39632249
+      },
+      {
+        "price": 1225,
+        "amount_currency_to_trade": 0.45982035
+      },
+      {
+        "price": 1195,
+        "amount_currency_to_trade": 0.53381185
+      },
+      {
+        "price": 1426,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1300,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1505,
+        "amount_currency_to_trade": 1.1
+      },
+      {
+        "price": 999,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 999,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1565.5,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1000,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 900,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 900,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 900,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 900,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 900,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 900,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1510,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1101.4,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1250,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1000,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1274,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1503.33,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1451,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1280,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.11
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1050,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1000,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.7
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.1528
+      },
+      {
+        "price": 1501,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 831,
+        "amount_currency_to_trade": 5.5
+      },
+      {
+        "price": 820,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1485,
+        "amount_currency_to_trade": 3.9
+      },
+      {
+        "price": 1499,
+        "amount_currency_to_trade": 0.08
+      },
+      {
+        "price": 1423,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1323,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.094
+      },
+      {
+        "price": 1223,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1411,
+        "amount_currency_to_trade": 0.175
+      },
+      {
+        "price": 1450,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1430.7,
+        "amount_currency_to_trade": 0.11
+      },
+      {
+        "price": 1555.02,
+        "amount_currency_to_trade": 0.763845
+      },
+      {
+        "price": 1100,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1485,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1488,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1225,
+        "amount_currency_to_trade": 1.011
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 815,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.102
+      },
+      {
+        "price": 1446,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1456,
+        "amount_currency_to_trade": 15
+      },
+      {
+        "price": 1442,
+        "amount_currency_to_trade": 15
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1506,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1300,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1201,
+        "amount_currency_to_trade": 2.5
+      },
+      {
+        "price": 1510,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1476,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1410,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.0506
+      },
+      {
+        "price": 1100,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 810,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1551,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 950,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1300,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1150,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1413,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 900,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 1540,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1425,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1501.11,
+        "amount_currency_to_trade": 0.06376619
+      },
+      {
+        "price": 1100,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 1.4
+      },
+      {
+        "price": 1300,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1500.11,
+        "amount_currency_to_trade": 10
+      },
+      {
+        "price": 1551,
+        "amount_currency_to_trade": 0.46692153
+      },
+      {
+        "price": 1520,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1560,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 1551,
+        "amount_currency_to_trade": 0.23668149
+      },
+      {
+        "price": 1497,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 0.0506
+      },
+      {
+        "price": 1501,
+        "amount_currency_to_trade": 0.66
+      },
+      {
+        "price": 1000,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1470,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1504.74,
+        "amount_currency_to_trade": 0.13896753
+      },
+      {
+        "price": 1555.03,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1515.31,
+        "amount_currency_to_trade": 0.13799817
+      },
+      {
+        "price": 1525.95,
+        "amount_currency_to_trade": 0.13703594
+      },
+      {
+        "price": 1536.67,
+        "amount_currency_to_trade": 0.13607997
+      },
+      {
+        "price": 1510,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1547.46,
+        "amount_currency_to_trade": 0.13513112
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1558.33,
+        "amount_currency_to_trade": 0.1343297
+      },
+      {
+        "price": 1569.27,
+        "amount_currency_to_trade": 0.13325304
+      },
+      {
+        "price": 1580.29,
+        "amount_currency_to_trade": 0.13232381
+      },
+      {
+        "price": 830,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1501,
+        "amount_currency_to_trade": 0.06
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1490.01,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 1570,
+        "amount_currency_to_trade": 0.0995223
+      },
+      {
+        "price": 1390.01,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 1540,
+        "amount_currency_to_trade": 0.12175325
+      },
+      {
+        "price": 1290.01,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 1510,
+        "amount_currency_to_trade": 0.14486755
+      },
+      {
+        "price": 1190.01,
+        "amount_currency_to_trade": 6
+      },
+      {
+        "price": 1480,
+        "amount_currency_to_trade": 0.16891892
+      },
+      {
+        "price": 1450,
+        "amount_currency_to_trade": 0.19396552
+      },
+      {
+        "price": 1420,
+        "amount_currency_to_trade": 0.22007043
+      },
+      {
+        "price": 1090.01,
+        "amount_currency_to_trade": 6
+      },
+      {
+        "price": 1390,
+        "amount_currency_to_trade": 0.24730216
+      },
+      {
+        "price": 1360,
+        "amount_currency_to_trade": 0.2757353
+      },
+      {
+        "price": 1330,
+        "amount_currency_to_trade": 0.30545113
+      },
+      {
+        "price": 1300,
+        "amount_currency_to_trade": 0.33653847
+      },
+      {
+        "price": 1000.01,
+        "amount_currency_to_trade": 10
+      },
+      {
+        "price": 1270,
+        "amount_currency_to_trade": 0.36909449
+      },
+      {
+        "price": 1240,
+        "amount_currency_to_trade": 0.40322581
+      },
+      {
+        "price": 1210,
+        "amount_currency_to_trade": 0.43904959
+      },
+      {
+        "price": 1180,
+        "amount_currency_to_trade": 0.47669492
+      },
+      {
+        "price": 1520,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1599,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1511,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1585,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1000,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1450,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.4285
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1570,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 790.09,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 1.4
+      },
+      {
+        "price": 820,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1510,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1503.75,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1527.2,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 800,
+        "amount_currency_to_trade": 2.5
+      },
+      {
+        "price": 1541.11,
+        "amount_currency_to_trade": 0.13
+      },
+      {
+        "price": 803,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1201,
+        "amount_currency_to_trade": 1.47
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1503,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1158,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1592,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 1492,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 1392,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 1300,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1591.39,
+        "amount_currency_to_trade": 0.13426627
+      },
+      {
+        "price": 1602.57,
+        "amount_currency_to_trade": 0.13048416
+      },
+      {
+        "price": 1613.82,
+        "amount_currency_to_trade": 0.12957455
+      },
+      {
+        "price": 1000,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.08
+      },
+      {
+        "price": 1613.93,
+        "amount_currency_to_trade": 0.03965785
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1509,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1502,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1402,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1302,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 1450,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.7
+      },
+      {
+        "price": 1503,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1600.91,
+        "amount_currency_to_trade": 0.11243915
+      },
+      {
+        "price": 1512.03,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1630,
+        "amount_currency_to_trade": 0.039
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1300,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 840,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 1605,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1625.15,
+        "amount_currency_to_trade": 0.6
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1526,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.71
+      },
+      {
+        "price": 1530,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 0.09
+      },
+      {
+        "price": 1450,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1611,
+        "amount_currency_to_trade": 0.6344
+      },
+      {
+        "price": 1530,
+        "amount_currency_to_trade": 0.1305
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1101,
+        "amount_currency_to_trade": 1.81
+      },
+      {
+        "price": 1510,
+        "amount_currency_to_trade": 1.324
+      },
+      {
+        "price": 1480,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1632,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1477.6,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1425,
+        "amount_currency_to_trade": 0.14
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1639,
+        "amount_currency_to_trade": 1.8
+      },
+      {
+        "price": 1601,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1633,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1001,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 1699.5,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1601.02,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1600.1,
+        "amount_currency_to_trade": 0.6
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1650,
+        "amount_currency_to_trade": 0.0506
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.0506
+      },
+      {
+        "price": 1649,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1300,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 1655,
+        "amount_currency_to_trade": 15
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1725,
+        "amount_currency_to_trade": 0.85
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1707.07,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1116,
+        "amount_currency_to_trade": 4.06
+      },
+      {
+        "price": 1749,
+        "amount_currency_to_trade": 1.1
+      },
+      {
+        "price": 1710.1,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1250,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1510,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 0.315
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1620,
+        "amount_currency_to_trade": 1.2
+      },
+      {
+        "price": 1649,
+        "amount_currency_to_trade": 13.117
+      },
+      {
+        "price": 900,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1000,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1710,
+        "amount_currency_to_trade": 0.9
+      },
+      {
+        "price": 1660,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1610,
+        "amount_currency_to_trade": 1.1
+      },
+      {
+        "price": 1560,
+        "amount_currency_to_trade": 1.2
+      },
+      {
+        "price": 895,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1510,
+        "amount_currency_to_trade": 1.3
+      },
+      {
+        "price": 895,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1460,
+        "amount_currency_to_trade": 1.4
+      },
+      {
+        "price": 1410,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 1360,
+        "amount_currency_to_trade": 1.6
+      },
+      {
+        "price": 1310,
+        "amount_currency_to_trade": 1.7
+      },
+      {
+        "price": 1260,
+        "amount_currency_to_trade": 1.8
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1660,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1000,
+        "amount_currency_to_trade": 0.06
+      },
+      {
+        "price": 1651,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1611.11,
+        "amount_currency_to_trade": 10
+      },
+      {
+        "price": 1450,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.065
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.07
+      },
+      {
+        "price": 1000,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 950,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1610,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1503.03,
+        "amount_currency_to_trade": 2.5
+      },
+      {
+        "price": 1703,
+        "amount_currency_to_trade": 0.35
+      },
+      {
+        "price": 1599,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1650,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1610,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.7142
+      },
+      {
+        "price": 1610,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1501.11,
+        "amount_currency_to_trade": 0.427
+      },
+      {
+        "price": 1496,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 1650,
+        "amount_currency_to_trade": 0.061
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 0.065
+      },
+      {
+        "price": 1625,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1450,
+        "amount_currency_to_trade": 0.069
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1585,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1580,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1525,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1431.1,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 1748,
+        "amount_currency_to_trade": 0.05050505
+      },
+      {
+        "price": 1350,
+        "amount_currency_to_trade": 0.0741
+      },
+      {
+        "price": 1250,
+        "amount_currency_to_trade": 0.08
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1701,
+        "amount_currency_to_trade": 7
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 1720,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1725,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1.33
+      },
+      {
+        "price": 1586.56,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1550.05,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 1100,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1709,
+        "amount_currency_to_trade": 0.09
+      },
+      {
+        "price": 1719,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1638,
+        "amount_currency_to_trade": 0.09
+      },
+      {
+        "price": 1671,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1510,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1711,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1701.01,
+        "amount_currency_to_trade": 0.0776
+      },
+      {
+        "price": 1711.01,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 0.048
+      },
+      {
+        "price": 1602,
+        "amount_currency_to_trade": 0.037
+      },
+      {
+        "price": 1506,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1660,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 1760,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 900,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 1721,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1749,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1555,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1430,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 905,
+        "amount_currency_to_trade": 0.65
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.125
+      },
+      {
+        "price": 1650,
+        "amount_currency_to_trade": 0.35
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1652,
+        "amount_currency_to_trade": 6.05
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.13
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1000,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1758,
+        "amount_currency_to_trade": 0.26
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1780,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.0506
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 0.0506
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.3529
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1386,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1665,
+        "amount_currency_to_trade": 0.14
+      },
+      {
+        "price": 1709.83,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1300,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1650,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1760,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 1756,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1715,
+        "amount_currency_to_trade": 0.035
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1815,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1675,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1820,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1010,
+        "amount_currency_to_trade": 0.06
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 910,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1840,
+        "amount_currency_to_trade": 0.11
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.0506
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1806,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1801,
+        "amount_currency_to_trade": 0.12
+      },
+      {
+        "price": 1701,
+        "amount_currency_to_trade": 0.12
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 950,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1505,
+        "amount_currency_to_trade": 0.3322
+      },
+      {
+        "price": 925,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1837.06,
+        "amount_currency_to_trade": 0.05282655
+      },
+      {
+        "price": 1555,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1801,
+        "amount_currency_to_trade": 3.89
+      },
+      {
+        "price": 1730,
+        "amount_currency_to_trade": 0.75
+      },
+      {
+        "price": 1790,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1792,
+        "amount_currency_to_trade": 0.05050505
+      },
+      {
+        "price": 1827.5,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1830,
+        "amount_currency_to_trade": 0.032
+      },
+      {
+        "price": 1050,
+        "amount_currency_to_trade": 0.52
+      },
+      {
+        "price": 1665,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1808,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 1579,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1677,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1701,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1860,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1837.11,
+        "amount_currency_to_trade": 0.34
+      },
+      {
+        "price": 1850,
+        "amount_currency_to_trade": 0.0506
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1562.64,
+        "amount_currency_to_trade": 0.6
+      },
+      {
+        "price": 1650,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 1858,
+        "amount_currency_to_trade": 1.076
+      },
+      {
+        "price": 1650,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1800.99,
+        "amount_currency_to_trade": 0.2935
+      },
+      {
+        "price": 1780,
+        "amount_currency_to_trade": 7.3
+      },
+      {
+        "price": 1860,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1850,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1720,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1680,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1650,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 1.25
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.55
+      },
+      {
+        "price": 946,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1720,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1680,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.433
+      },
+      {
+        "price": 1787,
+        "amount_currency_to_trade": 0.33
+      },
+      {
+        "price": 1758.88,
+        "amount_currency_to_trade": 0.34
+      },
+      {
+        "price": 1708,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1650,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 1770,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 970,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1910,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1905.01,
+        "amount_currency_to_trade": 0.308
+      },
+      {
+        "price": 1830.03,
+        "amount_currency_to_trade": 1.908
+      },
+      {
+        "price": 961,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1934,
+        "amount_currency_to_trade": 0.032
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 1707,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1657,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1607,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1557,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1507,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1457,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1407,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1706,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.06
+      },
+      {
+        "price": 1850.01,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1650,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1300,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1214.04,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 1196.68,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.0375
+      },
+      {
+        "price": 1720,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1867,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1811,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1628,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1935.1,
+        "amount_currency_to_trade": 0.032
+      },
+      {
+        "price": 1428,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1320,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1028.04,
+        "amount_currency_to_trade": 0.06
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1000,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 961,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1932,
+        "amount_currency_to_trade": 0.031055
+      },
+      {
+        "price": 1836,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 0.0506
+      },
+      {
+        "price": 1912.12,
+        "amount_currency_to_trade": 0.05230058
+      },
+      {
+        "price": 1922.22,
+        "amount_currency_to_trade": 0.05202578
+      },
+      {
+        "price": 1932.32,
+        "amount_currency_to_trade": 0.05175385
+      },
+      {
+        "price": 1940.4,
+        "amount_currency_to_trade": 0.05153834
+      },
+      {
+        "price": 1933.01,
+        "amount_currency_to_trade": 0.068
+      },
+      {
+        "price": 1934.1,
+        "amount_currency_to_trade": 0.032
+      },
+      {
+        "price": 1850,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1836,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1620,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1489,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1523,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1911,
+        "amount_currency_to_trade": 0.29
+      },
+      {
+        "price": 1840.04,
+        "amount_currency_to_trade": 0.11
+      },
+      {
+        "price": 1050,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1.33333
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 0.06
+      },
+      {
+        "price": 1901,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1790,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1711.11,
+        "amount_currency_to_trade": 0.0584445
+      },
+      {
+        "price": 1789.89,
+        "amount_currency_to_trade": 0.111741
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.08
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.075
+      },
+      {
+        "price": 1911,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1751.1,
+        "amount_currency_to_trade": 1.99
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1909.76,
+        "amount_currency_to_trade": 0.03351468
+      },
+      {
+        "price": 1880,
+        "amount_currency_to_trade": 0.32
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1250,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1650.01,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1640.01,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1850,
+        "amount_currency_to_trade": 0.035
+      },
+      {
+        "price": 1540,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1900.01,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1711,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1050,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1807,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1850,
+        "amount_currency_to_trade": 2.4
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.06
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1880,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1760,
+        "amount_currency_to_trade": 0.1136
+      },
+      {
+        "price": 1762,
+        "amount_currency_to_trade": 0.04040404
+      },
+      {
+        "price": 1780,
+        "amount_currency_to_trade": 1.02
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 1.02
+      },
+      {
+        "price": 1710,
+        "amount_currency_to_trade": 0.87
+      },
+      {
+        "price": 1690,
+        "amount_currency_to_trade": 1.02
+      },
+      {
+        "price": 1645,
+        "amount_currency_to_trade": 0.56
+      },
+      {
+        "price": 1630,
+        "amount_currency_to_trade": 1.02
+      },
+      {
+        "price": 1820,
+        "amount_currency_to_trade": 1.05
+      },
+      {
+        "price": 1801.03,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1100,
+        "amount_currency_to_trade": 4.5
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1702.03,
+        "amount_currency_to_trade": 0.145
+      },
+      {
+        "price": 1045.05,
+        "amount_currency_to_trade": 0.24
+      },
+      {
+        "price": 1300,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1772.34,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1702.61,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1641.33,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1591.33,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1531.33,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.33
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1801,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1760,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1850,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1828,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 1715,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1028,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1527,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1820,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 1751,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1910,
+        "amount_currency_to_trade": 0.13
+      },
+      {
+        "price": 1756,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1880,
+        "amount_currency_to_trade": 0.1095
+      },
+      {
+        "price": 1017.88,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1016.99,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1799,
+        "amount_currency_to_trade": 0.833
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 1.1
+      },
+      {
+        "price": 1050,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.16
+      },
+      {
+        "price": 1890,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1501,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 1150,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1650,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.6
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1625.15,
+        "amount_currency_to_trade": 0.12306556
+      },
+      {
+        "price": 1202,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1636.56,
+        "amount_currency_to_trade": 0.12220756
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1648.05,
+        "amount_currency_to_trade": 0.14094233
+      },
+      {
+        "price": 1920,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1896,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1860,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1899,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 1752,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1659.62,
+        "amount_currency_to_trade": 0.12050951
+      },
+      {
+        "price": 1671.28,
+        "amount_currency_to_trade": 0.13141425
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 0.13
+      },
+      {
+        "price": 1683.02,
+        "amount_currency_to_trade": 0.118834
+      },
+      {
+        "price": 1694.84,
+        "amount_currency_to_trade": 0.12338038
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1706.74,
+        "amount_currency_to_trade": 0.12810387
+      },
+      {
+        "price": 1718.73,
+        "amount_currency_to_trade": 0.12733821
+      },
+      {
+        "price": 1730.8,
+        "amount_currency_to_trade": 0.1155535
+      },
+      {
+        "price": 1742.96,
+        "amount_currency_to_trade": 0.12901042
+      },
+      {
+        "price": 1755.2,
+        "amount_currency_to_trade": 0.13869644
+      },
+      {
+        "price": 1767.53,
+        "amount_currency_to_trade": 0.11315225
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1779.94,
+        "amount_currency_to_trade": 0.11236334
+      },
+      {
+        "price": 1936.6,
+        "amount_currency_to_trade": 0.032
+      },
+      {
+        "price": 1180,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1792.44,
+        "amount_currency_to_trade": 0.11157975
+      },
+      {
+        "price": 1915,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1805.03,
+        "amount_currency_to_trade": 0.11888445
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 990,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1350,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1817.71,
+        "amount_currency_to_trade": 0.11002855
+      },
+      {
+        "price": 1450,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1300,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1830.48,
+        "amount_currency_to_trade": 0.1142378
+      },
+      {
+        "price": 1504,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1843.34,
+        "amount_currency_to_trade": 0.1084987
+      },
+      {
+        "price": 1250,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1856.29,
+        "amount_currency_to_trade": 0.11264942
+      },
+      {
+        "price": 1640,
+        "amount_currency_to_trade": 0.51
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1869.33,
+        "amount_currency_to_trade": 0.11186361
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 2.25
+      },
+      {
+        "price": 1158,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1882.46,
+        "amount_currency_to_trade": 0.10624396
+      },
+      {
+        "price": 1895.68,
+        "amount_currency_to_trade": 0.1103087
+      },
+      {
+        "price": 1908.99,
+        "amount_currency_to_trade": 0.10964961
+      },
+      {
+        "price": 1923,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1950,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1922.4,
+        "amount_currency_to_trade": 0.10403662
+      },
+      {
+        "price": 1760,
+        "amount_currency_to_trade": 0.6
+      },
+      {
+        "price": 1710,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1410,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1949.5,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1920.02,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 0.035
+      },
+      {
+        "price": 1940,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 6.5
+      },
+      {
+        "price": 1805,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1950,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1956.5,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1701,
+        "amount_currency_to_trade": 0.52
+      },
+      {
+        "price": 1650,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1970,
+        "amount_currency_to_trade": 0.2538
+      },
+      {
+        "price": 1760,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1920,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1525,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.055
+      },
+      {
+        "price": 1968,
+        "amount_currency_to_trade": 0.03125
+      },
+      {
+        "price": 1660,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 1.25
+      },
+      {
+        "price": 1935.93,
+        "amount_currency_to_trade": 0.31
+      },
+      {
+        "price": 1963,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1950,
+        "amount_currency_to_trade": 0.0506
+      },
+      {
+        "price": 1975,
+        "amount_currency_to_trade": 1.012
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.6
+      },
+      {
+        "price": 1980,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 1979,
+        "amount_currency_to_trade": 0.033
+      },
+      {
+        "price": 1977,
+        "amount_currency_to_trade": 0.036
+      },
+      {
+        "price": 1971,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1903,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1883,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1760,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2015,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2001,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1087,
+        "amount_currency_to_trade": 0.07
+      },
+      {
+        "price": 1885,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1952,
+        "amount_currency_to_trade": 6.6
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.06
+      },
+      {
+        "price": 1850,
+        "amount_currency_to_trade": 0.06
+      },
+      {
+        "price": 1999,
+        "amount_currency_to_trade": 0.033
+      },
+      {
+        "price": 1627,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1727,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1827,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1021,
+        "amount_currency_to_trade": 1.958
+      },
+      {
+        "price": 1537,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1951.5,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2003,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1896.06,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.21
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1990,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1501,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.05050506
+      },
+      {
+        "price": 1025,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1903.51,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2015.01,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1950,
+        "amount_currency_to_trade": 0.7
+      },
+      {
+        "price": 1952.9,
+        "amount_currency_to_trade": 7
+      },
+      {
+        "price": 1600.15,
+        "amount_currency_to_trade": 0.6
+      },
+      {
+        "price": 2000.02,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1990.01,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2019.85,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1025,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1990,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2020,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 2012.02,
+        "amount_currency_to_trade": 0.0536
+      },
+      {
+        "price": 1905,
+        "amount_currency_to_trade": 13
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 1950,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2020,
+        "amount_currency_to_trade": 0.055
+      },
+      {
+        "price": 2026.7,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2023.3,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2030,
+        "amount_currency_to_trade": 10
+      },
+      {
+        "price": 1506.1,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1880,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2080.05,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2036,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2081.1,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2060,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2060,
+        "amount_currency_to_trade": 6
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 2104,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2001.89,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 0.048
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.462
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1960,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2010,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1910,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1810,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1710,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2011,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2010.12,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.325
+      },
+      {
+        "price": 1911,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2050,
+        "amount_currency_to_trade": 0.27
+      },
+      {
+        "price": 2090,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1695,
+        "amount_currency_to_trade": 0.55
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.14
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.14
+      },
+      {
+        "price": 2118,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2136,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1250,
+        "amount_currency_to_trade": 0.21
+      },
+      {
+        "price": 1990,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2105.05,
+        "amount_currency_to_trade": 2.35
+      },
+      {
+        "price": 2148,
+        "amount_currency_to_trade": 0.039
+      },
+      {
+        "price": 1990,
+        "amount_currency_to_trade": 1.25025
+      },
+      {
+        "price": 2157,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2100.02,
+        "amount_currency_to_trade": 1.009
+      },
+      {
+        "price": 2160,
+        "amount_currency_to_trade": 0.0505
+      },
+      {
+        "price": 2150,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2179.78,
+        "amount_currency_to_trade": 0.05225
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 2.148
+      },
+      {
+        "price": 1100,
+        "amount_currency_to_trade": 0.75
+      },
+      {
+        "price": 1880,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1813,
+        "amount_currency_to_trade": 1.045
+      },
+      {
+        "price": 1550.52,
+        "amount_currency_to_trade": 0.125
+      },
+      {
+        "price": 1950,
+        "amount_currency_to_trade": 0.51
+      },
+      {
+        "price": 1637.89,
+        "amount_currency_to_trade": 0.125
+      },
+      {
+        "price": 1730.2,
+        "amount_currency_to_trade": 0.125
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2058,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2002,
+        "amount_currency_to_trade": 4.9
+      },
+      {
+        "price": 2115,
+        "amount_currency_to_trade": 0.45
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 4.9
+      },
+      {
+        "price": 2050,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 2125,
+        "amount_currency_to_trade": 0.47
+      },
+      {
+        "price": 2117,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1935.9,
+        "amount_currency_to_trade": 0.10894674
+      },
+      {
+        "price": 1949.5,
+        "amount_currency_to_trade": 0.10259041
+      },
+      {
+        "price": 1976.98,
+        "amount_currency_to_trade": 0.10466469
+      },
+      {
+        "price": 1990.87,
+        "amount_currency_to_trade": 0.10513996
+      },
+      {
+        "price": 2150.03,
+        "amount_currency_to_trade": 0.6
+      },
+      {
+        "price": 2004.85,
+        "amount_currency_to_trade": 0.10440681
+      },
+      {
+        "price": 2018.93,
+        "amount_currency_to_trade": 0.10367868
+      },
+      {
+        "price": 2033.11,
+        "amount_currency_to_trade": 0.10434753
+      },
+      {
+        "price": 2047.39,
+        "amount_currency_to_trade": 0.10223748
+      },
+      {
+        "price": 2061.77,
+        "amount_currency_to_trade": 0.10152442
+      },
+      {
+        "price": 2076.25,
+        "amount_currency_to_trade": 0.10081638
+      },
+      {
+        "price": 2105.52,
+        "amount_currency_to_trade": 0.09498841
+      },
+      {
+        "price": 1920,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2131,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2096,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 0.9
+      },
+      {
+        "price": 1950,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.0506
+      },
+      {
+        "price": 2150,
+        "amount_currency_to_trade": 0.0506
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 0.0506
+      },
+      {
+        "price": 2050,
+        "amount_currency_to_trade": 0.0506
+      },
+      {
+        "price": 2021,
+        "amount_currency_to_trade": 4.9
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2029,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1902,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1602,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2071.23,
+        "amount_currency_to_trade": 10
+      },
+      {
+        "price": 2111.12,
+        "amount_currency_to_trade": 1.417
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2119,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2005,
+        "amount_currency_to_trade": 1.3
+      },
+      {
+        "price": 2050,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2106,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 2.5
+      },
+      {
+        "price": 1938,
+        "amount_currency_to_trade": 0.51
+      },
+      {
+        "price": 1612.43,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 1455.77,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 1795,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2129,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1702,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2022.22,
+        "amount_currency_to_trade": 0.49450851
+      },
+      {
+        "price": 2098,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2156,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2020,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 2098,
+        "amount_currency_to_trade": 0.75
+      },
+      {
+        "price": 2040,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1999.99,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2162,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2092.09,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2110,
+        "amount_currency_to_trade": 11.8
+      },
+      {
+        "price": 2196,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2032,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.7
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2200,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 2171,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2051,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1950,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2135.2,
+        "amount_currency_to_trade": 0.09803297
+      },
+      {
+        "price": 2200,
+        "amount_currency_to_trade": 0.0506
+      },
+      {
+        "price": 2160,
+        "amount_currency_to_trade": 0.49284775
+      },
+      {
+        "price": 1963.19,
+        "amount_currency_to_trade": 0.12103261
+      },
+      {
+        "price": 2090.83,
+        "amount_currency_to_trade": 0.10001291
+      },
+      {
+        "price": 2120.31,
+        "amount_currency_to_trade": 0.09432583
+      },
+      {
+        "price": 2049,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2226.5,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 0.22
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1866,
+        "amount_currency_to_trade": 0.26
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 6
+      },
+      {
+        "price": 1910,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 2087,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2108,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1934,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 2136.06,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1950,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2170.07,
+        "amount_currency_to_trade": 0.028
+      },
+      {
+        "price": 2160.06,
+        "amount_currency_to_trade": 0.493
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1890,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1950,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2030,
+        "amount_currency_to_trade": 0.5050505
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.75
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2083,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2186,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2050,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2250,
+        "amount_currency_to_trade": 0.0506
+      },
+      {
+        "price": 2050,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2050,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2200,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2150,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 2204,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2229,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 2201.08,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2141.18,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2101.05,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 2021.1,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1954.15,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1861.05,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1801.1,
+        "amount_currency_to_trade": 0.3928
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 1990,
+        "amount_currency_to_trade": 1.005
+      },
+      {
+        "price": 2200,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1755,
+        "amount_currency_to_trade": 0.03846
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2102,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2200,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2056,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 1666,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 10
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.34
+      },
+      {
+        "price": 2201,
+        "amount_currency_to_trade": 0.45
+      },
+      {
+        "price": 1950,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.07
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1550,
+        "amount_currency_to_trade": 1.2
+      },
+      {
+        "price": 2150,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.7
+      },
+      {
+        "price": 1995.02,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 1850,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 1850,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1655,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1655,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2200.02,
+        "amount_currency_to_trade": 1.20099898
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 5.7
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 1646,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2130,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1930,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1730,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1530,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1330,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2224,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1850,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 0.562
+      },
+      {
+        "price": 2150,
+        "amount_currency_to_trade": 0.29
+      },
+      {
+        "price": 2150.2,
+        "amount_currency_to_trade": 0.14707004
+      },
+      {
+        "price": 2165.3,
+        "amount_currency_to_trade": 0.10107606
+      },
+      {
+        "price": 2180.51,
+        "amount_currency_to_trade": 0.09325341
+      },
+      {
+        "price": 2195.83,
+        "amount_currency_to_trade": 0.04204333
+      },
+      {
+        "price": 2050,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1755.6,
+        "amount_currency_to_trade": 0.1817
+      },
+      {
+        "price": 1995.78,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2113.77,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1850,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1325.81,
+        "amount_currency_to_trade": 2.24
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 1980,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.08
+      },
+      {
+        "price": 1510,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1210,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2200.55,
+        "amount_currency_to_trade": 0.13
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1950,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2059,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1999,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2111,
+        "amount_currency_to_trade": 0.11
+      },
+      {
+        "price": 2001,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2201,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2100.09,
+        "amount_currency_to_trade": 7.05
+      },
+      {
+        "price": 2200,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1975,
+        "amount_currency_to_trade": 8.55
+      },
+      {
+        "price": 2180,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2186.06,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1997,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1999,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1400,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1523,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2190,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2200,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2099.02,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2155.02,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 0.625
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2199.02,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.57
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.33
+      },
+      {
+        "price": 1850,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 1300,
+        "amount_currency_to_trade": 0.33
+      },
+      {
+        "price": 2049,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 2200,
+        "amount_currency_to_trade": 1.009
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2239.39,
+        "amount_currency_to_trade": 0.04465725
+      },
+      {
+        "price": 2219.19,
+        "amount_currency_to_trade": 0.04506373
+      },
+      {
+        "price": 2196.96,
+        "amount_currency_to_trade": 0.04551971
+      },
+      {
+        "price": 2188.88,
+        "amount_currency_to_trade": 0.04568774
+      },
+      {
+        "price": 2178.78,
+        "amount_currency_to_trade": 0.04589954
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 0.165
+      },
+      {
+        "price": 1600,
+        "amount_currency_to_trade": 1.25
+      },
+      {
+        "price": 2200,
+        "amount_currency_to_trade": 0.089
+      },
+      {
+        "price": 1940.3,
+        "amount_currency_to_trade": 0.67
+      },
+      {
+        "price": 2009,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1950,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 0.6
+      },
+      {
+        "price": 1809,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1760,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1660,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.108
+      },
+      {
+        "price": 1570,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2101,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2060,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.04
+      },
+      {
+        "price": 1740,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1650,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1675,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2009,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1970,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1902,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1987,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1632.66,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2151,
+        "amount_currency_to_trade": 0.11
+      },
+      {
+        "price": 2250,
+        "amount_currency_to_trade": 0.11
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 1.1
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 1.1
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.825
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1670,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1650,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 0.47
+      },
+      {
+        "price": 1630,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 1.1
+      },
+      {
+        "price": 1700,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1750,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1850,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2200,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2180.09,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 1827.7,
+        "amount_currency_to_trade": 0.125
+      },
+      {
+        "price": 2201,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2212.54,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1910.28,
+        "amount_currency_to_trade": 0.03350555
+      },
+      {
+        "price": 2055.81,
+        "amount_currency_to_trade": 0.03113371
+      },
+      {
+        "price": 2077.91,
+        "amount_currency_to_trade": 0.03080258
+      },
+      {
+        "price": 2088.06,
+        "amount_currency_to_trade": 0.03065285
+      },
+      {
+        "price": 2050,
+        "amount_currency_to_trade": 0.08
+      },
+      {
+        "price": 2105.08,
+        "amount_currency_to_trade": 0.03040502
+      },
+      {
+        "price": 2103.49,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2124.09,
+        "amount_currency_to_trade": 0.0301329
+      },
+      {
+        "price": 2107.28,
+        "amount_currency_to_trade": 0.03037327
+      },
+      {
+        "price": 2156.29,
+        "amount_currency_to_trade": 0.02968292
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2189.99,
+        "amount_currency_to_trade": 0.779
+      },
+      {
+        "price": 2102,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 2027,
+        "amount_currency_to_trade": 0.2375
+      },
+      {
+        "price": 2105,
+        "amount_currency_to_trade": 0.43
+      },
+      {
+        "price": 2000.5,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 1820,
+        "amount_currency_to_trade": 0.0857
+      },
+      {
+        "price": 1800,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2200,
+        "amount_currency_to_trade": 1.0416564
+      },
+      {
+        "price": 2248,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1940,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2035,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 1855,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 1625,
+        "amount_currency_to_trade": 3
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.07
+      },
+      {
+        "price": 1242,
+        "amount_currency_to_trade": 0.563607
+      },
+      {
+        "price": 2001,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1147,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 1902,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1560,
+        "amount_currency_to_trade": 0.192307
+      },
+      {
+        "price": 1418,
+        "amount_currency_to_trade": 0.352609
+      },
+      {
+        "price": 2120,
+        "amount_currency_to_trade": 0.055
+      },
+      {
+        "price": 1907,
+        "amount_currency_to_trade": 1.04876769
+      },
+      {
+        "price": 2250.55,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1880,
+        "amount_currency_to_trade": 0.612
+      },
+      {
+        "price": 2250,
+        "amount_currency_to_trade": 0.027108
+      },
+      {
+        "price": 2110,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2195,
+        "amount_currency_to_trade": 1.095
+      },
+      {
+        "price": 2050,
+        "amount_currency_to_trade": 1.6
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 1206,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2245,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 1975,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2220,
+        "amount_currency_to_trade": 0.45045
+      },
+      {
+        "price": 2246,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2180,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.49
+      },
+      {
+        "price": 1856,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 2250,
+        "amount_currency_to_trade": 2.69
+      },
+      {
+        "price": 2250,
+        "amount_currency_to_trade": 6
+      },
+      {
+        "price": 2222,
+        "amount_currency_to_trade": 0.446
+      },
+      {
+        "price": 2230,
+        "amount_currency_to_trade": 0.06
+      },
+      {
+        "price": 2280,
+        "amount_currency_to_trade": 1.02
+      },
+      {
+        "price": 2255,
+        "amount_currency_to_trade": 0.027
+      },
+      {
+        "price": 2250,
+        "amount_currency_to_trade": 0.17756905
+      },
+      {
+        "price": 2280.01,
+        "amount_currency_to_trade": 0.3175
+      },
+      {
+        "price": 2230,
+        "amount_currency_to_trade": 0.1004
+      },
+      {
+        "price": 2247,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2100.1,
+        "amount_currency_to_trade": 0.1004
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.8
+      },
+      {
+        "price": 2255,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2222,
+        "amount_currency_to_trade": 0.2884
+      },
+      {
+        "price": 1901,
+        "amount_currency_to_trade": 1.05
+      },
+      {
+        "price": 1901,
+        "amount_currency_to_trade": 1.05
+      },
+      {
+        "price": 1901,
+        "amount_currency_to_trade": 1.05
+      },
+      {
+        "price": 1901,
+        "amount_currency_to_trade": 1.05
+      },
+      {
+        "price": 1901,
+        "amount_currency_to_trade": 1.05
+      },
+      {
+        "price": 2300,
+        "amount_currency_to_trade": 0.03
+      },
+      {
+        "price": 1901,
+        "amount_currency_to_trade": 5.2
+      },
+      {
+        "price": 2290,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2317.98,
+        "amount_currency_to_trade": 0.9
+      },
+      {
+        "price": 2319.57,
+        "amount_currency_to_trade": 0.180544
+      },
+      {
+        "price": 2320,
+        "amount_currency_to_trade": 0.26303452
+      },
+      {
+        "price": 2300,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2300,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2310,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2315,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1850,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2250,
+        "amount_currency_to_trade": 0.44
+      },
+      {
+        "price": 1500,
+        "amount_currency_to_trade": 0.7
+      },
+      {
+        "price": 2260,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2300.05,
+        "amount_currency_to_trade": 0.027
+      },
+      {
+        "price": 2200,
+        "amount_currency_to_trade": 0.25
+      },
+      {
+        "price": 2105,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 1780,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2306,
+        "amount_currency_to_trade": 1.9
+      },
+      {
+        "price": 2215,
+        "amount_currency_to_trade": 0.75
+      },
+      {
+        "price": 2313,
+        "amount_currency_to_trade": 0.065
+      },
+      {
+        "price": 2249,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 1970,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2306.5,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2286,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2256,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2050,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2000,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2316,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 2300,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2307,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2200,
+        "amount_currency_to_trade": 0.436
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 0.443
+      },
+      {
+        "price": 2250,
+        "amount_currency_to_trade": 1.8666
+      },
+      {
+        "price": 1600.34,
+        "amount_currency_to_trade": 4.046
+      },
+      {
+        "price": 2358,
+        "amount_currency_to_trade": 0.07364865
+      },
+      {
+        "price": 2359,
+        "amount_currency_to_trade": 0.63
+      },
+      {
+        "price": 2359.51,
+        "amount_currency_to_trade": 0.24866806
+      },
+      {
+        "price": 2360.87,
+        "amount_currency_to_trade": 0.1455638
+      },
+      {
+        "price": 2315,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2369,
+        "amount_currency_to_trade": 0.8304
+      },
+      {
+        "price": 2251,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 2207,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 2151,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 2370,
+        "amount_currency_to_trade": 0.49
+      },
+      {
+        "price": 2316.03,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 2303.83,
+        "amount_currency_to_trade": 6
+      },
+      {
+        "price": 2351,
+        "amount_currency_to_trade": 1.4
+      },
+      {
+        "price": 2360.8,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2323.2,
+        "amount_currency_to_trade": 1.123
+      },
+      {
+        "price": 2200,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2320,
+        "amount_currency_to_trade": 10
+      },
+      {
+        "price": 2350,
+        "amount_currency_to_trade": 0.165
+      },
+      {
+        "price": 2270,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 1780,
+        "amount_currency_to_trade": 0.13
+      },
+      {
+        "price": 2345.8,
+        "amount_currency_to_trade": 5
+      },
+      {
+        "price": 2351.99,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2279.79,
+        "amount_currency_to_trade": 0.04386588
+      },
+      {
+        "price": 2287.87,
+        "amount_currency_to_trade": 0.04371096
+      },
+      {
+        "price": 2305.05,
+        "amount_currency_to_trade": 0.04338517
+      },
+      {
+        "price": 2323.23,
+        "amount_currency_to_trade": 0.04304567
+      },
+      {
+        "price": 2327.27,
+        "amount_currency_to_trade": 0.04297094
+      },
+      {
+        "price": 2351.11,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2305.8,
+        "amount_currency_to_trade": 20
+      },
+      {
+        "price": 2375.1,
+        "amount_currency_to_trade": 4.21
+      },
+      {
+        "price": 2375.6,
+        "amount_currency_to_trade": 2.52
+      },
+      {
+        "price": 2333.33,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1760,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2350,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2009,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2002,
+        "amount_currency_to_trade": 0.389
+      },
+      {
+        "price": 1991,
+        "amount_currency_to_trade": 1.35
+      },
+      {
+        "price": 2250,
+        "amount_currency_to_trade": 0.031
+      },
+      {
+        "price": 1450,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2260,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 2306.55,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2256.06,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2376,
+        "amount_currency_to_trade": 0.03524083
+      },
+      {
+        "price": 2200,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2150,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2050,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2160,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2377,
+        "amount_currency_to_trade": 0.841394
+      },
+      {
+        "price": 2347.15,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2250,
+        "amount_currency_to_trade": 0.15
+      },
+      {
+        "price": 2250.21,
+        "amount_currency_to_trade": 0.08888
+      },
+      {
+        "price": 2320,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2100,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2222.22,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 2301,
+        "amount_currency_to_trade": 0.05
+      },
+      {
+        "price": 2323.22,
+        "amount_currency_to_trade": 1.5
+      },
+      {
+        "price": 2367,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2356,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2300,
+        "amount_currency_to_trade": 0.0506
+      },
+      {
+        "price": 2362,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2348.11,
+        "amount_currency_to_trade": 1
+      },
+      {
+        "price": 2272,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2356.6,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2375.75,
+        "amount_currency_to_trade": 1.84499898
+      },
+      {
+        "price": 2360.88,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 1200,
+        "amount_currency_to_trade": 2
+      },
+      {
+        "price": 2300,
+        "amount_currency_to_trade": 0.065
+      },
+      {
+        "price": 2311,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2300,
+        "amount_currency_to_trade": 0.027
+      },
+      {
+        "price": 2352.85,
+        "amount_currency_to_trade": 5.3
+      },
+      {
+        "price": 2350,
+        "amount_currency_to_trade": 0.0506
+      },
+      {
+        "price": 2365,
+        "amount_currency_to_trade": 0.6342494
+      },
+      {
+        "price": 2346,
+        "amount_currency_to_trade": 0.06
+      },
+      {
+        "price": 2300,
+        "amount_currency_to_trade": 2.06
+      },
+      {
+        "price": 2401,
+        "amount_currency_to_trade": 4
+      },
+      {
+        "price": 2390,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2371.11,
+        "amount_currency_to_trade": 0.2
+      },
+      {
+        "price": 2300,
+        "amount_currency_to_trade": 0.06
+      },
+      {
+        "price": 2405,
+        "amount_currency_to_trade": 1.6
+      },
+      {
+        "price": 2316.04,
+        "amount_currency_to_trade": 7.7038
+      },
+      {
+        "price": 2360,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2105.06,
+        "amount_currency_to_trade": 10
+      },
+      {
+        "price": 2402,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 2376.11,
+        "amount_currency_to_trade": 0.1
+      },
+      {
+        "price": 2390.12,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 1900,
+        "amount_currency_to_trade": 0.13158
+      },
+      {
+        "price": 2390.1,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2376.22,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2406,
+        "amount_currency_to_trade": 0.3
+      },
+      {
+        "price": 2406,
+        "amount_currency_to_trade": 0.4
+      },
+      {
+        "price": 2405.16,
+        "amount_currency_to_trade": 0.9
+      },
+      {
+        "price": 2406.11,
+        "amount_currency_to_trade": 1.745
+      },
+      {
+        "price": 2399.79,
+        "amount_currency_to_trade": 0.30243
+      },
+      {
+        "price": 2406.02,
+        "amount_currency_to_trade": 0.9
+      },
+      {
+        "price": 2390.13,
+        "amount_currency_to_trade": 0.5
+      },
+      {
+        "price": 2392.6,
+        "amount_currency_to_trade": 0.27
+      }
+    ]
+  },
+  "errors": [],
+  "credits": 17
+}

--- a/xchange-bitcoinde/src/test/resources/org/knowm/xchange/bitcoinde/v4/dto/errors.json
+++ b/xchange-bitcoinde/src/test/resources/org/knowm/xchange/bitcoinde/v4/dto/errors.json
@@ -1,0 +1,14 @@
+{
+  "credits": -3,
+  "errors": [
+    {
+      "message": "Order not found",
+      "code": 13,
+      "field": "order_id"
+    },
+    {
+      "message": "Made up Error",
+      "code": 99
+    }
+  ]
+}

--- a/xchange-bitcoinde/src/test/resources/org/knowm/xchange/bitcoinde/v4/dto/maintenance.json
+++ b/xchange-bitcoinde/src/test/resources/org/knowm/xchange/bitcoinde/v4/dto/maintenance.json
@@ -1,0 +1,5 @@
+{
+  "message": "*** Scheduled maintainance on 2018\/01\/26 at 04:00 am until approx. 06:00 am (CEST)*** Due to network infrastructure maintenance Bitcoin.de will be unavailable between 04:00 am and approx. 06:00 am (CEST). ***",
+  "start": "2018-01-26T04:00:00+01:00",
+  "end": "2018-01-26T06:00:00+01:00"
+}

--- a/xchange-bitcoinde/src/test/resources/org/knowm/xchange/bitcoinde/v4/dto/my_orders.json
+++ b/xchange-bitcoinde/src/test/resources/org/knowm/xchange/bitcoinde/v4/dto/my_orders.json
@@ -1,0 +1,71 @@
+{
+	"orders": [
+		{
+			"order_id": "VNSP86",
+			"trading_pair": "btceur",
+			"is_external_wallet_order": false, 
+			"type": "buy",
+			"max_amount_currency_to_trade": 0.01,
+			"min_amount_currency_to_trade": 0.01,
+			"price": 6000,
+			"max_volume_currency_to_pay": 60,
+			"min_volume_currency_to_pay": 60,
+			"order_requirements": {
+				"min_trust_level": "silver",
+				"only_kyc_full": false,
+				"seat_of_bank": [
+					"AT",
+					"BE",
+					"BG",
+					"CH",
+					"CY",
+					"CZ",
+					"DE",
+					"DK",
+					"EE",
+					"ES",
+					"FI",
+					"FR",
+					"GB",
+					"GR",
+					"HR",
+					"HU",
+					"IE",
+					"IS",
+					"IT",
+					"LI",
+					"LT",
+					"LU",
+					"LV",
+					"MQ",
+					"MT",
+					"NL",
+					"NO",
+					"PL",
+					"PT",
+					"RO",
+					"SE",
+					"SI",
+					"SK"
+				],
+				"payment_option": 3
+			},
+			"new_order_for_remaining_amount": false,
+			"state": 0,
+			"end_datetime": "2018-01-30T23:45:00+01:00",
+			"created_at": "2018-01-25T17:35:19+01:00"
+		}
+	],
+	"page": {
+		"current": 1,
+		"last": 1
+	},
+	"errors": [
+	],
+	"credits": 13,
+	"maintenance": {
+		"message": "*** Scheduled maintainance on 2017\/01\/26 at 04:00 am until approx. 06:00 am (CEST)*** Due to network infrastructure maintenance Bitcoin.de will be unavailable between 04:00 am and approx. 06:00 am (CEST). ***",
+		"start": "2018-01-26T04:00:00+01:00",
+		"end": "2018-01-26T06:00:00+01:00"
+	}
+}

--- a/xchange-bitcoinde/src/test/resources/org/knowm/xchange/bitcoinde/v4/dto/my_trades.json
+++ b/xchange-bitcoinde/src/test/resources/org/knowm/xchange/bitcoinde/v4/dto/my_trades.json
@@ -1,0 +1,43 @@
+{
+  "trades": [
+    {
+      "trade_id": "2EDYNS",
+      "trading_pair": "btceur",
+      "is_external_wallet_trade": false,
+      "type": "sell",
+      "amount_currency_to_trade": 0.5,
+      "price": 250.55,
+      "volume_currency_to_pay": 125.28,
+      "volume_currency_to_pay_after_fee": 124.68,
+      "amount_currency_to_trade_after_fee": 0.4975,
+      "fee_currency_to_pay": 0.6,
+      "fee_currency_to_trade": 0.0025,
+      "new_order_id_for_remaining_amount": "C4Y8HD",
+      "state": 1,
+      "is_trade_marked_as_paid": false,
+      "my_rating_for_trading_partner": "positive",
+      "trading_partner_information":
+      {
+        "username":"testuser",
+        "is_kyc_full": true,
+        "depositor": "Max Musterman",
+        "iban": "DE02370501980001802057",
+        "bank_name": "sparkasse",
+        "bic": "HASPDEHHXXX",
+        "rating": 99,
+        "amount_trades": 42,
+        "trust_level": "gold",
+        "seat_of_bank": "DE"
+      },
+      "payment_method": 1,
+      "created_at": "2015-01-10T15:00:00+02:00",
+      "successfully_finished_at": "2015-01-10T15:00:00+02:00"
+    }
+  ],
+  "page": {
+    "current": 2,
+    "last": 4
+  },
+  "errors": [],
+  "credits": 15
+}

--- a/xchange-bitcoinde/src/test/resources/org/knowm/xchange/bitcoinde/v4/dto/orderbook.json
+++ b/xchange-bitcoinde/src/test/resources/org/knowm/xchange/bitcoinde/v4/dto/orderbook.json
@@ -1,0 +1,37 @@
+{
+   "orders": [{
+       "order_id": "A1B2D3",
+       "is_external_wallet_order": false,
+       "trading_pair": "btceur",
+       "type": "buy",
+       "max_amount_currency_to_trade": 0.5,
+       "min_amount_currency_to_trade": 0.1,
+       "price": 230.55,
+       "max_volume_currency_to_pay": 115.28,
+       "min_volume_currency_to_pay": 23.06,
+       "order_requirements_fullfilled": true,
+       "trading_partner_information": {
+           "username": "bla",
+           "is_kyc_full": true,
+           "trust_level": "gold",
+           "bank_name": "Sparkasse",
+           "bic": "HASPDEHHXXX",
+           "seat_of_bank": "DE",
+           "rating": 99,
+           "amount_trades": 52
+       },
+       "order_requirements": {
+           "min_trust_level": "gold",
+           "only_kyc_full": true,
+           "seat_of_bank": [
+               "DE",
+               "NL"
+           ],
+           "payment_option": 1
+       }
+   }],
+   "errors":[
+
+   ],
+   "credits":12
+}

--- a/xchange-bitcoinde/src/test/resources/org/knowm/xchange/bitcoinde/v4/dto/trades.json
+++ b/xchange-bitcoinde/src/test/resources/org/knowm/xchange/bitcoinde/v4/dto/trades.json
@@ -1,0 +1,559 @@
+{
+  "trading_pair":"btceur",
+  "trades": [
+    {
+      "date": 1500718454,
+      "price": 2391.48,
+      "amount_currency_to_trade": "0.90000000",
+      "tid": 2844384
+    },
+    {
+      "date": 1500718452,
+      "price": 2400,
+      "amount_currency_to_trade": "0.19751033",
+      "tid": 2844381
+    },
+    {
+      "date": 1500718401,
+      "price": 2400,
+      "amount_currency_to_trade": "0.83300000",
+      "tid": 2844378
+    },
+    {
+      "date": 1500718347,
+      "price": 2400,
+      "amount_currency_to_trade": "0.50403226",
+      "tid": 2844375
+    },
+    {
+      "date": 1500718307,
+      "price": 2400,
+      "amount_currency_to_trade": "0.04870000",
+      "tid": 2844372
+    },
+    {
+      "date": 1500718274,
+      "price": 2400,
+      "amount_currency_to_trade": "0.07000000",
+      "tid": 2844369
+    },
+    {
+      "date": 1500718247,
+      "price": 2399.99,
+      "amount_currency_to_trade": "0.08333400",
+      "tid": 2844366
+    },
+    {
+      "date": 1500718241,
+      "price": 2400,
+      "amount_currency_to_trade": "0.12800000",
+      "tid": 2844363
+    },
+    {
+      "date": 1500718234,
+      "price": 2400,
+      "amount_currency_to_trade": "0.19800000",
+      "tid": 2844360
+    },
+    {
+      "date": 1500718230,
+      "price": 2399.99,
+      "amount_currency_to_trade": "0.02600000",
+      "tid": 2844357
+    },
+    {
+      "date": 1500718229,
+      "price": 2399.99,
+      "amount_currency_to_trade": "0.10416700",
+      "tid": 2844354
+    },
+    {
+      "date": 1500718210,
+      "price": 2399.99,
+      "amount_currency_to_trade": "0.10000000",
+      "tid": 2844351
+    },
+    {
+      "date": 1500718208,
+      "price": 2399.99,
+      "amount_currency_to_trade": "0.03000000",
+      "tid": 2844348
+    },
+    {
+      "date": 1500718190,
+      "price": 2399.99,
+      "amount_currency_to_trade": "0.03000000",
+      "tid": 2844345
+    },
+    {
+      "date": 1500718186,
+      "price": 2395,
+      "amount_currency_to_trade": "0.15000000",
+      "tid": 2844342
+    },
+    {
+      "date": 1500718182,
+      "price": 2399.99,
+      "amount_currency_to_trade": "0.04166700",
+      "tid": 2844339
+    },
+    {
+      "date": 1500718175,
+      "price": 2399.95,
+      "amount_currency_to_trade": "0.10000000",
+      "tid": 2844336
+    },
+    {
+      "date": 1500718127,
+      "price": 2391.27,
+      "amount_currency_to_trade": "0.63589680",
+      "tid": 2844333
+    },
+    {
+      "date": 1500718126,
+      "price": 2399.99,
+      "amount_currency_to_trade": "0.03000000",
+      "tid": 2844330
+    },
+    {
+      "date": 1500718106,
+      "price": 2399.95,
+      "amount_currency_to_trade": "0.05000000",
+      "tid": 2844327
+    },
+    {
+      "date": 1500718104,
+      "price": 2399.99,
+      "amount_currency_to_trade": "0.05000000",
+      "tid": 2844324
+    },
+    {
+      "date": 1500718103,
+      "price": 2393,
+      "amount_currency_to_trade": "1.50000000",
+      "tid": 2844321
+    },
+    {
+      "date": 1500718086,
+      "price": 2400,
+      "amount_currency_to_trade": "0.40000000",
+      "tid": 2844318
+    },
+    {
+      "date": 1500718083,
+      "price": 2400,
+      "amount_currency_to_trade": "1.00000000",
+      "tid": 2844315
+    },
+    {
+      "date": 1500718071,
+      "price": 2399.8,
+      "amount_currency_to_trade": "0.02600000",
+      "tid": 2844312
+    },
+    {
+      "date": 1500718049,
+      "price": 2399.39,
+      "amount_currency_to_trade": "0.08585531",
+      "tid": 2844309
+    },
+    {
+      "date": 1500718040,
+      "price": 2400,
+      "amount_currency_to_trade": "0.46000000",
+      "tid": 2844306
+    },
+    {
+      "date": 1500718031,
+      "price": 2399.2,
+      "amount_currency_to_trade": "0.10000000",
+      "tid": 2844303
+    },
+    {
+      "date": 1500718029,
+      "price": 2400,
+      "amount_currency_to_trade": "3.00000000",
+      "tid": 2844300
+    },
+    {
+      "date": 1500718009,
+      "price": 2399,
+      "amount_currency_to_trade": "0.12978295",
+      "tid": 2844297
+    },
+    {
+      "date": 1500718006,
+      "price": 2399.99,
+      "amount_currency_to_trade": "0.20833400",
+      "tid": 2844294
+    },
+    {
+      "date": 1500717998,
+      "price": 2399,
+      "amount_currency_to_trade": "0.20000000",
+      "tid": 2844291
+    },
+    {
+      "date": 1500717992,
+      "price": 2399,
+      "amount_currency_to_trade": "0.16000000",
+      "tid": 2844288
+    },
+    {
+      "date": 1500717968,
+      "price": 2390.22,
+      "amount_currency_to_trade": "0.10000000",
+      "tid": 2844285
+    },
+    {
+      "date": 1500717938,
+      "price": 2395,
+      "amount_currency_to_trade": "0.06632000",
+      "tid": 2844282
+    },
+    {
+      "date": 1500717917,
+      "price": 2395,
+      "amount_currency_to_trade": "0.04900000",
+      "tid": 2844279
+    },
+    {
+      "date": 1500717841,
+      "price": 2399.99,
+      "amount_currency_to_trade": "0.41666800",
+      "tid": 2844276
+    },
+    {
+      "date": 1500717839,
+      "price": 2399,
+      "amount_currency_to_trade": "0.04000000",
+      "tid": 2844273
+    },
+    {
+      "date": 1500717823,
+      "price": 2399.5,
+      "amount_currency_to_trade": "0.49600000",
+      "tid": 2844270
+    },
+    {
+      "date": 1500717807,
+      "price": 2399.78,
+      "amount_currency_to_trade": "0.54822189",
+      "tid": 2844267
+    },
+    {
+      "date": 1500717801,
+      "price": 2390.33,
+      "amount_currency_to_trade": "0.10000000",
+      "tid": 2844264
+    },
+    {
+      "date": 1500717791,
+      "price": 2399.75,
+      "amount_currency_to_trade": "1.00000000",
+      "tid": 2844261
+    },
+    {
+      "date": 1500717782,
+      "price": 2399,
+      "amount_currency_to_trade": "0.19017657",
+      "tid": 2844258
+    },
+    {
+      "date": 1500717780,
+      "price": 2399,
+      "amount_currency_to_trade": "0.10000000",
+      "tid": 2844255
+    },
+    {
+      "date": 1500717777,
+      "price": 2399,
+      "amount_currency_to_trade": "0.05585807",
+      "tid": 2844252
+    },
+    {
+      "date": 1500717774,
+      "price": 2399,
+      "amount_currency_to_trade": "0.50000000",
+      "tid": 2844249
+    },
+    {
+      "date": 1500717771,
+      "price": 2399,
+      "amount_currency_to_trade": "0.10000000",
+      "tid": 2844246
+    },
+    {
+      "date": 1500717770,
+      "price": 2399.75,
+      "amount_currency_to_trade": "1.00000000",
+      "tid": 2844243
+    },
+    {
+      "date": 1500717769,
+      "price": 2398.99,
+      "amount_currency_to_trade": "0.41684200",
+      "tid": 2844240
+    },
+    {
+      "date": 1500717766,
+      "price": 2398.99,
+      "amount_currency_to_trade": "0.10421100",
+      "tid": 2844237
+    },
+    {
+      "date": 1500717766,
+      "price": 2395,
+      "amount_currency_to_trade": "0.77913000",
+      "tid": 2844234
+    },
+    {
+      "date": 1500717763,
+      "price": 2398.99,
+      "amount_currency_to_trade": "0.08336800",
+      "tid": 2844231
+    },
+    {
+      "date": 1500717760,
+      "price": 2398.99,
+      "amount_currency_to_trade": "0.04168400",
+      "tid": 2844228
+    },
+    {
+      "date": 1500717758,
+      "price": 2398.98,
+      "amount_currency_to_trade": "0.04168230",
+      "tid": 2844225
+    },
+    {
+      "date": 1500717755,
+      "price": 2398.8,
+      "amount_currency_to_trade": "0.25792000",
+      "tid": 2844222
+    },
+    {
+      "date": 1500717753,
+      "price": 2398.5,
+      "amount_currency_to_trade": "0.30000000",
+      "tid": 2844219
+    },
+    {
+      "date": 1500717750,
+      "price": 2397.9,
+      "amount_currency_to_trade": "0.02600000",
+      "tid": 2844216
+    },
+    {
+      "date": 1500717741,
+      "price": 2399,
+      "amount_currency_to_trade": "1.00000000",
+      "tid": 2844213
+    },
+    {
+      "date": 1500717733,
+      "price": 2390,
+      "amount_currency_to_trade": "0.06000000",
+      "tid": 2844210
+    },
+    {
+      "date": 1500717727,
+      "price": 2397.85,
+      "amount_currency_to_trade": "0.39680000",
+      "tid": 2844207
+    },
+    {
+      "date": 1500717718,
+      "price": 2399,
+      "amount_currency_to_trade": "0.80000000",
+      "tid": 2844204
+    },
+    {
+      "date": 1500717706,
+      "price": 2397.66,
+      "amount_currency_to_trade": "0.04500000",
+      "tid": 2844201
+    },
+    {
+      "date": 1500717698,
+      "price": 2301,
+      "amount_currency_to_trade": "0.45000000",
+      "tid": 2844198
+    },
+    {
+      "date": 1500717688,
+      "price": 2399,
+      "amount_currency_to_trade": "0.78000000",
+      "tid": 2844195
+    },
+    {
+      "date": 1500717668,
+      "price": 2396.93,
+      "amount_currency_to_trade": "0.04172000",
+      "tid": 2844192
+    },
+    {
+      "date": 1500717664,
+      "price": 2397.99,
+      "amount_currency_to_trade": "0.41701600",
+      "tid": 2844189
+    },
+    {
+      "date": 1500717645,
+      "price": 2389,
+      "amount_currency_to_trade": "0.10000000",
+      "tid": 2844186
+    },
+    {
+      "date": 1500717640,
+      "price": 2396.72,
+      "amount_currency_to_trade": "0.03000000",
+      "tid": 2844183
+    },
+    {
+      "date": 1500717636,
+      "price": 2398,
+      "amount_currency_to_trade": "0.63974579",
+      "tid": 2844180
+    },
+    {
+      "date": 1500717616,
+      "price": 2396.94,
+      "amount_currency_to_trade": "0.10430000",
+      "tid": 2844177
+    },
+    {
+      "date": 1500717608,
+      "price": 2396.11,
+      "amount_currency_to_trade": "0.03500000",
+      "tid": 2844174
+    },
+    {
+      "date": 1500717598,
+      "price": 2398,
+      "amount_currency_to_trade": "1.81000000",
+      "tid": 2844171
+    },
+    {
+      "date": 1500717582,
+      "price": 2398,
+      "amount_currency_to_trade": "2.06770000",
+      "tid": 2844168
+    },
+    {
+      "date": 1500717577,
+      "price": 2396,
+      "amount_currency_to_trade": "0.05000000",
+      "tid": 2844165
+    },
+    {
+      "date": 1500717565,
+      "price": 2398.99,
+      "amount_currency_to_trade": "0.20842100",
+      "tid": 2844162
+    },
+    {
+      "date": 1500717562,
+      "price": 2397,
+      "amount_currency_to_trade": "0.69440000",
+      "tid": 2844159
+    },
+    {
+      "date": 1500717521,
+      "price": 2396,
+      "amount_currency_to_trade": "0.04880000",
+      "tid": 2844156
+    },
+    {
+      "date": 1500717516,
+      "price": 2397,
+      "amount_currency_to_trade": "0.29700000",
+      "tid": 2844153
+    },
+    {
+      "date": 1500717487,
+      "price": 2396.69,
+      "amount_currency_to_trade": "1.00000000",
+      "tid": 2844150
+    },
+    {
+      "date": 1500717484,
+      "price": 2390.11,
+      "amount_currency_to_trade": "0.60000000",
+      "tid": 2844147
+    },
+    {
+      "date": 1500717482,
+      "price": 2396,
+      "amount_currency_to_trade": "1.89146678",
+      "tid": 2844144
+    },
+    {
+      "date": 1500717463,
+      "price": 2394.96,
+      "amount_currency_to_trade": "0.20000000",
+      "tid": 2844141
+    },
+    {
+      "date": 1500717447,
+      "price": 2338,
+      "amount_currency_to_trade": "0.10000000",
+      "tid": 2844138
+    },
+    {
+      "date": 1500717440,
+      "price": 2395,
+      "amount_currency_to_trade": "0.81600000",
+      "tid": 2844135
+    },
+    {
+      "date": 1500717424,
+      "price": 2395,
+      "amount_currency_to_trade": "0.98000000",
+      "tid": 2844132
+    },
+    {
+      "date": 1500717406,
+      "price": 2395,
+      "amount_currency_to_trade": "1.77000000",
+      "tid": 2844129
+    },
+    {
+      "date": 1500717304,
+      "price": 2396,
+      "amount_currency_to_trade": "0.06260434",
+      "tid": 2844126
+    },
+    {
+      "date": 1500717274,
+      "price": 2395.11,
+      "amount_currency_to_trade": "0.03000000",
+      "tid": 2844123
+    },
+    {
+      "date": 1500717225,
+      "price": 2395,
+      "amount_currency_to_trade": "0.04722364",
+      "tid": 2844120
+    },
+    {
+      "date": 1500717211,
+      "price": 2390,
+      "amount_currency_to_trade": "0.47000000",
+      "tid": 2844117
+    },
+    {
+      "date": 1500717169,
+      "price": 2390,
+      "amount_currency_to_trade": "0.80000000",
+      "tid": 2844114
+    },
+    {
+      "date": 1500717160,
+      "price": 2395,
+      "amount_currency_to_trade": "0.08064516",
+      "tid": 2844111
+    }
+  ],
+  "errors": [],
+  "credits": 17
+}


### PR DESCRIPTION
Bitcoin.de API is already on API version4 while still supporting version 2. That's why we decided to create additional support for version 4 in a separate package instead of upgrading the existing sources.

We implemented all already supported functions and added a couple of additional ones, mainly in TradeService.
Additionally all Json-DTOs are using Lombok.

I rewrote the commit history so that every commit adds exactly one functionality. That should make it easy to follow the changes.