### PR TITLE
[Poloniex] make poloniex returnOrderTrades public (used to get total field)

### DIFF
--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/trade/PoloniexUserTrade.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/trade/PoloniexUserTrade.java
@@ -13,8 +13,11 @@ import javax.annotation.Generated;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
-@JsonPropertyOrder({"tradeId", "date", "rate", "amount", "total", "fee", "orderNumber", "type"})
+@JsonPropertyOrder({"globalTradeID", "tradeID", "date", "rate", "amount", "total", "fee", "orderNumber", "type"})
 public class PoloniexUserTrade {
+
+  @JsonProperty("globalTradeID")
+  private String globalTradeID;
 
   @JsonProperty("tradeID")
   private String tradeID;
@@ -41,6 +44,18 @@ public class PoloniexUserTrade {
   private String type;
 
   @JsonIgnore private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+  @JsonProperty("globalTradeID")
+  public String getGlobalTradeID() {
+
+    return globalTradeID;
+  }
+
+  @JsonProperty("globalTradeID")
+  public void setGlobalTradeID(String globalTradeID) {
+
+    this.globalTradeID = globalTradeID;
+  }
 
   @JsonProperty("tradeID")
   public String getTradeID() {
@@ -152,8 +167,9 @@ public class PoloniexUserTrade {
 
   @Override
   public String toString() {
-
-    return "PoloniexUserTrade [tradeID= "
+    return "PoloniexUserTrade [globalTradeID="
+        + globalTradeID
+        + ", tradeID= "
         + tradeID
         + ", date="
         + date

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexTradeServiceRaw.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexTradeServiceRaw.java
@@ -32,7 +32,7 @@ public class PoloniexTradeServiceRaw extends PoloniexBaseService {
         apiKey, signatureCreator, exchange.getNonceFactory(), PoloniexAuthenticated.AllPairs.all);
   }
 
-  PoloniexUserTrade[] returnOrderTrades(String orderId) throws IOException {
+  public PoloniexUserTrade[] returnOrderTrades(String orderId) throws IOException {
     return poloniexAuthenticated.returnOrderTrades(
         apiKey, signatureCreator, exchange.getNonceFactory(), orderId);
   }


### PR DESCRIPTION
- make poloniex returnOrderTrades public (used to get total field)
   There is a field that is not mapped to xchange common api (in this case total -> cost of trade).
- add global trade id
