### PR TITLE
[BitMex Stream]: Remove nonce from BitMex stream as its now deprecated

### DIFF
--- a/xchange-stream-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexStreamingService.java
+++ b/xchange-stream-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexStreamingService.java
@@ -178,7 +178,6 @@ public class BitmexStreamingService extends JsonNettyStreamingService {
     String stringToDigest = "GET/realtime" + expires;
     String signature = bitmexDigester.digestString(stringToDigest);
 
-    customHeaders.add("api-nonce", expires);
     customHeaders.add("api-key", apiKey);
     customHeaders.add("api-signature", signature);
     return customHeaders;


### PR DESCRIPTION
See following announcement: https://blog.bitmex.com/api_announcement/deprecation-of-api-nonce-header/