### PR TITLE
[#3590] Independent Reserve - fixed case in currency comparison. i.e.…

### DIFF
--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveAccountService.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveAccountService.java
@@ -92,7 +92,7 @@ public class IndependentReserveAccountService extends IndependentReserveAccountS
     final IndependentReserveBalance bal = getIndependentReserveBalance();
     final Currency currency = historyParams.getCurrency();
     return bal.getIndependentReserveAccounts().stream()
-        .filter(acc -> currency == null || currency.getCurrencyCode().equals(acc.getCurrencyCode()))
+        .filter(acc -> currency == null || currency.getCurrencyCode().equalsIgnoreCase(acc.getCurrencyCode()))
         .map(
             acc -> {
               try {


### PR DESCRIPTION
[#3590] Independent Reserve - fixed case in currency comparison. i.e. "USD".equals("Usd") doesn't work.

Signed-off-by: Martin Zdarsky <zdary@zdary.cz>