### PR TITLE
[bittrex] Added xchange-bittrexV3

### DIFF
--- a/xchange-bittrexV3/api-specification.txt
+++ b/xchange-bittrexV3/api-specification.txt
@@ -1,0 +1,6 @@
+Bittrex Exchange API specification
+================================
+
+Documentation
+-------------
+https://bittrex.com/home/api

--- a/xchange-bittrexV3/pom.xml
+++ b/xchange-bittrexV3/pom.xml
@@ -1,0 +1,43 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.knowm.xchange</groupId>
+        <artifactId>xchange-parent</artifactId>
+        <version>5.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>xchange-bittrexV3</artifactId>
+
+    <name>XChange BittrexV3</name>
+    <description>XChange implementation for the BittrexV3 Exchange</description>
+
+    <url>http://knowm.org/open-source/xchange/</url>
+    <inceptionYear>2012</inceptionYear>
+
+    <organization>
+        <name>Knowm Inc.</name>
+        <url>http://knowm.org/open-source/xchange/</url>
+    </organization>
+
+    <!-- Parent provides default configuration for dependencies -->
+    <dependencies>
+
+        <dependency>
+            <groupId>org.knowm.xchange</groupId>
+            <artifactId>xchange-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/Bittrex.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/Bittrex.java
@@ -2,7 +2,6 @@ package org.knowm.xchange.bittrex;
 
 import java.io.IOException;
 import java.util.List;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/Bittrex.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/Bittrex.java
