### PR TITLE
[Bitmex] ratelimit header field for rate limiting changed

### DIFF
--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexBaseService.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexBaseService.java
@@ -102,9 +102,9 @@ public class BitmexBaseService extends BaseExchangeService<BitmexExchange> imple
       if (responseAware != null && !rateLimitsUpdated) {
         Map<String, List<String>> responseHeaders = responseAware.getResponseHeaders();
 
-        List<String> limitList = responseHeaders.get("X-RateLimit-Limit");
-        List<String> remainingList = responseHeaders.get("X-RateLimit-Remaining");
-        List<String> resetList = responseHeaders.get("X-RateLimit-Reset");
+        List<String> limitList = responseHeaders.get("x-ratelimit-limit");
+        List<String> remainingList = responseHeaders.get("x-ratelimit-remaining");
+        List<String> resetList = responseHeaders.get("x-ratelimit-reset");
 
         if (limitList != null
             && !limitList.isEmpty()


### PR DESCRIPTION
According to the latest [Bitmex REST API document](https://www.bitmex.com/app/restAPI#Viewing-Your-Request-Rate-Limit), the header field indicating rate limiting has changed as follows:

On each request to the API, these headers are returned:
```
"x-ratelimit-limit": 60
"x-ratelimit-remaining": 58
"x-ratelimit-reset": 1489791662
```