### PR TITLE
- Add missing features for bitbay.v3

### DIFF
--- a/xchange-bitbay/pom.xml
+++ b/xchange-bitbay/pom.xml
@@ -29,6 +29,10 @@
             <artifactId>xchange-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/BitbayAdapters.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/BitbayAdapters.java
@@ -43,9 +43,15 @@ public class BitbayAdapters {
               .currencyPair(pair)
               .price(trade.getRate())
               .timestamp(timestamp)
+              .feeAmount(trade.getCommissionValue())
+              .feeCurrency(trade.getCommissionValue() == null ? null : pair.base)
               .build());
     }
     return new UserTrades(
         trades, 0L, Trades.TradeSortType.SortByTimestamp, response.getNextPageCursor());
+  }
+
+  public static String adaptCurrencyPair(CurrencyPair currencyPair) {
+    return currencyPair.base + "-" + currencyPair.counter;
   }
 }

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/BitbayAuthenticated.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/BitbayAuthenticated.java
@@ -1,7 +1,6 @@
 package org.knowm.xchange.bitbay.v3;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.UUID;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -9,6 +8,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import org.knowm.xchange.bitbay.v3.dto.BitbayBalanceHistoryResponse;
 import org.knowm.xchange.bitbay.v3.dto.BitbayBalances;
 import org.knowm.xchange.bitbay.v3.dto.trade.BitbayUserTrades;
 import si.mazi.rescu.ParamsDigest;
