### PR TITLE
Upgrade Binance API based on change log release note.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -375,7 +375,7 @@
       <dependency>
         <groupId>com.pusher</groupId>
         <artifactId>pusher-java-client</artifactId>
-        <version>2.2.3</version>
+        <version>2.2.4</version>
       </dependency>
       <dependency>
         <groupId>javax.xml.bind</groupId>

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/Binance.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/Binance.java
@@ -15,12 +15,22 @@ import org.knowm.xchange.binance.dto.marketdata.BinanceOrderbook;
 import org.knowm.xchange.binance.dto.marketdata.BinancePrice;
 import org.knowm.xchange.binance.dto.marketdata.BinancePriceQuantity;
 import org.knowm.xchange.binance.dto.marketdata.BinanceTicker24h;
+import org.knowm.xchange.binance.dto.meta.BinanceSystemStatus;
 import org.knowm.xchange.binance.dto.meta.BinanceTime;
 import org.knowm.xchange.binance.dto.meta.exchangeinfo.BinanceExchangeInfo;
 
 @Path("")
 @Produces(MediaType.APPLICATION_JSON)
 public interface Binance {
+
+  @GET
+  @Path("wapi/v3/systemStatus.html")
+  /**
+   * Fetch system status which is normal or system maintenance.
+   *
+   * @throws IOException
+   */
+  BinanceSystemStatus systemStatus() throws IOException;
 
   @GET
   @Path("api/v3/ping")

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/Binance.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/Binance.java
@@ -23,7 +23,7 @@ import org.knowm.xchange.binance.dto.meta.exchangeinfo.BinanceExchangeInfo;
 public interface Binance {
 
   @GET
-  @Path("api/v1/ping")
+  @Path("api/v3/ping")
   /**
    * Test connectivity to the Rest API.
    *
@@ -33,7 +33,7 @@ public interface Binance {
   Object ping() throws IOException;
 
   @GET
-  @Path("api/v1/time")
+  @Path("api/v3/time")
   /**
    * Test connectivity to the Rest API and get the current server time.
    *
@@ -43,7 +43,7 @@ public interface Binance {
   BinanceTime time() throws IOException;
 
   @GET
-  @Path("api/v1/exchangeInfo")
+  @Path("api/v3/exchangeInfo")
   /**
    * Current exchange trading rules and symbol information.
    *
@@ -53,7 +53,7 @@ public interface Binance {
   BinanceExchangeInfo exchangeInfo() throws IOException;
 
   @GET
-  @Path("api/v1/depth")
+  @Path("api/v3/depth")
   /**
    * @param symbol
    * @param limit optional, default 100; valid limits: 5, 10, 20, 50, 100, 500, 1000, 5000
@@ -65,7 +65,7 @@ public interface Binance {
       throws IOException, BinanceException;
 
   @GET
-  @Path("api/v1/aggTrades")
+  @Path("api/v3/aggTrades")
   /**
    * Get compressed, aggregate trades. Trades that fill at the time, from the same order, with the
    * same price will have the quantity aggregated.<br>
@@ -92,7 +92,7 @@ public interface Binance {
       throws IOException, BinanceException;
 
   @GET
-  @Path("api/v1/klines")
+  @Path("api/v3/klines")
   /**
    * Kline/candlestick bars for a symbol. Klines are uniquely identified by their open time.<br>
    * If startTime and endTime are not sent, the most recent klines are returned.
@@ -115,7 +115,7 @@ public interface Binance {
       throws IOException, BinanceException;
 
   @GET
-  @Path("api/v1/ticker/24hr")
+  @Path("api/v3/ticker/24hr")
   /**
    * 24 hour price change statistics for all symbols. - bee carreful this api call have a big
    * weight, only about 4 call per minut can be without ban.
@@ -127,7 +127,7 @@ public interface Binance {
   List<BinanceTicker24h> ticker24h() throws IOException, BinanceException;
 
   @GET
-  @Path("api/v1/ticker/24hr")
+  @Path("api/v3/ticker/24hr")
   /**
    * 24 hour price change statistics.
    *
@@ -140,7 +140,18 @@ public interface Binance {
       throws IOException, BinanceException;
 
   @GET
-  @Path("api/v1/ticker/allPrices")
+  @Path("api/v3/ticker/price")
+  /**
+   * Latest price for a symbol.
+   *
+   * @return
+   * @throws IOException
+   * @throws BinanceException
+   */
+  BinancePrice tickerPrice(@QueryParam("symbol") String symbol) throws IOException, BinanceException;
+
+  @GET
+  @Path("api/v3/ticker/price")
   /**
    * Latest price for all symbols.
    *

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/Binance.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/Binance.java
@@ -56,7 +56,7 @@ public interface Binance {
   @Path("api/v3/depth")
   /**
    * @param symbol
-   * @param limit optional, default 100; valid limits: 5, 10, 20, 50, 100, 500, 1000, 5000
+   * @param limit optional, default 100 max 5000. Valid limits: [5, 10, 20, 50, 100, 500, 1000, 5000]
    * @return
    * @throws IOException
    * @throws BinanceException

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAuthenticated.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAuthenticated.java
@@ -471,7 +471,7 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    */
   @POST
-  @Path("/api/v1/userDataStream")
+  @Path("/api/v3/userDataStream")
   BinanceListenKey startUserDataStream(@HeaderParam(X_MBX_APIKEY) String apiKey)
       throws IOException, BinanceException;
 
@@ -485,7 +485,7 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    */
   @PUT
-  @Path("/api/v1/userDataStream?listenKey={listenKey}")
+  @Path("/api/v3/userDataStream?listenKey={listenKey}")
   Map<?, ?> keepAliveUserDataStream(
       @HeaderParam(X_MBX_APIKEY) String apiKey, @PathParam("listenKey") String listenKey)
       throws IOException, BinanceException;
@@ -500,7 +500,7 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    */
   @DELETE
-  @Path("/api/v1/userDataStream?listenKey={listenKey}")
+  @Path("/api/v3/userDataStream?listenKey={listenKey}")
   Map<?, ?> closeUserDataStream(
       @HeaderParam(X_MBX_APIKEY) String apiKey, @PathParam("listenKey") String listenKey)
       throws IOException, BinanceException;

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/account/BinanceAccountInformation.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/account/BinanceAccountInformation.java
@@ -15,6 +15,7 @@ public final class BinanceAccountInformation {
   public final boolean canDeposit;
   public final long updateTime;
   public List<BinanceBalance> balances;
+  public List<String> permissions;
 
   public BinanceAccountInformation(
       @JsonProperty("makerCommission") BigDecimal makerCommission,
@@ -25,7 +26,8 @@ public final class BinanceAccountInformation {
       @JsonProperty("canWithdraw") boolean canWithdraw,
       @JsonProperty("canDeposit") boolean canDeposit,
       @JsonProperty("updateTime") long updateTime,
-      @JsonProperty("balances") List<BinanceBalance> balances) {
+      @JsonProperty("balances") List<BinanceBalance> balances,
+      @JsonProperty("permissions") List<String> permissions) {
     this.makerCommission = makerCommission;
     this.takerCommission = takerCommission;
     this.buyerCommission = buyerCommission;
@@ -35,5 +37,6 @@ public final class BinanceAccountInformation {
     this.canDeposit = canDeposit;
     this.updateTime = updateTime;
     this.balances = balances;
+    this.permissions = permissions;
   }
 }

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/meta/BinanceSystemStatus.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/meta/BinanceSystemStatus.java
@@ -1,0 +1,20 @@
+package org.knowm.xchange.binance.dto.meta;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class BinanceSystemStatus {
+
+    // 0: normal，1：system maintenance
+    @JsonProperty
+    private String status;
+    // normal or system maintenance
+    @JsonProperty private String msg;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+}

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/meta/exchangeinfo/BinanceExchangeInfo.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/meta/exchangeinfo/BinanceExchangeInfo.java
@@ -11,6 +11,8 @@ public class BinanceExchangeInfo {
 
   private String[] exchangeFilters;
 
+  private String[] permissions;
+
   public String getTimezone() {
     return timezone;
   }
@@ -51,6 +53,14 @@ public class BinanceExchangeInfo {
     this.exchangeFilters = exchangeFilters;
   }
 
+  public String[] getPermissions() {
+    return permissions;
+  }
+
+  public void setPermissions(String[] permissions) {
+    this.permissions = permissions;
+  }
+
   @Override
   public String toString() {
     return "ClassPojo [timezone = "
@@ -63,6 +73,8 @@ public class BinanceExchangeInfo {
         + rateLimits
         + ", exchangeFilters = "
         + exchangeFilters
+        + ", permissions = "
+        + permissions
         + "]";
   }
 }

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/meta/exchangeinfo/Symbol.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/meta/exchangeinfo/Symbol.java
@@ -6,6 +6,12 @@ public class Symbol {
 
   private String icebergAllowed;
 
+  private String ocoAllowed;
+
+  private String isMarginTradingAllowed;
+
+  private String isSpotTradingAllowed;
+
   private String baseAsset;
 
   private String symbol;
@@ -14,11 +20,15 @@ public class Symbol {
 
   private String quotePrecision;
 
+  private String quoteAssetPrecision;
+
   private String baseAssetPrecision;
 
   private String[] orderTypes;
 
   private Filter[] filters;
+
+  private String[] permissions;
 
   public String getQuoteAsset() {
     return quoteAsset;
@@ -34,6 +44,30 @@ public class Symbol {
 
   public void setIcebergAllowed(String icebergAllowed) {
     this.icebergAllowed = icebergAllowed;
+  }
+
+  public String getOcoAllowed() {
+    return ocoAllowed;
+  }
+
+  public void setOcoAllowed(String ocoAllowed) {
+    this.ocoAllowed = ocoAllowed;
+  }
+
+  public String getIsMarginTradingAllowed() {
+    return isMarginTradingAllowed;
+  }
+
+  public void setIsMarginTradingAllowed(String isMarginTradingAllowed) {
+    this.isMarginTradingAllowed = isMarginTradingAllowed;
+  }
+
+  public String getIsSpotTradingAllowed() {
+    return isSpotTradingAllowed;
+  }
+
+  public void setIsSpotTradingAllowed(String isSpotTradingAllowed) {
+    this.isSpotTradingAllowed = isSpotTradingAllowed;
   }
 
   public String getBaseAsset() {
@@ -68,6 +102,14 @@ public class Symbol {
     this.quotePrecision = quotePrecision;
   }
 
+  public String getQuoteAssetPrecision() {
+    return quoteAssetPrecision;
+  }
+
+  public void setQuoteAssetPrecision(String quoteAssetPrecision) {
+    this.quoteAssetPrecision = quoteAssetPrecision;
+  }
+
   public String getBaseAssetPrecision() {
     return baseAssetPrecision;
   }
@@ -92,6 +134,14 @@ public class Symbol {
     this.filters = filters;
   }
 
+  public String[] getPermissions() {
+    return permissions;
+  }
+
+  public void setPermissions(String[] permissions) {
+    this.permissions = permissions;
+  }
+
   @Override
   public String toString() {
     return "ClassPojo [quoteAsset = "
@@ -106,12 +156,16 @@ public class Symbol {
         + status
         + ", quotePrecision = "
         + quotePrecision
+        + ", quoteAssetPrecision = "
+        + quoteAssetPrecision
         + ", baseAssetPrecision = "
         + baseAssetPrecision
         + ", orderTypes = "
         + orderTypes
         + ", filters = "
         + filters
+        + ", permissions = "
+        + permissions
         + "]";
   }
 }

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceBaseService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceBaseService.java
@@ -5,6 +5,7 @@ import static org.knowm.xchange.binance.BinanceResilience.REQUEST_WEIGHT_RATE_LI
 import java.io.IOException;
 import org.knowm.xchange.binance.BinanceAuthenticated;
 import org.knowm.xchange.binance.BinanceExchange;
+import org.knowm.xchange.binance.dto.meta.BinanceSystemStatus;
 import org.knowm.xchange.binance.dto.meta.exchangeinfo.BinanceExchangeInfo;
 import org.knowm.xchange.client.ResilienceRegistries;
 import org.knowm.xchange.service.BaseResilientExchangeService;
@@ -39,13 +40,17 @@ public class BinanceBaseService extends BaseResilientExchangeService<BinanceExch
   }
 
   public SynchronizedValueFactory<Long> getTimestampFactory() {
-    return ((BinanceExchange) exchange).getTimestampFactory();
+    return exchange.getTimestampFactory();
   }
 
   public BinanceExchangeInfo getExchangeInfo() throws IOException {
-    return decorateApiCall(() -> binance.exchangeInfo())
+    return decorateApiCall(binance::exchangeInfo)
         .withRetry(retry("exchangeInfo"))
         .withRateLimiter(rateLimiter(REQUEST_WEIGHT_RATE_LIMITER))
         .call();
+  }
+
+  public BinanceSystemStatus getSystemStatus() throws IOException {
+    return decorateApiCall(binance::systemStatus).call();
   }
 }

--- a/xchange-binance/src/test/java/org/knowm/xchange/binance/service/marketdata/MarketDataServiceResilienceTest.java
+++ b/xchange-binance/src/test/java/org/knowm/xchange/binance/service/marketdata/MarketDataServiceResilienceTest.java
@@ -95,13 +95,13 @@ public class MarketDataServiceResilienceTest extends AbstractResilienceTest {
 
   private void stubForTicker24WithFirstCallTimetoutAndSecondSuccessful() {
     stubFor(
-        get(urlPathEqualTo("/api/v1/ticker/24hr"))
+        get(urlPathEqualTo("/api/v3/ticker/24hr"))
             .inScenario("Retry read")
             .whenScenarioStateIs(STARTED)
             .willReturn(aResponse().withFixedDelay(READ_TIMEOUT_MS * 2).withStatus(500))
             .willSetStateTo("After fail"));
     stubFor(
-        get(urlPathEqualTo("/api/v1/ticker/24hr"))
+        get(urlPathEqualTo("/api/v3/ticker/24hr"))
             .inScenario("Retry read")
             .whenScenarioStateIs("After fail")
             .willReturn(
@@ -113,7 +113,7 @@ public class MarketDataServiceResilienceTest extends AbstractResilienceTest {
 
   private void stubForDepth() {
     stubFor(
-        get(urlPathEqualTo("/api/v1/depth"))
+        get(urlPathEqualTo("/api/v3/depth"))
             .willReturn(
                 aResponse()
                     .withStatus(200)

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/dto/OutboundAccountInfoBinanceWebsocketTransaction.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/dto/OutboundAccountInfoBinanceWebsocketTransaction.java
@@ -16,6 +16,7 @@ public class OutboundAccountInfoBinanceWebsocketTransaction
   private final boolean canDeposit;
   private final long lastUpdateTimestamp;
   private final List<BinanceWebsocketBalance> balances;
+  private List<String> permissions;
 
   public OutboundAccountInfoBinanceWebsocketTransaction(
       @JsonProperty("e") String eventType,
@@ -28,7 +29,8 @@ public class OutboundAccountInfoBinanceWebsocketTransaction
       @JsonProperty("W") boolean canWithdraw,
       @JsonProperty("D") boolean canDeposit,
       @JsonProperty("u") long lastUpdateTimestamp,
-      @JsonProperty("B") List<BinanceWebsocketBalance> balances) {
+      @JsonProperty("B") List<BinanceWebsocketBalance> balances,
+      @JsonProperty("P") List<String> permissions) {
     super(eventType, eventTime);
     this.makerCommissionRate = makerCommissionRate;
     this.takerCommissionRate = takerCommissionRate;
@@ -39,6 +41,7 @@ public class OutboundAccountInfoBinanceWebsocketTransaction
     this.canDeposit = canDeposit;
     this.lastUpdateTimestamp = lastUpdateTimestamp;
     this.balances = balances;
+    this.permissions = permissions;
   }
 
   public BigDecimal getMakerCommissionRate() {
@@ -77,6 +80,10 @@ public class OutboundAccountInfoBinanceWebsocketTransaction
     return balances;
   }
 
+  public List<String> getPermissions() {
+    return permissions;
+  }
+
   @Override
   public String toString() {
     return "OutboundAccountInfoBinanceWebsocketTransaction [makerCommissionRate="
@@ -97,6 +104,8 @@ public class OutboundAccountInfoBinanceWebsocketTransaction
         + lastUpdateTimestamp
         + ", balances="
         + balances
+        + ", permissions="
+        + permissions
         + "]";
   }
 }


### PR DESCRIPTION
- [x] Add permissions filed to BinanceExchangeInfo, OutboundAccountInfo and BinanceAccountInformation
- [x] Add permissions, quoteAssetPrecision, isSpotTradingAllowed,  isMarginTradingAllowed, ocoAllowed fields to Symbol.
- [x] Upgrade API version to V3 for tickerAllPrices, ticker24h, klines, aggTrades, depth, time, ping, closeUserDataStream, keepAliveUserDataStream, startUserDataStream services
- [x] Add tickerPrice service
- [x] Add System Status service

I think we can close [Binance - Deprecation of v1 endpoints](https://github.com/knowm/XChange/issues/3349) now!