### PR TITLE
CoinbasePro - Updated header names, correct the case

### DIFF
--- a/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/dto/CoinbaseProTrades.java
+++ b/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/dto/CoinbaseProTrades.java
@@ -39,8 +39,8 @@ public class CoinbaseProTrades extends ArrayList<CoinbaseProTrade> implements Ht
   @Override
   public void setResponseHeaders(Map<String, List<String>> headers) {
     this.headers = headers;
-    earliestTradeId = getHeaderAsLong("cb-after");
-    latestTradeId = getHeaderAsLong("cb-before");
+    earliestTradeId = getHeaderAsLong("Cb-After");
+    latestTradeId = getHeaderAsLong("Cb-Before");
   }
 
   @Override

--- a/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/service/CoinbaseProAccountService.java
+++ b/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/service/CoinbaseProAccountService.java
@@ -176,7 +176,7 @@ public class CoinbaseProAccountService extends CoinbaseProAccountServiceRaw
           fundingHistory.add(CoinbaseProAdapters.adaptFundingRecord(currency, coinbaseProTransfer));
         }
 
-        createdAt = transfers.getHeader("cb-after");
+        createdAt = transfers.getHeader("Cb-After");
       }
     }
 


### PR DESCRIPTION
Coinbase pro have changed the case of their http response headers relating to pagination.
Calls to private endpoints to collect trades or funding history/ledgers currently fails (leads to NPE).

Issue https://github.com/knowm/XChange/issues/3579  