### PR TITLE
[Bitbay] Use compact JSON instead of replacing whitespaces in String

### DIFF
--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/service/BitbayTradeServiceRaw.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/service/BitbayTradeServiceRaw.java
@@ -2,7 +2,6 @@ package org.knowm.xchange.bitbay.v3.service;
 
 import java.io.IOException;
 import java.util.UUID;
-import java.util.regex.Pattern;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitbay.v3.dto.trade.BitbayUserTrades;
 import org.knowm.xchange.bitbay.v3.dto.trade.BitbayUserTradesQuery;
@@ -12,17 +11,14 @@ import org.knowm.xchange.utils.ObjectMapperHelper;
 /** @author walec51 */
 public class BitbayTradeServiceRaw extends BitbayBaseService {
 
-  private static final Pattern WHITESPACES = Pattern.compile("\\s\\s");
-
   BitbayTradeServiceRaw(Exchange exchange) {
     super(exchange);
   }
 
   public BitbayUserTrades getBitbayTransactions(BitbayUserTradesQuery query)
       throws IOException, ExchangeException {
-    String jsonQuery = ObjectMapperHelper.toJSON(query);
-    jsonQuery = WHITESPACES.matcher(jsonQuery).replaceAll("");
-    BitbayUserTrades response =
+    final String jsonQuery = ObjectMapperHelper.toCompactJSON(query);
+    final BitbayUserTrades response =
         bitbayAuthenticated.getTransactionHistory(
             apiKey, sign, exchange.getNonceFactory(), UUID.randomUUID(), jsonQuery);
     checkError(response);


### PR DESCRIPTION
Use compact JSON instead of replacing whitespaces in String.

Issue: existing regexp is not replacing all whitespaces correctly, example (still new line in JSON):
```
{ "limit" : "300", "nextPageCursor" : "start", "markets" : [ ]
}
```

What is more, using the regex pattern is not necessary here, `ObjectMapperHelper.toCompactJSON` should be used.