### PR TITLE
Added support for ZMW (Zambian Kwacha)

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
@@ -272,7 +272,8 @@ public class Currency implements Comparable<Currency>, Serializable {
   public static final Currency ZAR = createCurrency("ZAR", "South African Rand", null);
   public static final Currency ZEC = createCurrency("ZEC", "Zcash", null);
   public static final Currency ZEN = createCurrency("ZEN", "ZenCash", null);
-  public static final Currency ZMK = createCurrency("ZMK", "Zambian Kwacha", null);
+  public static final Currency ZMW = createCurrency("ZMW", "Zambian Kwacha", null, "ZMK");
+  public static final Currency ZMK = getInstance("ZMK"); // Until 31.12.2012, afterwards ZMW used
   public static final Currency ZRC = createCurrency("ZRC", "ziftrCOIN", null);
   public static final Currency ZWL = createCurrency("ZWL", "Zimbabwean Dollar", null);
 

--- a/xchange-core/src/main/java/org/knowm/xchange/currency/CurrencyPair.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/CurrencyPair.java
@@ -71,6 +71,7 @@ public class CurrencyPair extends Instrument implements Comparable<CurrencyPair>
   public static final CurrencyPair BTC_INR = new CurrencyPair(Currency.BTC, Currency.INR);
   public static final CurrencyPair BTC_XAUR = new CurrencyPair(Currency.BTC, Currency.XAUR);
   public static final CurrencyPair BTC_IOC = new CurrencyPair(Currency.BTC, Currency.IOC);
+  public static final CurrencyPair BTC_ZMW = new CurrencyPair(Currency.BTC, Currency.ZMW);
   public static final CurrencyPair BTC_TRY = new CurrencyPair(Currency.BTC, Currency.TRY);
   public static final CurrencyPair ETH_TRY = new CurrencyPair(Currency.ETH, Currency.TRY);
 


### PR DESCRIPTION
Updated `Currency` and added corresponding `CurrencyPair`.

This currency is supported by Luno ( see https://www.luno.com/en/developers/api#tag/Currency )