@@ -41,7 +41,7 @@ public interface BitbayAuthenticated {
 
   @GET
   @Path("balances/BITBAY/history")
-  Map balanceHistory(
+  BitbayBalanceHistoryResponse balanceHistory(
       @HeaderParam("API-Key") String apiKey,
       @HeaderParam("API-Hash") ParamsDigest sign,
       @HeaderParam("Request-Timestamp") SynchronizedValueFactory<Long> timestamp,

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/dto/BitbayBalanceHistoryEntry.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/dto/BitbayBalanceHistoryEntry.java
@@ -1,0 +1,69 @@
+package org.knowm.xchange.bitbay.v3.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import java.math.BigDecimal;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@JsonDeserialize(builder = BitbayBalanceHistoryEntry.BitbayBalanceHistoryEntryBuilder.class)
+public class BitbayBalanceHistoryEntry {
+
+  UUID historyId;
+  BalanceInfo balance;
+  UUID detailId;
+  long time;
+  String type;
+  BigDecimal value;
+  FundsInfo fundsBefore;
+  FundsInfo fundsAfter;
+  FundsInfo change;
+
+  @JsonPOJOBuilder(withPrefix = "")
+  public static class BitbayBalanceHistoryEntryBuilder {}
+
+  @Value
+  @Builder
+  @JsonDeserialize(builder = BalanceInfo.BalanceInfoBuilder.class)
+  public static class BalanceInfo {
+    UUID id;
+    String currency;
+    BalanceType type;
+    UUID userId;
+    String name;
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class BalanceInfoBuilder {}
+  }
+
+  public enum BalanceType {
+    FIAT,
+    CRYPTO;
+
+    @JsonCreator
+    public static BalanceType fromValue(String strValue) {
+      for (BalanceType balanceType : BalanceType.values()) {
+        if (balanceType.name().equals(strValue)) {
+          return balanceType;
+        }
+      }
+      return null;
+    }
+  }
+
+  @Value
+  @Builder
+  @JsonDeserialize(builder = FundsInfo.FundsInfoBuilder.class)
+  public static class FundsInfo {
+    BigDecimal total;
+    BigDecimal available;
+    BigDecimal locked;
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class FundsInfoBuilder {}
+  }
+}

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/dto/BitbayBalanceHistoryResponse.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/dto/BitbayBalanceHistoryResponse.java
@@ -1,0 +1,24 @@
+package org.knowm.xchange.bitbay.v3.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString(callSuper = true)
+public class BitbayBalanceHistoryResponse extends BitbayBaseResponse {
+
+  private final List<BitbayBalanceHistoryEntry> items;
+  private final boolean hasNextPage;
+
+  public BitbayBalanceHistoryResponse(
+      @JsonProperty("status") String status,
+      @JsonProperty("errors") List<String> errors,
+      @JsonProperty("items") List<BitbayBalanceHistoryEntry> items,
+      @JsonProperty("hasNextPage") boolean hasNextPage) {
+    super(status, errors);
+    this.items = items;
+    this.hasNextPage = hasNextPage;
+  }
+}

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/dto/BitbayBalances.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/dto/BitbayBalances.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class BitbayBalances extends BitbayBaseResponse {
 
-  private List<BitbayBalance> balances;
+  private final List<BitbayBalance> balances;
 
   public BitbayBalances(
       @JsonProperty("status") String status,

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/dto/BitbayBaseResponse.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/dto/BitbayBaseResponse.java
@@ -3,8 +3,10 @@ package org.knowm.xchange.bitbay.v3.dto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import lombok.ToString;
 
 /** @author walec51 */
+@ToString
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BitbayBaseResponse {
 

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/dto/trade/BitbayBalancesHistoryQuery.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/dto/trade/BitbayBalancesHistoryQuery.java
@@ -1,34 +1,14 @@
 package org.knowm.xchange.bitbay.v3.dto.trade;
 
 import java.util.List;
+import lombok.Data;
 
+@Data
 public class BitbayBalancesHistoryQuery {
 
   private String limit;
   private String offset;
   private List<String> types;
-
-  public List<String> getTypes() {
-    return types;
-  }
-
-  public void setTypes(List<String> types) {
-    this.types = types;
-  }
-
-  public String getOffset() {
-    return offset;
-  }
-
-  public void setOffset(String offset) {
-    this.offset = offset;
-  }
-
-  public String getLimit() {
-    return limit;
-  }
-
-  public void setLimit(String limit) {
-    this.limit = limit;
-  }
+  private Long fromTime;
+  private Long toTime;
 }

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/dto/trade/BitbayUserTrade.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/dto/trade/BitbayUserTrade.java
@@ -13,6 +13,7 @@ public class BitbayUserTrade {
   private final BigDecimal amount;
   private final BigDecimal rate;
   private final String userAction;
+  private final BigDecimal commissionValue;
 
   public BitbayUserTrade(
       @JsonProperty("id") UUID id,
@@ -20,13 +21,15 @@ public class BitbayUserTrade {
       @JsonProperty("time") long time,
       @JsonProperty("amount") BigDecimal amount,
       @JsonProperty("rate") BigDecimal rate,
-      @JsonProperty("userAction") String userAction) {
+      @JsonProperty("userAction") String userAction,
+      @JsonProperty("commissionValue") BigDecimal commissionValue) {
     this.id = id;
     this.market = market;
     this.time = time;
     this.amount = amount;
     this.rate = rate;
     this.userAction = userAction;
+    this.commissionValue = commissionValue;
   }
 
   public UUID getId() {
@@ -51,5 +54,9 @@ public class BitbayUserTrade {
 
   public String getUserAction() {
     return userAction;
+  }
+
+  public BigDecimal getCommissionValue() {
+    return commissionValue;
   }
 }

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/service/BitbayAccountServiceRaw.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/service/BitbayAccountServiceRaw.java
@@ -2,9 +2,9 @@ package org.knowm.xchange.bitbay.v3.service;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import org.knowm.xchange.bitbay.v3.BitbayExchange;
+import org.knowm.xchange.bitbay.v3.dto.BitbayBalanceHistoryResponse;
 import org.knowm.xchange.bitbay.v3.dto.BitbayBalances;
 import org.knowm.xchange.bitbay.v3.dto.trade.BitbayBalancesHistoryQuery;
 import org.knowm.xchange.utils.ObjectMapperHelper;
@@ -20,7 +20,8 @@ public class BitbayAccountServiceRaw extends BitbayBaseService {
     return response.getBalances();
   }
 
-  public Map balanceHistory(BitbayBalancesHistoryQuery query) throws IOException {
+  public BitbayBalanceHistoryResponse balanceHistory(BitbayBalancesHistoryQuery query)
+      throws IOException {
     String jsonQuery = ObjectMapperHelper.toCompactJSON(query);
 
     return bitbayAuthenticated.balanceHistory(

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/service/BitbayTradeHistoryParams.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/service/BitbayTradeHistoryParams.java
@@ -1,13 +1,28 @@
 package org.knowm.xchange.bitbay.v3.service;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamLimit;
+import org.knowm.xchange.service.trade.params.TradeHistoryParamMultiCurrencyPair;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamNextPageCursor;
 
 /** @author walec51 */
 public class BitbayTradeHistoryParams
-    implements TradeHistoryParamLimit, TradeHistoryParamNextPageCursor {
+    implements TradeHistoryParamLimit,
+        TradeHistoryParamNextPageCursor,
+        TradeHistoryParamMultiCurrencyPair {
 
   public static final String START = "start"; // special value that enables paging
+
+  /**
+   * In order to get a cursor that enables paging you need initially set this to the value 'start'
+   */
+  private String nextPageCursor;
+
+  private Integer limit;
+
+  private Collection<CurrencyPair> currencyPairs = new ArrayList<>();
 
   public BitbayTradeHistoryParams() {
     this(START, 300);
@@ -22,13 +37,6 @@ public class BitbayTradeHistoryParams
   public static BitbayTradeHistoryParams startBitBayTradeHistoryParams(Integer limit) {
     return new BitbayTradeHistoryParams(START, limit);
   }
-
-  /**
-   * In order to get a cursor that enables paging you need initailly set this to the value 'start'
-   */
-  private String nextPageCursor;
-
-  private Integer limit;
 
   @Override
   public Integer getLimit() {
@@ -48,5 +56,15 @@ public class BitbayTradeHistoryParams
   @Override
   public void setNextPageCursor(String nextPageCursor) {
     this.nextPageCursor = nextPageCursor;
+  }
+
+  @Override
+  public Collection<CurrencyPair> getCurrencyPairs() {
+    return currencyPairs;
+  }
+
+  @Override
+  public void setCurrencyPairs(Collection<CurrencyPair> pairs) {
+    this.currencyPairs = pairs;
   }
 }

--- a/xchange-bitbay/src/test/java/org/knowm/xchange/bitbay/v3/service/BitbayAccountServiceIntegration.java
+++ b/xchange-bitbay/src/test/java/org/knowm/xchange/bitbay/v3/service/BitbayAccountServiceIntegration.java
@@ -1,0 +1,129 @@
+package org.knowm.xchange.bitbay.v3.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Before;
+import org.junit.Test;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.bitbay.v3.BitbayExchange;
+import org.knowm.xchange.bitbay.v3.dto.BitbayBalanceHistoryEntry;
+import org.knowm.xchange.bitbay.v3.dto.trade.BitbayBalancesHistoryQuery;
+import org.knowm.xchange.dto.account.FundingRecord;
+
+@Slf4j
+public class BitbayAccountServiceIntegration {
+
+  private String apiKey = null;
+  private String apiSecret = null;
+  private BitbayExchange exchange;
+
+  @Before
+  public void setUp() {
+    assumeTrue(apiKey != null && apiSecret != null);
+    exchange = ExchangeFactory.INSTANCE.createExchange(BitbayExchange.class, apiKey, apiSecret);
+  }
+
+  @Test
+  public void testGetFundingHistoryShouldCorrectMapFields() throws IOException {
+    final BitbayAccountService accountService = (BitbayAccountService) exchange.getAccountService();
+
+    final BitbayTradeHistoryParams tradeHistoryParams =
+        (BitbayTradeHistoryParams) exchange.getTradeService().createTradeHistoryParams();
+    tradeHistoryParams.setLimit(1000);
+
+    final List<FundingRecord> fundingHistory = accountService.getFundingHistory(tradeHistoryParams);
+    assertThat(fundingHistory).isNotNull();
+
+    fundingHistory.forEach(
+        fundingRecord -> {
+          assertThat(fundingRecord).isNotNull();
+          assertThat(fundingRecord.getAmount()).isNotNull();
+          assertThat(fundingRecord.getDate()).isNotNull();
+          assertThat(fundingRecord.getInternalId()).isNotBlank();
+          assertThat(fundingRecord.getType()).isNotNull();
+          assertThat(fundingRecord.getStatus()).isNotNull();
+          assertThat(fundingRecord.getBalance()).isNotNull();
+        });
+  }
+
+  @Test
+  public void testGetBalanceHistoryShouldCorrectMapFields() throws IOException {
+    final BitbayAccountService accountService = (BitbayAccountService) exchange.getAccountService();
+
+    final BitbayBalancesHistoryQuery bitbayBalancesHistoryQuery = new BitbayBalancesHistoryQuery();
+    bitbayBalancesHistoryQuery.setLimit("1000");
+
+    final List<BitbayBalanceHistoryEntry> bitbayBalanceHistoryEntries =
+        accountService.balanceHistory(bitbayBalancesHistoryQuery).getItems();
+
+    assertThat(bitbayBalanceHistoryEntries).isNotNull();
+
+    bitbayBalanceHistoryEntries.forEach(
+        balanceHistoryEntry -> {
+          assertThat(balanceHistoryEntry).isNotNull();
+          assertThat(balanceHistoryEntry.getHistoryId()).isNotNull();
+          assertThat(balanceHistoryEntry.getBalance()).isNotNull();
+          assertThat(balanceHistoryEntry.getBalance().getCurrency()).isNotBlank();
+          assertThat(balanceHistoryEntry.getBalance().getName()).isNotBlank();
+          assertThat(balanceHistoryEntry.getBalance().getType()).isNotNull();
+          assertThat(balanceHistoryEntry.getBalance().getUserId()).isNotNull();
+          assertThat(balanceHistoryEntry.getTime()).isPositive();
+          assertThat(balanceHistoryEntry.getType()).isNotBlank();
+          assertThat(balanceHistoryEntry.getValue()).isNotNull();
+          assertThat(balanceHistoryEntry.getFundsBefore())
+              .isNotNull(); // fields in fundsBefore are optional e.g. for type CREATE_BALANCE
+          assertThat(balanceHistoryEntry.getFundsAfter()).isNotNull();
+          assertThat(balanceHistoryEntry.getFundsAfter().getTotal()).isNotNull();
+          assertThat(balanceHistoryEntry.getFundsAfter().getAvailable()).isNotNull();
+          assertThat(balanceHistoryEntry.getFundsAfter().getLocked()).isNotNull();
+          assertThat(balanceHistoryEntry.getChange()).isNotNull();
+          assertThat(balanceHistoryEntry.getChange().getTotal()).isNotNull();
+          assertThat(balanceHistoryEntry.getChange().getAvailable()).isNotNull();
+          assertThat(balanceHistoryEntry.getChange().getLocked()).isNotNull();
+          // detailId is optional field
+        });
+  }
+
+  @Test
+  public void testGetBalanceHistoryWithTimeFilterShouldContainsOnlyEntriesInGivenPeriod()
+      throws IOException {
+    final ZonedDateTime start =
+        LocalDate.parse("2019-01-01").atStartOfDay(ZoneId.of("Europe/Warsaw"));
+    final ZonedDateTime end = start.plusYears(1);
+    final long startUnixTimestamp = start.toInstant().toEpochMilli();
+    final long endUnixTimestamp = end.toInstant().toEpochMilli();
+
+    final BitbayAccountService accountService = (BitbayAccountService) exchange.getAccountService();
+
+    final BitbayBalancesHistoryQuery bitbayBalancesHistoryQuery = new BitbayBalancesHistoryQuery();
+    bitbayBalancesHistoryQuery.setLimit("1000");
+    bitbayBalancesHistoryQuery.setFromTime(startUnixTimestamp);
+    bitbayBalancesHistoryQuery.setToTime(endUnixTimestamp);
+
+    log.debug(
+        "start: {}, end: {}, bitbayBalancesHistoryQuery: {}",
+        start,
+        end,
+        bitbayBalancesHistoryQuery);
+
+    final List<BitbayBalanceHistoryEntry> bitbayBalanceHistoryEntries =
+        accountService.balanceHistory(bitbayBalancesHistoryQuery).getItems();
+    log.debug("bitbayBalanceHistoryEntries size: {}", bitbayBalanceHistoryEntries.size());
+
+    assertThat(bitbayBalanceHistoryEntries).isNotNull();
+
+    bitbayBalanceHistoryEntries.forEach(
+        bitbayBalanceHistoryEntry -> {
+          assertThat(bitbayBalanceHistoryEntry).isNotNull();
+          assertThat(bitbayBalanceHistoryEntry.getTime())
+              .isBetween(startUnixTimestamp, endUnixTimestamp);
+        });
+  }
+}


### PR DESCRIPTION
- Added `BitbayUserTrade.commissionValue` and then filled `UserTrade.feeAmount `and `UserTrade.feeCurrency`
- Added support for `TradeHistoryParamMultiCurrencyPair` in `BitbayTradeHistoryParams`
- `BitbayAccountServiceRaw` changed method signature from `Map balanceHistory(BitbayBalancesHistoryQuery query)` to `BitbayBalanceHistoryResponse balanceHistory(BitbayBalancesHistoryQuery query)`