### PR TITLE
Fix for issue 3692

### DIFF
--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAdapters.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAdapters.java
@@ -263,7 +263,7 @@ public final class BitstampAdapters {
       List<BitstampUserTransaction> userTransactions) {
     List<FundingRecord> fundingRecords = new ArrayList<>();
     for (BitstampUserTransaction trans : userTransactions) {
-      if (trans.isDeposit() || trans.isWithdrawal()) {
+      if (trans.isDeposit() || trans.isWithdrawal() || trans.isSubAccountTransfer()) {
         FundingRecord.Type type =
             trans.isDeposit() ? FundingRecord.Type.DEPOSIT : FundingRecord.Type.WITHDRAWAL;
         Map.Entry<String, BigDecimal> amount = BitstampAdapters.findNonzeroAmount(trans);

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAdapters.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAdapters.java
@@ -264,9 +264,23 @@ public final class BitstampAdapters {
     List<FundingRecord> fundingRecords = new ArrayList<>();
     for (BitstampUserTransaction trans : userTransactions) {
       if (trans.isDeposit() || trans.isWithdrawal() || trans.isSubAccountTransfer()) {
-        FundingRecord.Type type =
-            trans.isDeposit() ? FundingRecord.Type.DEPOSIT : FundingRecord.Type.WITHDRAWAL;
+
         Map.Entry<String, BigDecimal> amount = BitstampAdapters.findNonzeroAmount(trans);
+
+        FundingRecord.Type type = FundingRecord.Type.DEPOSIT;
+
+        if (trans.isWithdrawal()) {
+          type = FundingRecord.Type.WITHDRAWAL;
+        } else {
+          if (trans.isSubAccountTransfer()) {
+            if (amount.getValue().compareTo(BigDecimal.ZERO) > 0) {
+              type = FundingRecord.Type.INTERNAL_DEPOSIT;
+            } else {
+              type = FundingRecord.Type.INTERNAL_WITHDRAWAL;
+            }
+          }
+        }
+
         FundingRecord record =
             new FundingRecord(
                 null,

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/trade/BitstampUserTransaction.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/trade/BitstampUserTransaction.java
@@ -97,6 +97,10 @@ public final class BitstampUserTransaction {
     return type == TransactionType.trade;
   }
 
+  public boolean isSubAccountTransfer() {
+    return type == TransactionType.subAccountTransfer;
+  }
+
   public BigDecimal getCounterAmount() {
     return amounts.get(counter);
   }


### PR DESCRIPTION
Hi all.

This is a quite simple fix for issue : https://github.com/knowm/XChange/issues/3692

Basically I'm modifying the `BitstampUserTransaction` to add one function and then `BitstampAdapters` to handle this case.

I tested it locally (because I have Bitstamp subaccounts, which had sub account transfers and they were not showing up before the fix and are now showing up.

Best