### PR TITLE
[bitfinex] updated the Status class according to the current api

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/Status.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/Status.java
@@ -17,11 +17,13 @@ import lombok.ToString;
 public class Status {
 
   private String symbol;
+  /** Millisecond timestamp */
   private long timestamp;
+
   private Object placeHolder0;
-  /** Derivative last traded price. */
+  /** Derivative book mid price. */
   private BigDecimal derivPrice;
-  /** Last traded price of the underlying Bitfinex spot trading pair */
+  /** Book mid price of the underlying Bitfinex spot trading pair */
   private BigDecimal spotPrice;
 
   private Object placeHolder1;
@@ -29,7 +31,8 @@ public class Status {
   private BigDecimal insuranceFundBalance;
 
   private Object placeHolder2;
-  private Object placeHolder3;
+  /** Millisecond timestamp of next funding event */
+  private long nextFundingEvtTimestampMillis;
   /** Current accrued funding for next 8h period */
   private BigDecimal nextFundingAccrued;
   /** Incremental accrual counter */
@@ -48,4 +51,12 @@ public class Status {
   private Object placeHolder8;
   /** Total number of outstanding derivative contracts */
   private BigDecimal openInterest;
+
+  private Object placeHolder9;
+  private Object placeHolder10;
+  private Object placeHolder11;
+  /** Range in the average spread that does not require a funding payment */
+  private BigDecimal clampMin;
+  /** Funding payment cap */
+  private BigDecimal clampMax;
 }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/Status.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/Status.java
@@ -1,8 +1,10 @@
 package org.knowm.xchange.bitfinex.v2.dto.marketdata;
 
+import java.math.BigDecimal;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import java.math.BigDecimal;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -32,7 +34,7 @@ public class Status {
 
   private Object placeHolder2;
   /** Millisecond timestamp of next funding event */
-  private long nextFundingEvtTimestampMillis;
+  private Long nextFundingEvtTimestampMillis;
   /** Current accrued funding for next 8h period */
   private BigDecimal nextFundingAccrued;
   /** Incremental accrual counter */

--- a/xchange-bitfinex/src/test/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexStatusJSONTest.java
+++ b/xchange-bitfinex/src/test/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexStatusJSONTest.java
@@ -36,5 +36,6 @@ public class BitfinexStatusJSONTest {
     assertThat(s0.getPlaceHolder2()).isNull();
     assertThat(s0.getMarkPrice()).isEqualByComparingTo("8413.376666666667");
     assertThat(s0.getOpenInterest()).isEqualByComparingTo("862.33402476");
+    assertThat(s0.getNextFundingEvtTimestampMillis()).isEqualTo(1579795200000L);
   }
 }


### PR DESCRIPTION
updated the Status class according to the current api
see the api doc: https://docs.bitfinex.com/reference#rest-public-status
added fields like 'nextFundingEvtTimestampMillis'