@@ -1,0 +1,52 @@
+package org.knowm.xchange.bittrex;
+
+import java.io.IOException;
+import java.util.List;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexDepth;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexMarketSummary;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexSymbol;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexTicker;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexTrade;
+
+@Path("v3")
+@Produces(MediaType.APPLICATION_JSON)
+public interface Bittrex {
+
+  @GET
+  @Path("markets/{marketSymbol}/orderbook")
+  BittrexDepth getOrderBook(
+      @PathParam("marketSymbol") String marketSymbol, @QueryParam("depth") int depth)
+      throws IOException;
+
+  @GET
+  @Path("markets")
+  List<BittrexSymbol> getMarkets() throws IOException;
+
+  @GET
+  @Path("markets/{marketSymbol}/summary")
+  BittrexMarketSummary getMarketSummary(@PathParam("marketSymbol") String marketSymbol)
+      throws IOException;
+
+  @GET
+  @Path("markets/summaries")
+  List<BittrexMarketSummary> getMarketSummaries() throws IOException;
+
+  @GET
+  @Path("markets/tickers")
+  List<BittrexTicker> getTickers() throws IOException;
+
+  @GET
+  @Path("markets/{marketSymbol}/trades")
+  List<BittrexTrade> getTrades(@PathParam("marketSymbol") String marketSymbol) throws IOException;
+
+  @GET
+  @Path("markets/{marketSymbol}/ticker")
+  BittrexTicker getTicker(@PathParam("marketSymbol") String marketSymbol) throws IOException;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexAdapters.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexAdapters.java
@@ -1,0 +1,221 @@
+package org.knowm.xchange.bittrex;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.knowm.xchange.bittrex.dto.account.BittrexBalance;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexLevel;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexMarketSummary;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexSymbol;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexTicker;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexTrade;
+import org.knowm.xchange.bittrex.dto.trade.BittrexOrder;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order.OrderStatus;
+import org.knowm.xchange.dto.Order.OrderType;
+import org.knowm.xchange.dto.account.Balance;
+import org.knowm.xchange.dto.account.Wallet;
+import org.knowm.xchange.dto.marketdata.Ticker;
+import org.knowm.xchange.dto.marketdata.Trade;
+import org.knowm.xchange.dto.marketdata.Trades;
+import org.knowm.xchange.dto.marketdata.Trades.TradeSortType;
+import org.knowm.xchange.dto.meta.ExchangeMetaData;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.dto.trade.UserTrade;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class BittrexAdapters {
+
+  public static final Logger log = LoggerFactory.getLogger(BittrexAdapters.class);
+
+  private BittrexAdapters() {}
+
+  public static List<CurrencyPair> adaptCurrencyPairs(Collection<BittrexSymbol> bittrexSymbols) {
+    return bittrexSymbols.stream()
+        .map(BittrexAdapters::adaptCurrencyPair)
+        .collect(Collectors.toList());
+  }
+
+  public static CurrencyPair adaptCurrencyPair(BittrexSymbol bittrexSymbol) {
+
+    Currency baseSymbol = bittrexSymbol.getBaseCurrencySymbol();
+    Currency counterSymbol = bittrexSymbol.getQuoteCurrencySymbol();
+    return new CurrencyPair(baseSymbol, counterSymbol);
+  }
+
+  public static List<LimitOrder> adaptOpenOrders(List<BittrexOrder> bittrexOpenOrders) {
+    return bittrexOpenOrders.stream().map(BittrexAdapters::adaptOrder).collect(Collectors.toList());
+  }
+
+  public static LimitOrder adaptOrder(BittrexOrder order, OrderStatus status) {
+
+    OrderType type =
+        order.getDirection().equalsIgnoreCase(BittrexConstants.SELL)
+            ? OrderType.ASK
+            : OrderType.BID;
+    CurrencyPair pair = BittrexUtils.toCurrencyPair(order.getMarketSymbol());
+
+    return new LimitOrder.Builder(type, pair)
+        .originalAmount(order.getQuantity())
+        .id(order.getId())
+        .timestamp(order.getUpdatedAt() != null ? order.getUpdatedAt() : order.getCreatedAt())
+        .limitPrice(order.getLimit())
+        .remainingAmount(order.getQuantity().subtract(order.getFillQuantity()))
+        .fee(order.getCommission())
+        .orderStatus(status)
+        .build();
+  }
+
+  public static List<LimitOrder> adaptOrders(
+      BittrexLevel[] orders, CurrencyPair currencyPair, OrderType orderType, String id, int depth) {
+
+    if (orders == null) {
+      return new ArrayList<>();
+    }
+
+    List<LimitOrder> limitOrders = new ArrayList<>(orders.length);
+
+    for (int i = 0; i < Math.min(orders.length, depth); i++) {
+      BittrexLevel order = orders[i];
+      limitOrders.add(adaptOrder(order.getAmount(), order.getPrice(), currencyPair, orderType, id));
+    }
+
+    return limitOrders;
+  }
+
+  public static LimitOrder adaptOrder(
+      BigDecimal amount,
+      BigDecimal price,
+      CurrencyPair currencyPair,
+      OrderType orderType,
+      String id) {
+    return new LimitOrder(orderType, amount, currencyPair, id, null, price);
+  }
+
+  public static LimitOrder adaptOrder(BittrexOrder order) {
+    return adaptOrder(order, adaptOrderStatus(order));
+  }
+
+  private static OrderStatus adaptOrderStatus(BittrexOrder order) {
+    OrderStatus status = OrderStatus.NEW;
+    BigDecimal qty = order.getQuantity();
+    BigDecimal qtyRem = order.getQuantity().subtract(order.getFillQuantity());
+    int qtyRemainingToQty = qtyRem.compareTo(qty);
+
+    if (qtyRemainingToQty < 0) {
+      /* The order is open and remaining quantity less than order quantity */
+      status = OrderStatus.PARTIALLY_FILLED;
+    }
+    return status;
+  }
+
+  public static Trade adaptTrade(BittrexTrade trade, CurrencyPair currencyPair) {
+
+    OrderType orderType =
+        BittrexConstants.BUY.equalsIgnoreCase(trade.getTakerSide()) ? OrderType.BID : OrderType.ASK;
+    BigDecimal amount = trade.getQuantity();
+    BigDecimal price = trade.getRate();
+    Date date = trade.getExecutedAt();
+    final String tradeId = String.valueOf(trade.getId());
+    return new Trade.Builder()
+        .type(orderType)
+        .originalAmount(amount)
+        .currencyPair(currencyPair)
+        .price(price)
+        .timestamp(date)
+        .id(tradeId)
+        .build();
+  }
+
+  public static Trades adaptTrades(List<BittrexTrade> trades, CurrencyPair currencyPair) {
+
+    List<Trade> tradesList = new ArrayList<>(trades.size());
+    long lastTradeId = 0;
+    for (BittrexTrade trade : trades) {
+      long tradeId = Long.parseLong(trade.getId());
+      if (tradeId > lastTradeId) {
+        lastTradeId = tradeId;
+      }
+      tradesList.add(adaptTrade(trade, currencyPair));
+    }
+    return new Trades(tradesList, lastTradeId, TradeSortType.SortByID);
+  }
+
+  public static List<UserTrade> adaptUserTrades(List<BittrexOrder> bittrexUserTrades) {
+    return bittrexUserTrades.stream()
+        .map(
+            bittrexOrder ->
+                new UserTrade.Builder()
+                    .type(
+                        BittrexConstants.BUY.equalsIgnoreCase(bittrexOrder.getType())
+                            ? OrderType.BID
+                            : OrderType.ASK)
+                    .originalAmount(bittrexOrder.getFillQuantity())
+                    .currencyPair(BittrexUtils.toCurrencyPair(bittrexOrder.getMarketSymbol()))
+                    .price(bittrexOrder.getLimit())
+                    .timestamp(bittrexOrder.getClosedAt())
+                    .id(bittrexOrder.getId())
+                    .feeAmount(bittrexOrder.getCommission())
+                    .feeCurrency(
+                        BittrexUtils.toCurrencyPair(bittrexOrder.getMarketSymbol()).counter)
+                    .build())
+        .collect(Collectors.toList());
+  }
+
+  public static Ticker adaptTicker(
+      BittrexMarketSummary bittrexMarketSummary, BittrexTicker bittrexTicker) {
+
+    CurrencyPair currencyPair = BittrexUtils.toCurrencyPair(bittrexTicker.getSymbol());
+    BigDecimal last = bittrexTicker.getLastTradeRate();
+    BigDecimal bid = bittrexTicker.getBidRate();
+    BigDecimal ask = bittrexTicker.getAskRate();
+    BigDecimal high = bittrexMarketSummary.getHigh();
+    BigDecimal low = bittrexMarketSummary.getLow();
+    BigDecimal quoteVolume = bittrexMarketSummary.getQuoteVolume();
+    BigDecimal volume = bittrexMarketSummary.getVolume();
+    Date timestamp = bittrexMarketSummary.getUpdatedAt();
+
+    return new Ticker.Builder()
+        .currencyPair(currencyPair)
+        .last(last)
+        .bid(bid)
+        .ask(ask)
+        .high(high)
+        .low(low)
+        .quoteVolume(quoteVolume)
+        .volume(volume)
+        .timestamp(timestamp)
+        .build();
+  }
+
+  public static Wallet adaptWallet(Collection<BittrexBalance> balances) {
+    List<Balance> wallets =
+        balances.stream()
+            .map(
+                bittrexBalance ->
+                    new Balance.Builder()
+                        .currency(bittrexBalance.getCurrencySymbol())
+                        .total(bittrexBalance.getTotal())
+                        .available(bittrexBalance.getAvailable())
+                        .timestamp(bittrexBalance.getUpdatedAt())
+                        .build())
+            .collect(Collectors.toList());
+
+    return Wallet.Builder.from(wallets).build();
+  }
+
+  public static void adaptMetaData(List<BittrexSymbol> rawSymbols, ExchangeMetaData metaData) {
+    BittrexAdapters.adaptCurrencyPairs(rawSymbols)
+        .forEach(
+            currencyPair -> {
+              metaData.getCurrencyPairs().putIfAbsent(currencyPair, null);
+              metaData.getCurrencies().putIfAbsent(currencyPair.base, null);
+              metaData.getCurrencies().putIfAbsent(currencyPair.counter, null);
+            });
+  }
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexAdapters.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexAdapters.java
@@ -27,8 +27,6 @@ import org.knowm.xchange.dto.marketdata.Trades.TradeSortType;
 import org.knowm.xchange.dto.meta.ExchangeMetaData;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.UserTrade;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class BittrexAdapters {
 

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexAuthenticated.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexAuthenticated.java
@@ -1,0 +1,118 @@
+package org.knowm.xchange.bittrex;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import org.knowm.xchange.bittrex.dto.account.BittrexAccountVolume;
+import org.knowm.xchange.bittrex.dto.account.BittrexBalance;
+import org.knowm.xchange.bittrex.dto.batch.BatchResponse;
+import org.knowm.xchange.bittrex.dto.batch.order.BatchOrder;
+import org.knowm.xchange.bittrex.dto.trade.BittrexNewOrder;
+import org.knowm.xchange.bittrex.dto.trade.BittrexOrder;
+import si.mazi.rescu.ParamsDigest;
+
+@Path("v3")
+@Produces(MediaType.APPLICATION_JSON)
+public interface BittrexAuthenticated extends Bittrex {
+
+  @GET
+  @Path("account/volume")
+  BittrexAccountVolume getAccountVolume(
+      @HeaderParam("Api-Key") String apiKey,
+      @HeaderParam("Api-Timestamp") Long timestamp,
+      @HeaderParam("Api-Content-Hash") ParamsDigest hash,
+      @HeaderParam("Api-Signature") ParamsDigest signature)
+      throws IOException;
+
+  @POST
+  @Path("batch")
+  @Consumes(MediaType.APPLICATION_JSON)
+  BatchResponse[] executeOrdersBatch(
+      @HeaderParam("Api-Key") String apiKey,
+      @HeaderParam("Api-Timestamp") Long timestamp,
+      @HeaderParam("Api-Content-Hash") ParamsDigest hash,
+      @HeaderParam("Api-Signature") ParamsDigest signature,
+      BatchOrder[] batchOrders)
+      throws IOException;
+
+  @DELETE
+  @Path("orders/{order_id}")
+  BittrexOrder cancelOrder(
+      @HeaderParam("Api-Key") String apiKey,
+      @HeaderParam("Api-Timestamp") Long timestamp,
+      @HeaderParam("Api-Content-Hash") ParamsDigest hash,
+      @HeaderParam("Api-Signature") ParamsDigest signature,
+      @PathParam("order_id") String accountId)
+      throws IOException;
+
+  @GET
+  @Path("balances")
+  Collection<BittrexBalance> getBalances(
+      @HeaderParam("Api-Key") String apiKey,
+      @HeaderParam("Api-Timestamp") Long timestamp,
+      @HeaderParam("Api-Content-Hash") ParamsDigest hash,
+      @HeaderParam("Api-Signature") ParamsDigest signature)
+      throws IOException;
+
+  @GET
+  @Path("balances/{currencySymbol}")
+  BittrexBalance getBalance(
+      @HeaderParam("Api-Key") String apiKey,
+      @HeaderParam("Api-Timestamp") Long timestamp,
+      @HeaderParam("Api-Content-Hash") ParamsDigest hash,
+      @HeaderParam("Api-Signature") ParamsDigest signature,
+      @PathParam("currencySymbol") String currencySymbol)
+      throws IOException;
+
+  @GET
+  @Path("orders/{orderId}")
+  BittrexOrder getOrder(
+      @HeaderParam("Api-Key") String apiKey,
+      @HeaderParam("Api-Timestamp") Long timestamp,
+      @HeaderParam("Api-Content-Hash") ParamsDigest hash,
+      @HeaderParam("Api-Signature") ParamsDigest signature,
+      @PathParam("orderId") String orderId)
+      throws IOException;
+
+  @POST
+  @Path("orders")
+  @Consumes(MediaType.APPLICATION_JSON)
+  BittrexOrder placeOrder(
+      @HeaderParam("Api-Key") String apiKey,
+      @HeaderParam("Api-Timestamp") Long timestamp,
+      @HeaderParam("Api-Content-Hash") ParamsDigest hash,
+      @HeaderParam("Api-Signature") ParamsDigest signature,
+      BittrexNewOrder newOrderPayload)
+      throws IOException;
+
+  @GET
+  @Path("orders/open")
+  List<BittrexOrder> getOpenOrders(
+      @HeaderParam("Api-Key") String apiKey,
+      @HeaderParam("Api-Timestamp") Long timestamp,
+      @HeaderParam("Api-Content-Hash") ParamsDigest hash,
+      @HeaderParam("Api-Signature") ParamsDigest signature)
+      throws IOException;
+
+  // V3 replacement for get order history
+  @GET
+  @Path("orders/closed")
+  List<BittrexOrder> getClosedOrders(
+      @HeaderParam("Api-Key") String apiKey,
+      @HeaderParam("Api-Timestamp") Long timestamp,
+      @HeaderParam("Api-Content-Hash") ParamsDigest hash,
+      @HeaderParam("Api-Signature") ParamsDigest signature,
+      @QueryParam("marketSymbol") String marketSymbol,
+      @QueryParam("pageSize") Integer pageSize)
+      throws IOException;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexConstants.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexConstants.java
@@ -1,0 +1,19 @@
+package org.knowm.xchange.bittrex;
+
+public class BittrexConstants {
+  public static final String BUY = "BUY";
+  public static final String SELL = "SELL";
+  public static final String LIMIT = "LIMIT";
+  public static final String MARKET = "MARKET";
+  public static final String CEILING_LIMIT = "CEILING_LIMIT";
+  public static final String CEILING_MARKET = "CEILING_MARKET";
+  public static final String GOOD_TIL_CANCELLED = "GOOD_TIL_CANCELLED";
+  public static final String IMMEDIATE_OR_CANCEL = "IMMEDIATE_OR_CANCEL";
+  public static final String FILL_OR_KILL = "FILL_OR_KILL";
+  public static final String POST_ONLY_GOOD_TIL_CANCELLED = "POST_ONLY_GOOD_TIL_CANCELLED";
+  public static final String BUY_NOW = "BUY_NOW";
+  public static final String ONLINE = "ONLINE";
+  public static final String OFFLINE = "OFFLINE";
+  public static final String POST = "Post";
+  public static final String DELETE = "Delete";
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexConstants.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexConstants.java
@@ -15,7 +15,6 @@ public final class BittrexConstants {
 
   // Orders time in force
   public static final String GOOD_TIL_CANCELLED = "GOOD_TIL_CANCELLED";
-
   public static final String IMMEDIATE_OR_CANCEL = "IMMEDIATE_OR_CANCEL";
   public static final String FILL_OR_KILL = "FILL_OR_KILL";
   public static final String POST_ONLY_GOOD_TIL_CANCELLED = "POST_ONLY_GOOD_TIL_CANCELLED";

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexConstants.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexConstants.java
@@ -1,19 +1,41 @@
 package org.knowm.xchange.bittrex;
 
-public class BittrexConstants {
+/** See https://bittrex.github.io/api/v3 */
+public final class BittrexConstants {
+
+  // Orders direction
   public static final String BUY = "BUY";
+
   public static final String SELL = "SELL";
+
+  // Order types
   public static final String LIMIT = "LIMIT";
+
   public static final String MARKET = "MARKET";
   public static final String CEILING_LIMIT = "CEILING_LIMIT";
   public static final String CEILING_MARKET = "CEILING_MARKET";
+
+  // Orders time in force
   public static final String GOOD_TIL_CANCELLED = "GOOD_TIL_CANCELLED";
+
   public static final String IMMEDIATE_OR_CANCEL = "IMMEDIATE_OR_CANCEL";
   public static final String FILL_OR_KILL = "FILL_OR_KILL";
   public static final String POST_ONLY_GOOD_TIL_CANCELLED = "POST_ONLY_GOOD_TIL_CANCELLED";
   public static final String BUY_NOW = "BUY_NOW";
+
+  // Orders status
+  public static final String OPEN = "OPEN";
+  public static final String CLOSED = "CLOSED";
+
+  // Currencies status
   public static final String ONLINE = "ONLINE";
   public static final String OFFLINE = "OFFLINE";
+
+  // Batch flags (not documented as of 07/01/2020)
   public static final String POST = "Post";
   public static final String DELETE = "Delete";
+
+  private BittrexConstants() {
+    throw new AssertionError();
+  }
 }

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexConstants.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexConstants.java
@@ -5,12 +5,10 @@ public final class BittrexConstants {
 
   // Orders direction
   public static final String BUY = "BUY";
-
   public static final String SELL = "SELL";
 
   // Order types
   public static final String LIMIT = "LIMIT";
-
   public static final String MARKET = "MARKET";
   public static final String CEILING_LIMIT = "CEILING_LIMIT";
   public static final String CEILING_MARKET = "CEILING_MARKET";

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexExchange.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexExchange.java
@@ -1,0 +1,61 @@
+package org.knowm.xchange.bittrex;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.knowm.xchange.BaseExchange;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexSymbol;
+import org.knowm.xchange.bittrex.service.BittrexAccountService;
+import org.knowm.xchange.bittrex.service.BittrexMarketDataService;
+import org.knowm.xchange.bittrex.service.BittrexMarketDataServiceRaw;
+import org.knowm.xchange.bittrex.service.BittrexTradeService;
+import org.knowm.xchange.utils.nonce.AtomicLongIncrementalTime2013NonceFactory;
+import si.mazi.rescu.SynchronizedValueFactory;
+
+public class BittrexExchange extends BaseExchange implements Exchange {
+
+  private final SynchronizedValueFactory<Long> nonceFactory =
+      new AtomicLongIncrementalTime2013NonceFactory();
+
+  private static List<BittrexSymbol> bittrexSymbols = new ArrayList<>();
+  private static final Object INIT_LOCK = new Object();
+
+  @Override
+  protected void initServices() {
+    this.marketDataService = new BittrexMarketDataService(this);
+    this.accountService = new BittrexAccountService(this);
+    this.tradeService = new BittrexTradeService(this);
+  }
+
+  @Override
+  public ExchangeSpecification getDefaultExchangeSpecification() {
+    ExchangeSpecification exchangeSpecification =
+        new ExchangeSpecification(this.getClass().getCanonicalName());
+    exchangeSpecification.setSslUri("https://api.bittrex.com/");
+    exchangeSpecification.setHost("bittrex.com");
+    exchangeSpecification.setPort(80);
+    exchangeSpecification.setExchangeName("Bittrex");
+    exchangeSpecification.setExchangeDescription("Bittrex is a bitcoin and altcoin exchange.");
+
+    return exchangeSpecification;
+  }
+
+  @Override
+  public SynchronizedValueFactory<Long> getNonceFactory() {
+    return nonceFactory;
+  }
+
+  @Override
+  public void remoteInit() throws IOException {
+    if (bittrexSymbols.isEmpty()) {
+      synchronized (INIT_LOCK) {
+        if (bittrexSymbols.isEmpty()) {
+          bittrexSymbols = ((BittrexMarketDataServiceRaw) marketDataService).getBittrexSymbols();
+          BittrexAdapters.adaptMetaData(bittrexSymbols, exchangeMetaData);
+        }
+      }
+    }
+  }
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexExchange.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexExchange.java
@@ -37,7 +37,7 @@ public class BittrexExchange extends BaseExchange implements Exchange {
     exchangeSpecification.setHost("bittrex.com");
     exchangeSpecification.setPort(80);
     exchangeSpecification.setExchangeName("Bittrex");
-    exchangeSpecification.setExchangeDescription("Bittrex is a bitcoin and altcoin exchange.");
+    exchangeSpecification.setExchangeDescription("Bittrex is a cryptocurrencies exchange.");
 
     return exchangeSpecification;
   }

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexUtils.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexUtils.java
@@ -25,5 +25,4 @@ public final class BittrexUtils {
   private BittrexUtils() {
     throw new AssertionError();
   }
-
 }

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexUtils.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexUtils.java
@@ -2,12 +2,10 @@ package org.knowm.xchange.bittrex;
 
 import org.knowm.xchange.currency.CurrencyPair;
 
-/** A central place for shared Bittrex properties */
+/** A central place for shared Bittrex utility operations */
 public final class BittrexUtils {
-  protected static final String MARKET_NAME_SEPARATOR = "-";
 
-  /** Utility class */
-  private BittrexUtils() {}
+  public static final String MARKET_NAME_SEPARATOR = "-";
 
   public static String toPairString(CurrencyPair currencyPair) {
     if (currencyPair == null) return null;
@@ -19,7 +17,13 @@ public final class BittrexUtils {
   public static CurrencyPair toCurrencyPair(String pairString) {
     if (pairString == null) return null;
     String[] pairStringSplit = pairString.split(MARKET_NAME_SEPARATOR);
-    if (pairStringSplit.length < 2) return null;
+    if (pairStringSplit.length != 2) return null;
     return new CurrencyPair(pairStringSplit[0], pairStringSplit[1]);
   }
+
+  /** Utility class */
+  private BittrexUtils() {
+    throw new AssertionError();
+  }
+
 }

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexUtils.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexUtils.java
@@ -1,0 +1,25 @@
+package org.knowm.xchange.bittrex;
+
+import org.knowm.xchange.currency.CurrencyPair;
+
+/** A central place for shared Bittrex properties */
+public final class BittrexUtils {
+  protected static final String MARKET_NAME_SEPARATOR = "-";
+
+  /** Utility class */
+  private BittrexUtils() {}
+
+  public static String toPairString(CurrencyPair currencyPair) {
+    if (currencyPair == null) return null;
+    return currencyPair.base.getCurrencyCode().toUpperCase()
+        + MARKET_NAME_SEPARATOR
+        + currencyPair.counter.getCurrencyCode().toUpperCase();
+  }
+
+  public static CurrencyPair toCurrencyPair(String pairString) {
+    if (pairString == null) return null;
+    String[] pairStringSplit = pairString.split(MARKET_NAME_SEPARATOR);
+    if (pairStringSplit.length < 2) return null;
+    return new CurrencyPair(pairStringSplit[0], pairStringSplit[1]);
+  }
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/account/BittrexAccountVolume.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/account/BittrexAccountVolume.java
@@ -1,0 +1,41 @@
+package org.knowm.xchange.bittrex.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+
+public class BittrexAccountVolume {
+
+  private String updated;
+  private BigDecimal volume30days;
+
+  public BittrexAccountVolume(
+      @JsonProperty("updated") String updated,
+      @JsonProperty("volume30days") BigDecimal volume30days) {
+
+    super();
+    this.updated = updated;
+    this.volume30days = volume30days;
+  }
+
+  public String getUpdated() {
+    return updated;
+  }
+
+  public void setUpdated(String updated) {
+    this.updated = updated;
+  }
+
+  public BigDecimal getVolume30days() {
+    return volume30days;
+  }
+
+  public void setVolume30days(BigDecimal volume30days) {
+    this.volume30days = volume30days;
+  }
+
+  @Override
+  public String toString() {
+
+    return "BittrexAccountVolume [updated=" + updated + ", volume30days=" + volume30days + "]";
+  }
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/account/BittrexBalance.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/account/BittrexBalance.java
@@ -1,0 +1,16 @@
+package org.knowm.xchange.bittrex.dto.account;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.knowm.xchange.currency.Currency;
+
+@Data
+@NoArgsConstructor
+public class BittrexBalance {
+  private Currency currencySymbol;
+  private BigDecimal total;
+  private BigDecimal available;
+  private Date updatedAt;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/account/BittrexBalances.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/account/BittrexBalances.java
@@ -1,0 +1,8 @@
+package org.knowm.xchange.bittrex.dto.account;
+
+import lombok.Data;
+
+@Data
+public class BittrexBalances {
+  private final BittrexBalance[] bittrexBalance;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/BatchResponse.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/BatchResponse.java
@@ -1,0 +1,24 @@
+package org.knowm.xchange.bittrex.dto.batch;
+
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class BatchResponse {
+  /**
+   * possible payloads examples:
+   *
+   * 1st example:
+   * BatchResponse(payload={id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx,
+   * marketSymbol=ANT-ETH, direction=BUY, type=LIMIT, quantity=93.47332424, limit=0.00610003,
+   * timeInForce=GOOD_TIL_CANCELLED, fillQuantity=0.00000000, commission=0.00000000,
+   * proceeds=0.00000000, status=CLOSED, createdAt=2020-07-01T08:57:51.26Z,
+   * updatedAt=2020-07-01T08:57:52.62Z, closedAt=2020-07-01T08:57:52.62Z}, status=200)
+   *
+   * 2nd example:
+   * BatchResponse(payload={code=INSUFFICIENT_FUNDS}, status=409)
+   */
+  private Map payload;
+
+  private String status;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/BatchResponse.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/BatchResponse.java
@@ -8,15 +8,13 @@ public class BatchResponse {
   /**
    * possible payloads examples:
    *
-   * 1st example:
-   * BatchResponse(payload={id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx,
+   * <p>1st example: BatchResponse(payload={id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx,
    * marketSymbol=ANT-ETH, direction=BUY, type=LIMIT, quantity=93.47332424, limit=0.00610003,
    * timeInForce=GOOD_TIL_CANCELLED, fillQuantity=0.00000000, commission=0.00000000,
    * proceeds=0.00000000, status=CLOSED, createdAt=2020-07-01T08:57:51.26Z,
    * updatedAt=2020-07-01T08:57:52.62Z, closedAt=2020-07-01T08:57:52.62Z}, status=200)
    *
-   * 2nd example:
-   * BatchResponse(payload={code=INSUFFICIENT_FUNDS}, status=409)
+   * <p>2nd example: BatchResponse(payload={code=INSUFFICIENT_FUNDS}, status=409)
    */
   private Map payload;
 

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/Payload.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/Payload.java
@@ -1,0 +1,8 @@
+package org.knowm.xchange.bittrex.dto.batch;
+
+import lombok.Data;
+
+@Data
+public class Payload {
+  private String id;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/BatchOrder.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/BatchOrder.java
@@ -1,0 +1,21 @@
+package org.knowm.xchange.bittrex.dto.batch.order;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class BatchOrder {
+  @JsonProperty("Resource")
+  private String resource = "Order";
+
+  @JsonProperty("Operation")
+  private Operation operation;
+
+  @JsonProperty("Payload")
+  private OrderPayload payload;
+
+  public BatchOrder(Operation operation, OrderPayload payload) {
+    this.operation = operation;
+    this.payload = payload;
+  }
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/Operation.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/Operation.java
@@ -1,0 +1,14 @@
+package org.knowm.xchange.bittrex.dto.batch.order;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.knowm.xchange.bittrex.BittrexConstants;
+
+@AllArgsConstructor
+@Getter
+public enum Operation {
+  POST(BittrexConstants.POST),
+  DELETE(BittrexConstants.DELETE);
+
+  private final String operation;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/OrderPayload.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/OrderPayload.java
@@ -1,0 +1,3 @@
+package org.knowm.xchange.bittrex.dto.batch.order;
+
+public class OrderPayload {}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/cancelorder/CancelOrderPayload.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/cancelorder/CancelOrderPayload.java
@@ -1,0 +1,11 @@
+package org.knowm.xchange.bittrex.dto.batch.order.cancelorder;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.knowm.xchange.bittrex.dto.batch.order.OrderPayload;
+
+@Data
+@AllArgsConstructor
+public class CancelOrderPayload extends OrderPayload {
+  private String id;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/cancelorder/CancelOrderPayload.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/cancelorder/CancelOrderPayload.java
@@ -2,10 +2,13 @@ package org.knowm.xchange.bittrex.dto.batch.order.cancelorder;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+
 import org.knowm.xchange.bittrex.dto.batch.order.OrderPayload;
 
 @Data
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper=true)
 public class CancelOrderPayload extends OrderPayload {
   private String id;
 }

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/neworder/Direction.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/neworder/Direction.java
@@ -1,0 +1,14 @@
+package org.knowm.xchange.bittrex.dto.batch.order.neworder;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.knowm.xchange.bittrex.BittrexConstants;
+
+@AllArgsConstructor
+@Getter
+public enum Direction {
+  BUY(BittrexConstants.BUY),
+  SELL(BittrexConstants.SELL);
+
+  private final String direction;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/neworder/NewOrderPayload.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/neworder/NewOrderPayload.java
@@ -1,0 +1,16 @@
+package org.knowm.xchange.bittrex.dto.batch.order.neworder;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.knowm.xchange.bittrex.dto.batch.order.OrderPayload;
+
+@Data
+@AllArgsConstructor
+public class NewOrderPayload extends OrderPayload {
+  private String marketSymbol;
+  private Direction direction;
+  private Type type;
+  private String quantity;
+  private String limit;
+  private TimeInForce timeInForce;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/neworder/NewOrderPayload.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/neworder/NewOrderPayload.java
@@ -2,10 +2,13 @@ package org.knowm.xchange.bittrex.dto.batch.order.neworder;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+
 import org.knowm.xchange.bittrex.dto.batch.order.OrderPayload;
 
 @Data
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper=true)
 public class NewOrderPayload extends OrderPayload {
   private String marketSymbol;
   private Direction direction;

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/neworder/TimeInForce.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/neworder/TimeInForce.java
@@ -1,0 +1,17 @@
+package org.knowm.xchange.bittrex.dto.batch.order.neworder;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.knowm.xchange.bittrex.BittrexConstants;
+
+@AllArgsConstructor
+@Getter
+public enum TimeInForce {
+  GOOD_TIL_CANCELLED(BittrexConstants.GOOD_TIL_CANCELLED),
+  IMMEDIATE_OR_CANCEL(BittrexConstants.IMMEDIATE_OR_CANCEL),
+  FILL_OR_KILL(BittrexConstants.FILL_OR_KILL),
+  POST_ONLY_GOOD_TIL_CANCELLED(BittrexConstants.POST_ONLY_GOOD_TIL_CANCELLED),
+  BUY_NOW(BittrexConstants.BUY_NOW);
+
+  private final String timeInForce;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/neworder/Type.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/batch/order/neworder/Type.java
@@ -1,0 +1,16 @@
+package org.knowm.xchange.bittrex.dto.batch.order.neworder;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.knowm.xchange.bittrex.BittrexConstants;
+
+@AllArgsConstructor
+@Getter
+public enum Type {
+  LIMIT(BittrexConstants.LIMIT),
+  MARKET(BittrexConstants.MARKET),
+  CEILING_LIMIT(BittrexConstants.CEILING_LIMIT),
+  CEILING_MARKET(BittrexConstants.CEILING_MARKET);
+
+  private final String type;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/marketdata/BittrexDepth.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/marketdata/BittrexDepth.java
@@ -1,0 +1,62 @@
+package org.knowm.xchange.bittrex.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import si.mazi.rescu.HttpResponseAware;
+
+public class BittrexDepth implements HttpResponseAware {
+
+  public static final String SEQUENCE = "Sequence";
+  private Map<String, List<String>> headers;
+  private final BittrexLevel[] asks;
+  private final BittrexLevel[] bids;
+
+  /**
+   * Constructor
+   *
+   * @param asks
+   * @param bids
+   */
+  public BittrexDepth(
+      @JsonProperty("ask") BittrexLevel[] asks, @JsonProperty("bid") BittrexLevel[] bids) {
+
+    this.asks = asks;
+    this.bids = bids;
+  }
+
+  public BittrexLevel[] getAsks() {
+
+    return asks;
+  }
+
+  public BittrexLevel[] getBids() {
+
+    return bids;
+  }
+
+  @Override
+  public String toString() {
+
+    return "BittrexDepth [asks=" + Arrays.toString(asks) + ", bids=" + Arrays.toString(bids) + "]";
+  }
+
+  @Override
+  public void setResponseHeaders(Map<String, List<String>> headers) {
+    this.headers = headers;
+  }
+
+  @Override
+  public Map<String, List<String>> getResponseHeaders() {
+    return headers;
+  }
+
+  public String getHeader(String key) {
+    return getResponseHeaders().get(key).get(0);
+  }
+
+  public String getSequence() {
+    return getResponseHeaders().get(SEQUENCE).get(0);
+  }
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/marketdata/BittrexLevel.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/marketdata/BittrexLevel.java
@@ -1,0 +1,39 @@
+package org.knowm.xchange.bittrex.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+
+public class BittrexLevel {
+
+  private final BigDecimal rate;
+  private final BigDecimal quantity;
+
+  /**
+   * Constructor
+   *
+   * @param rate
+   * @param quantity
+   */
+  public BittrexLevel(
+      @JsonProperty("rate") BigDecimal rate, @JsonProperty("quantity") BigDecimal quantity) {
+
+    this.rate = rate;
+    this.quantity = quantity;
+  }
+
+  public BigDecimal getPrice() {
+
+    return rate;
+  }
+
+  public BigDecimal getAmount() {
+
+    return quantity;
+  }
+
+  @Override
+  public String toString() {
+
+    return "BittrexLevel [rate=" + rate + ", quantity=" + quantity + "]";
+  }
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/marketdata/BittrexMarketSummary.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/marketdata/BittrexMarketSummary.java
@@ -1,0 +1,18 @@
+package org.knowm.xchange.bittrex.dto.marketdata;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class BittrexMarketSummary {
+  private String symbol;
+  private BigDecimal high;
+  private BigDecimal low;
+  private BigDecimal volume;
+  private BigDecimal quoteVolume;
+  private BigDecimal percentChange;
+  private Date updatedAt;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/marketdata/BittrexSymbol.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/marketdata/BittrexSymbol.java
@@ -1,0 +1,21 @@
+package org.knowm.xchange.bittrex.dto.marketdata;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.knowm.xchange.currency.Currency;
+
+@Data
+@NoArgsConstructor
+public class BittrexSymbol {
+  private String symbol;
+  private Date createdAt;
+  private String[] prohibitedIn;
+  private BigDecimal minTradeSize;
+  private Integer precision;
+  private Currency quoteCurrencySymbol;
+  private Currency baseCurrencySymbol;
+  private String status;
+  private String notice;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/marketdata/BittrexTicker.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/marketdata/BittrexTicker.java
@@ -1,0 +1,14 @@
+package org.knowm.xchange.bittrex.dto.marketdata;
+
+import java.math.BigDecimal;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class BittrexTicker {
+  private String symbol;
+  private BigDecimal lastTradeRate;
+  private BigDecimal bidRate;
+  private BigDecimal askRate;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/marketdata/BittrexTrade.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/marketdata/BittrexTrade.java
@@ -1,0 +1,16 @@
+package org.knowm.xchange.bittrex.dto.marketdata;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class BittrexTrade {
+  private String id;
+  private Date executedAt;
+  private BigDecimal quantity;
+  private BigDecimal rate;
+  private String takerSide;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/trade/BittrexNewOrder.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/trade/BittrexNewOrder.java
@@ -1,0 +1,20 @@
+package org.knowm.xchange.bittrex.dto.trade;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BittrexNewOrder {
+  private String marketSymbol;
+  private String direction;
+  private String type;
+  private String quantity;
+  private String ceiling;
+  private String limit;
+  private String timeInForce;
+  private String clientOrderId;
+  private String useAwards;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/trade/BittrexOrder.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/trade/BittrexOrder.java
@@ -1,0 +1,31 @@
+package org.knowm.xchange.bittrex.dto.trade;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BittrexOrder {
+
+  private String id;
+  private String marketSymbol;
+  private String direction;
+  private String type;
+  private BigDecimal quantity;
+  private BigDecimal limit;
+  private BigDecimal ceiling;
+  private String timeInForce;
+  private String clientOrderId;
+  private BigDecimal fillQuantity;
+  private BigDecimal commission;
+  private BigDecimal proceeds;
+  private String status;
+  private Date createdAt;
+  private Date updatedAt;
+  private Date closedAt;
+  private OrderToCancel orderToCancel;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/trade/BittrexUserTrade.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/trade/BittrexUserTrade.java
@@ -1,0 +1,150 @@
+package org.knowm.xchange.bittrex.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+
+public class BittrexUserTrade {
+
+  private final String orderUuid;
+  private final String exchange;
+  private final String timeStamp;
+  private final String orderType;
+  private final BigDecimal limit;
+  private final BigDecimal quantity;
+  private final BigDecimal quantityRemaining;
+  private final BigDecimal commission;
+  private final BigDecimal price;
+  private final BigDecimal pricePerUnit;
+  private final Boolean isConditional;
+  private final String condition;
+  private final Object conditionTarget;
+  private final Boolean immediateOrCancel;
+  private final String closed;
+
+  public BittrexUserTrade(
+      @JsonProperty("OrderUuid") String orderUuid,
+      @JsonProperty("Exchange") String exchange,
+      @JsonProperty("TimeStamp") String timeStamp,
+      @JsonProperty("OrderType") String orderType,
+      @JsonProperty("Limit") BigDecimal limit,
+      @JsonProperty("Quantity") BigDecimal quantity,
+      @JsonProperty("QuantityRemaining") BigDecimal quantityRemaining,
+      @JsonProperty("Commission") BigDecimal commission,
+      @JsonProperty("Price") BigDecimal price,
+      @JsonProperty("PricePerUnit") BigDecimal pricePerUnit,
+      @JsonProperty("IsConditional") Boolean isConditional,
+      @JsonProperty("Condition") String condition,
+      @JsonProperty("ConditionTarget") Object conditionTarget,
+      @JsonProperty("ImmediateOrCancel") Boolean immediateOrCancel,
+      @JsonProperty("Closed") String closed) {
+    this.orderUuid = orderUuid;
+    this.exchange = exchange;
+    this.timeStamp = timeStamp;
+    this.orderType = orderType;
+    this.limit = limit;
+    this.quantity = quantity;
+    this.quantityRemaining = quantityRemaining;
+    this.commission = commission;
+    this.price = price;
+    this.pricePerUnit = pricePerUnit;
+    this.isConditional = isConditional;
+    this.condition = condition;
+    this.conditionTarget = conditionTarget;
+    this.immediateOrCancel = immediateOrCancel;
+    this.closed = closed;
+  }
+
+  public String getOrderUuid() {
+    return orderUuid;
+  }
+
+  public String getExchange() {
+    return exchange;
+  }
+
+  public String getTimeStamp() {
+    return timeStamp;
+  }
+
+  public String getOrderType() {
+    return orderType;
+  }
+
+  public BigDecimal getLimit() {
+    return limit;
+  }
+
+  public BigDecimal getQuantity() {
+    return quantity;
+  }
+
+  public BigDecimal getQuantityRemaining() {
+    return quantityRemaining;
+  }
+
+  public BigDecimal getCommission() {
+    return commission;
+  }
+
+  public BigDecimal getPrice() {
+    return price;
+  }
+
+  public BigDecimal getPricePerUnit() {
+    return pricePerUnit;
+  }
+
+  public Boolean getConditional() {
+    return isConditional;
+  }
+
+  public String getCondition() {
+    return condition;
+  }
+
+  public Object getConditionTarget() {
+    return conditionTarget;
+  }
+
+  public Boolean getImmediateOrCancel() {
+    return immediateOrCancel;
+  }
+
+  public String getClosed() {
+    return closed;
+  }
+
+  @Override
+  public String toString() {
+
+    return "BittrexUserTrade [orderUuid="
+        + getOrderUuid()
+        + ", exchange="
+        + getExchange()
+        + ", timeStamp="
+        + getTimeStamp()
+        + ", orderType="
+        + getOrderType()
+        + ", limit="
+        + getLimit()
+        + ", quantity="
+        + getQuantity()
+        + ", quantityRemaining="
+        + getQuantityRemaining()
+        + ", commission="
+        + getCommission()
+        + ", price="
+        + getPrice()
+        + ", pricePerUnit="
+        + getPricePerUnit()
+        + ", isConditional="
+        + getConditional()
+        + ", condition="
+        + getCondition()
+        + ", conditionTarget="
+        + getConditionTarget()
+        + ", immediateOrCancel="
+        + getImmediateOrCancel()
+        + "]";
+  }
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/trade/OrderToCancel.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/dto/trade/OrderToCancel.java
@@ -1,0 +1,11 @@
+package org.knowm.xchange.bittrex.dto.trade;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class OrderToCancel {
+  private String type;
+  private String id;
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexAccountService.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexAccountService.java
@@ -1,0 +1,30 @@
+package org.knowm.xchange.bittrex.service;
+
+import java.io.IOException;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.bittrex.BittrexAdapters;
+import org.knowm.xchange.dto.account.AccountInfo;
+import org.knowm.xchange.service.account.AccountService;
+import org.knowm.xchange.service.trade.params.*;
+
+public class BittrexAccountService extends BittrexAccountServiceRaw implements AccountService {
+
+  /**
+   * Constructor
+   *
+   * @param exchange
+   */
+  public BittrexAccountService(Exchange exchange) {
+    super(exchange);
+  }
+
+  @Override
+  public AccountInfo getAccountInfo() throws IOException {
+    return new AccountInfo(BittrexAdapters.adaptWallet(getBittrexBalances()));
+  }
+
+  @Override
+  public TradeHistoryParams createFundingHistoryParams() {
+    return TradeHistoryParamsZero.PARAMS_ZERO;
+  }
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexAccountService.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexAccountService.java
@@ -1,8 +1,8 @@
 package org.knowm.xchange.bittrex.service;
 
 import java.io.IOException;
-import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bittrex.BittrexAdapters;
+import org.knowm.xchange.bittrex.BittrexExchange;
 import org.knowm.xchange.dto.account.AccountInfo;
 import org.knowm.xchange.service.account.AccountService;
 import org.knowm.xchange.service.trade.params.*;
@@ -14,7 +14,7 @@ public class BittrexAccountService extends BittrexAccountServiceRaw implements A
    *
    * @param exchange
    */
-  public BittrexAccountService(Exchange exchange) {
+  public BittrexAccountService(BittrexExchange exchange) {
     super(exchange);
   }
 

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexAccountServiceRaw.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexAccountServiceRaw.java
@@ -1,0 +1,45 @@
+package org.knowm.xchange.bittrex.service;
+
+import java.io.IOException;
+import java.util.Collection;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.bittrex.dto.account.BittrexAccountVolume;
+import org.knowm.xchange.bittrex.dto.account.BittrexBalance;
+import org.knowm.xchange.bittrex.dto.trade.BittrexOrder;
+import org.knowm.xchange.currency.Currency;
+
+public class BittrexAccountServiceRaw extends BittrexBaseService {
+
+  /**
+   * Constructor
+   *
+   * @param exchange
+   */
+  public BittrexAccountServiceRaw(Exchange exchange) {
+    super(exchange);
+  }
+
+  public Collection<BittrexBalance> getBittrexBalances() throws IOException {
+    return bittrexAuthenticated.getBalances(
+        apiKey, System.currentTimeMillis(), contentCreator, signatureCreator);
+  }
+
+  public BittrexBalance getBittrexBalance(Currency currency) throws IOException {
+    return bittrexAuthenticated.getBalance(
+        apiKey,
+        System.currentTimeMillis(),
+        contentCreator,
+        signatureCreator,
+        currency.getCurrencyCode());
+  }
+
+  public BittrexOrder getBittrexOrder(String orderId) throws IOException {
+    return bittrexAuthenticated.getOrder(
+        apiKey, System.currentTimeMillis(), contentCreator, signatureCreator, orderId);
+  }
+
+  public BittrexAccountVolume getAccountVolume() throws IOException {
+    return bittrexAuthenticated.getAccountVolume(
+        apiKey, System.currentTimeMillis(), contentCreator, signatureCreator);
+  }
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexAccountServiceRaw.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexAccountServiceRaw.java
@@ -2,7 +2,7 @@ package org.knowm.xchange.bittrex.service;
 
 import java.io.IOException;
 import java.util.Collection;
-import org.knowm.xchange.Exchange;
+import org.knowm.xchange.bittrex.BittrexExchange;
 import org.knowm.xchange.bittrex.dto.account.BittrexAccountVolume;
 import org.knowm.xchange.bittrex.dto.account.BittrexBalance;
 import org.knowm.xchange.bittrex.dto.trade.BittrexOrder;
@@ -15,7 +15,7 @@ public class BittrexAccountServiceRaw extends BittrexBaseService {
    *
    * @param exchange
    */
-  public BittrexAccountServiceRaw(Exchange exchange) {
+  public BittrexAccountServiceRaw(BittrexExchange exchange) {
     super(exchange);
   }
 

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexBaseService.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexBaseService.java
@@ -1,0 +1,37 @@
+package org.knowm.xchange.bittrex.service;
+
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.bittrex.BittrexAuthenticated;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
+import org.knowm.xchange.service.BaseExchangeService;
+import org.knowm.xchange.service.BaseService;
+import si.mazi.rescu.ParamsDigest;
+import si.mazi.rescu.RestProxyFactory;
+
+public class BittrexBaseService extends BaseExchangeService implements BaseService {
+
+  protected final String apiKey;
+  protected final BittrexAuthenticated bittrexAuthenticated;
+  protected final ParamsDigest contentCreator;
+  protected final BittrexDigest signatureCreator;
+
+  /**
+   * Constructor
+   *
+   * @param exchange
+   */
+  public BittrexBaseService(Exchange exchange) {
+
+    super(exchange);
+    this.bittrexAuthenticated =
+        RestProxyFactory.createProxy(
+            BittrexAuthenticated.class,
+            exchange.getExchangeSpecification().getSslUri(),
+            ExchangeRestProxyBuilder.createClientConfig(exchange.getExchangeSpecification()));
+    this.apiKey = exchange.getExchangeSpecification().getApiKey();
+    this.contentCreator =
+        BittrexContentDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
+    this.signatureCreator =
+        BittrexDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
+  }
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexBaseService.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexBaseService.java
@@ -1,14 +1,15 @@
 package org.knowm.xchange.bittrex.service;
 
-import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bittrex.BittrexAuthenticated;
+import org.knowm.xchange.bittrex.BittrexExchange;
 import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.RestProxyFactory;
 
-public class BittrexBaseService extends BaseExchangeService implements BaseService {
+public class BittrexBaseService extends BaseExchangeService<BittrexExchange>
+    implements BaseService {
 
   protected final String apiKey;
   protected final BittrexAuthenticated bittrexAuthenticated;
@@ -20,7 +21,7 @@ public class BittrexBaseService extends BaseExchangeService implements BaseServi
    *
    * @param exchange
    */
-  public BittrexBaseService(Exchange exchange) {
+  public BittrexBaseService(BittrexExchange exchange) {
 
     super(exchange);
     this.bittrexAuthenticated =

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexContentDigest.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexContentDigest.java
@@ -1,0 +1,40 @@
+package org.knowm.xchange.bittrex.service;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.knowm.xchange.service.BaseParamsDigest;
+import org.knowm.xchange.utils.DigestUtils;
+import si.mazi.rescu.RestInvocation;
+
+public class BittrexContentDigest extends BaseParamsDigest {
+
+  /**
+   * Constructor
+   *
+   * @param secretKeyBase64
+   * @throws IllegalArgumentException if key is invalid (cannot be base-64-decoded or the decoded
+   *     key is invalid).
+   */
+  private BittrexContentDigest(String secretKeyBase64) {
+
+    super(secretKeyBase64, HMAC_SHA_512);
+  }
+
+  public static BittrexContentDigest createInstance(String secretKeyBase64) {
+
+    return secretKeyBase64 == null ? null : new BittrexContentDigest(secretKeyBase64);
+  }
+
+  @Override
+  public String digestParams(RestInvocation restInvocation) {
+    MessageDigest md;
+    try {
+      md = MessageDigest.getInstance("SHA-512");
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalArgumentException(e);
+    }
+
+    String content = restInvocation.getRequestBody();
+    return DigestUtils.bytesToHex(md.digest(content.getBytes()));
+  }
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexDigest.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexDigest.java
@@ -1,0 +1,54 @@
+package org.knowm.xchange.bittrex.service;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.Mac;
+import javax.ws.rs.HeaderParam;
+import org.knowm.xchange.service.BaseParamsDigest;
+import org.knowm.xchange.utils.DigestUtils;
+import si.mazi.rescu.RestInvocation;
+
+public class BittrexDigest extends BaseParamsDigest {
+
+  /**
+   * Constructor
+   *
+   * @param secretKeyBase64
+   * @throws IllegalArgumentException if key is invalid (cannot be base-64-decoded or the decoded
+   *     key is invalid).
+   */
+  private BittrexDigest(String secretKeyBase64) {
+
+    super(secretKeyBase64, HMAC_SHA_512);
+  }
+
+  public static BittrexDigest createInstance(String secretKeyBase64) {
+
+    return secretKeyBase64 == null ? null : new BittrexDigest(secretKeyBase64);
+  }
+
+  @Override
+  public String digestParams(RestInvocation restInvocation) {
+
+    MessageDigest md;
+    try {
+      md = MessageDigest.getInstance("SHA-512");
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalArgumentException(e);
+    }
+
+    String content = restInvocation.getRequestBody();
+    String contentHash = DigestUtils.bytesToHex(md.digest(content.getBytes()));
+
+    String uri = restInvocation.getInvocationUrl();
+    Long timestamp = (Long) restInvocation.getParamValue(HeaderParam.class, "Api-Timestamp");
+    String method = restInvocation.getHttpMethod();
+
+    String preSign = timestamp + uri + method + contentHash;
+
+    Mac mac = getMac();
+    mac.update(preSign.getBytes());
+
+    return DigestUtils.bytesToHex(mac.doFinal());
+  }
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexMarketDataService.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexMarketDataService.java
@@ -8,8 +8,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bittrex.BittrexAdapters;
+import org.knowm.xchange.bittrex.BittrexExchange;
 import org.knowm.xchange.bittrex.BittrexUtils;
 import org.knowm.xchange.bittrex.dto.marketdata.BittrexMarketSummary;
 import org.knowm.xchange.bittrex.dto.marketdata.BittrexTicker;
@@ -37,14 +37,15 @@ public class BittrexMarketDataService extends BittrexMarketDataServiceRaw
    *
    * @param exchange
    */
-  public BittrexMarketDataService(Exchange exchange) {
+  public BittrexMarketDataService(BittrexExchange exchange) {
     super(exchange);
   }
 
   @Override
   public Ticker getTicker(CurrencyPair currencyPair, Object... args) throws IOException {
     String marketSymbol = BittrexUtils.toPairString(currencyPair);
-    // The only way is to make two API calls since the information is split between market summary
+    // The only way is to make two API calls since the essential information is split between market
+    // summary
     // and ticker calls...
     BittrexMarketSummary bittrexMarketSummary = bittrexAuthenticated.getMarketSummary(marketSymbol);
     BittrexTicker bittrexTicker = bittrexAuthenticated.getTicker(marketSymbol);
@@ -58,7 +59,8 @@ public class BittrexMarketDataService extends BittrexMarketDataServiceRaw
             ? new ArrayList<>(((CurrencyPairsParam) params).getCurrencyPairs())
             : new ArrayList<>();
 
-    // The only way is to make two API calls since the information is split between market summary
+    // The only way is to make two API calls since the essential information is split between market
+    // summary
     // and ticker calls...
     List<BittrexMarketSummary> bittrexMarketSummaries = getBittrexMarketSummaries();
     List<BittrexTicker> bittrexTickers = getBittrexTickers();
@@ -95,7 +97,7 @@ public class BittrexMarketDataService extends BittrexMarketDataServiceRaw
     int depth = 500;
 
     if (args != null && args.length > 0) {
-      if (args[0] instanceof Integer && (Integer) args[0] > 0 && (Integer) args[0] <= 500) {
+      if (args[0] instanceof Integer && (Integer) args[0] > 0 && (Integer) args[0] < 500) {
         depth = (Integer) args[0];
       }
     }

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexMarketDataService.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexMarketDataService.java
@@ -1,0 +1,118 @@
+package org.knowm.xchange.bittrex.service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.bittrex.BittrexAdapters;
+import org.knowm.xchange.bittrex.BittrexUtils;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexMarketSummary;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexTicker;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexTrade;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.marketdata.Ticker;
+import org.knowm.xchange.dto.marketdata.Trades;
+import org.knowm.xchange.service.marketdata.MarketDataService;
+import org.knowm.xchange.service.marketdata.params.CurrencyPairsParam;
+import org.knowm.xchange.service.marketdata.params.Params;
+
+/**
+ * Implementation of the market data service for Bittrex
+ *
+ * <ul>
+ *   <li>Provides access to various market data values
+ * </ul>
+ */
+public class BittrexMarketDataService extends BittrexMarketDataServiceRaw
+    implements MarketDataService {
+
+  /**
+   * Constructor
+   *
+   * @param exchange
+   */
+  public BittrexMarketDataService(Exchange exchange) {
+    super(exchange);
+  }
+
+  @Override
+  public Ticker getTicker(CurrencyPair currencyPair, Object... args) throws IOException {
+    String marketSymbol = BittrexUtils.toPairString(currencyPair);
+    // The only way is to make two API calls since the information is split between market summary
+    // and ticker calls...
+    BittrexMarketSummary bittrexMarketSummary = bittrexAuthenticated.getMarketSummary(marketSymbol);
+    BittrexTicker bittrexTicker = bittrexAuthenticated.getTicker(marketSymbol);
+    return BittrexAdapters.adaptTicker(bittrexMarketSummary, bittrexTicker);
+  }
+
+  @Override
+  public List<Ticker> getTickers(Params params) throws IOException {
+    List<CurrencyPair> currencyPairs =
+        (params instanceof CurrencyPairsParam)
+            ? new ArrayList<>(((CurrencyPairsParam) params).getCurrencyPairs())
+            : new ArrayList<>();
+
+    // The only way is to make two API calls since the information is split between market summary
+    // and ticker calls...
+    List<BittrexMarketSummary> bittrexMarketSummaries = getBittrexMarketSummaries();
+    List<BittrexTicker> bittrexTickers = getBittrexTickers();
+    Map<CurrencyPair, SummaryTickerPair> tickerCombinationMap =
+        new HashMap<>(Math.min(bittrexMarketSummaries.size(), bittrexTickers.size()));
+    bittrexMarketSummaries.forEach(
+        marketSummary ->
+            tickerCombinationMap.put(
+                BittrexUtils.toCurrencyPair(marketSummary.getSymbol()),
+                new SummaryTickerPair(marketSummary, null)));
+    bittrexTickers.forEach(
+        ticker -> {
+          CurrencyPair currencyPair = BittrexUtils.toCurrencyPair(ticker.getSymbol());
+          if (tickerCombinationMap.containsKey(currencyPair)) {
+            tickerCombinationMap.get(currencyPair).setTicker(ticker);
+          }
+        });
+
+    return tickerCombinationMap.entrySet().stream()
+        .filter(entry -> currencyPairs.isEmpty() || currencyPairs.contains(entry.getKey()))
+        .map(Map.Entry::getValue)
+        .filter(
+            summaryTickerPair ->
+                summaryTickerPair.getSummary() != null && summaryTickerPair.getTicker() != null)
+        .map(
+            summaryTickerPair ->
+                BittrexAdapters.adaptTicker(
+                    summaryTickerPair.getSummary(), summaryTickerPair.getTicker()))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public OrderBook getOrderBook(CurrencyPair currencyPair, Object... args) throws IOException {
+    int depth = 500;
+
+    if (args != null && args.length > 0) {
+      if (args[0] instanceof Integer && (Integer) args[0] > 0 && (Integer) args[0] <= 500) {
+        depth = (Integer) args[0];
+      }
+    }
+    return getBittrexSequencedOrderBook(BittrexUtils.toPairString(currencyPair), depth)
+        .getOrderBook();
+  }
+
+  @Override
+  public Trades getTrades(CurrencyPair currencyPair, Object... args) throws IOException {
+    List<BittrexTrade> trades = getBittrexTrades(BittrexUtils.toPairString(currencyPair));
+    return BittrexAdapters.adaptTrades(trades, currencyPair);
+  }
+
+  @Data
+  @AllArgsConstructor
+  private static class SummaryTickerPair {
+    private BittrexMarketSummary summary;
+    private BittrexTicker ticker;
+  }
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexMarketDataServiceRaw.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexMarketDataServiceRaw.java
@@ -3,8 +3,8 @@ package org.knowm.xchange.bittrex.service;
 import java.io.IOException;
 import java.util.List;
 import lombok.Data;
-import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bittrex.BittrexAdapters;
+import org.knowm.xchange.bittrex.BittrexExchange;
 import org.knowm.xchange.bittrex.BittrexUtils;
 import org.knowm.xchange.bittrex.dto.marketdata.BittrexDepth;
 import org.knowm.xchange.bittrex.dto.marketdata.BittrexMarketSummary;
@@ -23,7 +23,7 @@ public class BittrexMarketDataServiceRaw extends BittrexBaseService {
    *
    * @param exchange
    */
-  public BittrexMarketDataServiceRaw(Exchange exchange) {
+  public BittrexMarketDataServiceRaw(BittrexExchange exchange) {
     super(exchange);
   }
 

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexMarketDataServiceRaw.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexMarketDataServiceRaw.java
@@ -1,0 +1,75 @@
+package org.knowm.xchange.bittrex.service;
+
+import java.io.IOException;
+import java.util.List;
+import lombok.Data;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.bittrex.BittrexAdapters;
+import org.knowm.xchange.bittrex.BittrexUtils;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexDepth;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexMarketSummary;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexSymbol;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexTicker;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexTrade;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.trade.LimitOrder;
+
+public class BittrexMarketDataServiceRaw extends BittrexBaseService {
+
+  /**
+   * Constructor
+   *
+   * @param exchange
+   */
+  public BittrexMarketDataServiceRaw(Exchange exchange) {
+    super(exchange);
+  }
+
+  public List<BittrexSymbol> getBittrexSymbols() throws IOException {
+    return bittrexAuthenticated.getMarkets();
+  }
+
+  public BittrexMarketSummary getBittrexMarketSummary(String pair) throws IOException {
+    return bittrexAuthenticated.getMarketSummary(pair);
+  }
+
+  public List<BittrexMarketSummary> getBittrexMarketSummaries() throws IOException {
+    return bittrexAuthenticated.getMarketSummaries();
+  }
+
+  public BittrexTicker getBittrexTicker(String pair) throws IOException {
+    return bittrexAuthenticated.getTicker(pair);
+  }
+
+  public List<BittrexTicker> getBittrexTickers() throws IOException {
+    return bittrexAuthenticated.getTickers();
+  }
+
+  public SequencedOrderBook getBittrexSequencedOrderBook(String market, int depth)
+      throws IOException {
+    BittrexDepth bittrexDepth = bittrexAuthenticated.getOrderBook(market, depth);
+
+    CurrencyPair currencyPair = BittrexUtils.toCurrencyPair(market);
+    List<LimitOrder> asks =
+        BittrexAdapters.adaptOrders(
+            bittrexDepth.getAsks(), currencyPair, Order.OrderType.ASK, null, depth);
+    List<LimitOrder> bids =
+        BittrexAdapters.adaptOrders(
+            bittrexDepth.getBids(), currencyPair, Order.OrderType.BID, null, depth);
+
+    OrderBook orderBook = new OrderBook(null, asks, bids);
+    return new SequencedOrderBook(bittrexDepth.getSequence(), orderBook);
+  }
+
+  public List<BittrexTrade> getBittrexTrades(String pair) throws IOException {
+    return bittrexAuthenticated.getTrades(pair);
+  }
+
+  @Data
+  public static class SequencedOrderBook {
+    private final String sequence;
+    private final OrderBook orderBook;
+  }
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexMarketDataServiceRaw.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexMarketDataServiceRaw.java
@@ -54,10 +54,10 @@ public class BittrexMarketDataServiceRaw extends BittrexBaseService {
     CurrencyPair currencyPair = BittrexUtils.toCurrencyPair(market);
     List<LimitOrder> asks =
         BittrexAdapters.adaptOrders(
-            bittrexDepth.getAsks(), currencyPair, Order.OrderType.ASK, null, depth);
+            bittrexDepth.getAsks(), currencyPair, Order.OrderType.ASK, depth);
     List<LimitOrder> bids =
         BittrexAdapters.adaptOrders(
-            bittrexDepth.getBids(), currencyPair, Order.OrderType.BID, null, depth);
+            bittrexDepth.getBids(), currencyPair, Order.OrderType.BID, depth);
 
     OrderBook orderBook = new OrderBook(null, asks, bids);
     return new SequencedOrderBook(bittrexDepth.getSequence(), orderBook);

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeService.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeService.java
@@ -4,9 +4,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bittrex.BittrexAdapters;
 import org.knowm.xchange.bittrex.BittrexConstants;
+import org.knowm.xchange.bittrex.BittrexExchange;
 import org.knowm.xchange.bittrex.dto.trade.BittrexOrder;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.marketdata.Trades;
@@ -29,8 +29,7 @@ public class BittrexTradeService extends BittrexTradeServiceRaw implements Trade
    *
    * @param exchange
    */
-  public BittrexTradeService(Exchange exchange) {
-
+  public BittrexTradeService(BittrexExchange exchange) {
     super(exchange);
   }
 

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeService.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeService.java
@@ -1,0 +1,96 @@
+package org.knowm.xchange.bittrex.service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.bittrex.BittrexAdapters;
+import org.knowm.xchange.bittrex.dto.trade.BittrexOrder;
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.marketdata.Trades;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.dto.trade.OpenOrders;
+import org.knowm.xchange.dto.trade.UserTrades;
+import org.knowm.xchange.service.trade.TradeService;
+import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
+import org.knowm.xchange.service.trade.params.CancelOrderParams;
+import org.knowm.xchange.service.trade.params.DefaultTradeHistoryParamCurrencyPair;
+import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
+import org.knowm.xchange.service.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.trade.params.orders.DefaultOpenOrdersParamCurrencyPair;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
+
+public class BittrexTradeService extends BittrexTradeServiceRaw implements TradeService {
+
+  /**
+   * Constructor
+   *
+   * @param exchange
+   */
+  public BittrexTradeService(Exchange exchange) {
+
+    super(exchange);
+  }
+
+  @Override
+  public String placeLimitOrder(LimitOrder limitOrder) throws IOException {
+    return placeBittrexLimitOrder(limitOrder);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders() throws IOException {
+    return getOpenOrders(createOpenOrdersParams());
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws IOException {
+    return new OpenOrders(BittrexAdapters.adaptOpenOrders(getBittrexOpenOrders(params)));
+  }
+
+  @Override
+  public boolean cancelOrder(String orderId) throws IOException {
+    return "CLOSED".equalsIgnoreCase(cancelBittrexLimitOrder(orderId).getStatus());
+  }
+
+  @Override
+  public boolean cancelOrder(CancelOrderParams orderParams) throws IOException {
+    if (orderParams instanceof CancelOrderByIdParams) {
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    }
+    return false;
+  }
+
+  @Override
+  public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
+    List<BittrexOrder> tradeHistory =
+        (params instanceof TradeHistoryParamCurrencyPair)
+            ? getBittrexUserTradeHistory(((TradeHistoryParamCurrencyPair) params).getCurrencyPair())
+            : getBittrexUserTradeHistory();
+    return new UserTrades(
+        BittrexAdapters.adaptUserTrades(tradeHistory), Trades.TradeSortType.SortByTimestamp);
+  }
+
+  @Override
+  public TradeHistoryParams createTradeHistoryParams() {
+    return new DefaultTradeHistoryParamCurrencyPair();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return new DefaultOpenOrdersParamCurrencyPair();
+  }
+
+  @Override
+  public Collection<Order> getOrder(String... orderIds) throws IOException {
+    List<Order> orders = new ArrayList<>();
+    for (String orderId : orderIds) {
+      BittrexOrder order = getBittrexOrder(orderId);
+      if (order != null) {
+        LimitOrder limitOrder = BittrexAdapters.adaptOrder(order);
+        orders.add(limitOrder);
+      }
+    }
+    return orders;
+  }
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeService.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeService.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.List;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bittrex.BittrexAdapters;
+import org.knowm.xchange.bittrex.BittrexConstants;
 import org.knowm.xchange.bittrex.dto.trade.BittrexOrder;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.marketdata.Trades;
@@ -50,7 +51,7 @@ public class BittrexTradeService extends BittrexTradeServiceRaw implements Trade
 
   @Override
   public boolean cancelOrder(String orderId) throws IOException {
-    return "CLOSED".equalsIgnoreCase(cancelBittrexLimitOrder(orderId).getStatus());
+    return BittrexConstants.CLOSED.equalsIgnoreCase(cancelBittrexLimitOrder(orderId).getStatus());
   }
 
   @Override

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeServiceRaw.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeServiceRaw.java
@@ -1,0 +1,82 @@
+package org.knowm.xchange.bittrex.service;
+
+import java.io.IOException;
+import java.util.List;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.bittrex.BittrexConstants;
+import org.knowm.xchange.bittrex.BittrexUtils;
+import org.knowm.xchange.bittrex.dto.batch.BatchResponse;
+import org.knowm.xchange.bittrex.dto.batch.order.BatchOrder;
+import org.knowm.xchange.bittrex.dto.trade.BittrexNewOrder;
+import org.knowm.xchange.bittrex.dto.trade.BittrexOrder;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order.OrderType;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
+
+public class BittrexTradeServiceRaw extends BittrexBaseService {
+
+  /**
+   * Constructor
+   *
+   * @param exchange
+   */
+  public BittrexTradeServiceRaw(Exchange exchange) {
+    super(exchange);
+  }
+
+  public String placeBittrexLimitOrder(LimitOrder limitOrder) throws IOException {
+    BittrexNewOrder bittrexNewOrder =
+        new BittrexNewOrder(
+            BittrexUtils.toPairString(limitOrder.getCurrencyPair()),
+            OrderType.BID.equals(limitOrder.getType())
+                ? BittrexConstants.BUY
+                : BittrexConstants.SELL,
+            BittrexConstants.LIMIT,
+            limitOrder.getRemainingAmount().toPlainString(),
+            null,
+            limitOrder.getLimitPrice().toPlainString(),
+            BittrexConstants.GOOD_TIL_CANCELLED,
+            null,
+            null);
+    return bittrexAuthenticated
+        .placeOrder(
+            apiKey, System.currentTimeMillis(), contentCreator, signatureCreator, bittrexNewOrder)
+        .getId();
+  }
+
+  public BittrexOrder cancelBittrexLimitOrder(String orderId) throws IOException {
+    return bittrexAuthenticated.cancelOrder(
+        apiKey, System.currentTimeMillis(), contentCreator, signatureCreator, orderId);
+  }
+
+  public List<BittrexOrder> getBittrexOpenOrders(OpenOrdersParams params) throws IOException {
+    return bittrexAuthenticated.getOpenOrders(
+        apiKey, System.currentTimeMillis(), contentCreator, signatureCreator);
+  }
+
+  public List<BittrexOrder> getBittrexUserTradeHistory(CurrencyPair currencyPair)
+      throws IOException {
+    return bittrexAuthenticated.getClosedOrders(
+        apiKey,
+        System.currentTimeMillis(),
+        contentCreator,
+        signatureCreator,
+        BittrexUtils.toPairString(currencyPair),
+        200);
+  }
+
+  public List<BittrexOrder> getBittrexUserTradeHistory() throws IOException {
+    return getBittrexUserTradeHistory(null);
+  }
+
+  public BittrexOrder getBittrexOrder(String orderId) throws IOException {
+    return bittrexAuthenticated.getOrder(
+        apiKey, System.currentTimeMillis(), contentCreator, signatureCreator, orderId);
+  }
+
+  public BatchResponse[] executeOrdersBatch(BatchOrder[] batchOrders) throws IOException {
+    return bittrexAuthenticated.executeOrdersBatch(
+        apiKey, System.currentTimeMillis(), contentCreator, signatureCreator, batchOrders);
+  }
+}

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeServiceRaw.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeServiceRaw.java
@@ -2,8 +2,8 @@ package org.knowm.xchange.bittrex.service;
 
 import java.io.IOException;
 import java.util.List;
-import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bittrex.BittrexConstants;
+import org.knowm.xchange.bittrex.BittrexExchange;
 import org.knowm.xchange.bittrex.BittrexUtils;
 import org.knowm.xchange.bittrex.dto.batch.BatchResponse;
 import org.knowm.xchange.bittrex.dto.batch.order.BatchOrder;
@@ -21,7 +21,7 @@ public class BittrexTradeServiceRaw extends BittrexBaseService {
    *
    * @param exchange
    */
-  public BittrexTradeServiceRaw(Exchange exchange) {
+  public BittrexTradeServiceRaw(BittrexExchange exchange) {
     super(exchange);
   }
 

--- a/xchange-bittrexV3/src/main/resources/bittrex.json
+++ b/xchange-bittrexV3/src/main/resources/bittrex.json
@@ -1,0 +1,758 @@
+{
+  "currency_pairs": {
+    "ADA/BTC": {
+      "price_scale": 8,
+      "min_amount": 25.00000000,
+      "trading_fee": 0.0025
+    },
+    "ADA/ETH": {
+      "price_scale": 8,
+      "min_amount": 25.00000000,
+      "trading_fee": 0.0025
+    },
+    "ADA/USDT": {
+      "price_scale": 8,
+      "min_amount": 25.00000000,
+      "trading_fee": 0.0025
+    },
+    "AMP/BTC": {
+      "price_scale": 8,
+      "min_amount": 15.00000000,
+      "trading_fee": 0.0025
+    },
+    "ARK/BTC": {
+      "price_scale": 8,
+      "min_amount": 1.75000000,
+      "trading_fee": 0.0025
+    },
+    "BCH/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.00600000,
+      "trading_fee": 0.0025
+    },
+    "BCH/ETH": {
+      "price_scale": 8,
+      "min_amount": 0.00600000,
+      "trading_fee": 0.0025
+    },
+    "BCH/USDT": {
+      "price_scale": 8,
+      "min_amount": 0.00600000,
+      "trading_fee": 0.0025
+    },
+    "BCY/BTC": {
+      "price_scale": 8,
+      "min_amount": 18.00000000,
+      "trading_fee": 0.0025
+    },
+    "BLK/BTC": {
+      "price_scale": 8,
+      "min_amount": 20.00000000,
+      "trading_fee": 0.0025
+    },
+    "BTC/USDT": {
+      "price_scale": 8,
+      "min_amount": 0.00055000,
+      "trading_fee": 0.0025
+    },
+    "BTG/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.07000000,
+      "trading_fee": 0.0025
+    },
+    "BTG/ETH": {
+      "price_scale": 8,
+      "min_amount": 0.07000000,
+      "trading_fee": 0.0025
+    },
+    "BTG/USDT": {
+      "price_scale": 8,
+      "min_amount": 0.07000000,
+      "trading_fee": 0.0025
+    },
+    "DASH/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.01200000,
+      "trading_fee": 0.0025
+    },
+    "DASH/ETH": {
+      "price_scale": 8,
+      "min_amount": 0.01200000,
+      "trading_fee": 0.0025
+    },
+    "DASH/USDT": {
+      "price_scale": 8,
+      "min_amount": 0.01200000,
+      "trading_fee": 0.0025
+    },
+    "DCR/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.06000000,
+      "trading_fee": 0.0025
+    },
+    "DGB/BTC": {
+      "price_scale": 8,
+      "min_amount": 230.00000000,
+      "trading_fee": 0.0025
+    },
+    "DGB/ETH": {
+      "price_scale": 8,
+      "min_amount": 230.00000000,
+      "trading_fee": 0.0025
+    },
+    "DMT/BTC": {
+      "price_scale": 8,
+      "min_amount": 13.00000000,
+      "trading_fee": 0.0025
+    },
+    "DMT/ETH": {
+      "price_scale": 8,
+      "min_amount": 13.00000000,
+      "trading_fee": 0.0025
+    },
+    "DOGE/BTC": {
+      "price_scale": 8,
+      "min_amount": 1600.00000000,
+      "trading_fee": 0.0025
+    },
+    "EMC2/BTC": {
+      "price_scale": 8,
+      "min_amount": 30.00000000,
+      "trading_fee": 0.0025
+    },
+    "EOS/BTC": {
+      "price_scale": 8,
+      "min_amount": 1.5,
+      "trading_fee": 0.0025
+    },
+    "EOS/ETH": {
+      "price_scale": 8,
+      "min_amount": 1.0,
+      "trading_fee": 0.0025
+    },
+    "ETC/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.30000000,
+      "trading_fee": 0.0025
+    },
+    "ETC/ETH": {
+      "price_scale": 8,
+      "min_amount": 0.30000000,
+      "trading_fee": 0.0025
+    },
+    "ETC/USDT": {
+      "price_scale": 8,
+      "min_amount": 0.30000000,
+      "trading_fee": 0.0025
+    },
+    "ETH/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.00860000,
+      "trading_fee": 0.0025
+    },
+    "ETH/USDT": {
+      "price_scale": 8,
+      "min_amount": 0.00860000,
+      "trading_fee": 0.0025
+    },
+    "FCT/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.25000000,
+      "trading_fee": 0.0025
+    },
+    "FCT/ETH": {
+      "price_scale": 8,
+      "min_amount": 0.25000000,
+      "trading_fee": 0.0025
+    },
+    "GAME/BTC": {
+      "price_scale": 8,
+      "min_amount": 3.50000000,
+      "trading_fee": 0.0025
+    },
+    "GRS/BTC": {
+      "price_scale": 8,
+      "min_amount": 4.00000000,
+      "trading_fee": 0.0025
+    },
+    "IOC/BTC": {
+      "price_scale": 8,
+      "min_amount": 4.00000000,
+      "trading_fee": 0.0025
+    },
+    "LTC/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.03500000,
+      "trading_fee": 0.0025
+    },
+    "LTC/ETH": {
+      "price_scale": 8,
+      "min_amount": 0.03500000,
+      "trading_fee": 0.0025
+    },
+    "LTC/USDT": {
+      "price_scale": 8,
+      "min_amount": 0.03500000,
+      "trading_fee": 0.0025
+    },
+    "LRC/BTC": {
+      "price_scale": 8,
+      "min_amount": 7.00000000,
+      "trading_fee": 0.0025
+    },
+    "LSK/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.50000000,
+      "trading_fee": 0.0025
+    },
+    "MCO/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.50000000,
+      "trading_fee": 0.0025
+    },
+    "MCO/ETH": {
+      "price_scale": 8,
+      "min_amount": 0.50000000,
+      "trading_fee": 0.0025
+    },
+    "NEO/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.07000000,
+      "trading_fee": 0.0025
+    },
+    "NEO/ETH": {
+      "price_scale": 8,
+      "min_amount": 0.07000000,
+      "trading_fee": 0.0025
+    },
+    "NEO/USDT": {
+      "price_scale": 8,
+      "min_amount": 0.07000000,
+      "trading_fee": 0.0025
+    },
+    "OMG/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.50000000,
+      "trading_fee": 0.0025
+    },
+    "OMG/ETH": {
+      "price_scale": 8,
+      "min_amount": 0.50000000,
+      "trading_fee": 0.0025
+    },
+    "OMG/USDT": {
+      "price_scale": 8,
+      "min_amount": 0.50000000,
+      "trading_fee": 0.0025
+    },
+    "PART/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.40000000,
+      "trading_fee": 0.0025
+    },
+    "PAY/BTC": {
+      "price_scale": 8,
+      "min_amount": 4.00000000,
+      "trading_fee": 0.0025
+    },
+    "PAY/ETH": {
+      "price_scale": 8,
+      "min_amount": 4.00000000,
+      "trading_fee": 0.0025
+    },
+    "POLY/BTC": {
+      "price_scale": 8,
+      "min_amount": 6.00000000,
+      "trading_fee": 0.0025
+    },
+    "POLY/ETH": {
+      "price_scale": 8,
+      "min_amount": 6.00000000,
+      "trading_fee": 0.0025
+    },
+    "POWR/BTC": {
+      "price_scale": 8,
+      "min_amount": 12.00000000,
+      "trading_fee": 0.0025
+    },
+    "POWR/ETH": {
+      "price_scale": 8,
+      "min_amount": 12.00000000,
+      "trading_fee": 0.0025
+    },
+    "PPC/BTC": {
+      "price_scale": 8,
+      "min_amount": 3.00000000,
+      "trading_fee": 0.0025
+    },
+    "REP/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.10000000,
+      "trading_fee": 0.0025
+    },
+    "REP/ETH": {
+      "price_scale": 8,
+      "min_amount": 0.10000000,
+      "trading_fee": 0.0025
+    },
+    "RDD/BTC": {
+      "price_scale": 8,
+      "min_amount": 600.00000000,
+      "trading_fee": 0.0025
+    },
+    "RVN/BTC": {
+      "price_scale": 8,
+      "min_amount": 150.0,
+      "trading_fee": 0.0025
+    },
+    "STEEM/BTC": {
+      "price_scale": 8,
+      "min_amount": 2.50000000,
+      "trading_fee": 0.0025
+    },
+    "SC/BTC": {
+      "price_scale": 8,
+      "min_amount": 430.00000000,
+      "trading_fee": 0.0025
+    },
+    "SC/ETH": {
+      "price_scale": 8,
+      "min_amount": 430.00000000,
+      "trading_fee": 0.0025
+    },
+    "SC/USDT": {
+      "price_scale": 8,
+      "min_amount": 430.00000000,
+      "trading_fee": 0.0025
+    },
+    "SRN/BTC": {
+      "price_scale": 8,
+      "min_amount": 15.00000000,
+      "trading_fee": 0.0025
+    },
+    "SRN/ETH": {
+      "price_scale": 8,
+      "min_amount": 15.00000000,
+      "trading_fee": 0.0025
+    },
+    "STORM/BTC": {
+      "price_scale": 8,
+      "min_amount": 120.00000000,
+      "trading_fee": 0.0025
+    },
+    "STORM/ETH": {
+      "price_scale": 8,
+      "min_amount": 120.00000000,
+      "trading_fee": 0.0025
+    },
+    "STRAT/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.10000000,
+      "trading_fee": 0.0025
+    },
+    "STRAT/ETH": {
+      "price_scale": 8,
+      "min_amount": 0.10000000,
+      "trading_fee": 0.0025
+    },
+    "SYS/BTC": {
+      "price_scale": 8,
+      "min_amount": 12.00000000,
+      "trading_fee": 0.0025
+    },
+    "TRX/BTC": {
+      "price_scale": 8,
+      "min_amount": 80.00000000,
+      "trading_fee": 0.0025
+    },
+    "TRX/ETH": {
+      "price_scale": 8,
+      "min_amount": 80.00000000,
+      "trading_fee": 0.0025
+    },
+    "TRX/USDT": {
+      "price_scale": 8,
+      "min_amount": 80.00000000,
+      "trading_fee": 0.0025
+    },
+    "VIB/BTC": {
+      "price_scale": 8,
+      "min_amount": 20.00000000,
+      "trading_fee": 0.0025
+    },
+    "VIB/ETH": {
+      "price_scale": 8,
+      "min_amount": 20.00000000,
+      "trading_fee": 0.0025
+    },
+    "VTC/BTC": {
+      "price_scale": 8,
+      "min_amount": 2.50000000,
+      "trading_fee": 0.0025
+    },
+    "WAVES/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.80000000,
+      "trading_fee": 0.0025
+    },
+    "WAVES/ETH": {
+      "price_scale": 8,
+      "min_amount": 0.80000000,
+      "trading_fee": 0.0025
+    },
+    "WAX/BTC": {
+      "price_scale": 8,
+      "min_amount": 20.00000000,
+      "trading_fee": 0.0025
+    },
+    "WAX/ETH": {
+      "price_scale": 8,
+      "min_amount": 20.00000000,
+      "trading_fee": 0.0025
+    },
+    "XCP/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.50000000,
+      "trading_fee": 0.0025
+    },
+    "XEM/BTC": {
+      "price_scale": 8,
+      "min_amount": 1.20000000,
+      "trading_fee": 0.0025
+    },
+    "XEM/ETH": {
+      "price_scale": 8,
+      "min_amount": 1.20000000,
+      "trading_fee": 0.0025
+    },
+    "XLM/BTC": {
+      "price_scale": 8,
+      "min_amount": 25.00000000,
+      "trading_fee": 0.0025
+    },
+    "XLM/ETH": {
+      "price_scale": 8,
+      "min_amount": 25.00000000,
+      "trading_fee": 0.0025
+    },
+    "XMR/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.01800000,
+      "trading_fee": 0.0025
+    },
+    "XMR/ETH": {
+      "price_scale": 8,
+      "min_amount": 0.01800000,
+      "trading_fee": 0.0025
+    },
+    "XMR/USDT": {
+      "price_scale": 8,
+      "min_amount": 0.01800000,
+      "trading_fee": 0.0025
+    },
+    "XRP/BTC": {
+      "price_scale": 8,
+      "min_amount": 7.00000000,
+      "trading_fee": 0.0025
+    },
+    "XRP/ETH": {
+      "price_scale": 8,
+      "min_amount": 7.00000000,
+      "trading_fee": 0.0025
+    },
+    "XRP/USDT": {
+      "price_scale": 8,
+      "min_amount": 7.00000000,
+      "trading_fee": 0.0025
+    },
+    "XVG/BTC": {
+      "price_scale": 8,
+      "min_amount": 160.00000000,
+      "trading_fee": 0.0025
+    },
+    "XVG/USDT": {
+      "price_scale": 8,
+      "min_amount": 160.00000000,
+      "trading_fee": 0.0025
+    },
+    "ZEC/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.01800000,
+      "trading_fee": 0.0025
+    },
+    "ZEC/ETH": {
+      "price_scale": 8,
+      "min_amount": 0.01800000,
+      "trading_fee": 0.0025
+    },
+    "ZEC/USDT": {
+      "price_scale": 8,
+      "min_amount": 0.01800000,
+      "trading_fee": 0.0025
+    },
+    "ZCL/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.35000000,
+      "trading_fee": 0.0025
+    },
+    "ZRX/BTC": {
+      "price_scale": 8,
+      "min_amount": 0.30000000,
+      "trading_fee": 0.0025
+    },
+    "ZRX/ETH": {
+      "price_scale": 8,
+      "min_amount": 0.30000000,
+      "trading_fee": 0.0025
+    }
+  },
+  "currencies": {
+    "ADA": {
+      "scale": 8,
+      "withdrawal_fee": 0.2
+    },
+    "ADX": {
+      "scale": 8,
+      "withdrawal_fee": 3.0
+    },
+    "AMP": {
+      "scale": 8,
+      "withdrawal_fee": 5.0
+    },
+    "ARK": {
+      "scale": 8,
+      "withdrawal_fee": 0.1
+    },
+    "BCH": {
+      "scale": 8,
+      "withdrawal_fee": 0.001
+    },
+    "BCY": {
+      "scale": 8,
+      "withdrawal_fee": 0.2
+    },
+    "BLK": {
+      "scale": 8,
+      "withdrawal_fee": 0.02
+    },
+    "BNT": {
+      "scale": 8,
+      "withdrawal_fee": 0.85
+    },
+    "BTC": {
+      "scale": 8,
+      "withdrawal_fee": 0.001
+    },
+    "BTCD": {
+      "scale": 8,
+      "withdrawal_fee": 0.02
+    },
+    "BTG": {
+      "scale": 8,
+      "withdrawal_fee": 0.001
+    },
+    "DASH": {
+      "scale": 8,
+      "withdrawal_fee": 0.002
+    },
+    "DCR": {
+      "scale": 8,
+      "withdrawal_fee": 0.1
+    },
+    "DGB": {
+      "scale": 8,
+      "withdrawal_fee": 0.02
+    },
+    "DMT": {
+      "scale": 8,
+      "withdrawal_fee": 1
+    },
+    "DOGE": {
+      "scale": 8,
+      "withdrawal_fee": 0
+    },
+    "EMC2": {
+      "scale": 8,
+      "withdrawal_fee": 0.2
+    },
+    "EOS": {
+      "scale": 8,
+      "withdrawal_fee": 0.1
+    },
+    "ETC": {
+      "scale": 8,
+      "withdrawal_fee": 0.01
+    },
+    "ETH": {
+      "scale": 8,
+      "withdrawal_fee": 0.005
+    },
+    "FCT": {
+      "scale": 8,
+      "withdrawal_fee": 0.01
+    },
+    "GAME": {
+      "scale": 8,
+      "withdrawal_fee": 0.2
+    },
+    "GRS": {
+      "scale": 8,
+      "withdrawal_fee": 0.2
+    },
+    "IOC": {
+      "scale": 8,
+      "withdrawal_fee": 0.01
+    },
+    "LRC": {
+      "scale": 8,
+      "withdrawal_fee": 1
+    },
+    "LSK": {
+      "scale": 8,
+      "withdrawal_fee": 0.1
+    },
+    "LTC": {
+      "scale": 8,
+      "withdrawal_fee": 0.01
+    },
+    "MCO": {
+      "scale": 8,
+      "withdrawal_fee": 0.5
+    },
+    "NEO": {
+      "scale": 8,
+      "withdrawal_fee": 0.025
+    },
+    "OMG": {
+      "scale": 8,
+      "withdrawal_fee": 0.35
+    },
+    "PART": {
+      "scale": 8,
+      "withdrawal_fee": 0.1
+    },
+    "PAY": {
+      "scale": 8,
+      "withdrawal_fee": 2
+    },
+    "PPC": {
+      "scale": 8,
+      "withdrawal_fee": 0.02
+    },
+    "POLY": {
+      "scale": 8,
+      "withdrawal_fee": 1
+    },
+    "POWR": {
+      "scale": 8,
+      "withdrawal_fee": 5
+    },
+    "QTUM": {
+      "scale": 8,
+      "withdrawal_fee": 0.01
+    },
+    "RDD": {
+      "scale": 8,
+      "withdrawal_fee": 2
+    },
+    "REP": {
+      "scale": 8,
+      "withdrawal_fee": 0.1
+    },
+    "RVN": {
+      "scale": 8,
+      "withdrawal_fee": 1.0
+    },
+    "SC": {
+      "scale": 8,
+      "withdrawal_fee": 0.1
+    },
+    "SRN": {
+      "scale": 8,
+      "withdrawal_fee": 1
+    },
+    "STEEM": {
+      "scale": 8,
+      "withdrawal_fee": 0.01
+    },
+    "STORM": {
+      "scale": 8,
+      "withdrawal_fee": 1
+    },
+    "STRAT": {
+      "scale": 8,
+      "withdrawal_fee": 0.2
+    },
+    "SYS": {
+      "scale": 8,
+      "withdrawal_fee": 0.0002
+    },
+    "TRX": {
+      "scale": 8,
+      "withdrawal_fee": 1
+    },
+    "USDT": {
+      "scale": 8,
+      "withdrawal_fee": 25
+    },
+    "VIB": {
+      "scale": 8,
+      "withdrawal_fee": 13
+    },
+    "VTC": {
+      "scale": 8,
+      "withdrawal_fee": 0.02
+    },
+    "WAVES": {
+      "scale": 8,
+      "withdrawal_fee": 0.001
+    },
+    "WAX": {
+      "scale": 8,
+      "withdrawal_fee": 1
+    },
+    "XCP": {
+      "scale": 8,
+      "withdrawal_fee": 0.2
+    },
+    "XEM": {
+      "scale": 8,
+      "withdrawal_fee": 4
+    },
+    "XLM": {
+      "scale": 8,
+      "withdrawal_fee": 0.001
+    },
+    "XMR": {
+      "scale": 8,
+      "withdrawal_fee": 0.04
+    },
+    "XRP": {
+      "scale": 8,
+      "withdrawal_fee": 5.0
+    },
+    "XVG": {
+      "scale": 8,
+      "withdrawal_fee": 0.1
+    },
+    "ZCL": {
+      "scale": 8,
+      "withdrawal_fee": 0.002
+    },
+    "ZEC": {
+      "scale": 8,
+      "withdrawal_fee": 0.005
+    },
+    "ZRX": {
+      "scale": 8,
+      "withdrawal_fee": 1
+    }
+  },
+  "public_rate_limits": [
+    {
+      "calls": 3,
+      "time_span": 1,
+      "time_unit": "SECONDS"
+    }
+  ]
+}

--- a/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/BittrexAdaptersTest.java
+++ b/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/BittrexAdaptersTest.java
@@ -1,0 +1,136 @@
+package org.knowm.xchange.bittrex;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexLevel;
+import org.knowm.xchange.bittrex.dto.trade.BittrexOrder;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.trade.LimitOrder;
+
+import junit.framework.TestCase;
+
+public class BittrexAdaptersTest extends TestCase {
+
+  @Test
+  public void testAdaptOrders() {
+    BittrexLevel ask1 = new BittrexLevel(new BigDecimal("10"), new BigDecimal("1"));
+    BittrexLevel ask2 = new BittrexLevel(new BigDecimal("11"), new BigDecimal("2"));
+    BittrexLevel ask3 = new BittrexLevel(new BigDecimal("12"), new BigDecimal("3"));
+
+    BittrexLevel bid1 = new BittrexLevel(new BigDecimal("9"), new BigDecimal("4"));
+    BittrexLevel bid2 = new BittrexLevel(new BigDecimal("8"), new BigDecimal("5"));
+    BittrexLevel bid3 = new BittrexLevel(new BigDecimal("7"), new BigDecimal("6"));
+
+    BittrexLevel[] asks = {ask1, ask2, ask3};
+    BittrexLevel[] bids = {bid1, bid2, bid3};
+    CurrencyPair currencyPair = CurrencyPair.ETH_BTC;
+    Order.OrderType askType = Order.OrderType.ASK;
+    Order.OrderType bidType = Order.OrderType.BID;
+    int depth = 2;
+
+    List<LimitOrder> expectedAsks =
+        Arrays.asList(
+            new LimitOrder(askType, ask1.getAmount(), currencyPair, null, null, ask1.getPrice()),
+            new LimitOrder(askType, ask2.getAmount(), currencyPair, null, null, ask2.getPrice()));
+
+    List<LimitOrder> expectedBids =
+        Arrays.asList(
+            new LimitOrder(bidType, bid1.getAmount(), currencyPair, null, null, bid1.getPrice()),
+            new LimitOrder(bidType, bid2.getAmount(), currencyPair, null, null, bid2.getPrice()));
+
+    List<LimitOrder> adaptedAsks = BittrexAdapters.adaptOrders(asks, currencyPair, askType, depth);
+    List<LimitOrder> adaptedBids = BittrexAdapters.adaptOrders(bids, currencyPair, bidType, depth);
+
+    Assert.assertEquals(expectedAsks, adaptedAsks);
+    Assert.assertEquals(expectedBids, adaptedBids);
+  }
+
+  public void testAdaptOrderStatus() {
+    BittrexOrder orderPartiallyFilled =
+        new BittrexOrder(
+            null,
+            null,
+            null,
+            null,
+            new BigDecimal("10"),
+            null,
+            null,
+            null,
+            null,
+            new BigDecimal("5"),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    BittrexOrder orderFilled =
+        new BittrexOrder(
+            null,
+            null,
+            null,
+            null,
+            new BigDecimal("10"),
+            null,
+            null,
+            null,
+            null,
+            new BigDecimal("10"),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    BittrexOrder orderNew =
+        new BittrexOrder(
+            null,
+            null,
+            null,
+            null,
+            new BigDecimal("10"),
+            null,
+            null,
+            null,
+            null,
+            new BigDecimal("0"),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    BittrexOrder orderUnknown =
+        new BittrexOrder(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    Assert.assertEquals(
+        Order.OrderStatus.PARTIALLY_FILLED, BittrexAdapters.adaptOrderStatus(orderPartiallyFilled));
+    Assert.assertEquals(Order.OrderStatus.FILLED, BittrexAdapters.adaptOrderStatus(orderFilled));
+    Assert.assertEquals(Order.OrderStatus.NEW, BittrexAdapters.adaptOrderStatus(orderNew));
+    Assert.assertEquals(Order.OrderStatus.UNKNOWN, BittrexAdapters.adaptOrderStatus(orderUnknown));
+  }
+}

--- a/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/BittrexAdaptersTest.java
+++ b/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/BittrexAdaptersTest.java
@@ -4,7 +4,7 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-
+import junit.framework.TestCase;
 import org.junit.Assert;
 import org.junit.Test;
 import org.knowm.xchange.bittrex.dto.marketdata.BittrexLevel;
@@ -15,9 +15,6 @@ import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.marketdata.Trade;
 import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.dto.trade.LimitOrder;
-
-import io.vavr.collection.Array;
-import junit.framework.TestCase;
 
 public class BittrexAdaptersTest extends TestCase {
 
@@ -148,9 +145,11 @@ public class BittrexAdaptersTest extends TestCase {
     List<Trade> tradesList = Arrays.asList(adaptedTrade1, adaptedTrade2);
 
     Trades adaptedTrades = BittrexAdapters.adaptTrades(bittrexTradesList, pair);
-    Trades trades = new Trades(tradesList,
-                               Math.max(Long.parseLong(trade1.getId()), Long.parseLong(trade2.getId())),
-                               Trades.TradeSortType.SortByID);
+    Trades trades =
+        new Trades(
+            tradesList,
+            Math.max(Long.parseLong(trade1.getId()), Long.parseLong(trade2.getId())),
+            Trades.TradeSortType.SortByID);
     Assert.assertEquals(trades.getlastID(), adaptedTrades.getlastID());
     Assert.assertEquals(trades.getNextPageCursor(), adaptedTrades.getNextPageCursor());
     Assert.assertEquals(trades.getTrades(), adaptedTrades.getTrades());

--- a/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/BittrexAdaptersTest.java
+++ b/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/BittrexAdaptersTest.java
@@ -2,16 +2,21 @@ package org.knowm.xchange.bittrex;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.knowm.xchange.bittrex.dto.marketdata.BittrexLevel;
+import org.knowm.xchange.bittrex.dto.marketdata.BittrexTrade;
 import org.knowm.xchange.bittrex.dto.trade.BittrexOrder;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.marketdata.Trade;
+import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.dto.trade.LimitOrder;
 
+import io.vavr.collection.Array;
 import junit.framework.TestCase;
 
 public class BittrexAdaptersTest extends TestCase {
@@ -110,27 +115,45 @@ public class BittrexAdaptersTest extends TestCase {
             null);
     BittrexOrder orderUnknown =
         new BittrexOrder(
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null);
+            null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+            null, null, null);
     Assert.assertEquals(
         Order.OrderStatus.PARTIALLY_FILLED, BittrexAdapters.adaptOrderStatus(orderPartiallyFilled));
     Assert.assertEquals(Order.OrderStatus.FILLED, BittrexAdapters.adaptOrderStatus(orderFilled));
     Assert.assertEquals(Order.OrderStatus.NEW, BittrexAdapters.adaptOrderStatus(orderNew));
     Assert.assertEquals(Order.OrderStatus.UNKNOWN, BittrexAdapters.adaptOrderStatus(orderUnknown));
+  }
+
+  public void testAdaptTrades() {
+    CurrencyPair pair = CurrencyPair.ETH_BTC;
+
+    BittrexTrade trade1 = new BittrexTrade();
+    trade1.setExecutedAt(new Date());
+    trade1.setId("123");
+    trade1.setQuantity(new BigDecimal("1"));
+    trade1.setRate(new BigDecimal("2"));
+    trade1.setTakerSide(BittrexConstants.BUY);
+
+    BittrexTrade trade2 = new BittrexTrade();
+    trade2.setExecutedAt(new Date());
+    trade2.setId("456");
+    trade2.setQuantity(new BigDecimal("3"));
+    trade2.setRate(new BigDecimal("4"));
+    trade2.setTakerSide(BittrexConstants.SELL);
+
+    Trade adaptedTrade1 = BittrexAdapters.adaptTrade(trade1, pair);
+    Trade adaptedTrade2 = BittrexAdapters.adaptTrade(trade2, pair);
+
+    List<BittrexTrade> bittrexTradesList = Arrays.asList(trade1, trade2);
+    List<Trade> tradesList = Arrays.asList(adaptedTrade1, adaptedTrade2);
+
+    Trades adaptedTrades = BittrexAdapters.adaptTrades(bittrexTradesList, pair);
+    Trades trades = new Trades(tradesList,
+                               Math.max(Long.parseLong(trade1.getId()), Long.parseLong(trade2.getId())),
+                               Trades.TradeSortType.SortByID);
+    Assert.assertEquals(trades.getlastID(), adaptedTrades.getlastID());
+    Assert.assertEquals(trades.getNextPageCursor(), adaptedTrades.getNextPageCursor());
+    Assert.assertEquals(trades.getTrades(), adaptedTrades.getTrades());
+    Assert.assertEquals(trades.getTradeSortType(), adaptedTrades.getTradeSortType());
   }
 }

--- a/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/AccountMockedIntegrationTest.java
+++ b/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/AccountMockedIntegrationTest.java
@@ -1,0 +1,70 @@
+package org.knowm.xchange.bittrex.service;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import org.junit.Before;
+import org.junit.Test;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.dto.account.AccountInfo;
+import org.knowm.xchange.dto.account.Balance;
+import org.knowm.xchange.dto.account.Wallet;
+
+/** @author walec51 */
+public class AccountMockedIntegrationTest extends BaseMockedIntegrationTest {
+
+  private static BittrexAccountService accountService;
+  private static final String BALANCES_FILE_NAME = "balances.json";
+
+  @Before
+  public void setUp() {
+    accountService = (BittrexAccountService) createExchange().getAccountService();
+  }
+
+  @Test
+  public void accountInfoTest() throws Exception {
+    stubFor(
+        get(urlEqualTo("/v3/balances"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBodyFile(BALANCES_FILE_NAME)));
+    AccountInfo accountInfo = accountService.getAccountInfo();
+    assertThat(accountInfo).isNotNull();
+
+    Wallet wallet = accountInfo.getWallet();
+    assertThat(wallet).isNotNull();
+
+    // What's in the mocked json
+    final ObjectMapper mapper = new ObjectMapper();
+    JsonNode jsonRoot =
+        mapper.readTree(
+            this.getClass().getResource("/" + WIREMOCK_FILES_PATH + "/" + BALANCES_FILE_NAME));
+    JsonNode jsonBtcBalance = jsonRoot.get(0);
+    Currency expectedCurrency = new Currency(jsonBtcBalance.get("currencySymbol").textValue());
+    BigDecimal expectedTotal = new BigDecimal(jsonBtcBalance.get("total").textValue());
+    BigDecimal expectedAvailable = new BigDecimal(jsonBtcBalance.get("available").textValue());
+    BigDecimal expectedFrozen = expectedTotal.subtract(expectedAvailable);
+    Date expectedTimestamp =
+        Date.from(ZonedDateTime.parse(jsonBtcBalance.get("updatedAt").textValue()).toInstant());
+    int expectedNumberOfBalances = jsonRoot.size();
+
+    Balance btcBalance = wallet.getBalance(expectedCurrency);
+
+    assertThat(wallet.getBalances().size()).isEqualTo(expectedNumberOfBalances);
+    assertThat(btcBalance.getCurrency()).isEqualTo(expectedCurrency);
+    assertThat(btcBalance.getTotal().compareTo(expectedTotal)).isEqualTo(0);
+    assertThat(btcBalance.getAvailable().compareTo(expectedAvailable)).isEqualTo(0);
+    assertThat(btcBalance.getFrozen().compareTo(expectedFrozen)).isEqualTo(0);
+    assertThat(btcBalance.getTimestamp()).isEqualTo(expectedTimestamp);
+  }
+}

--- a/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/AccountMockedTestIntegration.java
+++ b/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/AccountMockedTestIntegration.java
@@ -19,7 +19,7 @@ import org.knowm.xchange.dto.account.Balance;
 import org.knowm.xchange.dto.account.Wallet;
 
 /** @author walec51 */
-public class AccountMockedIntegrationTest extends BaseMockedIntegrationTest {
+public class AccountMockedTestIntegration extends BaseMockedTestIntegration {
 
   private static BittrexAccountService accountService;
   private static final String BALANCES_FILE_NAME = "balances.json";

--- a/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/BaseMockedIntegrationTest.java
+++ b/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/BaseMockedIntegrationTest.java
@@ -1,0 +1,28 @@
+package org.knowm.xchange.bittrex.service;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Rule;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.bittrex.BittrexExchange;
+
+/** @author walec51 */
+public class BaseMockedIntegrationTest {
+
+  @Rule public WireMockRule wireMockRule = new WireMockRule();
+  public static final String WIREMOCK_FILES_PATH = "__files";
+
+  public Exchange createExchange() {
+    Exchange exchange =
+        ExchangeFactory.INSTANCE.createExchangeWithoutSpecification(
+            BittrexExchange.class.getName());
+    ExchangeSpecification specification = exchange.getDefaultExchangeSpecification();
+    specification.setHost("localhost");
+    specification.setSslUri("http://localhost:" + wireMockRule.port());
+    specification.setPort(wireMockRule.port());
+    specification.setShouldLoadRemoteMetaData(false);
+    exchange.applySpecification(specification);
+    return exchange;
+  }
+}

--- a/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/BaseMockedTestIntegration.java
+++ b/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/BaseMockedTestIntegration.java
@@ -8,7 +8,7 @@ import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.bittrex.BittrexExchange;
 
 /** @author walec51 */
-public class BaseMockedIntegrationTest {
+public class BaseMockedTestIntegration {
 
   @Rule public WireMockRule wireMockRule = new WireMockRule();
   public static final String WIREMOCK_FILES_PATH = "__files";

--- a/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/MarketDataIntegration.java
+++ b/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/MarketDataIntegration.java
@@ -1,0 +1,61 @@
+package org.knowm.xchange.bittrex.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.bittrex.BittrexExchange;
+import org.knowm.xchange.bittrex.BittrexUtils;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.marketdata.Ticker;
+import org.knowm.xchange.dto.trade.LimitOrder;
+
+/** @author walec51 */
+public class MarketDataIntegration {
+
+  private static BittrexMarketDataService marketDataService;
+
+  @BeforeClass
+  public static void setUp() {
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BittrexExchange.class.getName());
+    marketDataService = (BittrexMarketDataService) exchange.getMarketDataService();
+  }
+
+  @Test
+  public void tickerTest() throws Exception {
+    Ticker ticker = marketDataService.getTicker(CurrencyPair.ETH_BTC);
+    System.out.println(ticker.toString());
+    assertThat(ticker).isNotNull();
+    assertThat(ticker.getLast()).isNotNull().isPositive();
+    assertThat(ticker.getQuoteVolume()).isNotNull().isPositive();
+    assertThat(ticker.getVolume()).isNotNull().isPositive();
+    assertThat(ticker.getHigh()).isNotNull().isPositive();
+  }
+
+  @Test
+  public void orderBooksTest() throws Exception {
+    OrderBook orderBook = marketDataService.getOrderBook(CurrencyPair.ETH_BTC);
+    List<LimitOrder> asks = orderBook.getAsks();
+    assertThat(asks).isNotEmpty();
+    LimitOrder firstAsk = asks.get(0);
+    assertThat(firstAsk.getLimitPrice()).isNotNull().isPositive();
+    assertThat(firstAsk.getRemainingAmount()).isNotNull().isPositive();
+  }
+
+  @Test
+  public void sequencedOrderBookTest() throws Exception {
+    BittrexMarketDataServiceRaw.SequencedOrderBook sequencedOrderBook =
+        marketDataService.getBittrexSequencedOrderBook(
+            BittrexUtils.toPairString(CurrencyPair.ETH_BTC), 500);
+    List<LimitOrder> asks = sequencedOrderBook.getOrderBook().getAsks();
+    assertThat(asks).isNotEmpty();
+    assertThat(sequencedOrderBook.getSequence().length()).isGreaterThan(1);
+    LimitOrder firstAsk = asks.get(0);
+    assertThat(firstAsk.getLimitPrice()).isNotNull().isPositive();
+    assertThat(firstAsk.getRemainingAmount()).isNotNull().isPositive();
+  }
+}

--- a/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/MarketDataTestIntegration.java
+++ b/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/MarketDataTestIntegration.java
@@ -15,7 +15,7 @@ import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.trade.LimitOrder;
 
 /** @author walec51 */
-public class MarketDataIntegration {
+public class MarketDataTestIntegration {
 
   private static BittrexMarketDataService marketDataService;
 

--- a/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/TradeMockedIntegrationTest.java
+++ b/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/TradeMockedIntegrationTest.java
@@ -1,0 +1,106 @@
+package org.knowm.xchange.bittrex.service;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import org.junit.Before;
+import org.junit.Test;
+import org.knowm.xchange.bittrex.BittrexConstants;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.dto.trade.OpenOrders;
+import org.knowm.xchange.dto.trade.UserTrade;
+import org.knowm.xchange.dto.trade.UserTrades;
+import org.knowm.xchange.service.trade.params.TradeHistoryParams;
+
+/** @author walec51 */
+public class TradeMockedIntegrationTest extends BaseMockedIntegrationTest {
+
+  private static BittrexTradeService tradeService;
+  private static final String NEWORDER_FILE_NAME = "newOrder.json";
+  private static final String OPENORDERS_FILE_NAME = "openOrders.json";
+
+  @Before
+  public void setUp() {
+    tradeService = (BittrexTradeService) createExchange().getTradeService();
+  }
+
+  @Test
+  public void placeOrderTest() throws Exception {
+    final ObjectMapper mapper = new ObjectMapper();
+    JsonNode jsonRoot =
+        mapper.readTree(
+            this.getClass().getResource("/" + WIREMOCK_FILES_PATH + "/" + NEWORDER_FILE_NAME));
+
+    stubFor(
+        post(urlPathEqualTo("/v3/orders"))
+            .withRequestBody(equalToJson(jsonRoot.toString()))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBodyFile("placedorder.json")));
+
+    Order.OrderType type =
+        BittrexConstants.BUY.equals(jsonRoot.get("direction").asText())
+            ? Order.OrderType.BID
+            : Order.OrderType.ASK;
+    String[] currencyPairSplit = jsonRoot.get("marketSymbol").asText().split("-");
+    CurrencyPair market = new CurrencyPair(currencyPairSplit[0], currencyPairSplit[1]);
+    BigDecimal price = new BigDecimal(jsonRoot.get("limit").asText());
+    BigDecimal quantity = new BigDecimal(jsonRoot.get("quantity").asText());
+    String orderId =
+        tradeService.placeLimitOrder(
+            new LimitOrder.Builder(type, market)
+                .limitPrice(price)
+                .originalAmount(quantity)
+                .build());
+    assertThat(orderId).isNotNull().isNotEmpty();
+  }
+
+  @Test
+  public void openOrdersTest() throws Exception {
+    final ObjectMapper mapper = new ObjectMapper();
+    JsonNode jsonRoot =
+        mapper.readTree(
+            this.getClass().getResource("/" + WIREMOCK_FILES_PATH + "/" + OPENORDERS_FILE_NAME));
+    stubFor(
+        get(urlPathEqualTo("/v3/orders/open"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBodyFile("openOrders.json")));
+
+    OpenOrders openOrders = tradeService.getOpenOrders();
+    assertThat(openOrders).isNotNull();
+    assertThat(openOrders.getOpenOrders()).hasSize(jsonRoot.size());
+    LimitOrder firstOrder = openOrders.getOpenOrders().get(0);
+    assertThat(firstOrder).isNotNull();
+    assertThat(firstOrder.getOriginalAmount()).isNotNull().isPositive();
+    assertThat(firstOrder.getId()).isNotBlank();
+  }
+
+  @Test
+  public void tradeHistoryTest() throws Exception {
+    stubFor(
+        get(urlPathEqualTo("/v3/orders/closed"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBodyFile("orderhistory.json")));
+    TradeHistoryParams params = tradeService.createTradeHistoryParams();
+    UserTrades tradeHistory = tradeService.getTradeHistory(params);
+    assertThat(tradeHistory).isNotNull();
+    assertThat(tradeHistory.getUserTrades()).isNotEmpty();
+    UserTrade trade = tradeHistory.getUserTrades().get(0);
+    assertThat(trade).isNotNull();
+    assertThat(trade.getOriginalAmount()).isNotNull().isPositive();
+    assertThat(trade.getPrice()).isNotNull().isPositive();
+  }
+}

--- a/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/TradeMockedTestIntegration.java
+++ b/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/TradeMockedTestIntegration.java
@@ -18,7 +18,7 @@ import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 
 /** @author walec51 */
-public class TradeMockedIntegrationTest extends BaseMockedIntegrationTest {
+public class TradeMockedTestIntegration extends BaseMockedTestIntegration {
 
   private static BittrexTradeService tradeService;
   private static final String NEWORDER_FILE_NAME = "newOrder.json";

--- a/xchange-bittrexV3/src/test/resources/__files/balances.json
+++ b/xchange-bittrexV3/src/test/resources/__files/balances.json
@@ -1,0 +1,20 @@
+[
+  {
+    "currencySymbol": "BTC",
+    "total": "5265.89272032",
+    "available": "626.54401024",
+    "updatedAt": "2020-06-25T14:38:46.06Z"
+  },
+  {
+    "currencySymbol": "ETH",
+    "total": "0.00000000",
+    "available": "0.00000000",
+    "updatedAt": "2020-06-25T13:40:26.5Z"
+  },
+  {
+    "currencySymbol": "USDT",
+    "total": "3.49239942",
+    "available": "3.49239942",
+    "updatedAt": "2019-09-03T16:11:47.38Z"
+  }
+]

--- a/xchange-bittrexV3/src/test/resources/__files/newOrder.json
+++ b/xchange-bittrexV3/src/test/resources/__files/newOrder.json
@@ -1,0 +1,11 @@
+{
+  "marketSymbol": "ETH-BTC",
+  "direction": "BUY",
+  "type": "LIMIT",
+  "quantity": "0.1",
+  "ceiling" : null,
+  "limit": "0.01",
+  "timeInForce" : "GOOD_TIL_CANCELLED",
+  "clientOrderId" : null,
+  "useAwards" : null
+}

--- a/xchange-bittrexV3/src/test/resources/__files/openOrders.json
+++ b/xchange-bittrexV3/src/test/resources/__files/openOrders.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "12d1b21f-d37d-42fd-ba3a-f5aacfd3962a",
+    "marketSymbol": "PART-BTC",
+    "direction": "SELL",
+    "type": "LIMIT",
+    "quantity": "355.11561170",
+    "limit": "0.00007410",
+    "timeInForce": "GOOD_TIL_CANCELLED",
+    "fillQuantity": "0.00000000",
+    "commission": "0.00000000",
+    "proceeds": "0.00000000",
+    "status": "OPEN",
+    "createdAt": "2020-06-28T07:21:13.89Z",
+    "updatedAt": "2020-06-28T07:21:13.89Z"
+  },
+  {
+    "id": "123be5a5-bbcc-48f7-870b-29829f41b2a7",
+    "marketSymbol": "BOA-BTC",
+    "direction": "BUY",
+    "type": "LIMIT",
+    "quantity": "4975.01823919",
+    "limit": "0.00000868",
+    "timeInForce": "GOOD_TIL_CANCELLED",
+    "fillQuantity": "0.00000000",
+    "commission": "0.00000000",
+    "proceeds": "0.00000000",
+    "status": "OPEN",
+    "createdAt": "2020-06-28T07:21:13.85Z",
+    "updatedAt": "2020-06-28T07:21:13.85Z"
+  }
+]

--- a/xchange-bittrexV3/src/test/resources/__files/orderhistory.json
+++ b/xchange-bittrexV3/src/test/resources/__files/orderhistory.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "123456fr-d7ca-4f16-a149-d8cea6917985",
+    "marketSymbol": "XHV-BTC",
+    "direction": "BUY",
+    "type": "LIMIT",
+    "quantity": "87.42156583",
+    "limit": "0.00016143",
+    "timeInForce": "GOOD_TIL_CANCELLED",
+    "fillQuantity": "25.52000000",
+    "commission": "0.00000000",
+    "proceeds": "0.00411969",
+    "status": "CLOSED",
+    "createdAt": "2020-06-28T07:30:06.97Z",
+    "updatedAt": "2020-06-28T07:30:17.11Z",
+    "closedAt": "2020-06-28T07:30:17.11Z"
+  },
+  {
+    "id": "43082242-43d5-4b02-a234-090a3cfa2345",
+    "marketSymbol": "QNT-BTC",
+    "direction": "SELL",
+    "type": "LIMIT",
+    "quantity": "113.32485631",
+    "limit": "0.00094822",
+    "timeInForce": "GOOD_TIL_CANCELLED",
+    "fillQuantity": "3.36087071",
+    "commission": "0.00000000",
+    "proceeds": "0.00318684",
+    "status": "CLOSED",
+    "createdAt": "2020-06-28T07:30:06.11Z",
+    "updatedAt": "2020-06-28T07:30:07.39Z",
+    "closedAt": "2020-06-28T07:30:07.39Z"
+  }
+]

--- a/xchange-bittrexV3/src/test/resources/__files/placedorder.json
+++ b/xchange-bittrexV3/src/test/resources/__files/placedorder.json
@@ -1,0 +1,15 @@
+{
+  "id": "c123456-4d92-4ec2-9bcf-12345d6bb205",
+  "marketSymbol": "ETH-BTC",
+  "direction": "BUY",
+  "type": "LIMIT",
+  "quantity": "0.1",
+  "limit": "0.01",
+  "timeInForce": "GOOD_TIL_CANCELLED",
+  "fillQuantity": "0.00000000",
+  "commission": "0.00000000",
+  "proceeds": "0.00000000",
+  "status": "OPEN",
+  "createdAt": "2020-06-25T20:29:23.57Z",
+  "updatedAt": "2020-06-25T20:29:23.57Z"
+}

--- a/xchange-bittrexV3/src/test/resources/logback.xml
+++ b/xchange-bittrexV3/src/test/resources/logback.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+
+    <!-- Standard console appender for checking activity (short on detail) -->
+    <appender name="CONSOLE_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- Simplified standard logging encoder -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%contextName] [%thread] %-5level %logger{36} - %msg %xEx%n</pattern>
+        </encoder>
+    </appender>
+
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE_APPENDER"/>
+    </root>
+
+
+    <logger name="org.eclipse.jetty" level="WARN"/>
+    <logger name="org.knowm.xchange" level="DEBUG"/>
+    <logger name="si.mazi.rescu" level="TRACE"/>
+
+</configuration>


### PR DESCRIPTION
The current xchange-bittrex module is 90% implemented using the old v1.1 api, mixed with a limited number of calls to undocumented v2 and v3. The v1.1 api is reaching end of life in septembre 2020.
From [Bittrex](https://bittrex.github.io/api/v1-1):
`The v1.1 API will reach its planned end of life and no longer be supported as of 9/30/2020.`

Instead of fixing the old xchange-bittrex module, this new module is meant to have a parallel life until the v1.1 complete unplug, and will then be renamed xchange-bittrex and replace it. 
Reasons:
- Not all of the v1.1 calls have been migrated (candles, withdrawal and deposit histories for example), and applications using the library may be using these legacy calls, which are still valid for a little less than 3 months before nothing works anymore. 
- Not much of the xchange-bittrex source code has been conserved (new API calls, new DTOs, widely changed adapters...)

There is still some work which has to be done in further PR, here is an (incomplete) list:
- candles
- deposit + withdrawal history
- [Error codes](https://bittrex.github.io/api/v3#definition-Error)