### PR TITLE
Improve Binance CancelOrder service

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAuthenticated.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAuthenticated.java
@@ -168,6 +168,26 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
+  @DELETE
+  @Path("api/v3/openOrders")
+  /**
+   * Cancels all active orders on a symbol. This includes OCO orders.
+   *
+   * @param symbol
+   * @param recvWindow optional
+   * @param timestamp
+   * @return
+   * @throws IOException
+   * @throws BinanceException
+   */
+  List<BinanceCancelledOrder> cancelAllOpenOrders(
+      @QueryParam("symbol") String symbol,
+      @QueryParam("recvWindow") Long recvWindow,
+      @QueryParam("timestamp") SynchronizedValueFactory<Long> timestamp,
+      @HeaderParam(X_MBX_APIKEY) String apiKey,
+      @QueryParam(SIGNATURE) ParamsDigest signature)
+      throws IOException, BinanceException;
+
   @GET
   @Path("api/v3/openOrders")
   /**

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/trade/BinanceCancelledOrder.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/trade/BinanceCancelledOrder.java
@@ -4,20 +4,44 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public final class BinanceCancelledOrder {
 
-  public final String symbol;
-  public final String origClientOrderId;
-  public final long orderId;
-  public final String clientOrderId;
+    public final String symbol;
+    public final String origClientOrderId;
+    public final long orderId;
+    public final String clientOrderId;
+    public String price;
+    public String origQty;
+    public String executedQty;
+    public String cummulativeQuoteQty;
+    public String status;
+    public String timeInForce;
+    public String type;
+    public String side;
 
-  public BinanceCancelledOrder(
-      @JsonProperty("symbol") String symbol,
-      @JsonProperty("origClientOrderId") String origClientOrderId,
-      @JsonProperty("orderId") long orderId,
-      @JsonProperty("clientOrderId") String clientOrderId) {
-    super();
-    this.symbol = symbol;
-    this.origClientOrderId = origClientOrderId;
-    this.orderId = orderId;
-    this.clientOrderId = clientOrderId;
-  }
+    public BinanceCancelledOrder(
+            @JsonProperty("symbol") String symbol,
+            @JsonProperty("origClientOrderId") String origClientOrderId,
+            @JsonProperty("orderId") long orderId,
+            @JsonProperty("clientOrderId") String clientOrderId,
+            @JsonProperty("price") String price,
+            @JsonProperty("origQty") String origQty,
+            @JsonProperty("executedQty") String executedQty,
+            @JsonProperty("cummulativeQuoteQty") String cummulativeQuoteQty,
+            @JsonProperty("status") String status,
+            @JsonProperty("timeInForce") String timeInForce,
+            @JsonProperty("type") String type,
+            @JsonProperty("side") String side) {
+        super();
+        this.symbol = symbol;
+        this.origClientOrderId = origClientOrderId;
+        this.orderId = orderId;
+        this.clientOrderId = clientOrderId;
+        this.price = price;
+        this.origQty = origQty;
+        this.executedQty = executedQty;
+        this.cummulativeQuoteQty = cummulativeQuoteQty;
+        this.status = status;
+        this.timeInForce = timeInForce;
+        this.type = type;
+        this.side = side;
+    }
 }

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeServiceRaw.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeServiceRaw.java
@@ -151,6 +151,21 @@ public class BinanceTradeServiceRaw extends BinanceBaseService {
         .call();
   }
 
+  public List<BinanceCancelledOrder> cancelAllOpenOrders(CurrencyPair pair)
+      throws IOException, BinanceException {
+    return decorateApiCall(
+            () ->
+                binance.cancelAllOpenOrders(
+                    BinanceAdapters.toSymbol(pair),
+                    getRecvWindow(),
+                    getTimestampFactory(),
+                    super.apiKey,
+                    super.signatureCreator))
+        .withRetry(retry("cancelAllOpenOrders"))
+        .withRateLimiter(rateLimiter(REQUEST_WEIGHT_RATE_LIMITER))
+        .call();
+  }
+
   public List<BinanceOrder> allOrders(CurrencyPair pair, Long orderId, Integer limit)
       throws BinanceException, IOException {
     return decorateApiCall(


### PR DESCRIPTION
Add missing reponse fields based on binance documentation [(Cancel Order)](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#cancel-order-trade)
```
{
  "symbol": "LTCBTC",
  "origClientOrderId": "myOrder1",
  "orderId": 4,
  "orderListId": -1, //Unless part of an OCO, the value will always be -1.
  "clientOrderId": "cancelMyOrder1",
  "price": "2.00000000",
  "origQty": "1.00000000",
  "executedQty": "0.00000000",
  "cummulativeQuoteQty": "0.00000000",
  "status": "CANCELED",
  "timeInForce": "GTC",
  "type": "LIMIT",
  "side": "BUY"
}
```
and add new CancelAllOpenOrders service based on binance documentation [(Cancel All Open Orders)](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#cancel-all-open-orders-on-a-symbol-trade)
Cancel All Open Orders on a Symbol (TRADE)
`DELETE /api/v3/openOrders (HMAC SHA256)`
Cancels all active orders on a symbol. This includes OCO orders.