### PR TITLE
[core]Proposal for instrument enhancements and FuturesContract

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/Exchange.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/Exchange.java
@@ -7,6 +7,7 @@ import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.meta.ExchangeMetaData;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
+import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.service.account.AccountService;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 import org.knowm.xchange.service.trade.TradeService;
@@ -41,6 +42,16 @@ public interface Exchange {
    * @return The exchange's symbols
    */
   List<CurrencyPair> getExchangeSymbols();
+
+  /**
+   * Returns a list of Instrument objects. This list can either come originally from a loaded json
+   * file or from a remote call if the implementation override's the `remoteInit` method.
+   *
+   * @return The exchange's instruments
+   */
+  default List<Instrument> getExchangeInstruments() {
+    throw new NotYetImplementedForExchangeException();
+  }
 
   /**
    * The nonce factory used to create a nonce value. Allows services to accept a placeholder that is

--- a/xchange-core/src/main/java/org/knowm/xchange/Exchange.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/Exchange.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import org.knowm.xchange.client.ResilienceRegistries;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -50,7 +51,7 @@ public interface Exchange {
    * @return The exchange's instruments
    */
   default List<Instrument> getExchangeInstruments() {
-    throw new NotYetImplementedForExchangeException();
+    return new ArrayList<>(getExchangeSymbols());
   }
 
   /**

--- a/xchange-core/src/main/java/org/knowm/xchange/derivative/Derivative.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/derivative/Derivative.java
@@ -1,0 +1,7 @@
+package org.knowm.xchange.derivative;
+
+import org.knowm.xchange.currency.CurrencyPair;
+
+public interface Derivative {
+  CurrencyPair getCurrencyPair();
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/derivative/FuturesContract.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/derivative/FuturesContract.java
@@ -1,0 +1,105 @@
+package org.knowm.xchange.derivative;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.instrument.Instrument;
+
+import java.io.Serializable;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.Objects;
+
+public class FuturesContract extends Instrument
+    implements Derivative, Comparable<FuturesContract>, Serializable {
+
+  private static final long serialVersionUID = 6876906648149216819L;
+
+  private static final ThreadLocal<DateFormat> DATE_PARSER =
+      ThreadLocal.withInitial(() -> new SimpleDateFormat("yyMMdd"));
+  private static final String PERPETUAL = "perpetual";
+
+  private static final Comparator<FuturesContract> COMPARATOR =
+      Comparator.comparing(FuturesContract::getCurrencyPair)
+          .thenComparing(FuturesContract::getExpireDate);
+
+  /** The CurrencyPair the FuturesContract is based upon */
+  private final CurrencyPair currencyPair;
+
+  /** The Date when the FuturesContract expires, when null it is perpetual */
+  private final Date expireDate;
+
+  public FuturesContract(CurrencyPair currencyPair, Date expireDate) {
+    this.currencyPair = currencyPair;
+    this.expireDate = expireDate;
+  }
+
+  @JsonCreator
+  public FuturesContract(final String symbol) {
+    String[] parts = symbol.split("/");
+    if (parts.length < 3) {
+      throw new IllegalArgumentException("Could not parse futures contract from '" + symbol + "'");
+    }
+
+    String base = parts[0];
+    String counter = parts[1];
+    String expireDate = parts[2];
+    this.currencyPair = new CurrencyPair(base, counter);
+    if (!PERPETUAL.equalsIgnoreCase(expireDate)) {
+      try {
+        this.expireDate = DATE_PARSER.get().parse(expireDate);
+      } catch (ParseException e) {
+        throw new IllegalArgumentException(
+            "Could not parse expire date from '"
+                + symbol
+                + "'. It has to be either a 'yyMMdd' date or 'perpetual'");
+      }
+    } else {
+      this.expireDate = null;
+    }
+  }
+
+  @Override
+  public CurrencyPair getCurrencyPair() {
+    return currencyPair;
+  }
+
+  public Date getExpireDate() {
+    return expireDate;
+  }
+
+  public boolean isPerpetual() {
+    return this.expireDate == null;
+  }
+
+  @Override
+  public int compareTo(final FuturesContract that) {
+    return COMPARATOR.compare(this, that);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final FuturesContract contract = (FuturesContract) o;
+    return Objects.equals(currencyPair, contract.currencyPair)
+        && Objects.equals(expireDate, contract.expireDate);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(currencyPair, expireDate);
+  }
+
+  @JsonValue
+  @Override
+  public String toString() {
+
+    return currencyPair
+        + "/"
+        + (expireDate == null ? PERPETUAL : DATE_PARSER.get().format(this.expireDate));
+  }
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/account/AccountInfo.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/account/AccountInfo.java
@@ -26,6 +26,9 @@ public final class AccountInfo implements Serializable {
   /** The wallets owned by this account */
   private final Map<String, Wallet> wallets;
 
+  /** The open positions owned by this account */
+  private final Collection<OpenPosition> openPositions;
+
   /**
    * The timestamp at which this account information was generated. May be null if not provided by
    * the exchange.
@@ -88,9 +91,29 @@ public final class AccountInfo implements Serializable {
   public AccountInfo(
       String username, BigDecimal tradingFee, Collection<Wallet> wallets, Date timestamp) {
 
+    this(username, tradingFee, wallets, Collections.emptySet(), timestamp);
+  }
+
+  /**
+   * Constructs an {@link AccountInfo}.
+   *
+   * @param username the user name.
+   * @param tradingFee the trading fee.
+   * @param wallets the user's wallets
+   * @param openPositions the users's open positions
+   * @param timestamp the timestamp for the account snapshot.
+   */
+  public AccountInfo(
+      String username,
+      BigDecimal tradingFee,
+      Collection<Wallet> wallets,
+      Collection<OpenPosition> openPositions,
+      Date timestamp) {
+
     this.username = username;
     this.tradingFee = tradingFee;
     this.timestamp = timestamp;
+    this.openPositions = openPositions;
 
     if (wallets.size() == 0) {
       this.wallets = Collections.emptyMap();

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/account/OpenPosition.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/account/OpenPosition.java
@@ -1,0 +1,114 @@
+package org.knowm.xchange.dto.account;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import org.knowm.xchange.instrument.Instrument;
+
+public class OpenPosition {
+  /** The instrument */
+  private Instrument instrument;
+  /** Is this a long or a short position */
+  private Type type;
+  /** The size of the position */
+  private BigDecimal size;
+  /** The avarage entry price for the position */
+  private BigDecimal price;
+
+  public OpenPosition(
+      final Instrument instrument, final Type type, final BigDecimal size, final BigDecimal price) {
+    this.instrument = instrument;
+    this.type = type;
+    this.size = size;
+    this.price = price;
+  }
+
+  public Instrument getInstrument() {
+    return instrument;
+  }
+
+  public Type getType() {
+    return type;
+  }
+
+  public BigDecimal getSize() {
+    return size;
+  }
+
+  public BigDecimal getPrice() {
+    return price;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final OpenPosition that = (OpenPosition) o;
+    return Objects.equals(instrument, that.instrument)
+        && type == that.type
+        && Objects.equals(size, that.size)
+        && Objects.equals(price, that.price);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(instrument, type, size, price);
+  }
+
+  @Override
+  public String toString() {
+    return "OpenPosition{"
+        + "instrument="
+        + instrument
+        + ", type="
+        + type
+        + ", size="
+        + size
+        + ", price="
+        + price
+        + '}';
+  }
+
+  public enum Type {
+    LONG,
+    SHORT;
+  }
+
+  public static class Builder {
+    private Instrument instrument;
+    private Type type;
+    private BigDecimal size;
+    private BigDecimal price;
+
+    public static Builder from(OpenPosition openPosition) {
+      return new Builder()
+          .instrument(openPosition.getInstrument())
+          .type(openPosition.getType())
+          .size(openPosition.getSize())
+          .price(openPosition.getPrice());
+    }
+
+    public Builder instrument(final Instrument instrument) {
+      this.instrument = instrument;
+      return this;
+    }
+
+    public Builder type(final Type type) {
+      this.type = type;
+      return this;
+    }
+
+    public Builder size(final BigDecimal size) {
+      this.size = size;
+      return this;
+    }
+
+    public Builder price(final BigDecimal price) {
+      this.price = price;
+      return this;
+    }
+
+    public OpenPosition build() {
+      return new OpenPosition(instrument, type, size, price);
+    }
+  }
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/OrderBookUpdate.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/OrderBookUpdate.java
@@ -3,9 +3,9 @@ package org.knowm.xchange.dto.marketdata;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Date;
-import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.instrument.Instrument;
 
 /** Immutable data object representing a Market Depth update. */
 public final class OrderBookUpdate implements Serializable {
@@ -22,7 +22,7 @@ public final class OrderBookUpdate implements Serializable {
    *
    * @param type the order type (BID/ASK)
    * @param volume volume of the limit order in the base currency (i.e. BTC for BTC/USD)
-   * @param currencyPair the currencies traded (e.g. BTC/USD)
+   * @param instrument the instrument traded (e.g. BTC/USD)
    * @param limitPrice the price of this update in counter currency per base currency (i.e. $/BTC in
    *     BTC/USD)
    * @param timestamp the timestamp for the update
@@ -33,12 +33,12 @@ public final class OrderBookUpdate implements Serializable {
   public OrderBookUpdate(
       OrderType type,
       BigDecimal volume,
-      CurrencyPair currencyPair,
+      Instrument instrument,
       BigDecimal limitPrice,
       Date timestamp,
       BigDecimal totalVolume) {
 
-    this.limitOrder = new LimitOrder(type, volume, currencyPair, "", timestamp, limitPrice);
+    this.limitOrder = new LimitOrder(type, volume, instrument, "", timestamp, limitPrice);
     this.totalVolume = totalVolume;
   }
 

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/Ticker.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/Ticker.java
@@ -6,6 +6,7 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Date;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.utils.Assert;
 import org.knowm.xchange.utils.DateUtils;
 
@@ -20,7 +21,7 @@ public final class Ticker implements Serializable {
 
   private static final long serialVersionUID = -3247730106987193154L;
 
-  private final CurrencyPair currencyPair;
+  private final Instrument instrument;
   private final BigDecimal open;
   private final BigDecimal last;
   private final BigDecimal bid;
@@ -39,7 +40,7 @@ public final class Ticker implements Serializable {
   /**
    * Constructor
    *
-   * @param currencyPair The tradable identifier (e.g. BTC in BTC/USD)
+   * @param instrument The tradable identifier (e.g. BTC in BTC/USD)
    * @param last Last price
    * @param bid Bid price
    * @param ask Ask price
@@ -54,7 +55,7 @@ public final class Ticker implements Serializable {
    * @param askSize The instantaneous size at the ask price
    */
   private Ticker(
-      CurrencyPair currencyPair,
+      Instrument instrument,
       BigDecimal open,
       BigDecimal last,
       BigDecimal bid,
@@ -68,7 +69,7 @@ public final class Ticker implements Serializable {
       BigDecimal bidSize,
       BigDecimal askSize) {
     this.open = open;
-    this.currencyPair = currencyPair;
+    this.instrument = instrument;
     this.last = last;
     this.bid = bid;
     this.ask = ask;
@@ -82,9 +83,22 @@ public final class Ticker implements Serializable {
     this.askSize = askSize;
   }
 
-  public CurrencyPair getCurrencyPair() {
+  public Instrument getInstrument() {
+    return instrument;
+  }
 
-    return currencyPair;
+  /**
+   * @deprecated CurrencyPair is a subtype of Instrument - this method will throw an exception if
+   *     the order was for a derivative
+   *     <p>use {@link #getInstrument()} instead
+   */
+  @Deprecated
+  public CurrencyPair getCurrencyPair() {
+    if (!(instrument instanceof CurrencyPair)) {
+      throw new IllegalStateException(
+          "The instrument of this order is not a currency pair: " + instrument);
+    }
+    return (CurrencyPair) instrument;
   }
 
   public BigDecimal getOpen() {
@@ -150,8 +164,8 @@ public final class Ticker implements Serializable {
   @Override
   public String toString() {
 
-    return "Ticker [currencyPair="
-        + currencyPair
+    return "Ticker [instrument="
+        + instrument
         + ", open="
         + open
         + ", last="
@@ -189,7 +203,7 @@ public final class Ticker implements Serializable {
   @JsonPOJOBuilder(withPrefix = "")
   public static class Builder {
 
-    private CurrencyPair currencyPair;
+    private Instrument instrument;
     private BigDecimal open;
     private BigDecimal last;
     private BigDecimal bid;
@@ -212,7 +226,7 @@ public final class Ticker implements Serializable {
 
       Ticker ticker =
           new Ticker(
-              currencyPair,
+              instrument,
               open,
               last,
               bid,
@@ -238,10 +252,16 @@ public final class Ticker implements Serializable {
       }
     }
 
-    public Builder currencyPair(CurrencyPair currencyPair) {
-      Assert.notNull(currencyPair, "Null currencyPair");
-      this.currencyPair = currencyPair;
+    public Builder instrument(Instrument instrument) {
+      Assert.notNull(instrument, "Null instrument");
+      this.instrument = instrument;
       return this;
+    }
+
+    /** @deprecated Use {@link #instrument(Instrument)} */
+    @Deprecated
+    public Builder currencyPair(CurrencyPair currencyPair) {
+      return instrument(currencyPair);
     }
 
     public Builder open(BigDecimal open) {

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/Trade.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/Trade.java
@@ -8,6 +8,7 @@ import java.util.Date;
 import java.util.Objects;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
+import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 
 /** Data object representing a Trade */
@@ -22,8 +23,8 @@ public class Trade implements Serializable {
   /** Amount that was traded */
   protected final BigDecimal originalAmount;
 
-  /** The currency pair */
-  protected final CurrencyPair currencyPair;
+  /** The instrument */
+  protected final Instrument instrument;
 
   /** The price */
   protected final BigDecimal price;
@@ -55,7 +56,7 @@ public class Trade implements Serializable {
   public Trade(
       OrderType type,
       BigDecimal originalAmount,
-      CurrencyPair currencyPair,
+      Instrument instrument,
       BigDecimal price,
       Date timestamp,
       String id,
@@ -64,7 +65,7 @@ public class Trade implements Serializable {
 
     this.type = type;
     this.originalAmount = originalAmount;
-    this.currencyPair = currencyPair;
+    this.instrument = instrument;
     this.price = price;
     this.timestamp = timestamp;
     this.id = id;
@@ -82,9 +83,23 @@ public class Trade implements Serializable {
     return originalAmount;
   }
 
-  public CurrencyPair getCurrencyPair() {
+  public Instrument getInstrument() {
 
-    return currencyPair;
+    return instrument;
+  }
+
+  /**
+   * @deprecated CurrencyPair is a subtype of Instrument - this method will throw an exception if
+   *     the order was for a derivative
+   *     <p>use {@link #getInstrument()} instead
+   */
+  @Deprecated
+  public CurrencyPair getCurrencyPair() {
+    if (!(instrument instanceof CurrencyPair)) {
+      throw new IllegalStateException(
+          "The instrument of this order is not a currency pair: " + instrument);
+    }
+    return (CurrencyPair) instrument;
   }
 
   public BigDecimal getPrice() {
@@ -135,8 +150,8 @@ public class Trade implements Serializable {
         + type
         + ", originalAmount="
         + originalAmount
-        + ", currencyPair="
-        + currencyPair
+        + ", instrument="
+        + instrument
         + ", price="
         + price
         + ", timestamp="
@@ -158,7 +173,7 @@ public class Trade implements Serializable {
 
     protected OrderType type;
     protected BigDecimal originalAmount;
-    protected CurrencyPair currencyPair;
+    protected Instrument instrument;
     protected BigDecimal price;
     protected Date timestamp;
     protected String id;
@@ -169,7 +184,7 @@ public class Trade implements Serializable {
       return new Builder()
           .type(trade.getType())
           .originalAmount(trade.getOriginalAmount())
-          .currencyPair(trade.getCurrencyPair())
+          .instrument(trade.getInstrument())
           .price(trade.getPrice())
           .timestamp(trade.getTimestamp())
           .id(trade.getId());
@@ -187,10 +202,21 @@ public class Trade implements Serializable {
       return this;
     }
 
+    public Builder instrument(Instrument instrument) {
+
+      this.instrument = instrument;
+      return this;
+    }
+
+    /**
+     * @deprecated CurrencyPair is a subtype of Instrument - this method will throw an exception if
+     *     the order was for a derivative
+     *     <p>use {@link #instrument(Instrument)} instead
+     */
+    @Deprecated
     public Builder currencyPair(CurrencyPair currencyPair) {
 
-      this.currencyPair = currencyPair;
-      return this;
+      return instrument(currencyPair);
     }
 
     public Builder price(BigDecimal price) {
@@ -226,7 +252,7 @@ public class Trade implements Serializable {
     public Trade build() {
 
       return new Trade(
-          type, originalAmount, currencyPair, price, timestamp, id, makerOrderId, takerOrderId);
+          type, originalAmount, instrument, price, timestamp, id, makerOrderId, takerOrderId);
     }
   }
 }

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/StopOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/StopOrder.java
@@ -99,7 +99,7 @@ public class StopOrder extends Order implements Comparable<StopOrder> {
   /**
    * @param type Either BID (buying) or ASK (selling)
    * @param originalAmount The amount to trade
-   * @param Instrument The identifier (e.g. BTC/USD)
+   * @param instrument The identifier (e.g. BTC/USD)
    * @param id An id (usually provided by the exchange)
    * @param timestamp a Date object representing the order's timestamp according to the exchange's
    *     server, null if not provided

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/UserTrade.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/UserTrade.java
@@ -9,6 +9,7 @@ import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.marketdata.Trade;
+import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.service.trade.TradeService;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 
@@ -36,7 +37,7 @@ public class UserTrade extends Trade {
    *
    * @param type The trade type (BID side or ASK side)
    * @param originalAmount The depth of this trade
-   * @param currencyPair The exchange identifier (e.g. "BTC/USD")
+   * @param instrument The exchange identifier (e.g. "BTC/USD")
    * @param price The price (either the bid or the ask)
    * @param timestamp The timestamp of the trade
    * @param id The id of the trade
@@ -48,7 +49,7 @@ public class UserTrade extends Trade {
   public UserTrade(
       OrderType type,
       BigDecimal originalAmount,
-      CurrencyPair currencyPair,
+      Instrument instrument,
       BigDecimal price,
       Date timestamp,
       String id,
@@ -57,7 +58,7 @@ public class UserTrade extends Trade {
       Currency feeCurrency,
       String orderUserReference) {
 
-    super(type, originalAmount, currencyPair, price, timestamp, id, null, null);
+    super(type, originalAmount, instrument, price, timestamp, id, null, null);
 
     this.orderId = orderId;
     this.feeAmount = feeAmount;
@@ -90,8 +91,8 @@ public class UserTrade extends Trade {
         + type
         + ", originalAmount="
         + originalAmount
-        + ", currencyPair="
-        + currencyPair
+        + ", instrument="
+        + instrument
         + ", price="
         + price
         + ", timestamp="
@@ -140,7 +141,7 @@ public class UserTrade extends Trade {
       return new Builder()
           .type(trade.getType())
           .originalAmount(trade.getOriginalAmount())
-          .currencyPair(trade.getCurrencyPair())
+          .instrument(trade.getInstrument())
           .price(trade.getPrice())
           .timestamp(trade.getTimestamp())
           .id(trade.getId())
@@ -157,6 +158,11 @@ public class UserTrade extends Trade {
     @Override
     public Builder originalAmount(BigDecimal originalAmount) {
       return (Builder) super.originalAmount(originalAmount);
+    }
+
+    @Override
+    public Builder instrument(Instrument instrument) {
+      return (Builder) super.instrument(instrument);
     }
 
     @Override
@@ -204,7 +210,7 @@ public class UserTrade extends Trade {
       return new UserTrade(
           type,
           originalAmount,
-          currencyPair,
+          instrument,
           price,
           timestamp,
           id,

--- a/xchange-core/src/main/java/org/knowm/xchange/exceptions/InstrumentNotValidException.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/exceptions/InstrumentNotValidException.java
@@ -1,0 +1,54 @@
+package org.knowm.xchange.exceptions;
+
+import org.knowm.xchange.instrument.Instrument;
+
+/**
+ * Exception indicating that a request was made with a {@link Instrument} that is not supported on
+ * this exchange.
+ *
+ * @author bryant_harris
+ */
+public class InstrumentNotValidException extends ExchangeException {
+  private Instrument instrument;
+
+  public InstrumentNotValidException() {
+    super("Invalid currency pair for this operation");
+  }
+
+  public InstrumentNotValidException(String message, Throwable cause, Instrument instrument) {
+    super(message, cause);
+    this.instrument = instrument;
+  }
+
+  public InstrumentNotValidException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public InstrumentNotValidException(String message) {
+    super(message);
+  }
+
+  public InstrumentNotValidException(String message, Instrument instrument) {
+    super(message);
+    this.instrument = instrument;
+  }
+
+  public InstrumentNotValidException(Throwable cause) {
+    super(cause);
+  }
+
+  public InstrumentNotValidException(Throwable cause, Instrument instrument) {
+    super(instrument + " is not valid for this operation", cause);
+    this.instrument = instrument;
+  }
+
+  public InstrumentNotValidException(Instrument instrument) {
+    this(instrument + " is not valid for this operation");
+    this.instrument = instrument;
+  }
+
+  /** @return The Instrument that caused the exception. */
+  public Instrument getInstrument() {
+    return instrument;
+  }
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/exceptions/MarketSuspendedException.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/exceptions/MarketSuspendedException.java
@@ -1,9 +1,9 @@
 package org.knowm.xchange.exceptions;
 
-import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.instrument.Instrument;
 
 /**
- * Exception indicating the {@link CurrencyPair} was recognized by the exchange but their market is
+ * Exception indicating the {@link Instrument} was recognized by the exchange but their market is
  * suspended - either temporarly or permanently.
  *
  * <p>This exception does not suggest that the entire exhange is down (we have the {@link

--- a/xchange-core/src/main/java/org/knowm/xchange/service/account/AccountService.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/account/AccountService.java
@@ -14,6 +14,7 @@ import org.knowm.xchange.dto.account.FundingRecord;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
+import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.service.BaseService;
 import org.knowm.xchange.service.trade.params.DefaultWithdrawFundsParams;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
@@ -168,6 +169,25 @@ public interface AccountService extends BaseService {
   default List<FundingRecord> getFundingHistory(TradeHistoryParams params) throws IOException {
     throw new NotYetImplementedForExchangeException();
   }
+
+  /**
+   * Get the trading fees per instrument as determined by the given exchange's rules for adjusting
+   * fees by recent volume traded. Some exchanges will provide the current fees per currency via a
+   * single API request, while others require more logic to compute by hand.
+   *
+   * @return map between currency pairs and their fees at the time of invocation.
+   * @throws ExchangeException - Indication that the exchange reported some kind of error with the
+   *     request or response
+   * @throws NotAvailableFromExchangeException - Indication that the exchange does not support the
+   *     requested function or data
+   * @throws NotYetImplementedForExchangeException - Indication that the exchange supports the
+   *     requested function or data, but it has not yet been implemented
+   * @throws IOException - Indication that a networking error occurred while fetching JSON data
+   */
+  default Map<Instrument, Fee> getDynamicTradingFeesByInstrument() throws IOException {
+    throw new NotYetImplementedForExchangeException();
+  }
+
   /**
    * Get the trading fees per currency pair as determined by the given exchange's rules for
    * adjusting fees by recent volume traded. Some exchanges will provide the current fees per

--- a/xchange-core/src/main/java/org/knowm/xchange/service/marketdata/MarketDataService.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/marketdata/MarketDataService.java
@@ -75,6 +75,23 @@ public interface MarketDataService extends BaseService {
   }
 
   /**
+   * Get an order book representing the current offered exchange rates (market depth)
+   *
+   * @param params Exchange-specific
+   * @return The OrderBook, null if some sort of error occurred. Implementers should log the error.
+   * @throws ExchangeException - Indication that the exchange reported some kind of error with the
+   *     request or response
+   * @throws NotAvailableFromExchangeException - Indication that the exchange does not support the
+   *     requested function or data
+   * @throws NotYetImplementedForExchangeException - Indication that the exchange supports the
+   *     requested function or data, but it has not yet been implemented
+   * @throws IOException - Indication that a networking error occurred while fetching JSON data
+   */
+  default OrderBook getOrderBook(Params params) throws IOException {
+    throw new NotYetImplementedForExchangeException();
+  }
+
+  /**
    * Get the trades recently performed by the exchange
    *
    * @param args Optional arguments. Exchange-specific
@@ -88,6 +105,23 @@ public interface MarketDataService extends BaseService {
    * @throws IOException - Indication that a networking error occurred while fetching JSON data
    */
   default Trades getTrades(CurrencyPair currencyPair, Object... args) throws IOException {
+    throw new NotYetImplementedForExchangeException();
+  }
+
+  /**
+   * Get the trades recently performed by the exchange
+   *
+   * @param params Exchange-specific
+   * @return The Trades, null if some sort of error occurred. Implementers should log the error.
+   * @throws ExchangeException - Indication that the exchange reported some kind of error with the
+   *     request or response
+   * @throws NotAvailableFromExchangeException - Indication that the exchange does not support the
+   *     requested function or data
+   * @throws NotYetImplementedForExchangeException - Indication that the exchange supports the
+   *     requested function or data, but it has not yet been implemented
+   * @throws IOException - Indication that a networking error occurred while fetching JSON data
+   */
+  default Trades getTrades(Params params) throws IOException {
     throw new NotYetImplementedForExchangeException();
   }
 }

--- a/xchange-core/src/main/java/org/knowm/xchange/service/marketdata/params/InstrumentsParams.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/marketdata/params/InstrumentsParams.java
@@ -1,0 +1,8 @@
+package org.knowm.xchange.service.marketdata.params;
+
+import java.util.Collection;
+import org.knowm.xchange.instrument.Instrument;
+
+public interface InstrumentsParams {
+  Collection<Instrument> getInstruments();
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/DefaultTradeHistoryParamInstrument.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/DefaultTradeHistoryParamInstrument.java
@@ -1,0 +1,24 @@
+package org.knowm.xchange.service.trade.params;
+
+import org.knowm.xchange.instrument.Instrument;
+
+public class DefaultTradeHistoryParamInstrument implements TradeHistoryParamInstrument {
+
+  private Instrument instrument;
+
+  public DefaultTradeHistoryParamInstrument() {}
+
+  public DefaultTradeHistoryParamInstrument(Instrument instrument) {
+    this.instrument = instrument;
+  }
+
+  @Override
+  public Instrument getInstrument() {
+    return instrument;
+  }
+
+  @Override
+  public void setInstrument(final Instrument instrument) {
+    this.instrument = instrument;
+  }
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/DefaultTradeHistoryParamMultiInstrument.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/DefaultTradeHistoryParamMultiInstrument.java
@@ -1,0 +1,26 @@
+package org.knowm.xchange.service.trade.params;
+
+import java.util.Collection;
+import java.util.Collections;
+import org.knowm.xchange.instrument.Instrument;
+
+public class DefaultTradeHistoryParamMultiInstrument implements TradeHistoryParamMultiInstrument {
+
+  private Collection<Instrument> instruments = Collections.emptySet();
+
+  public DefaultTradeHistoryParamMultiInstrument() {}
+
+  public DefaultTradeHistoryParamMultiInstrument(final Collection<Instrument> instruments) {
+    this.instruments = instruments;
+  }
+
+  @Override
+  public Collection<Instrument> getInstruments() {
+    return instruments;
+  }
+
+  @Override
+  public void setInstruments(final Collection<Instrument> instruments) {
+    this.instruments = instruments;
+  }
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/InstrumentParam.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/InstrumentParam.java
@@ -1,0 +1,9 @@
+package org.knowm.xchange.service.trade.params;
+
+import org.knowm.xchange.instrument.Instrument;
+
+public interface InstrumentParam {
+  Instrument getInstrument();
+
+  void setInstrument(Instrument instrument);
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/TradeHistoryParamInstrument.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/TradeHistoryParamInstrument.java
@@ -1,0 +1,3 @@
+package org.knowm.xchange.service.trade.params;
+
+public interface TradeHistoryParamInstrument extends TradeHistoryParams, InstrumentParam {}

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/TradeHistoryParamMultiInstrument.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/TradeHistoryParamMultiInstrument.java
@@ -1,0 +1,11 @@
+package org.knowm.xchange.service.trade.params;
+
+import java.util.Collection;
+import org.knowm.xchange.instrument.Instrument;
+
+public interface TradeHistoryParamMultiInstrument extends TradeHistoryParams {
+
+  Collection<Instrument> getInstruments();
+
+  void setInstruments(Collection<Instrument> instruments);
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/TradeHistoryParamsAll.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/TradeHistoryParamsAll.java
@@ -1,12 +1,14 @@
 package org.knowm.xchange.service.trade.params;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.stream.Collectors;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.service.trade.TradeService;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.stream.Collectors;
 
 /**
  * Generic {@link TradeHistoryParams} implementation that implements all the interfaces in the
@@ -32,8 +34,6 @@ public class TradeHistoryParamsAll
   private Date startTime;
   private Date endTime;
   private Long offset;
-  private CurrencyPair pair;
-  private Collection<CurrencyPair> pairs = Collections.emptySet();
   private Instrument instrument;
   private Collection<Instrument> instruments = Collections.emptySet();
   private Integer limit;
@@ -125,41 +125,36 @@ public class TradeHistoryParamsAll
 
   @Override
   public CurrencyPair getCurrencyPair() {
-    if (pair == null && instrument instanceof CurrencyPair) {
+    if (instrument instanceof CurrencyPair) {
       return (CurrencyPair) instrument;
     }
-    return pair;
+
+    return null;
   }
 
   @Override
   public void setCurrencyPair(CurrencyPair pair) {
-
-    this.pair = pair;
+    this.instrument = pair;
   }
 
   @Override
   public Collection<CurrencyPair> getCurrencyPairs() {
-    if (pairs.isEmpty() && !instruments.isEmpty()) {
+    if (!instruments.isEmpty()) {
       return instruments.stream()
           .filter(instrument -> instrument instanceof CurrencyPair)
           .map(instrument -> (CurrencyPair) instrument)
           .collect(Collectors.toSet());
     }
-    return pairs;
+    return Collections.emptySet();
   }
 
   @Override
   public void setCurrencyPairs(Collection<CurrencyPair> value) {
-
-    pairs = value;
+    this.instruments = new HashSet<>(value);
   }
 
   @Override
   public Instrument getInstrument() {
-    if (instrument == null && pair != null) {
-      return pair;
-    }
-
     return instrument;
   }
 
@@ -170,10 +165,6 @@ public class TradeHistoryParamsAll
 
   @Override
   public Collection<Instrument> getInstruments() {
-    if (instruments.isEmpty() && !pairs.isEmpty()) {
-      return pairs.stream().map(pair -> (Instrument) pair).collect(Collectors.toList());
-    }
-
     return instruments;
   }
 

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/TradeHistoryParamsAll.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/TradeHistoryParamsAll.java
@@ -3,7 +3,9 @@ package org.knowm.xchange.service.trade.params;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.stream.Collectors;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.service.trade.TradeService;
 
 /**
@@ -19,6 +21,8 @@ public class TradeHistoryParamsAll
         TradeHistoryParamOffset,
         TradeHistoryParamCurrencyPair,
         TradeHistoryParamMultiCurrencyPair,
+        TradeHistoryParamInstrument,
+        TradeHistoryParamMultiInstrument,
         TradeHistoryParamLimit {
 
   private Integer pageLength;
@@ -30,6 +34,8 @@ public class TradeHistoryParamsAll
   private Long offset;
   private CurrencyPair pair;
   private Collection<CurrencyPair> pairs = Collections.emptySet();
+  private Instrument instrument;
+  private Collection<Instrument> instruments = Collections.emptySet();
   private Integer limit;
 
   @Override
@@ -119,7 +125,9 @@ public class TradeHistoryParamsAll
 
   @Override
   public CurrencyPair getCurrencyPair() {
-
+    if (pair == null && instrument instanceof CurrencyPair) {
+      return (CurrencyPair) instrument;
+    }
     return pair;
   }
 
@@ -131,7 +139,12 @@ public class TradeHistoryParamsAll
 
   @Override
   public Collection<CurrencyPair> getCurrencyPairs() {
-
+    if (pairs.isEmpty() && !instruments.isEmpty()) {
+      return instruments.stream()
+          .filter(instrument -> instrument instanceof CurrencyPair)
+          .map(instrument -> (CurrencyPair) instrument)
+          .collect(Collectors.toSet());
+    }
     return pairs;
   }
 
@@ -139,6 +152,34 @@ public class TradeHistoryParamsAll
   public void setCurrencyPairs(Collection<CurrencyPair> value) {
 
     pairs = value;
+  }
+
+  @Override
+  public Instrument getInstrument() {
+    if (instrument == null && pair != null) {
+      return pair;
+    }
+
+    return instrument;
+  }
+
+  @Override
+  public void setInstrument(final Instrument instrument) {
+    this.instrument = instrument;
+  }
+
+  @Override
+  public Collection<Instrument> getInstruments() {
+    if (instruments.isEmpty() && !pairs.isEmpty()) {
+      return pairs.stream().map(pair -> (Instrument) pair).collect(Collectors.toList());
+    }
+
+    return instruments;
+  }
+
+  @Override
+  public void setInstruments(final Collection<Instrument> instruments) {
+    this.instruments = instruments;
   }
 
   @Override

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/DefaultOpenOrdersParamInstrument.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/DefaultOpenOrdersParamInstrument.java
@@ -1,0 +1,45 @@
+package org.knowm.xchange.service.trade.params.orders;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.instrument.Instrument;
+
+public class DefaultOpenOrdersParamInstrument implements OpenOrdersParamInstrument {
+
+  private Instrument instrument;
+
+  public DefaultOpenOrdersParamInstrument() {}
+
+  public DefaultOpenOrdersParamInstrument(CurrencyPair instrument) {
+    this.instrument = instrument;
+  }
+
+  public static List<Instrument> getInstruments(OpenOrdersParams params, Exchange exchange) {
+    List<Instrument> instruments = new ArrayList<>();
+    if (params instanceof OpenOrdersParamInstrument) {
+      final Instrument paramsInst = ((OpenOrdersParamInstrument) params).getInstrument();
+      if (paramsInst != null) {
+        instruments.add(paramsInst);
+      }
+    }
+    if (instruments.isEmpty()) {
+      instruments = exchange.getExchangeInstruments();
+    }
+    return instruments;
+  }
+
+  @Override
+  public Instrument getInstrument() {
+    return null;
+  }
+
+  @Override
+  public void setInstrument(final Instrument instrument) {}
+
+  @Override
+  public String toString() {
+    return String.format("DefaultOpenOrdersParamInstrument{%s}", instrument);
+  }
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/DefaultOpenOrdersParamMultiInstrument.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/DefaultOpenOrdersParamMultiInstrument.java
@@ -1,0 +1,26 @@
+package org.knowm.xchange.service.trade.params.orders;
+
+import java.util.Collection;
+import java.util.Collections;
+import org.knowm.xchange.instrument.Instrument;
+
+public class DefaultOpenOrdersParamMultiInstrument implements OpenOrdersParamMultiInstrument {
+
+  private Collection<Instrument> instruments = Collections.emptySet();
+
+  public DefaultOpenOrdersParamMultiInstrument() {}
+
+  public DefaultOpenOrdersParamMultiInstrument(final Collection<Instrument> instruments) {
+    this.instruments = instruments;
+  }
+
+  @Override
+  public Collection<Instrument> getInstruments() {
+    return instruments;
+  }
+
+  @Override
+  public void setInstruments(Collection<Instrument> value) {
+    instruments = value;
+  }
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/OpenOrdersParamInstrument.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/OpenOrdersParamInstrument.java
@@ -1,0 +1,18 @@
+package org.knowm.xchange.service.trade.params.orders;
+
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.service.trade.params.InstrumentParam;
+
+public interface OpenOrdersParamInstrument extends OpenOrdersParams, InstrumentParam {
+  @Override
+  default boolean accept(LimitOrder order) {
+    return accept((Order) order);
+  }
+
+  @Override
+  default boolean accept(Order order) {
+    return order != null
+        && (getInstrument() == null || getInstrument().equals(order.getInstrument()));
+  }
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/OpenOrdersParamMultiInstrument.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/OpenOrdersParamMultiInstrument.java
@@ -1,0 +1,18 @@
+package org.knowm.xchange.service.trade.params.orders;
+
+import java.util.Collection;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.instrument.Instrument;
+
+public interface OpenOrdersParamMultiInstrument extends OpenOrdersParams {
+  @Override
+  default boolean accept(LimitOrder order) {
+    return order != null
+        && getInstruments() != null
+        && getInstruments().contains(order.getCurrencyPair());
+  }
+
+  Collection<Instrument> getInstruments();
+
+  void setInstruments(Collection<Instrument> instruments);
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/utils/jackson/InstrumentDeserializer.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/utils/jackson/InstrumentDeserializer.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.derivative.FuturesContract;
 import org.knowm.xchange.instrument.Instrument;
 
 public class InstrumentDeserializer extends JsonDeserializer<Instrument> {
@@ -30,6 +31,7 @@ public class InstrumentDeserializer extends JsonDeserializer<Instrument> {
     // CurrencyPair (Base/Counter) i.e. BTC/USD
     if (count == 1) return new CurrencyPair(instrumentString);
     // Futures/Swaps (Base/Counter/Prompt) i.e. BTC/USD/200925
+    if (count == 2) return new FuturesContract(instrumentString);
     // Options (Base/Counter/Prompt/StrikePrice/Put?Call) i.e. BTC/USD/200925/8956.67/P
     else return null;
   }

--- a/xchange-core/src/test/java/org/knowm/xchange/derivative/FuturesContractTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/derivative/FuturesContractTest.java
@@ -1,0 +1,22 @@
+package org.knowm.xchange.derivative;
+
+import org.junit.Test;
+import org.knowm.xchange.utils.ObjectMapperHelper;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FuturesContractTest {
+
+  @Test
+  public void testSerializeDeserialize() throws IOException {
+    FuturesContract contractExpire = new FuturesContract("XBT/USD/200925");
+    FuturesContract jsonCopy = ObjectMapperHelper.viaJSON(contractExpire);
+    assertThat(jsonCopy).isEqualTo(contractExpire);
+
+    FuturesContract contractPerpetual = new FuturesContract("XBT/USD/perpetual");
+    FuturesContract jsonCopy2 = ObjectMapperHelper.viaJSON(contractPerpetual);
+    assertThat(jsonCopy2).isEqualTo(contractPerpetual);
+  }
+}

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/trade/KrakenUserTrade.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/trade/KrakenUserTrade.java
@@ -70,7 +70,7 @@ public class KrakenUserTrade extends UserTrade {
           new KrakenUserTrade(
               type,
               originalAmount,
-              currencyPair,
+              (CurrencyPair) instrument,
               price,
               timestamp,
               id,

--- a/xchange-ripple/src/main/java/org/knowm/xchange/ripple/dto/trade/RippleUserTrade.java
+++ b/xchange-ripple/src/main/java/org/knowm/xchange/ripple/dto/trade/RippleUserTrade.java
@@ -60,7 +60,7 @@ public class RippleUserTrade extends UserTrade {
   }
 
   public Currency getBaseTransferFeeCurrency() {
-    return currencyPair.base;
+    return getCurrencyPair().base;
   }
 
   public BigDecimal getCounterTransferFee() {
@@ -68,7 +68,7 @@ public class RippleUserTrade extends UserTrade {
   }
 
   public Currency getCounterTransferFeeCurrency() {
-    return currencyPair.counter;
+    return getCurrencyPair().counter;
   }
 
   public static class Builder extends UserTrade.Builder {
@@ -124,7 +124,7 @@ public class RippleUserTrade extends UserTrade {
           new RippleUserTrade(
               type,
               originalAmount,
-              currencyPair,
+              (CurrencyPair)instrument,
               price,
               timestamp,
               id,


### PR DESCRIPTION
We are trying to implement the kraken futures and binance futures APIs. While implementing the *Raw services is straight forward, we are struggling with the non-*Raw services.
For some of those challenges this pull request offers solutions:

- some DTOs were still accepting only CurrencyPair, those now support Instrument

- some service methods accept only CurrencyPair, those now accept neutral Params

- There was no OpenPositions method: I added it to AccountInfo, because from our point of view a open positions is quite similar to a balance. 

- I added some interfaces and implementations for *InstrumentParam classes toi mirror existing *CurrencyPairParam classes

- I added a proposal for a FuturesContract, but I'm not very confided that it is already in a state to be used universally like CurrencyPair. As far as I can evaluate it, it is good enough for our use cases.

This proposal does not include any code for an equivalent of CurrencyPairMetaData for Instruments or FuturesContracts. I tried a couple of different approaches to make the Exchange and/ or CurrencyPairMetaData generic but I was not successful without breaking the current API-Interface.
So I' m very open to ideas how to deal with ExchangeMetaData. As far as I can see, that's the last building block preventing us to  implement the futures APIs for Kraken and Binance.

With this proposal I tried to stick closely to the discussion in #3171. My FuturesContract is inspired by #3461