### PR TITLE
[kucoin] fixed inner-transfer method according to kucoin api v2

### DIFF
--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/request/InnerTransferRequest.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/request/InnerTransferRequest.java
@@ -15,13 +15,12 @@ public class InnerTransferRequest {
 
   /** Request ID */
   private final String clientOid;
-  /** Account ID of payer(obtained through the "list account" interface). */
-  private final String payAccountId;
-  /** Account ID of receiver */
-  private final String recAccountId;
-  /**
-   * Transfer amount, a quantity that exceeds the precision of the currency（ Obtained through the
-   * currencies interface ）.
-   */
+  /** currency */
+  private final String currency;
+  /** Account type of payer: main, trade, margin or pool */
+  private final String from;
+  /** Account type of payee: main, trade, margin or pool */
+  private final String to;
+  /** Transfer amount, the amount is a positive integer multiple of the currency precision. */
   private final BigDecimal amount;
 }

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/AccountAPI.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/AccountAPI.java
@@ -22,7 +22,7 @@ import org.knowm.xchange.kucoin.dto.response.Pagination;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.SynchronizedValueFactory;
 
-@Path("/api/v1/accounts")
+@Path("api")
 @Produces(MediaType.APPLICATION_JSON)
 public interface AccountAPI {
 
@@ -39,6 +39,7 @@ public interface AccountAPI {
    * @throws KucoinApiException when errors are returned from the exchange.
    */
   @GET
+  @Path("v1/accounts")
   KucoinResponse<List<AccountBalancesResponse>> getAccountList(
       @HeaderParam(APIConstants.API_HEADER_KEY) String apiKey,
       @HeaderParam(APIConstants.API_HEADER_SIGN) ParamsDigest signature,
@@ -49,6 +50,7 @@ public interface AccountAPI {
       throws IOException;
 
   @POST
+  @Path("v1/accounts")
   @Consumes(MediaType.APPLICATION_JSON)
   KucoinResponse<Void> createAccount(
       @HeaderParam(APIConstants.API_HEADER_KEY) String apiKey,
@@ -59,7 +61,7 @@ public interface AccountAPI {
       throws IOException;
 
   @POST
-  @Path("inner-transfer")
+  @Path("v2/accounts/inner-transfer")
   @Consumes(MediaType.APPLICATION_JSON)
   KucoinResponse<InternalTransferResponse> innerTransfer(
       @HeaderParam(APIConstants.API_HEADER_KEY) String apiKey,
@@ -70,7 +72,7 @@ public interface AccountAPI {
       throws IOException;
 
   @GET
-  @Path("{accountId}/ledgers")
+  @Path("v1/accounts/{accountId}/ledgers")
   KucoinResponse<Pagination<AccountLedgersResponse>> getAccountLedgers(
       @HeaderParam(APIConstants.API_HEADER_KEY) String apiKey,
       @HeaderParam(APIConstants.API_HEADER_SIGN) ParamsDigest signature,


### PR DESCRIPTION
The [inner-transfer method at Kucoin API](https://docs.kucoin.com/#inner-transfer) swiched from v1 to v2
See [Changelog](https://docs.kucoin.com/#upcoming-changes) from 10/20/19:

> Deprecate '/api/v1/accounts/inner-transfer' endpoint for Inner Transfer.