### PR TITLE
Migration to ExchangeRestProxyBuilder

### DIFF
--- a/xchange-bankera/src/main/java/org/knowm/xchange/bankera/service/BankeraBaseService.java
+++ b/xchange-bankera/src/main/java/org/knowm/xchange/bankera/service/BankeraBaseService.java
@@ -5,9 +5,9 @@ import org.knowm.xchange.bankera.Bankera;
 import org.knowm.xchange.bankera.BankeraAuthenticated;
 import org.knowm.xchange.bankera.dto.BankeraException;
 import org.knowm.xchange.bankera.dto.BankeraToken;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BankeraBaseService extends BaseExchangeService implements BaseService {
 
@@ -15,18 +15,14 @@ public class BankeraBaseService extends BaseExchangeService implements BaseServi
   protected final BankeraAuthenticated bankeraAuthenticated;
 
   public BankeraBaseService(Exchange exchange) {
-
     super(exchange);
-
     bankera =
-        RestProxyFactory.createProxy(
-            Bankera.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
-
+        ExchangeRestProxyBuilder.forInterface(Bankera.class, exchange.getExchangeSpecification())
+            .build();
     bankeraAuthenticated =
-        RestProxyFactory.createProxy(
-            BankeraAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BankeraAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public BankeraToken createToken() throws BankeraException {

--- a/xchange-bibox/src/main/java/org/knowm/xchange/bibox/service/BiboxBaseService.java
+++ b/xchange-bibox/src/main/java/org/knowm/xchange/bibox/service/BiboxBaseService.java
@@ -3,11 +3,11 @@ package org.knowm.xchange.bibox.service;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bibox.BiboxAuthenticated;
 import org.knowm.xchange.bibox.dto.BiboxResponse;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BiboxBaseService extends BaseExchangeService implements BaseService {
 
@@ -23,10 +23,9 @@ public class BiboxBaseService extends BaseExchangeService implements BaseService
   protected BiboxBaseService(Exchange exchange) {
     super(exchange);
     this.bibox =
-        RestProxyFactory.createProxy(
-            BiboxAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BiboxAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =
         BiboxDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/service/BitbayBaseService.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/service/BitbayBaseService.java
@@ -5,11 +5,11 @@ import org.knowm.xchange.bitbay.Bitbay;
 import org.knowm.xchange.bitbay.BitbayAuthenticated;
 import org.knowm.xchange.bitbay.BitbayDigest;
 import org.knowm.xchange.bitbay.dto.BitbayBaseResponse;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BitbayBaseService extends BaseExchangeService implements BaseService {
   protected final Bitbay bitbay;
@@ -26,13 +26,12 @@ public class BitbayBaseService extends BaseExchangeService implements BaseServic
     super(exchange);
 
     bitbay =
-        RestProxyFactory.createProxy(
-            Bitbay.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Bitbay.class, exchange.getExchangeSpecification())
+            .build();
     bitbayAuthenticated =
-        RestProxyFactory.createProxy(
-            BitbayAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BitbayAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     sign = BitbayDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
     apiKey = exchange.getExchangeSpecification().getApiKey();
   }

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/service/BitbayBaseService.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/service/BitbayBaseService.java
@@ -6,11 +6,11 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitbay.v3.BitbayAuthenticated;
 import org.knowm.xchange.bitbay.v3.BitbayDigest;
 import org.knowm.xchange.bitbay.v3.dto.BitbayBaseResponse;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BitbayBaseService extends BaseExchangeService implements BaseService {
 
@@ -27,10 +27,9 @@ public class BitbayBaseService extends BaseExchangeService implements BaseServic
     super(exchange);
 
     bitbayAuthenticated =
-        RestProxyFactory.createProxy(
-            BitbayAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BitbayAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     sign = BitbayDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
     apiKey = exchange.getExchangeSpecification().getApiKey();
   }

--- a/xchange-bitcoinaverage/src/main/java/org/knowm/xchange/bitcoinaverage/service/BitcoinAverageMarketDataServiceRaw.java
+++ b/xchange-bitcoinaverage/src/main/java/org/knowm/xchange/bitcoinaverage/service/BitcoinAverageMarketDataServiceRaw.java
@@ -5,7 +5,7 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitcoinaverage.BitcoinAverage;
 import org.knowm.xchange.bitcoinaverage.dto.marketdata.BitcoinAverageTicker;
 import org.knowm.xchange.bitcoinaverage.dto.marketdata.BitcoinAverageTickers;
-import si.mazi.rescu.RestProxyFactory;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 
 /**
  * Implementation of the raw market data service for BitcoinAverage
@@ -27,10 +27,9 @@ public class BitcoinAverageMarketDataServiceRaw extends BitcoinAverageBaseServic
 
     super(exchange);
     this.bitcoinAverage =
-        RestProxyFactory.createProxy(
-            BitcoinAverage.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BitcoinAverage.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public BitcoinAverageTicker getBitcoinAverageTicker(String tradable, String currency)

--- a/xchange-bitcoincharts/src/main/java/org/knowm/xchange/bitcoincharts/service/BitcoinChartsMarketDataService.java
+++ b/xchange-bitcoincharts/src/main/java/org/knowm/xchange/bitcoincharts/service/BitcoinChartsMarketDataService.java
@@ -5,13 +5,13 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitcoincharts.BitcoinCharts;
 import org.knowm.xchange.bitcoincharts.BitcoinChartsAdapters;
 import org.knowm.xchange.bitcoincharts.dto.marketdata.BitcoinChartsTicker;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.service.marketdata.MarketDataService;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author timmolter */
 public class BitcoinChartsMarketDataService extends BitcoinChartsBaseService
@@ -25,13 +25,11 @@ public class BitcoinChartsMarketDataService extends BitcoinChartsBaseService
    * @param exchange
    */
   public BitcoinChartsMarketDataService(Exchange exchange) {
-
     super(exchange);
     this.bitcoinCharts =
-        RestProxyFactory.createProxy(
-            BitcoinCharts.class,
-            exchange.getExchangeSpecification().getPlainTextUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BitcoinCharts.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   @Override

--- a/xchange-bitcoincore/src/main/java/org/knowm/xchange/bitcoincore/service/BitcoinCoreAccountServiceRaw.java
+++ b/xchange-bitcoincore/src/main/java/org/knowm/xchange/bitcoincore/service/BitcoinCoreAccountServiceRaw.java
@@ -8,11 +8,11 @@ import org.knowm.xchange.bitcoincore.dto.BitcoinCoreException;
 import org.knowm.xchange.bitcoincore.dto.account.BitcoinCoreBalanceRequest;
 import org.knowm.xchange.bitcoincore.dto.account.BitcoinCoreBalanceResponse;
 import org.knowm.xchange.bitcoincore.dto.account.BitcoinCoreUnconfirmedBalanceRequest;
+import org.knowm.xchange.client.ClientConfigCustomizer;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.service.BaseExchangeService;
-import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.ClientConfigUtil;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BitcoinCoreAccountServiceRaw extends BaseExchangeService {
 
@@ -27,13 +27,15 @@ public class BitcoinCoreAccountServiceRaw extends BaseExchangeService {
 
     ExchangeSpecification specification = exchange.getExchangeSpecification();
 
-    ClientConfig config = getClientConfig();
     String user = specification.getUserName();
-    ClientConfigUtil.addBasicAuthCredentials(
-        config, user == null ? "" : user, specification.getPassword());
-
+    ClientConfigCustomizer clientConfigCustomizer =
+        config ->
+            ClientConfigUtil.addBasicAuthCredentials(
+                config, user == null ? "" : user, specification.getPassword());
     bitcoinCore =
-        RestProxyFactory.createProxy(BitcoinCore.class, specification.getPlainTextUri(), config);
+        ExchangeRestProxyBuilder.forInterface(BitcoinCore.class, specification)
+            .clientConfigCustomizer(clientConfigCustomizer)
+            .build();
   }
 
   public BitcoinCoreBalanceResponse getBalance() throws IOException {

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/service/BitcoindeBaseService.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/service/BitcoindeBaseService.java
@@ -3,11 +3,11 @@ package org.knowm.xchange.bitcoinde.service;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitcoinde.Bitcoinde;
 import org.knowm.xchange.bitcoinde.dto.BitcoindeException;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.RateLimitExceededException;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BitcoindeBaseService extends BaseExchangeService implements BaseService {
 
@@ -20,8 +20,8 @@ public class BitcoindeBaseService extends BaseExchangeService implements BaseSer
 
     super(exchange);
     this.bitcoinde =
-        RestProxyFactory.createProxy(
-            Bitcoinde.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Bitcoinde.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =
         BitcoindeDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(), apiKey);

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeBaseService.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/service/BitcoindeBaseService.java
@@ -7,7 +7,6 @@ import org.knowm.xchange.bitcoinde.v4.dto.BitcoindeException;
 import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BitcoindeBaseService extends BaseExchangeService<BitcoindeExchange>
     implements BaseService {
@@ -19,10 +18,8 @@ public class BitcoindeBaseService extends BaseExchangeService<BitcoindeExchange>
   protected BitcoindeBaseService(BitcoindeExchange exchange) {
     super(exchange);
     this.bitcoinde =
-        RestProxyFactory.createProxy(
-            Bitcoinde.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            ExchangeRestProxyBuilder.createClientConfig(exchange.getExchangeSpecification()));
+        ExchangeRestProxyBuilder.forInterface(Bitcoinde.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =
         BitcoindeDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(), apiKey);

--- a/xchange-bitcoinium/src/main/java/org/knowm/xchange/bitcoinium/service/BitcoiniumMarketDataServiceRaw.java
+++ b/xchange-bitcoinium/src/main/java/org/knowm/xchange/bitcoinium/service/BitcoiniumMarketDataServiceRaw.java
@@ -7,8 +7,8 @@ import org.knowm.xchange.bitcoinium.BitcoiniumUtils;
 import org.knowm.xchange.bitcoinium.dto.marketdata.BitcoiniumOrderbook;
 import org.knowm.xchange.bitcoinium.dto.marketdata.BitcoiniumTicker;
 import org.knowm.xchange.bitcoinium.dto.marketdata.BitcoiniumTickerHistory;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.utils.Assert;
-import si.mazi.rescu.RestProxyFactory;
 
 /**
  * Implementation of the raw market data service for Bitcoinium
@@ -30,8 +30,8 @@ public class BitcoiniumMarketDataServiceRaw extends BitcoiniumBaseService {
 
     super(exchange);
     this.bitcoinium =
-        RestProxyFactory.createProxy(
-            Bitcoinium.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Bitcoinium.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   /**

--- a/xchange-bitcointoyou/src/main/java/org/knowm/xchange/bitcointoyou/service/polling/BitcointoyouBasePollingService.java
+++ b/xchange-bitcointoyou/src/main/java/org/knowm/xchange/bitcointoyou/service/polling/BitcointoyouBasePollingService.java
@@ -4,10 +4,10 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitcointoyou.Bitcointoyou;
 import org.knowm.xchange.bitcointoyou.BitcointoyouAuthenticated;
 import org.knowm.xchange.bitcointoyou.service.BitcointoyouDigest;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author Jonathas Carrijo */
 public class BitcointoyouBasePollingService extends BaseExchangeService implements BaseService {
@@ -26,15 +26,17 @@ public class BitcointoyouBasePollingService extends BaseExchangeService implemen
 
     super(exchange);
     this.bitcointoyouAuthenticated =
-        RestProxyFactory.createProxy(
-            BitcointoyouAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+        ExchangeRestProxyBuilder.forInterface(
+                BitcointoyouAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =
         BitcointoyouDigest.createInstance(
             exchange.getExchangeSpecification().getSecretKey(), this.apiKey);
 
     this.bitcointoyou =
-        RestProxyFactory.createProxy(
-            Bitcointoyou.class, exchange.getExchangeSpecification().getSslUri());
+        ExchangeRestProxyBuilder.forInterface(
+                Bitcointoyou.class, exchange.getExchangeSpecification())
+            .build();
   }
 }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexBaseService.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexBaseService.java
@@ -4,10 +4,10 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitfinex.v1.BitfinexAuthenticated;
 import org.knowm.xchange.bitfinex.v1.BitfinexHmacPostBodyDigest;
 import org.knowm.xchange.bitfinex.v2.BitfinexHmacSignature;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BitfinexBaseService extends BaseExchangeService implements BaseService {
 
@@ -29,10 +29,9 @@ public class BitfinexBaseService extends BaseExchangeService implements BaseServ
     super(exchange);
 
     this.bitfinex =
-        RestProxyFactory.createProxy(
-            BitfinexAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BitfinexAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =
         BitfinexHmacPostBodyDigest.createInstance(
@@ -40,10 +39,10 @@ public class BitfinexBaseService extends BaseExchangeService implements BaseServ
     this.payloadCreator = new BitfinexPayloadDigest();
 
     this.bitfinexV2 =
-        RestProxyFactory.createProxy(
-            org.knowm.xchange.bitfinex.v2.BitfinexAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                org.knowm.xchange.bitfinex.v2.BitfinexAuthenticated.class,
+                exchange.getExchangeSpecification())
+            .build();
     this.signatureV2 =
         BitfinexHmacSignature.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }

--- a/xchange-bitflyer/src/main/java/org/knowm/xchange/bitflyer/service/BitflyerBaseService.java
+++ b/xchange-bitflyer/src/main/java/org/knowm/xchange/bitflyer/service/BitflyerBaseService.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.bitflyer.service;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitflyer.Bitflyer;
 import org.knowm.xchange.bitflyer.dto.BitflyerException;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.FundsExceededException;
 import org.knowm.xchange.exceptions.InternalServerException;
@@ -10,7 +11,6 @@ import org.knowm.xchange.exceptions.RateLimitExceededException;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BitflyerBaseService extends BaseExchangeService implements BaseService {
 
@@ -28,8 +28,8 @@ public class BitflyerBaseService extends BaseExchangeService implements BaseServ
     super(exchange);
 
     this.bitflyer =
-        RestProxyFactory.createProxy(
-            Bitflyer.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Bitflyer.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =
         BitflyerDigest.createInstance(

--- a/xchange-bithumb/src/main/java/org/knowm/xchange/bithumb/service/BithumbBaseService.java
+++ b/xchange-bithumb/src/main/java/org/knowm/xchange/bithumb/service/BithumbBaseService.java
@@ -3,10 +3,10 @@ package org.knowm.xchange.bithumb.service;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bithumb.Bithumb;
 import org.knowm.xchange.bithumb.BithumbAuthenticated;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BithumbBaseService extends BaseExchangeService implements BaseService {
 
@@ -25,14 +25,15 @@ public class BithumbBaseService extends BaseExchangeService implements BaseServi
     super(exchange);
 
     this.bithumbAuthenticated =
-        RestProxyFactory.createProxy(
-            BithumbAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+        ExchangeRestProxyBuilder.forInterface(
+                BithumbAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =
         BithumbDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
     this.bithumb =
-        RestProxyFactory.createProxy(
-            Bithumb.class, exchange.getExchangeSpecification().getSslUri());
+        ExchangeRestProxyBuilder.forInterface(Bithumb.class, exchange.getExchangeSpecification())
+            .build();
     this.endpointGenerator = new BithumbEndpointGenerator();
   }
 }

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexBaseService.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexBaseService.java
@@ -7,12 +7,16 @@ import org.knowm.xchange.bitmex.BitmexAuthenticated;
 import org.knowm.xchange.bitmex.BitmexException;
 import org.knowm.xchange.bitmex.BitmexExchange;
 import org.knowm.xchange.bitmex.RateLimitUpdateListener;
-import org.knowm.xchange.exceptions.*;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
+import org.knowm.xchange.exceptions.ExchangeException;
+import org.knowm.xchange.exceptions.FundsExceededException;
+import org.knowm.xchange.exceptions.InternalServerException;
+import org.knowm.xchange.exceptions.RateLimitExceededException;
+import org.knowm.xchange.exceptions.SystemOverloadException;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.HttpResponseAware;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 @SuppressWarnings({"WeakerAccess", "unused"})
 public class BitmexBaseService extends BaseExchangeService<BitmexExchange> implements BaseService {
@@ -29,13 +33,11 @@ public class BitmexBaseService extends BaseExchangeService<BitmexExchange> imple
    * @param exchange
    */
   public BitmexBaseService(BitmexExchange exchange) {
-
     super(exchange);
     bitmex =
-        RestProxyFactory.createProxy(
-            BitmexAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BitmexAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     signatureCreator =
         BitmexDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }

--- a/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/BitsoAccountServiceRaw.java
+++ b/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/BitsoAccountServiceRaw.java
@@ -6,9 +6,9 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitso.BitsoAuthenticated;
 import org.knowm.xchange.bitso.dto.account.BitsoBalance;
 import org.knowm.xchange.bitso.dto.account.BitsoDepositAddress;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.exceptions.ExchangeException;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BitsoAccountServiceRaw extends BitsoBaseService {
 
@@ -19,10 +19,9 @@ public class BitsoAccountServiceRaw extends BitsoBaseService {
     super(exchange);
 
     this.bitsoAuthenticated =
-        RestProxyFactory.createProxy(
-            BitsoAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BitsoAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.signatureCreator =
         BitsoDigest.createInstance(
             exchange.getExchangeSpecification().getSecretKey(),

--- a/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/BitsoMarketDataServiceRaw.java
+++ b/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/BitsoMarketDataServiceRaw.java
@@ -6,9 +6,9 @@ import org.knowm.xchange.bitso.Bitso;
 import org.knowm.xchange.bitso.dto.marketdata.BitsoOrderBook;
 import org.knowm.xchange.bitso.dto.marketdata.BitsoTicker;
 import org.knowm.xchange.bitso.dto.marketdata.BitsoTransaction;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.exceptions.ExchangeException;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author Piotr Ładyżyński */
 public class BitsoMarketDataServiceRaw extends BitsoBaseService {
@@ -18,8 +18,8 @@ public class BitsoMarketDataServiceRaw extends BitsoBaseService {
   public BitsoMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
     this.bitso =
-        RestProxyFactory.createProxy(
-            Bitso.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Bitso.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public BitsoOrderBook getBitsoOrderBook(CurrencyPair pair) throws IOException {

--- a/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/BitsoTradeServiceRaw.java
+++ b/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/BitsoTradeServiceRaw.java
@@ -6,7 +6,7 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitso.BitsoAuthenticated;
 import org.knowm.xchange.bitso.dto.trade.BitsoOrder;
 import org.knowm.xchange.bitso.dto.trade.BitsoUserTransaction;
-import si.mazi.rescu.RestProxyFactory;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 
 /** @author Piotr Ładyżyński */
 public class BitsoTradeServiceRaw extends BitsoBaseService {
@@ -19,10 +19,9 @@ public class BitsoTradeServiceRaw extends BitsoBaseService {
 
     super(exchange);
     this.bitsoAuthenticated =
-        RestProxyFactory.createProxy(
-            BitsoAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BitsoAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.signatureCreator =
         BitsoDigest.createInstance(
             exchange.getExchangeSpecification().getSecretKey(),

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountServiceRaw.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountServiceRaw.java
@@ -20,11 +20,11 @@ import org.knowm.xchange.bitstamp.dto.account.BitstampWithdrawal;
 import org.knowm.xchange.bitstamp.dto.account.DepositTransaction;
 import org.knowm.xchange.bitstamp.dto.account.WithdrawalRequest;
 import org.knowm.xchange.bitstamp.dto.trade.BitstampUserTransaction;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.FundsExceededException;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 /** @author gnandiga */
@@ -47,15 +47,13 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
     super(exchange);
 
     this.bitstampAuthenticated =
-        RestProxyFactory.createProxy(
-            BitstampAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BitstampAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.bitstampAuthenticatedV2 =
-        RestProxyFactory.createProxy(
-            BitstampAuthenticatedV2.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BitstampAuthenticatedV2.class, exchange.getExchangeSpecification())
+            .build();
 
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampMarketDataServiceRaw.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampMarketDataServiceRaw.java
@@ -9,8 +9,8 @@ import org.knowm.xchange.bitstamp.dto.marketdata.BitstampOrderBook;
 import org.knowm.xchange.bitstamp.dto.marketdata.BitstampPairInfo;
 import org.knowm.xchange.bitstamp.dto.marketdata.BitstampTicker;
 import org.knowm.xchange.bitstamp.dto.marketdata.BitstampTransaction;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.CurrencyPair;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author gnandiga */
 public class BitstampMarketDataServiceRaw extends BitstampBaseService {
@@ -21,8 +21,8 @@ public class BitstampMarketDataServiceRaw extends BitstampBaseService {
 
     super(exchange);
     this.bitstampV2 =
-        RestProxyFactory.createProxy(
-            BitstampV2.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(BitstampV2.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public BitstampTicker getBitstampTicker(CurrencyPair pair) throws IOException {

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeServiceRaw.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeServiceRaw.java
@@ -10,8 +10,8 @@ import org.knowm.xchange.bitstamp.dto.BitstampException;
 import org.knowm.xchange.bitstamp.dto.trade.BitstampOrder;
 import org.knowm.xchange.bitstamp.dto.trade.BitstampOrderStatusResponse;
 import org.knowm.xchange.bitstamp.dto.trade.BitstampUserTransaction;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.CurrencyPair;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 /** @author gnandiga */
@@ -20,22 +20,20 @@ public class BitstampTradeServiceRaw extends BitstampBaseService {
   private final BitstampAuthenticated bitstampAuthenticated;
   private final BitstampAuthenticatedV2 bitstampAuthenticatedV2;
   private final BitstampDigest signatureCreator;
-  private String apiKey;
-  private SynchronizedValueFactory<Long> nonceFactory;
+  private final String apiKey;
+  private final SynchronizedValueFactory<Long> nonceFactory;
 
   public BitstampTradeServiceRaw(Exchange exchange) {
 
     super(exchange);
     this.bitstampAuthenticated =
-        RestProxyFactory.createProxy(
-            BitstampAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BitstampAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.bitstampAuthenticatedV2 =
-        RestProxyFactory.createProxy(
-            BitstampAuthenticatedV2.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BitstampAuthenticatedV2.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.nonceFactory = exchange.getNonceFactory();
     this.signatureCreator =

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexBaseService.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexBaseService.java
@@ -4,10 +4,10 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bittrex.BittrexAuthenticated;
 import org.knowm.xchange.bittrex.BittrexAuthenticatedV3;
 import org.knowm.xchange.bittrex.BittrexV2;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BittrexBaseService extends BaseExchangeService implements BaseService {
 
@@ -25,22 +25,22 @@ public class BittrexBaseService extends BaseExchangeService implements BaseServi
    * @param exchange
    */
   public BittrexBaseService(Exchange exchange) {
-
     super(exchange);
 
     this.bittrexAuthenticated =
-        RestProxyFactory.createProxy(
-            BittrexAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BittrexAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
+    final String bittrexV3BaseUrl =
+        (String) exchange.getExchangeSpecification().getParameter("rest.v3.url");
     this.bittrexAuthenticatedV3 =
-        RestProxyFactory.createProxy(
-            BittrexAuthenticatedV3.class,
-            (String) exchange.getExchangeSpecification().getParameter("rest.v3.url"),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BittrexAuthenticatedV3.class, exchange.getExchangeSpecification())
+            .baseUrl(bittrexV3BaseUrl)
+            .build();
     this.bittrexV2 =
-        RestProxyFactory.createProxy(
-            BittrexV2.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(BittrexV2.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =
         BittrexDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexBaseService.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/service/BittrexBaseService.java
@@ -6,7 +6,6 @@ import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BittrexBaseService extends BaseExchangeService<BittrexExchange>
     implements BaseService {
@@ -25,10 +24,9 @@ public class BittrexBaseService extends BaseExchangeService<BittrexExchange>
 
     super(exchange);
     this.bittrexAuthenticated =
-        RestProxyFactory.createProxy(
-            BittrexAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            ExchangeRestProxyBuilder.createClientConfig(exchange.getExchangeSpecification()));
+        ExchangeRestProxyBuilder.forInterface(
+                BittrexAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.contentCreator =
         BittrexContentDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());

--- a/xchange-bity/src/main/java/org/knowm/xchange/bity/service/BityBaseService.java
+++ b/xchange-bity/src/main/java/org/knowm/xchange/bity/service/BityBaseService.java
@@ -4,9 +4,9 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bity.BityAuthenticated;
 import org.knowm.xchange.bity.dto.BityException;
 import org.knowm.xchange.bity.dto.account.BityToken;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BityBaseService extends BaseExchangeService implements BaseService {
 
@@ -18,14 +18,12 @@ public class BityBaseService extends BaseExchangeService implements BaseService 
    * @param exchange
    */
   protected BityBaseService(Exchange exchange) {
-
     super(exchange);
 
     bity =
-        RestProxyFactory.createProxy(
-            BityAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BityAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public BityToken createToken() throws BityException {

--- a/xchange-bitz/src/main/java/org/knowm/xchange/bitz/service/BitZBaseService.java
+++ b/xchange-bitz/src/main/java/org/knowm/xchange/bitz/service/BitZBaseService.java
@@ -2,9 +2,9 @@ package org.knowm.xchange.bitz.service;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitz.BitZ;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BitZBaseService extends BaseExchangeService implements BaseService {
 
@@ -13,6 +13,7 @@ public class BitZBaseService extends BaseExchangeService implements BaseService 
   public BitZBaseService(Exchange exchange) {
     super(exchange);
     this.bitz =
-        RestProxyFactory.createProxy(BitZ.class, exchange.getExchangeSpecification().getSslUri());
+        ExchangeRestProxyBuilder.forInterface(BitZ.class, exchange.getExchangeSpecification())
+            .build();
   }
 }

--- a/xchange-bitz/src/main/java/org/knowm/xchange/bitz/service/BitZTradeServiceRaw.java
+++ b/xchange-bitz/src/main/java/org/knowm/xchange/bitz/service/BitZTradeServiceRaw.java
@@ -9,9 +9,9 @@ import org.knowm.xchange.bitz.BitZAuthenticated;
 import org.knowm.xchange.bitz.dto.account.result.BitZUserAssetsResult;
 import org.knowm.xchange.bitz.dto.marketdata.BitZPublicOrder;
 import org.knowm.xchange.bitz.dto.trade.result.*;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 public class BitZTradeServiceRaw extends BitZBaseService {
@@ -29,10 +29,12 @@ public class BitZTradeServiceRaw extends BitZBaseService {
     super(exchange);
 
     this.bitz =
-        RestProxyFactory.createProxy(BitZ.class, exchange.getExchangeSpecification().getSslUri());
+        ExchangeRestProxyBuilder.forInterface(BitZ.class, exchange.getExchangeSpecification())
+            .build();
     this.bitzAuthenticated =
-        RestProxyFactory.createProxy(
-            BitZAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+        ExchangeRestProxyBuilder.forInterface(
+                BitZAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
 
     // TODO: Implement Password
     this.tradePwd = "";

--- a/xchange-bl3p/src/main/java/org/knowm/xchange/bl3p/service/Bl3pBaseService.java
+++ b/xchange-bl3p/src/main/java/org/knowm/xchange/bl3p/service/Bl3pBaseService.java
@@ -2,10 +2,10 @@ package org.knowm.xchange.bl3p.service;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bl3p.Bl3pAuthenticated;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 public class Bl3pBaseService extends BaseExchangeService implements BaseService {
@@ -20,10 +20,9 @@ public class Bl3pBaseService extends BaseExchangeService implements BaseService 
 
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.bl3p =
-        RestProxyFactory.createProxy(
-            Bl3pAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                Bl3pAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.nonceFactory = this.exchange.getNonceFactory();
     this.signatureCreator =
         Bl3pDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());

--- a/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/service/BleutradeBaseService.java
+++ b/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/service/BleutradeBaseService.java
@@ -2,6 +2,7 @@ package org.knowm.xchange.bleutrade.service;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bleutrade.BleutradeAuthenticated;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.IRestProxyFactory;
@@ -23,10 +24,10 @@ public class BleutradeBaseService extends BaseExchangeService implements BaseSer
     super(exchange);
 
     this.bleutrade =
-        restProxyFactory.createProxy(
-            BleutradeAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BleutradeAuthenticated.class, exchange.getExchangeSpecification())
+            .restProxyFactory(restProxyFactory)
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =
         BleutradeDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());

--- a/xchange-blockchain/src/main/java/org/knowm/xchange/blockchain/service/BlockchainBaseService.java
+++ b/xchange-blockchain/src/main/java/org/knowm/xchange/blockchain/service/BlockchainBaseService.java
@@ -2,9 +2,9 @@ package org.knowm.xchange.blockchain.service;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.blockchain.Blockchain;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BlockchainBaseService extends BaseExchangeService implements BaseService {
 
@@ -14,8 +14,8 @@ public class BlockchainBaseService extends BaseExchangeService implements BaseSe
   protected BlockchainBaseService(Exchange exchange) {
     super(exchange);
     this.blockchain =
-        RestProxyFactory.createProxy(
-            Blockchain.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Blockchain.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
   }
 }

--- a/xchange-btcc/src/main/java/org/knowm/xchange/btcc/service/BTCCBaseService.java
+++ b/xchange-btcc/src/main/java/org/knowm/xchange/btcc/service/BTCCBaseService.java
@@ -3,9 +3,9 @@ package org.knowm.xchange.btcc.service;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.btcc.BTCC;
 import org.knowm.xchange.btcc.BTCCExchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BTCCBaseService<T extends BTCC> extends BaseExchangeService implements BaseService {
 
@@ -13,13 +13,14 @@ public class BTCCBaseService<T extends BTCC> extends BaseExchangeService impleme
 
   protected BTCCBaseService(Exchange exchange, Class<T> type) {
     super(exchange);
-    this.btcc =
-        RestProxyFactory.createProxy(
-            type,
+    final String baseUrl =
+        (String)
             exchange
                 .getExchangeSpecification()
-                .getExchangeSpecificParametersItem(BTCCExchange.DATA_API_URI_KEY)
-                .toString(),
-            getClientConfig());
+                .getExchangeSpecificParametersItem(BTCCExchange.DATA_API_URI_KEY);
+    this.btcc =
+        ExchangeRestProxyBuilder.forInterface(type, exchange.getExchangeSpecification())
+            .baseUrl(baseUrl)
+            .build();
   }
 }

--- a/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/BTCMarketsBaseService.java
+++ b/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/BTCMarketsBaseService.java
@@ -5,9 +5,9 @@ import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.btcmarkets.BTCMarkets;
 import org.knowm.xchange.btcmarkets.BTCMarketsAuthenticated;
 import org.knowm.xchange.btcmarkets.BTCMarketsAuthenticatedV3;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 public class BTCMarketsBaseService extends BaseExchangeService implements BaseService {
@@ -23,15 +23,12 @@ public class BTCMarketsBaseService extends BaseExchangeService implements BaseSe
   public BTCMarketsBaseService(Exchange exchange) {
     super(exchange);
     final ExchangeSpecification spec = exchange.getExchangeSpecification();
-    this.btcm =
-        RestProxyFactory.createProxy(
-            BTCMarketsAuthenticated.class, spec.getSslUri(), getClientConfig());
+    this.btcm = ExchangeRestProxyBuilder.forInterface(BTCMarketsAuthenticated.class, spec).build();
     this.btcmv3 =
-        RestProxyFactory.createProxy(
-            BTCMarketsAuthenticatedV3.class, spec.getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(BTCMarketsAuthenticatedV3.class, spec).build();
     this.btcmPublic =
-        RestProxyFactory.createProxy(
-            BTCMarkets.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(BTCMarkets.class, exchange.getExchangeSpecification())
+            .build();
     if (spec.getSecretKey() != null) {
       this.signerV1 = new BTCMarketsDigest(spec.getSecretKey(), false);
       this.signerV2 = new BTCMarketsDigest(spec.getSecretKey(), true);

--- a/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/service/BTCMarketsMarketDataServiceTest.java
+++ b/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/service/BTCMarketsMarketDataServiceTest.java
@@ -15,9 +15,12 @@ import org.junit.runner.RunWith;
 import org.knowm.xchange.ExchangeFactory;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.btcmarkets.BTCMarkets;
+import org.knowm.xchange.btcmarkets.BTCMarketsAuthenticated;
+import org.knowm.xchange.btcmarkets.BTCMarketsAuthenticatedV3;
 import org.knowm.xchange.btcmarkets.BTCMarketsExchange;
 import org.knowm.xchange.btcmarkets.BtcMarketsAssert;
 import org.knowm.xchange.btcmarkets.dto.marketdata.BTCMarketsOrderBook;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
@@ -26,10 +29,9 @@ import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import si.mazi.rescu.RestProxyFactory;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(RestProxyFactory.class)
+@PrepareForTest(ExchangeRestProxyBuilder.class)
 public class BTCMarketsMarketDataServiceTest extends BTCMarketsTestSupport {
 
   private BTCMarkets btcmarkets;
@@ -38,9 +40,31 @@ public class BTCMarketsMarketDataServiceTest extends BTCMarketsTestSupport {
   @Before
   public void setUp() {
     btcmarkets = mock(BTCMarkets.class);
-    PowerMockito.mockStatic(RestProxyFactory.class);
-    given(RestProxyFactory.createProxy(eq(BTCMarkets.class), any(), any(), any()))
-        .willReturn(btcmarkets);
+    BTCMarketsAuthenticated btcMarketsAuthenticated = mock(BTCMarketsAuthenticated.class);
+    BTCMarketsAuthenticatedV3 btcMarketsAuthenticatedV3 = mock(BTCMarketsAuthenticatedV3.class);
+    PowerMockito.mockStatic(ExchangeRestProxyBuilder.class);
+
+    ExchangeRestProxyBuilder<BTCMarkets> exchangeRestProxyBuilderBtcMarketsMock =
+        mock(ExchangeRestProxyBuilder.class);
+    given(ExchangeRestProxyBuilder.forInterface(eq(BTCMarkets.class), any()))
+        .willReturn(exchangeRestProxyBuilderBtcMarketsMock);
+    given(exchangeRestProxyBuilderBtcMarketsMock.build()).willReturn(btcmarkets);
+
+    ExchangeRestProxyBuilder<BTCMarketsAuthenticated>
+        exchangeRestProxyBuilderBTCMarketsAuthenticatedMock = mock(ExchangeRestProxyBuilder.class);
+    given(ExchangeRestProxyBuilder.forInterface(eq(BTCMarketsAuthenticated.class), any()))
+        .willReturn(exchangeRestProxyBuilderBTCMarketsAuthenticatedMock);
+    given(exchangeRestProxyBuilderBTCMarketsAuthenticatedMock.build())
+        .willReturn(btcMarketsAuthenticated);
+
+    ExchangeRestProxyBuilder<BTCMarketsAuthenticatedV3>
+        exchangeRestProxyBuilderBTCMarketsAuthenticatedV3Mock =
+            mock(ExchangeRestProxyBuilder.class);
+    given(ExchangeRestProxyBuilder.forInterface(eq(BTCMarketsAuthenticatedV3.class), any()))
+        .willReturn(exchangeRestProxyBuilderBTCMarketsAuthenticatedV3Mock);
+    given(exchangeRestProxyBuilderBTCMarketsAuthenticatedV3Mock.build())
+        .willReturn(btcMarketsAuthenticatedV3);
+
     BTCMarketsExchange exchange =
         (BTCMarketsExchange)
             ExchangeFactory.INSTANCE.createExchange(BTCMarketsExchange.class.getCanonicalName());

--- a/xchange-btctrade/src/main/java/org/knowm/xchange/btctrade/service/BTCTradeBaseService.java
+++ b/xchange-btctrade/src/main/java/org/knowm/xchange/btctrade/service/BTCTradeBaseService.java
@@ -3,11 +3,11 @@ package org.knowm.xchange.btctrade.service;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.btctrade.BTCTrade;
+import org.knowm.xchange.client.ClientConfigCustomizer;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import org.knowm.xchange.utils.CertHelper;
-import si.mazi.rescu.ClientConfig;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BTCTradeBaseService extends BaseExchangeService implements BaseService {
 
@@ -24,15 +24,18 @@ public class BTCTradeBaseService extends BaseExchangeService implements BaseServ
 
     ExchangeSpecification exchangeSpecification = exchange.getExchangeSpecification();
 
-    ClientConfig config = getClientConfig();
     // btctrade is using an ssl certificate for 33option.com
-    config.setHostnameVerifier(
-        CertHelper.createIncorrectHostnameVerifier(
-            exchangeSpecification.getHost(),
-            "CN=www.33option.com,OU=IT,O=OPTIONFORTUNE TRADE LIMITED,L=KOWLOON,ST=HONGKONG,C=HK"));
+    ClientConfigCustomizer clientConfigCustomizer =
+        config ->
+            config.setHostnameVerifier(
+                CertHelper.createIncorrectHostnameVerifier(
+                    exchangeSpecification.getHost(),
+                    "CN=www.33option.com,OU=IT,O=OPTIONFORTUNE TRADE LIMITED,L=KOWLOON,ST=HONGKONG,C=HK"));
 
     btcTrade =
-        RestProxyFactory.createProxy(BTCTrade.class, exchangeSpecification.getSslUri(), config);
+        ExchangeRestProxyBuilder.forInterface(BTCTrade.class, exchangeSpecification)
+            .clientConfigCustomizer(clientConfigCustomizer)
+            .build();
   }
 
   protected long toLong(Object object) {

--- a/xchange-btcturk/src/main/java/org/knowm/xchange/btcturk/service/BTCTurkBaseService.java
+++ b/xchange-btcturk/src/main/java/org/knowm/xchange/btcturk/service/BTCTurkBaseService.java
@@ -2,10 +2,10 @@ package org.knowm.xchange.btcturk.service;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.btcturk.BTCTurkAuthenticated;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 /**
  * @author semihunaldi
@@ -21,10 +21,9 @@ public class BTCTurkBaseService extends BaseExchangeService implements BaseServi
     super(exchange);
 
     btcTurk =
-        RestProxyFactory.createProxy(
-            BTCTurkAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BTCTurkAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     signatureCreator =
         BTCTurkDigest.createInstance(
             exchange.getExchangeSpecification().getSecretKey(),

--- a/xchange-bx/src/main/java/org/knowm/xchange/bx/service/BxBaseService.java
+++ b/xchange-bx/src/main/java/org/knowm/xchange/bx/service/BxBaseService.java
@@ -3,11 +3,11 @@ package org.knowm.xchange.bx.service;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bx.BxAuthenticated;
 import org.knowm.xchange.bx.dto.BxResult;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BxBaseService extends BaseExchangeService implements BaseService {
 
@@ -17,10 +17,9 @@ public class BxBaseService extends BaseExchangeService implements BaseService {
   public BxBaseService(Exchange exchange) {
     super(exchange);
     bx =
-        RestProxyFactory.createProxy(
-            BxAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                BxAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     signatureCreator = BxDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }
 

--- a/xchange-campbx/src/main/java/org/knowm/xchange/campbx/service/CampBXBaseService.java
+++ b/xchange-campbx/src/main/java/org/knowm/xchange/campbx/service/CampBXBaseService.java
@@ -2,11 +2,11 @@ package org.knowm.xchange.campbx.service;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.campbx.CampBX;
+import org.knowm.xchange.client.ClientConfigCustomizer;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import org.knowm.xchange.utils.CertHelper;
-import si.mazi.rescu.ClientConfig;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author timmolter */
 public class CampBXBaseService extends BaseExchangeService implements BaseService {
@@ -22,12 +22,15 @@ public class CampBXBaseService extends BaseExchangeService implements BaseServic
 
     super(exchange);
 
-    ClientConfig config = getClientConfig();
     // campbx server raises "internal error" if connected via these protocol versions
-    config.setSslSocketFactory(CertHelper.createRestrictedSSLSocketFactory("TLSv1", "TLSv1.1"));
+    ClientConfigCustomizer clientConfigCustomizer =
+        config ->
+            config.setSslSocketFactory(
+                CertHelper.createRestrictedSSLSocketFactory("TLSv1", "TLSv1.1"));
 
     this.campBX =
-        RestProxyFactory.createProxy(
-            CampBX.class, exchange.getExchangeSpecification().getSslUri(), config);
+        ExchangeRestProxyBuilder.forInterface(CampBX.class, exchange.getExchangeSpecification())
+            .clientConfigCustomizer(clientConfigCustomizer)
+            .build();
   }
 }

--- a/xchange-ccex/src/main/java/org/knowm/xchange/ccex/service/CCEXBaseService.java
+++ b/xchange-ccex/src/main/java/org/knowm/xchange/ccex/service/CCEXBaseService.java
@@ -2,10 +2,10 @@ package org.knowm.xchange.ccex.service;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ccex.CCEXAuthenticated;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author Andraž Prinčič */
 public class CCEXBaseService extends BaseExchangeService implements BaseService {
@@ -24,10 +24,9 @@ public class CCEXBaseService extends BaseExchangeService implements BaseService 
     super(exchange);
 
     this.cCEXAuthenticated =
-        RestProxyFactory.createProxy(
-            CCEXAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CCEXAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =
         CCEXDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());

--- a/xchange-ccex/src/main/java/org/knowm/xchange/ccex/service/CCEXMarketDataServiceRaw.java
+++ b/xchange-ccex/src/main/java/org/knowm/xchange/ccex/service/CCEXMarketDataServiceRaw.java
@@ -10,8 +10,8 @@ import org.knowm.xchange.ccex.dto.marketdata.CCEXMarkets;
 import org.knowm.xchange.ccex.dto.marketdata.CCEXTrades;
 import org.knowm.xchange.ccex.dto.ticker.CCEXPriceResponse;
 import org.knowm.xchange.ccex.dto.ticker.CCEXTickerResponse;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.CurrencyPair;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author Andraž Prinčič */
 public class CCEXMarketDataServiceRaw extends CCEXBaseService {
@@ -21,8 +21,8 @@ public class CCEXMarketDataServiceRaw extends CCEXBaseService {
   public CCEXMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
     this.ccex =
-        RestProxyFactory.createProxy(
-            CCEX.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(CCEX.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public CCEXGetorderbook getCCEXOrderBook(CurrencyPair pair, int depth) throws IOException {

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOBaseService.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOBaseService.java
@@ -2,9 +2,9 @@ package org.knowm.xchange.cexio.service;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.cexio.CexIOAuthenticated;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author timmolter */
 public class CexIOBaseService extends BaseExchangeService implements BaseService {
@@ -22,8 +22,9 @@ public class CexIOBaseService extends BaseExchangeService implements BaseService
     super(exchange);
 
     cexIOAuthenticated =
-        RestProxyFactory.createProxy(
-            CexIOAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+        ExchangeRestProxyBuilder.forInterface(
+                CexIOAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     signatureCreator =
         CexIODigest.createInstance(
             exchange.getExchangeSpecification().getSecretKey(),

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOMarketDataServiceRaw.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOMarketDataServiceRaw.java
@@ -8,8 +8,8 @@ import org.knowm.xchange.cexio.dto.marketdata.CexIOCurrencyLimits;
 import org.knowm.xchange.cexio.dto.marketdata.CexIODepth;
 import org.knowm.xchange.cexio.dto.marketdata.CexIOTicker;
 import org.knowm.xchange.cexio.dto.marketdata.CexIOTrade;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.CurrencyPair;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author timmolter */
 public class CexIOMarketDataServiceRaw extends CexIOBaseService {
@@ -26,8 +26,8 @@ public class CexIOMarketDataServiceRaw extends CexIOBaseService {
     super(exchange);
 
     this.cexio =
-        RestProxyFactory.createProxy(
-            CexIO.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(CexIO.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   List<CexIOTicker> getAllCexIOTickers() throws IOException {

--- a/xchange-cobinhood/src/main/java/org/knowm/xchange/cobinhood/service/CobinhoodBaseService.java
+++ b/xchange-cobinhood/src/main/java/org/knowm/xchange/cobinhood/service/CobinhoodBaseService.java
@@ -1,10 +1,10 @@
 package org.knowm.xchange.cobinhood.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.cobinhood.CobinhoodAuthenticated;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class CobinhoodBaseService extends BaseExchangeService implements BaseService {
 
@@ -19,10 +19,9 @@ public class CobinhoodBaseService extends BaseExchangeService implements BaseSer
   protected CobinhoodBaseService(Exchange exchange) {
     super(exchange);
     this.cobinhood =
-        RestProxyFactory.createProxy(
-            CobinhoodAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CobinhoodAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
   }
 }

--- a/xchange-coinbase/src/main/java/org/knowm/xchange/coinbase/service/CoinbaseBaseService.java
+++ b/xchange-coinbase/src/main/java/org/knowm/xchange/coinbase/service/CoinbaseBaseService.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.coinbase.service;
 import java.io.IOException;
 import java.util.List;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinbase.CoinbaseAuthenticated;
 import org.knowm.xchange.coinbase.dto.CoinbaseBaseResponse;
 import org.knowm.xchange.coinbase.dto.account.CoinbaseToken;
@@ -12,7 +13,6 @@ import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author jamespedwards42 */
 public class CoinbaseBaseService extends BaseExchangeService implements BaseService {
@@ -30,10 +30,9 @@ public class CoinbaseBaseService extends BaseExchangeService implements BaseServ
     super(exchange);
 
     coinbase =
-        RestProxyFactory.createProxy(
-            CoinbaseAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CoinbaseAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     signatureCreator =
         CoinbaseDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }

--- a/xchange-coinbase/src/main/java/org/knowm/xchange/coinbase/v2/service/CoinbaseBaseService.java
+++ b/xchange-coinbase/src/main/java/org/knowm/xchange/coinbase/v2/service/CoinbaseBaseService.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import javax.ws.rs.core.MediaType;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinbase.v2.Coinbase;
 import org.knowm.xchange.coinbase.v2.CoinbaseAuthenticated;
 import org.knowm.xchange.coinbase.v2.CoinbaseV2Digest;
@@ -13,7 +14,6 @@ import org.knowm.xchange.coinbase.v2.dto.marketdata.CoinbaseTimeData.CoinbaseTim
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import org.knowm.xchange.utils.HmacDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class CoinbaseBaseService extends BaseExchangeService implements BaseService {
 
@@ -24,10 +24,9 @@ public class CoinbaseBaseService extends BaseExchangeService implements BaseServ
 
     super(exchange);
     coinbase =
-        RestProxyFactory.createProxy(
-            CoinbaseAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CoinbaseAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
 
     signatureCreator2 =
         CoinbaseV2Digest.createInstance(exchange.getExchangeSpecification().getSecretKey());

--- a/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/dto/trade/CoinbaseProTradeHistoryParams.java
+++ b/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/dto/trade/CoinbaseProTradeHistoryParams.java
@@ -7,8 +7,11 @@ import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamLimit;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamTransactionId;
 
-public class CoinbaseProTradeHistoryParams implements TradeHistoryParamTransactionId, TradeHistoryParamCurrencyPair,
-    TradeHistoryParamLimit, HistoryParamsFundingType {
+public class CoinbaseProTradeHistoryParams
+    implements TradeHistoryParamTransactionId,
+        TradeHistoryParamCurrencyPair,
+        TradeHistoryParamLimit,
+        HistoryParamsFundingType {
 
   private CurrencyPair currencyPair;
   private String txId;

--- a/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/service/CoinbaseProBaseService.java
+++ b/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/service/CoinbaseProBaseService.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.coinbasepro.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinbasepro.CoinbasePro;
 import org.knowm.xchange.coinbasepro.dto.CoinbaseProException;
 import org.knowm.xchange.exceptions.ExchangeException;
@@ -10,7 +11,6 @@ import org.knowm.xchange.exceptions.RateLimitExceededException;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class CoinbaseProBaseService extends BaseExchangeService implements BaseService {
 
@@ -24,8 +24,9 @@ public class CoinbaseProBaseService extends BaseExchangeService implements BaseS
 
     super(exchange);
     coinbasePro =
-        RestProxyFactory.createProxy(
-            CoinbasePro.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CoinbasePro.class, exchange.getExchangeSpecification())
+            .build();
     digest = CoinbaseProDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
     apiKey = exchange.getExchangeSpecification().getApiKey();
     passphrase =

--- a/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/service/CoinbeneBaseService.java
+++ b/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/service/CoinbeneBaseService.java
@@ -6,12 +6,12 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Map;
 import java.util.TreeMap;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinbene.CoinbeneAuthenticated;
 import org.knowm.xchange.coinbene.CoinbeneException;
 import org.knowm.xchange.coinbene.dto.CoinbeneResponse;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class CoinbeneBaseService extends BaseExchangeService implements BaseService {
 
@@ -29,10 +29,9 @@ public class CoinbeneBaseService extends BaseExchangeService implements BaseServ
   protected CoinbeneBaseService(Exchange exchange) {
     super(exchange);
     this.coinbene =
-        RestProxyFactory.createProxy(
-            CoinbeneAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CoinbeneAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.secretKey = exchange.getExchangeSpecification().getSecretKey();
   }

--- a/xchange-coindeal/src/main/java/org/knowm/xchange/coindeal/service/CoindealBaseService.java
+++ b/xchange-coindeal/src/main/java/org/knowm/xchange/coindeal/service/CoindealBaseService.java
@@ -1,11 +1,11 @@
 package org.knowm.xchange.coindeal.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coindeal.CoindealAuthenticated;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class CoindealBaseService extends BaseExchangeService implements BaseService {
 
@@ -15,10 +15,9 @@ public class CoindealBaseService extends BaseExchangeService implements BaseServ
   public CoindealBaseService(Exchange exchange) {
     super(exchange);
     coindeal =
-        RestProxyFactory.createProxy(
-            CoindealAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CoindealAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     basicAuthentication =
         CoindealDigest.createInstance(
             exchange.getExchangeSpecification().getSecretKey(),

--- a/xchange-coindeal/src/main/java/org/knowm/xchange/coindeal/service/CoindealMarketDataServiceRaw.java
+++ b/xchange-coindeal/src/main/java/org/knowm/xchange/coindeal/service/CoindealMarketDataServiceRaw.java
@@ -2,13 +2,13 @@ package org.knowm.xchange.coindeal.service;
 
 import java.io.IOException;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coindeal.Coindeal;
 import org.knowm.xchange.coindeal.CoindealAdapters;
 import org.knowm.xchange.coindeal.CoindealErrorAdapter;
 import org.knowm.xchange.coindeal.dto.CoindealException;
 import org.knowm.xchange.coindeal.dto.marketdata.CoindealOrderBook;
 import org.knowm.xchange.currency.CurrencyPair;
-import si.mazi.rescu.RestProxyFactory;
 
 public class CoindealMarketDataServiceRaw extends CoindealBaseService {
 
@@ -17,8 +17,8 @@ public class CoindealMarketDataServiceRaw extends CoindealBaseService {
   public CoindealMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
     this.coindeal =
-        RestProxyFactory.createProxy(
-            Coindeal.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Coindeal.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public CoindealOrderBook getCoindealOrderbook(CurrencyPair currencyPair) throws IOException {

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectBaseService.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectBaseService.java
@@ -1,13 +1,13 @@
 package org.knowm.xchange.coindirect.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coindirect.CoindirectAuthenticated;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class CoindirectBaseService extends BaseExchangeService implements BaseService {
   protected final Logger LOG = LoggerFactory.getLogger(getClass());
@@ -24,10 +24,9 @@ public class CoindirectBaseService extends BaseExchangeService implements BaseSe
     super(exchange);
 
     this.coindirect =
-        RestProxyFactory.createProxy(
-            CoindirectAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CoindirectAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =
         CoindirectHawkDigest.createInstance(

--- a/xchange-coinegg/src/main/java/org/knowm/xchange/coinegg/service/CoinEggAccountServiceRaw.java
+++ b/xchange-coinegg/src/main/java/org/knowm/xchange/coinegg/service/CoinEggAccountServiceRaw.java
@@ -3,9 +3,9 @@ package org.knowm.xchange.coinegg.service;
 import java.io.IOException;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinegg.CoinEggAuthenticated;
 import org.knowm.xchange.coinegg.dto.accounts.CoinEggBalance;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 public class CoinEggAccountServiceRaw extends CoinEggBaseService {
@@ -27,8 +27,9 @@ public class CoinEggAccountServiceRaw extends CoinEggBaseService {
     this.tradePassword = spec.getPassword();
     this.nonceFactory = exchange.getNonceFactory();
     this.coinEggAuthenticated =
-        RestProxyFactory.createProxy(
-            CoinEggAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+        ExchangeRestProxyBuilder.forInterface(
+                CoinEggAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public CoinEggBalance getCoinEggBalance() throws IOException {

--- a/xchange-coinegg/src/main/java/org/knowm/xchange/coinegg/service/CoinEggBaseService.java
+++ b/xchange-coinegg/src/main/java/org/knowm/xchange/coinegg/service/CoinEggBaseService.java
@@ -1,10 +1,10 @@
 package org.knowm.xchange.coinegg.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinegg.CoinEgg;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class CoinEggBaseService extends BaseExchangeService implements BaseService {
 
@@ -13,7 +13,7 @@ public class CoinEggBaseService extends BaseExchangeService implements BaseServi
   public CoinEggBaseService(Exchange exchange) {
     super(exchange);
     this.coinEgg =
-        RestProxyFactory.createProxy(
-            CoinEgg.class, exchange.getExchangeSpecification().getSslUri());
+        ExchangeRestProxyBuilder.forInterface(CoinEgg.class, exchange.getExchangeSpecification())
+            .build();
   }
 }

--- a/xchange-coinegg/src/main/java/org/knowm/xchange/coinegg/service/CoinEggTradeServiceRaw.java
+++ b/xchange-coinegg/src/main/java/org/knowm/xchange/coinegg/service/CoinEggTradeServiceRaw.java
@@ -4,11 +4,11 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinegg.CoinEggAuthenticated;
 import org.knowm.xchange.coinegg.dto.trade.CoinEggTradeAdd;
 import org.knowm.xchange.coinegg.dto.trade.CoinEggTradeCancel;
 import org.knowm.xchange.coinegg.dto.trade.CoinEggTradeView;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 public class CoinEggTradeServiceRaw extends CoinEggBaseService {
@@ -30,8 +30,9 @@ public class CoinEggTradeServiceRaw extends CoinEggBaseService {
     this.tradePassword = spec.getPassword();
     this.nonceFactory = exchange.getNonceFactory();
     this.coinEggAuthenticated =
-        RestProxyFactory.createProxy(
-            CoinEggAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+        ExchangeRestProxyBuilder.forInterface(
+                CoinEggAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   // TODO: Sort Out Method Grammar

--- a/xchange-coinex/src/main/java/org/knowm/xchange/coinex/service/CoinexBaseService.java
+++ b/xchange-coinex/src/main/java/org/knowm/xchange/coinex/service/CoinexBaseService.java
@@ -1,16 +1,15 @@
 package org.knowm.xchange.coinex.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinex.CoinexAuthenticated;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class CoinexBaseService extends BaseExchangeService implements BaseService {
 
   protected final String apiKey;
   protected final CoinexAuthenticated coinex;
-  //    protected final ParamsDigest signatureCreator;
   protected final String USER_AGENT_INFO =
       "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36";
 
@@ -22,12 +21,9 @@ public class CoinexBaseService extends BaseExchangeService implements BaseServic
   protected CoinexBaseService(Exchange exchange) {
     super(exchange);
     this.coinex =
-        RestProxyFactory.createProxy(
-            CoinexAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CoinexAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
-    //        this.signatureCreator =
-    // CoinexDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }
 }

--- a/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/service/CoinfloorAuthenticatedService.java
+++ b/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/service/CoinfloorAuthenticatedService.java
@@ -2,12 +2,12 @@ package org.knowm.xchange.coinfloor.service;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.client.ClientConfigCustomizer;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinfloor.CoinfloorAuthenticated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.ClientConfigUtil;
-import si.mazi.rescu.RestProxyFactory;
 
 public class CoinfloorAuthenticatedService extends CoinfloorService {
   private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -26,12 +26,14 @@ public class CoinfloorAuthenticatedService extends CoinfloorService {
       return;
     }
 
-    ClientConfig config = getClientConfig();
-    ClientConfigUtil.addBasicAuthCredentials(
-        config, specification.getUserName(), specification.getPassword());
-
+    ClientConfigCustomizer clientConfigCustomizer =
+        config ->
+            ClientConfigUtil.addBasicAuthCredentials(
+                config, specification.getUserName(), specification.getPassword());
     coinfloor =
-        RestProxyFactory.createProxy(
-            CoinfloorAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), config);
+        ExchangeRestProxyBuilder.forInterface(
+                CoinfloorAuthenticated.class, exchange.getExchangeSpecification())
+            .clientConfigCustomizer(clientConfigCustomizer)
+            .build();
   }
 }

--- a/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/service/CoinfloorMarketDataServiceRaw.java
+++ b/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/service/CoinfloorMarketDataServiceRaw.java
@@ -2,6 +2,7 @@ package org.knowm.xchange.coinfloor.service;
 
 import java.io.IOException;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinfloor.CoinfloorPublic;
 import org.knowm.xchange.coinfloor.dto.markedata.CoinfloorOrderBook;
 import org.knowm.xchange.coinfloor.dto.markedata.CoinfloorTicker;
@@ -9,7 +10,6 @@ import org.knowm.xchange.coinfloor.dto.markedata.CoinfloorTransaction;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.service.BaseExchangeService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class CoinfloorMarketDataServiceRaw extends BaseExchangeService {
 
@@ -19,10 +19,9 @@ public class CoinfloorMarketDataServiceRaw extends BaseExchangeService {
     super(exchange);
 
     coinfloor =
-        RestProxyFactory.createProxy(
-            CoinfloorPublic.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CoinfloorPublic.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public CoinfloorTicker getCoinfloorTicker(CurrencyPair pair) throws IOException {

--- a/xchange-coingi/src/main/java/org/knowm/xchange/coingi/service/CoingiAccountServiceRaw.java
+++ b/xchange-coingi/src/main/java/org/knowm/xchange/coingi/service/CoingiAccountServiceRaw.java
@@ -2,23 +2,26 @@ package org.knowm.xchange.coingi.service;
 
 import java.io.IOException;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coingi.CoingiAuthenticated;
-import org.knowm.xchange.coingi.dto.account.*;
+import org.knowm.xchange.coingi.dto.account.CoingiBalanceRequest;
+import org.knowm.xchange.coingi.dto.account.CoingiBalances;
+import org.knowm.xchange.coingi.dto.account.CoingiDepositWalletRequest;
+import org.knowm.xchange.coingi.dto.account.CoingiDepositWalletResponse;
+import org.knowm.xchange.coingi.dto.account.CoingiUserTransactionList;
+import org.knowm.xchange.coingi.dto.account.CoingiWithdrawalRequest;
+import org.knowm.xchange.coingi.dto.account.CoingiWithdrawalResponse;
 import org.knowm.xchange.coingi.dto.trade.CoingiTransactionHistoryRequest;
-import si.mazi.rescu.ClientConfig;
-import si.mazi.rescu.RestProxyFactory;
 
 public class CoingiAccountServiceRaw extends CoingiBaseService {
   private final CoingiAuthenticated coingiAuthenticated;
 
   protected CoingiAccountServiceRaw(Exchange exchange) {
     super(exchange);
-    ClientConfig clientConfig = getClientConfig();
     this.coingiAuthenticated =
-        RestProxyFactory.createProxy(
-            CoingiAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            clientConfig);
+        ExchangeRestProxyBuilder.forInterface(
+                CoingiAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     String apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =
         CoingiDigest.createInstance(

--- a/xchange-coingi/src/main/java/org/knowm/xchange/coingi/service/CoingiMarketDataServiceRaw.java
+++ b/xchange-coingi/src/main/java/org/knowm/xchange/coingi/service/CoingiMarketDataServiceRaw.java
@@ -3,13 +3,13 @@ package org.knowm.xchange.coingi.service;
 import java.io.IOException;
 import java.util.List;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coingi.Coingi;
 import org.knowm.xchange.coingi.CoingiAdapters;
 import org.knowm.xchange.coingi.dto.marketdata.CoingiOrderBook;
 import org.knowm.xchange.coingi.dto.marketdata.CoingiTicker;
 import org.knowm.xchange.coingi.dto.marketdata.CoingiTransaction;
 import org.knowm.xchange.currency.CurrencyPair;
-import si.mazi.rescu.RestProxyFactory;
 
 public class CoingiMarketDataServiceRaw extends CoingiBaseService {
   private final Coingi coingi;
@@ -17,8 +17,8 @@ public class CoingiMarketDataServiceRaw extends CoingiBaseService {
   protected CoingiMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
     coingi =
-        RestProxyFactory.createProxy(
-            Coingi.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Coingi.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public CoingiOrderBook getCoingiOrderBook(

--- a/xchange-coingi/src/main/java/org/knowm/xchange/coingi/service/CoingiTradeServiceRaw.java
+++ b/xchange-coingi/src/main/java/org/knowm/xchange/coingi/service/CoingiTradeServiceRaw.java
@@ -2,9 +2,15 @@ package org.knowm.xchange.coingi.service;
 
 import java.io.IOException;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coingi.CoingiAuthenticated;
-import org.knowm.xchange.coingi.dto.trade.*;
-import si.mazi.rescu.RestProxyFactory;
+import org.knowm.xchange.coingi.dto.trade.CoingiCancelOrderRequest;
+import org.knowm.xchange.coingi.dto.trade.CoingiGetOrderHistoryRequest;
+import org.knowm.xchange.coingi.dto.trade.CoingiGetOrderRequest;
+import org.knowm.xchange.coingi.dto.trade.CoingiOrder;
+import org.knowm.xchange.coingi.dto.trade.CoingiOrdersList;
+import org.knowm.xchange.coingi.dto.trade.CoingiPlaceLimitOrderRequest;
+import org.knowm.xchange.coingi.dto.trade.CoingiPlaceOrderResponse;
 
 public class CoingiTradeServiceRaw extends CoingiBaseService {
   private final CoingiAuthenticated coingiAuthenticated;
@@ -12,10 +18,9 @@ public class CoingiTradeServiceRaw extends CoingiBaseService {
   public CoingiTradeServiceRaw(Exchange exchange) {
     super(exchange);
     this.coingiAuthenticated =
-        RestProxyFactory.createProxy(
-            CoingiAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CoingiAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
 
     String apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =

--- a/xchange-coinjar/src/main/java/org/knowm/xchange/coinjar/service/CoinjarBaseService.java
+++ b/xchange-coinjar/src/main/java/org/knowm/xchange/coinjar/service/CoinjarBaseService.java
@@ -1,11 +1,11 @@
 package org.knowm.xchange.coinjar.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinjar.CoinjarData;
 import org.knowm.xchange.coinjar.CoinjarTrading;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class CoinjarBaseService extends BaseExchangeService implements BaseService {
 
@@ -46,12 +46,18 @@ public class CoinjarBaseService extends BaseExchangeService implements BaseServi
     } else {
       domain = "coinjar";
     }
+    final String baseUrlData = "https://data.exchange." + domain + ".com/";
     this.coinjarData =
-        RestProxyFactory.createProxy(
-            CoinjarData.class, "https://data.exchange." + domain + ".com/", getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CoinjarData.class, exchange.getExchangeSpecification())
+            .baseUrl(baseUrlData)
+            .build();
 
+    final String baseUrlTrading = "https://api.exchange." + domain + ".com/";
     this.coinjarTrading =
-        RestProxyFactory.createProxy(
-            CoinjarTrading.class, "https://api.exchange." + domain + ".com/", getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CoinjarTrading.class, exchange.getExchangeSpecification())
+            .baseUrl(baseUrlTrading)
+            .build();
   }
 }

--- a/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/deprecated/v2/service/CoinMarketCapMarketDataServiceRaw.java
+++ b/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/deprecated/v2/service/CoinMarketCapMarketDataServiceRaw.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinmarketcap.deprecated.v2.CoinMarketCap;
 import org.knowm.xchange.coinmarketcap.deprecated.v2.dto.marketdata.CoinMarketCapCurrency;
 import org.knowm.xchange.coinmarketcap.deprecated.v2.dto.marketdata.CoinMarketCapTicker;
@@ -11,7 +12,6 @@ import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author allenday */
 class CoinMarketCapMarketDataServiceRaw extends BaseExchangeService implements BaseService {
@@ -22,10 +22,9 @@ class CoinMarketCapMarketDataServiceRaw extends BaseExchangeService implements B
 
     super(exchange);
     this.coinmarketcap =
-        RestProxyFactory.createProxy(
-            CoinMarketCap.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CoinMarketCap.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public CoinMarketCapTicker getCoinMarketCapTicker(CurrencyPair pair) {

--- a/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/pro/v1/service/CmcBaseService.java
+++ b/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/pro/v1/service/CmcBaseService.java
@@ -1,10 +1,10 @@
 package org.knowm.xchange.coinmarketcap.pro.v1.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinmarketcap.pro.v1.CmcAuthenticated;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 class CmcBaseService extends BaseExchangeService implements BaseService {
 
@@ -16,9 +16,8 @@ class CmcBaseService extends BaseExchangeService implements BaseService {
 
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.cmcAuthenticated =
-        RestProxyFactory.createProxy(
-            CmcAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CmcAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
   }
 }

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateAccountServiceRaw.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateAccountServiceRaw.java
@@ -26,12 +26,12 @@ package org.knowm.xchange.coinmate.service;
 import java.io.IOException;
 import java.math.BigDecimal;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinmate.CoinmateAuthenticated;
 import org.knowm.xchange.coinmate.dto.account.CoinmateBalance;
 import org.knowm.xchange.coinmate.dto.account.CoinmateDepositAddresses;
 import org.knowm.xchange.coinmate.dto.trade.CoinmateTradeResponse;
 import org.knowm.xchange.coinmate.dto.trade.CoinmateTransactionHistory;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author Martin Stachon */
 public class CoinmateAccountServiceRaw extends CoinmateBaseService {
@@ -43,10 +43,9 @@ public class CoinmateAccountServiceRaw extends CoinmateBaseService {
     super(exchange);
 
     this.coinmateAuthenticated =
-        RestProxyFactory.createProxy(
-            CoinmateAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CoinmateAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.signatureCreator =
         CoinmateDigest.createInstance(
             exchange.getExchangeSpecification().getSecretKey(),

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateMarketDataServiceRaw.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateMarketDataServiceRaw.java
@@ -25,11 +25,11 @@ package org.knowm.xchange.coinmate.service;
 
 import java.io.IOException;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinmate.Coinmate;
 import org.knowm.xchange.coinmate.dto.marketdata.CoinmateOrderBook;
 import org.knowm.xchange.coinmate.dto.marketdata.CoinmateTicker;
 import org.knowm.xchange.coinmate.dto.marketdata.CoinmateTransactions;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author Martin Stachon */
 public class CoinmateMarketDataServiceRaw extends CoinmateBaseService {
@@ -39,8 +39,8 @@ public class CoinmateMarketDataServiceRaw extends CoinmateBaseService {
   public CoinmateMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
     this.coinmate =
-        RestProxyFactory.createProxy(
-            Coinmate.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Coinmate.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public CoinmateTicker getCoinmateTicker(String currencyPair) throws IOException {

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateMetadataServiceRaw.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateMetadataServiceRaw.java
@@ -2,9 +2,9 @@ package org.knowm.xchange.coinmate.service;
 
 import java.io.IOException;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinmate.CoinmateStatic;
 import org.knowm.xchange.dto.meta.ExchangeMetaData;
-import si.mazi.rescu.RestProxyFactory;
 
 public class CoinmateMetadataServiceRaw extends CoinmateBaseService {
   private final CoinmateStatic coinmateStatic;
@@ -13,10 +13,9 @@ public class CoinmateMetadataServiceRaw extends CoinmateBaseService {
     super(exchange);
 
     this.coinmateStatic =
-        RestProxyFactory.createProxy(
-            CoinmateStatic.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CoinmateStatic.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public ExchangeMetaData getMetadata() throws IOException {

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateTradeServiceRaw.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateTradeServiceRaw.java
@@ -26,9 +26,17 @@ package org.knowm.xchange.coinmate.service;
 import java.io.IOException;
 import java.math.BigDecimal;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinmate.CoinmateAuthenticated;
-import org.knowm.xchange.coinmate.dto.trade.*;
-import si.mazi.rescu.RestProxyFactory;
+import org.knowm.xchange.coinmate.dto.trade.CoinmateCancelOrderResponse;
+import org.knowm.xchange.coinmate.dto.trade.CoinmateCancelOrderWithInfoResponse;
+import org.knowm.xchange.coinmate.dto.trade.CoinmateOpenOrders;
+import org.knowm.xchange.coinmate.dto.trade.CoinmateOrderHistory;
+import org.knowm.xchange.coinmate.dto.trade.CoinmateReplaceResponse;
+import org.knowm.xchange.coinmate.dto.trade.CoinmateTradeHistory;
+import org.knowm.xchange.coinmate.dto.trade.CoinmateTradeResponse;
+import org.knowm.xchange.coinmate.dto.trade.CoinmateTransactionHistory;
+import org.knowm.xchange.coinmate.dto.trade.CoinmateTransferHistory;
 
 /** @author Martin Stachon */
 public class CoinmateTradeServiceRaw extends CoinmateBaseService {
@@ -40,10 +48,9 @@ public class CoinmateTradeServiceRaw extends CoinmateBaseService {
     super(exchange);
 
     this.coinmateAuthenticated =
-        RestProxyFactory.createProxy(
-            CoinmateAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CoinmateAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.signatureCreator =
         CoinmateDigest.createInstance(
             exchange.getExchangeSpecification().getSecretKey(),

--- a/xchange-coinone/src/main/java/org/knowm/xchange/coinone/service/CoinoneBaseService.java
+++ b/xchange-coinone/src/main/java/org/knowm/xchange/coinone/service/CoinoneBaseService.java
@@ -1,11 +1,11 @@
 package org.knowm.xchange.coinone.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinone.CoinoneAuthenticated;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class CoinoneBaseService extends BaseExchangeService implements BaseService {
 
@@ -13,8 +13,6 @@ public class CoinoneBaseService extends BaseExchangeService implements BaseServi
   protected final String apiKey;
   protected final String apiSecret;
   protected final String url;
-  private static final String DEFAULT_ENCODING = "UTF-8";
-  private static final String HMAC_SHA512 = "HmacSHA512";
   protected ParamsDigest signatureCreator;
   protected ParamsDigest payloadCreator;
 
@@ -26,8 +24,9 @@ public class CoinoneBaseService extends BaseExchangeService implements BaseServi
   public CoinoneBaseService(Exchange exchange) {
     super(exchange);
     this.coinone =
-        RestProxyFactory.createProxy(
-            CoinoneAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+        ExchangeRestProxyBuilder.forInterface(
+                CoinoneAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.apiSecret = exchange.getExchangeSpecification().getSecretKey();
     this.url = exchange.getExchangeSpecification().getSslUri();

--- a/xchange-coinsuper/src/main/java/org/knowm/xchange/coinsuper/service/CoinsuperAccountServiceRaw.java
+++ b/xchange-coinsuper/src/main/java/org/knowm/xchange/coinsuper/service/CoinsuperAccountServiceRaw.java
@@ -4,30 +4,29 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinsuper.CoinsuperAuthenticated;
 import org.knowm.xchange.coinsuper.dto.CoinsuperResponse;
 import org.knowm.xchange.coinsuper.dto.account.CoinsuperUserAssetInfo;
 import org.knowm.xchange.coinsuper.utils.RestApiRequestHandler;
 import org.knowm.xchange.coinsuper.utils.RestRequestParam;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 public class CoinsuperAccountServiceRaw extends CoinsuperBaseService {
   private final CoinsuperAuthenticated coinsuper;
 
-  private String apiKey;
-  private String secretKey;
-  private SynchronizedValueFactory<Long> nonceFactory;
+  private final String apiKey;
+  private final String secretKey;
+  private final SynchronizedValueFactory<Long> nonceFactory;
 
   public CoinsuperAccountServiceRaw(Exchange exchange) {
 
     super(exchange);
 
     this.coinsuper =
-        RestProxyFactory.createProxy(
-            CoinsuperAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CoinsuperAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
 
     this.apiKey = super.apiKey;
     this.secretKey = super.secretKey;
@@ -42,7 +41,7 @@ public class CoinsuperAccountServiceRaw extends CoinsuperBaseService {
    */
   public CoinsuperResponse<CoinsuperUserAssetInfo> getUserAssetInfo() throws IOException {
 
-    Map<String, String> parameters = new HashMap<String, String>();
+    Map<String, String> parameters = new HashMap<>();
 
     RestRequestParam restRequestParam =
         RestApiRequestHandler.generateRequestParam(parameters, this.apiKey, this.secretKey);

--- a/xchange-coinsuper/src/main/java/org/knowm/xchange/coinsuper/service/CoinsuperMarketDataServiceRaw.java
+++ b/xchange-coinsuper/src/main/java/org/knowm/xchange/coinsuper/service/CoinsuperMarketDataServiceRaw.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinsuper.CoinsuperAuthenticated;
 import org.knowm.xchange.coinsuper.dto.CoinsuperResponse;
 import org.knowm.xchange.coinsuper.dto.marketdata.CoinsuperOrderbook;
@@ -13,25 +14,23 @@ import org.knowm.xchange.coinsuper.dto.marketdata.CoinsuperTicker;
 import org.knowm.xchange.coinsuper.utils.RestApiRequestHandler;
 import org.knowm.xchange.coinsuper.utils.RestRequestParam;
 import org.knowm.xchange.currency.CurrencyPair;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 public class CoinsuperMarketDataServiceRaw extends CoinsuperBaseService {
   private final CoinsuperAuthenticated coinsuper;
 
-  private String apiKey;
-  private String secretKey;
-  private SynchronizedValueFactory<Long> nonceFactory;
+  private final String apiKey;
+  private final String secretKey;
+  private final SynchronizedValueFactory<Long> nonceFactory;
 
   public CoinsuperMarketDataServiceRaw(Exchange exchange) {
 
     super(exchange);
 
     this.coinsuper =
-        RestProxyFactory.createProxy(
-            CoinsuperAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CoinsuperAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
 
     this.apiKey = super.apiKey;
     this.secretKey = super.secretKey;
@@ -88,7 +87,7 @@ public class CoinsuperMarketDataServiceRaw extends CoinsuperBaseService {
   public CoinsuperResponse<List<CoinsuperTicker>> getCoinsuperTicker(CurrencyPair currencyPair)
       throws IOException {
 
-    Map<String, String> data = new HashMap<String, String>();
+    Map<String, String> data = new HashMap<>();
     data.put("symbol", currencyPair.toString());
 
     RestRequestParam parameters =
@@ -105,7 +104,7 @@ public class CoinsuperMarketDataServiceRaw extends CoinsuperBaseService {
    */
   public Object getKlines(CurrencyPair currencyPair) throws IOException {
 
-    Map<String, String> data = new HashMap<String, String>();
+    Map<String, String> data = new HashMap<>();
     data.put("symbol", currencyPair.toString());
 
     RestRequestParam parameters =

--- a/xchange-coinsuper/src/main/java/org/knowm/xchange/coinsuper/service/CoinsuperTradeServiceRaw.java
+++ b/xchange-coinsuper/src/main/java/org/knowm/xchange/coinsuper/service/CoinsuperTradeServiceRaw.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinsuper.CoinsuperAuthenticated;
 import org.knowm.xchange.coinsuper.dto.CoinsuperResponse;
 import org.knowm.xchange.coinsuper.dto.trade.CoinsuperCancelOrder;
@@ -12,25 +13,23 @@ import org.knowm.xchange.coinsuper.dto.trade.OrderDetail;
 import org.knowm.xchange.coinsuper.dto.trade.OrderList;
 import org.knowm.xchange.coinsuper.utils.RestApiRequestHandler;
 import org.knowm.xchange.coinsuper.utils.RestRequestParam;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 public class CoinsuperTradeServiceRaw extends CoinsuperBaseService {
   private final CoinsuperAuthenticated coinsuper;
 
-  private String apiKey;
-  private String secretKey;
-  private SynchronizedValueFactory<Long> nonceFactory;
+  private final String apiKey;
+  private final String secretKey;
+  private final SynchronizedValueFactory<Long> nonceFactory;
 
   public CoinsuperTradeServiceRaw(Exchange exchange) {
 
     super(exchange);
 
     this.coinsuper =
-        RestProxyFactory.createProxy(
-            CoinsuperAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CoinsuperAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
 
     this.apiKey = super.apiKey;
     this.secretKey = super.secretKey;
@@ -45,7 +44,7 @@ public class CoinsuperTradeServiceRaw extends CoinsuperBaseService {
   public CoinsuperResponse<CoinsuperOrder> createOrder(Map<String, String> order)
       throws IOException {
     RestRequestParam parameters =
-        parameters = RestApiRequestHandler.generateRequestParam(order, this.apiKey, this.secretKey);
+        RestApiRequestHandler.generateRequestParam(order, this.apiKey, this.secretKey);
     if (order.get("side") == "BID") {
       return coinsuper.createBuyOrder(parameters);
     } else if (order.get("side") == "ASK") {

--- a/xchange-core/src/main/java/org/knowm/xchange/client/ClientConfigCustomizer.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/client/ClientConfigCustomizer.java
@@ -1,0 +1,8 @@
+package org.knowm.xchange.client;
+
+import si.mazi.rescu.ClientConfig;
+
+public interface ClientConfigCustomizer {
+
+  void customize(ClientConfig clientConfig);
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/client/ExchangeRestProxyBuilder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/client/ExchangeRestProxyBuilder.java
@@ -2,28 +2,36 @@ package org.knowm.xchange.client;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.knowm.xchange.ExchangeSpecification;
 import si.mazi.rescu.ClientConfig;
+import si.mazi.rescu.IRestProxyFactory;
 import si.mazi.rescu.Interceptor;
-import si.mazi.rescu.RestProxyFactory;
+import si.mazi.rescu.RestProxyFactoryImpl;
 
 public final class ExchangeRestProxyBuilder<T> {
 
   private final Class<T> restInterface;
   private final ExchangeSpecification exchangeSpecification;
+  private final List<Interceptor> customInterceptors = new ArrayList<>();
+  private final List<ClientConfigCustomizer> clientConfigCustomizers = new ArrayList<>();
   private ClientConfig clientConfig;
   private ResilienceRegistries resilienceRegistries;
-  private List<Interceptor> customInterceptors = new ArrayList<>();
+  private String baseUrl;
+  private IRestProxyFactory restProxyFactory = new RestProxyFactoryImpl();
 
   private ExchangeRestProxyBuilder(
       Class<T> restInterface, ExchangeSpecification exchangeSpecification) {
     this.restInterface = restInterface;
     this.exchangeSpecification = exchangeSpecification;
+    this.baseUrl =
+        Optional.ofNullable(exchangeSpecification.getSslUri())
+            .orElseGet(exchangeSpecification::getPlainTextUri);
   }
 
   public static <T> ExchangeRestProxyBuilder<T> forInterface(
       Class<T> restInterface, ExchangeSpecification exchangeSpecification) {
-    return new ExchangeRestProxyBuilder(restInterface, exchangeSpecification);
+    return new ExchangeRestProxyBuilder<>(restInterface, exchangeSpecification);
   }
 
   public ExchangeRestProxyBuilder<T> clientConfig(ClientConfig value) {
@@ -31,8 +39,24 @@ public final class ExchangeRestProxyBuilder<T> {
     return this;
   }
 
+  public ExchangeRestProxyBuilder<T> clientConfigCustomizer(
+      ClientConfigCustomizer clientConfigCustomizer) {
+    this.clientConfigCustomizers.add(clientConfigCustomizer);
+    return this;
+  }
+
+  public ExchangeRestProxyBuilder<T> baseUrl(String baseUrl) {
+    this.baseUrl = baseUrl;
+    return this;
+  }
+
   public ExchangeRestProxyBuilder<T> customInterceptor(Interceptor value) {
-    customInterceptors.add(value);
+    this.customInterceptors.add(value);
+    return this;
+  }
+
+  public ExchangeRestProxyBuilder<T> restProxyFactory(IRestProxyFactory restProxyFactory) {
+    this.restProxyFactory = restProxyFactory;
     return this;
   }
 
@@ -43,11 +67,10 @@ public final class ExchangeRestProxyBuilder<T> {
     if (resilienceRegistries == null) {
       resilienceRegistries = new ResilienceRegistries();
     }
-    return RestProxyFactory.createProxy(
-        restInterface,
-        exchangeSpecification.getSslUri(),
-        clientConfig,
-        customInterceptors.toArray(new Interceptor[0]));
+    clientConfigCustomizers.forEach(
+        clientConfigCustomizer -> clientConfigCustomizer.customize(clientConfig));
+    return restProxyFactory.createProxy(
+        restInterface, baseUrl, clientConfig, customInterceptors.toArray(new Interceptor[0]));
   }
 
   /**

--- a/xchange-core/src/main/java/org/knowm/xchange/service/BaseExchangeService.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/BaseExchangeService.java
@@ -2,13 +2,11 @@ package org.knowm.xchange.service;
 
 import java.math.BigDecimal;
 import org.knowm.xchange.Exchange;
-import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
 import org.knowm.xchange.dto.meta.ExchangeMetaData;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
-import si.mazi.rescu.ClientConfig;
 
 /** Top of the hierarchy abstract class for an "exchange service" */
 public abstract class BaseExchangeService<E extends Exchange> {
@@ -40,12 +38,6 @@ public abstract class BaseExchangeService<E extends Exchange> {
   public void verifyOrder(MarketOrder marketOrder) {
 
     verifyOrder(marketOrder, exchange.getExchangeMetaData());
-  }
-
-  /** @deprecated use {@link ExchangeRestProxyBuilder} */
-  @Deprecated
-  public ClientConfig getClientConfig() {
-    return ExchangeRestProxyBuilder.createClientConfig(exchange.getExchangeSpecification());
   }
 
   protected final void verifyOrder(Order order, ExchangeMetaData exchangeMetaData) {

--- a/xchange-cryptofacilities/src/main/java/org/knowm/xchange/cryptofacilities/service/CryptoFacilitiesBaseService.java
+++ b/xchange-cryptofacilities/src/main/java/org/knowm/xchange/cryptofacilities/service/CryptoFacilitiesBaseService.java
@@ -1,11 +1,11 @@
 package org.knowm.xchange.cryptofacilities.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.cryptofacilities.CryptoFacilitiesAuthenticated;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author Jean-Christophe Laruelle */
 public class CryptoFacilitiesBaseService extends BaseExchangeService implements BaseService {
@@ -23,10 +23,9 @@ public class CryptoFacilitiesBaseService extends BaseExchangeService implements 
     super(exchange);
 
     cryptoFacilities =
-        RestProxyFactory.createProxy(
-            CryptoFacilitiesAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CryptoFacilitiesAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     signatureCreator =
         CryptoFacilitiesDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }

--- a/xchange-cryptonit/src/main/java/org/knowm/xchange/cryptonit2/service/CryptonitAccountServiceRaw.java
+++ b/xchange-cryptonit/src/main/java/org/knowm/xchange/cryptonit2/service/CryptonitAccountServiceRaw.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.cryptonit2.CryptonitAuthenticated;
 import org.knowm.xchange.cryptonit2.CryptonitAuthenticatedV2;
 import org.knowm.xchange.cryptonit2.CryptonitV2;
@@ -19,7 +20,6 @@ import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.FundsExceededException;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 /** @author yurivin */
@@ -32,6 +32,7 @@ public class CryptonitAccountServiceRaw extends CryptonitBaseService {
   private final String apiKey;
   private final SynchronizedValueFactory<Long> nonceFactory;
   private final ObjectMapper mapper = new ObjectMapper();
+
   /**
    * Constructor
    *
@@ -42,15 +43,13 @@ public class CryptonitAccountServiceRaw extends CryptonitBaseService {
     super(exchange);
 
     this.cryptonitAuthenticated =
-        RestProxyFactory.createProxy(
-            CryptonitAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CryptonitAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.cryptonitAuthenticatedV2 =
-        RestProxyFactory.createProxy(
-            CryptonitAuthenticatedV2.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CryptonitAuthenticatedV2.class, exchange.getExchangeSpecification())
+            .build();
 
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =

--- a/xchange-cryptonit/src/main/java/org/knowm/xchange/cryptonit2/service/CryptonitMarketDataServiceRaw.java
+++ b/xchange-cryptonit/src/main/java/org/knowm/xchange/cryptonit2/service/CryptonitMarketDataServiceRaw.java
@@ -3,13 +3,13 @@ package org.knowm.xchange.cryptonit2.service;
 import java.io.IOException;
 import javax.annotation.Nullable;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.cryptonit2.CryptonitV2;
 import org.knowm.xchange.cryptonit2.dto.CryptonitException;
 import org.knowm.xchange.cryptonit2.dto.marketdata.CryptonitOrderBook;
 import org.knowm.xchange.cryptonit2.dto.marketdata.CryptonitTicker;
 import org.knowm.xchange.cryptonit2.dto.marketdata.CryptonitTransaction;
 import org.knowm.xchange.currency.CurrencyPair;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author gnandiga */
 public class CryptonitMarketDataServiceRaw extends CryptonitBaseService {
@@ -20,8 +20,9 @@ public class CryptonitMarketDataServiceRaw extends CryptonitBaseService {
 
     super(exchange);
     this.cryptonitV2 =
-        RestProxyFactory.createProxy(
-            CryptonitV2.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CryptonitV2.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public CryptonitTicker getCryptonitTicker(CurrencyPair pair) throws IOException {

--- a/xchange-cryptonit/src/main/java/org/knowm/xchange/cryptonit2/service/CryptonitTradeServiceRaw.java
+++ b/xchange-cryptonit/src/main/java/org/knowm/xchange/cryptonit2/service/CryptonitTradeServiceRaw.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.cryptonit2.service;
 import java.io.IOException;
 import java.math.BigDecimal;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.cryptonit2.CryptonitAuthenticated;
 import org.knowm.xchange.cryptonit2.CryptonitAuthenticatedV2;
 import org.knowm.xchange.cryptonit2.CryptonitV2;
@@ -11,7 +12,6 @@ import org.knowm.xchange.cryptonit2.dto.trade.CryptonitOrder;
 import org.knowm.xchange.cryptonit2.dto.trade.CryptonitOrderStatusResponse;
 import org.knowm.xchange.cryptonit2.dto.trade.CryptonitUserTransaction;
 import org.knowm.xchange.currency.CurrencyPair;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 /** @author gnandiga */
@@ -20,22 +20,20 @@ public class CryptonitTradeServiceRaw extends CryptonitBaseService {
   private final CryptonitAuthenticated CryptonitAuthenticated;
   private final CryptonitAuthenticatedV2 CryptonitAuthenticatedV2;
   private final CryptonitDigest signatureCreator;
-  private String apiKey;
-  private SynchronizedValueFactory<Long> nonceFactory;
+  private final String apiKey;
+  private final SynchronizedValueFactory<Long> nonceFactory;
 
   public CryptonitTradeServiceRaw(Exchange exchange) {
 
     super(exchange);
     this.CryptonitAuthenticated =
-        RestProxyFactory.createProxy(
-            CryptonitAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CryptonitAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.CryptonitAuthenticatedV2 =
-        RestProxyFactory.createProxy(
-            CryptonitAuthenticatedV2.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                CryptonitAuthenticatedV2.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.nonceFactory = exchange.getNonceFactory();
     this.signatureCreator =

--- a/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/service/CryptopiaBaseService.java
+++ b/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/service/CryptopiaBaseService.java
@@ -1,11 +1,11 @@
 package org.knowm.xchange.cryptopia.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.cryptopia.Cryptopia;
 import org.knowm.xchange.cryptopia.CryptopiaDigest;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class CryptopiaBaseService extends BaseExchangeService implements BaseService {
 
@@ -16,8 +16,8 @@ public class CryptopiaBaseService extends BaseExchangeService implements BaseSer
 
     super(exchange);
     this.cryptopia =
-        RestProxyFactory.createProxy(
-            Cryptopia.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Cryptopia.class, exchange.getExchangeSpecification())
+            .build();
     this.signatureCreator =
         CryptopiaDigest.createInstance(
             exchange.getNonceFactory(),

--- a/xchange-cryptowatch/src/main/java/org/knowm/xchange/cryptowatch/service/CryptowatchBaseService.java
+++ b/xchange-cryptowatch/src/main/java/org/knowm/xchange/cryptowatch/service/CryptowatchBaseService.java
@@ -1,11 +1,11 @@
 package org.knowm.xchange.cryptowatch.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ClientConfigCustomizer;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.cryptowatch.Cryptowatch;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.ClientConfig;
-import si.mazi.rescu.RestProxyFactory;
 
 public class CryptowatchBaseService extends BaseExchangeService implements BaseService {
 
@@ -13,10 +13,11 @@ public class CryptowatchBaseService extends BaseExchangeService implements BaseS
 
   public CryptowatchBaseService(Exchange exchange) {
     super(exchange);
-    ClientConfig clientConfig = getClientConfig();
-    clientConfig.setIgnoreHttpErrorCodes(true);
+    ClientConfigCustomizer clientConfigCustomizer = config -> config.setIgnoreHttpErrorCodes(true);
     cryptowatch =
-        RestProxyFactory.createProxy(
-            Cryptowatch.class, exchange.getExchangeSpecification().getSslUri(), clientConfig);
+        ExchangeRestProxyBuilder.forInterface(
+                Cryptowatch.class, exchange.getExchangeSpecification())
+            .clientConfigCustomizer(clientConfigCustomizer)
+            .build();
   }
 }

--- a/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/service/DeribitBaseService.java
+++ b/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/service/DeribitBaseService.java
@@ -7,6 +7,7 @@ import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import lombok.Getter;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.deribit.v2.Deribit;
 import org.knowm.xchange.deribit.v2.DeribitAuthenticated;
 import org.knowm.xchange.deribit.v2.DeribitExchange;
@@ -20,7 +21,6 @@ import org.knowm.xchange.service.BaseParamsDigest;
 import org.knowm.xchange.service.BaseService;
 import org.knowm.xchange.utils.DigestUtils;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class DeribitBaseService extends BaseExchangeService<DeribitExchange>
     implements BaseService {
@@ -39,14 +39,13 @@ public class DeribitBaseService extends BaseExchangeService<DeribitExchange>
 
     super(exchange);
     deribit =
-        RestProxyFactory.createProxy(
-            Deribit.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Deribit.class, exchange.getExchangeSpecification())
+            .build();
 
     deribitAuthenticated =
-        RestProxyFactory.createProxy(
-            DeribitAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                DeribitAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
 
     deribitAuth =
         DeribitAuth.createDeribitAuth(

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/DragonexExchange.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/DragonexExchange.java
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.knowm.xchange.BaseExchange;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dragonex.dto.DragonexException;
 import org.knowm.xchange.dragonex.dto.Token;
@@ -19,9 +20,7 @@ import org.knowm.xchange.dragonex.service.DragonexAccountServiceRaw;
 import org.knowm.xchange.dragonex.service.DragonexMarketDataService;
 import org.knowm.xchange.dragonex.service.DragonexTradeService;
 import org.knowm.xchange.exceptions.ExchangeException;
-import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 public class DragonexExchange extends BaseExchange implements Exchange {
@@ -41,15 +40,12 @@ public class DragonexExchange extends BaseExchange implements Exchange {
     this.accountService = new DragonexAccountService(this);
     this.tradeService = new DragonexTradeService(this);
 
-    ClientConfig rescuConfig =
-        ((DragonexMarketDataService) this.marketDataService).getClientConfig();
     ExchangeSpecification spec = this.getExchangeSpecification();
-    this.dragonexPublic =
-        RestProxyFactory.createProxy(Dragonex.class, spec.getSslUri(), rescuConfig);
+    this.dragonexPublic = ExchangeRestProxyBuilder.forInterface(Dragonex.class, spec).build();
 
     if (spec.getApiKey() != null && spec.getSecretKey() != null) {
       this.dragonexAuthenticated =
-          RestProxyFactory.createProxy(DragonexAuthenticated.class, spec.getSslUri(), rescuConfig);
+          ExchangeRestProxyBuilder.forInterface(DragonexAuthenticated.class, spec).build();
       this.signatureCreator = new DragonDigest(spec.getApiKey(), spec.getSecretKey());
     }
 

--- a/xchange-dsx/src/main/java/org/knowm/xchange/dsx/service/DsxBaseService.java
+++ b/xchange-dsx/src/main/java/org/knowm/xchange/dsx/service/DsxBaseService.java
@@ -1,28 +1,29 @@
 package org.knowm.xchange.dsx.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ClientConfigCustomizer;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.dsx.DsxAuthenticated;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.ClientConfigUtil;
-import si.mazi.rescu.RestProxyFactory;
 
 public class DsxBaseService extends BaseExchangeService implements BaseService {
 
   protected final DsxAuthenticated dsx;
 
   protected DsxBaseService(Exchange exchange) {
-
     super(exchange);
 
     String apiKey = exchange.getExchangeSpecification().getApiKey();
     String secretKey = exchange.getExchangeSpecification().getSecretKey();
 
-    ClientConfig config = getClientConfig();
-    ClientConfigUtil.addBasicAuthCredentials(config, apiKey, secretKey);
+    ClientConfigCustomizer clientConfigCustomizer =
+        config -> ClientConfigUtil.addBasicAuthCredentials(config, apiKey, secretKey);
     dsx =
-        RestProxyFactory.createProxy(
-            DsxAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), config);
+        ExchangeRestProxyBuilder.forInterface(
+                DsxAuthenticated.class, exchange.getExchangeSpecification())
+            .clientConfigCustomizer(clientConfigCustomizer)
+            .build();
   }
 }

--- a/xchange-dvchain/src/main/java/org/knowm/xchange/dvchain/service/DVChainBaseService.java
+++ b/xchange-dvchain/src/main/java/org/knowm/xchange/dvchain/service/DVChainBaseService.java
@@ -1,13 +1,13 @@
 package org.knowm.xchange.dvchain.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.dvchain.DVChain;
 import org.knowm.xchange.dvchain.dto.DVChainException;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.InternalServerException;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class DVChainBaseService extends BaseExchangeService implements BaseService {
   protected final DVChain dvChain;
@@ -17,8 +17,8 @@ public class DVChainBaseService extends BaseExchangeService implements BaseServi
 
     super(exchange);
     dvChain =
-        RestProxyFactory.createProxy(
-            DVChain.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(DVChain.class, exchange.getExchangeSpecification())
+            .build();
     authToken = exchange.getExchangeSpecification().getSecretKey();
   }
 

--- a/xchange-enigma/src/main/java/org/knowm/xchange/enigma/service/EnigmaBaseService.java
+++ b/xchange-enigma/src/main/java/org/knowm/xchange/enigma/service/EnigmaBaseService.java
@@ -3,12 +3,12 @@ package org.knowm.xchange.enigma.service;
 import java.io.IOException;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.enigma.EnigmaAuthenticated;
 import org.knowm.xchange.enigma.dto.account.EnigmaCredentials;
 import org.knowm.xchange.enigma.dto.account.EnigmaLoginResponse;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 public abstract class EnigmaBaseService extends BaseExchangeService implements BaseService {
@@ -19,10 +19,9 @@ public abstract class EnigmaBaseService extends BaseExchangeService implements B
   protected EnigmaBaseService(Exchange exchange) {
     super(exchange);
     this.enigmaAuthenticated =
-        RestProxyFactory.createProxy(
-            EnigmaAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                EnigmaAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.nonceFactory = exchange.getNonceFactory();
   }
 

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/blockchain/BlockchainAddressDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/blockchain/BlockchainAddressDemo.java
@@ -7,7 +7,7 @@ import org.knowm.xchange.blockchain.Blockchain;
 import org.knowm.xchange.blockchain.BlockchainExchange;
 import org.knowm.xchange.blockchain.dto.BitcoinAddress;
 import org.knowm.xchange.blockchain.dto.BitcoinAddresses;
-import si.mazi.rescu.RestProxyFactory;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 
 /** @author timmolter */
 public class BlockchainAddressDemo {
@@ -17,9 +17,9 @@ public class BlockchainAddressDemo {
     Exchange blockchainExchangexchange =
         ExchangeFactory.INSTANCE.createExchange(BlockchainExchange.class.getName());
     Blockchain blockchain =
-        RestProxyFactory.createProxy(
-            Blockchain.class,
-            blockchainExchangexchange.getExchangeSpecification().getPlainTextUri());
+        ExchangeRestProxyBuilder.forInterface(
+                Blockchain.class, blockchainExchangexchange.getExchangeSpecification())
+            .build();
 
     BitcoinAddress bitcoinAddress = blockchain.getBitcoinAddress("XXX");
     System.out.println(bitcoinAddress.toString());

--- a/xchange-exmo/src/main/java/org/knowm/xchange/exmo/service/BaseExmoService.java
+++ b/xchange-exmo/src/main/java/org/knowm/xchange/exmo/service/BaseExmoService.java
@@ -2,12 +2,12 @@ package org.knowm.xchange.exmo.service;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.exmo.Exmo;
 import org.knowm.xchange.exmo.ExmoDigest;
 import org.knowm.xchange.service.BaseExchangeService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BaseExmoService extends BaseExchangeService {
   protected final Exmo exmo;
@@ -19,9 +19,7 @@ public class BaseExmoService extends BaseExchangeService {
 
     ExchangeSpecification exchangeSpecification = exchange.getExchangeSpecification();
 
-    this.exmo =
-        RestProxyFactory.createProxy(
-            Exmo.class, exchangeSpecification.getSslUri(), getClientConfig());
+    this.exmo = ExchangeRestProxyBuilder.forInterface(Exmo.class, exchangeSpecification).build();
     this.apiKey = exchangeSpecification.getApiKey();
     this.signatureCreator = ExmoDigest.createInstance(exchangeSpecification.getSecretKey());
   }

--- a/xchange-exx/src/main/java/org/knowm/xchange/exx/service/EXXAccountServiceRaw.java
+++ b/xchange-exx/src/main/java/org/knowm/xchange/exx/service/EXXAccountServiceRaw.java
@@ -2,10 +2,10 @@ package org.knowm.xchange.exx.service;
 
 import java.io.IOException;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.exx.EXXAuthenticated;
 import org.knowm.xchange.exx.dto.account.EXXAccountInformation;
 import org.knowm.xchange.exx.utils.CommonUtil;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 public class EXXAccountServiceRaw extends EXXBaseService {
@@ -17,10 +17,9 @@ public class EXXAccountServiceRaw extends EXXBaseService {
   public EXXAccountServiceRaw(Exchange exchange) {
     super(exchange);
     this.exxAuthenticated =
-        RestProxyFactory.createProxy(
-            EXXAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                EXXAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
 
     this.apiKey = super.apiKey;
     this.secretKey = super.secretKey;

--- a/xchange-exx/src/main/java/org/knowm/xchange/exx/service/EXXMarketDataServiceRaw.java
+++ b/xchange-exx/src/main/java/org/knowm/xchange/exx/service/EXXMarketDataServiceRaw.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.exx.service;
 import java.io.IOException;
 import java.util.Map;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.exx.EXX;
 import org.knowm.xchange.exx.EXXAdapters;
@@ -10,7 +11,6 @@ import org.knowm.xchange.exx.dto.marketdata.EXXOrderbook;
 import org.knowm.xchange.exx.dto.marketdata.EXXTicker;
 import org.knowm.xchange.exx.dto.marketdata.EXXTickerResponse;
 import org.knowm.xchange.exx.dto.marketdata.EXXTransaction;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 public class EXXMarketDataServiceRaw extends EXXBaseService {
@@ -25,8 +25,8 @@ public class EXXMarketDataServiceRaw extends EXXBaseService {
     super(exchange);
 
     this.exx =
-        RestProxyFactory.createProxy(
-            EXX.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(EXX.class, exchange.getExchangeSpecification())
+            .build();
 
     this.apiKey = super.apiKey;
     this.secretKey = super.secretKey;

--- a/xchange-exx/src/main/java/org/knowm/xchange/exx/service/EXXTradeServiceRaw.java
+++ b/xchange-exx/src/main/java/org/knowm/xchange/exx/service/EXXTradeServiceRaw.java
@@ -4,31 +4,27 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.exx.EXXAuthenticated;
 import org.knowm.xchange.exx.dto.trade.EXXCancelOrder;
 import org.knowm.xchange.exx.dto.trade.EXXOrder;
 import org.knowm.xchange.exx.dto.trade.EXXPlaceOrder;
 import org.knowm.xchange.exx.utils.CommonUtil;
-import si.mazi.rescu.RestProxyFactory;
-import si.mazi.rescu.SynchronizedValueFactory;
 
 public class EXXTradeServiceRaw extends EXXBaseService {
   private final EXXAuthenticated exxAuthenticated;
-  private String apiKey;
-  private String secretKey;
-  private SynchronizedValueFactory<Long> nonceFactory;
+  private final String apiKey;
+  private final String secretKey;
 
   public EXXTradeServiceRaw(Exchange exchange) {
     super(exchange);
     this.exxAuthenticated =
-        RestProxyFactory.createProxy(
-            EXXAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                EXXAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
 
     this.apiKey = super.apiKey;
     this.secretKey = super.secretKey;
-    this.nonceFactory = exchange.getNonceFactory();
   }
 
   /**

--- a/xchange-fcoin/src/main/java/org/knowm/xchange/fcoin/service/FCoinBaseService.java
+++ b/xchange-fcoin/src/main/java/org/knowm/xchange/fcoin/service/FCoinBaseService.java
@@ -1,11 +1,11 @@
 package org.knowm.xchange.fcoin.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.fcoin.FCoin;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class FCoinBaseService extends BaseExchangeService implements BaseService {
 
@@ -23,8 +23,8 @@ public class FCoinBaseService extends BaseExchangeService implements BaseService
     super(exchange);
     apiKey = exchange.getExchangeSpecification().getApiKey();
     fcoin =
-        RestProxyFactory.createProxy(
-            FCoin.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(FCoin.class, exchange.getExchangeSpecification())
+            .build();
     signatureCreator =
         FCoinDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(), apiKey);
   }

--- a/xchange-gateio/src/main/java/org/knowm/xchange/gateio/service/GateioBaseService.java
+++ b/xchange-gateio/src/main/java/org/knowm/xchange/gateio/service/GateioBaseService.java
@@ -1,13 +1,13 @@
 package org.knowm.xchange.gateio.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.gateio.GateioAuthenticated;
 import org.knowm.xchange.gateio.dto.GateioBaseResponse;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class GateioBaseService extends BaseExchangeService implements BaseService {
 
@@ -25,10 +25,9 @@ public class GateioBaseService extends BaseExchangeService implements BaseServic
     super(exchange);
 
     this.bter =
-        RestProxyFactory.createProxy(
-            GateioAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                GateioAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =
         GateioHmacPostBodyDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/GeminiBaseService.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/GeminiBaseService.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.gemini.v1.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.FundsExceededException;
 import org.knowm.xchange.gemini.v1.GeminiAuthenticated;
@@ -9,7 +10,6 @@ import org.knowm.xchange.gemini.v2.Gemini2;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class GeminiBaseService extends BaseExchangeService implements BaseService {
 
@@ -29,14 +29,13 @@ public class GeminiBaseService extends BaseExchangeService implements BaseServic
     super(exchange);
 
     this.gemini =
-        RestProxyFactory.createProxy(
-            GeminiAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                GeminiAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
 
     this.gemini2 =
-        RestProxyFactory.createProxy(
-            Gemini2.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Gemini2.class, exchange.getExchangeSpecification())
+            .build();
 
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =

--- a/xchange-globitex/src/main/java/org/knowm/xchange/globitex/service/GlobitexBaseService.java
+++ b/xchange-globitex/src/main/java/org/knowm/xchange/globitex/service/GlobitexBaseService.java
@@ -1,11 +1,11 @@
 package org.knowm.xchange.globitex.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.globitex.GlobitexAuthenticated;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class GlobitexBaseService extends BaseExchangeService implements BaseService {
 
@@ -16,10 +16,9 @@ public class GlobitexBaseService extends BaseExchangeService implements BaseServ
     super(exchange);
 
     globitex =
-        RestProxyFactory.createProxy(
-            GlobitexAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                GlobitexAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
 
     signatureCreator =
         GlobitexDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcBaseService.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcBaseService.java
@@ -1,12 +1,12 @@
 package org.knowm.xchange.hitbtc.v2.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ClientConfigCustomizer;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.hitbtc.v2.HitbtcAuthenticated;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.ClientConfigUtil;
-import si.mazi.rescu.RestProxyFactory;
 
 public class HitbtcBaseService extends BaseExchangeService implements BaseService {
 
@@ -19,10 +19,12 @@ public class HitbtcBaseService extends BaseExchangeService implements BaseServic
     String apiKey = exchange.getExchangeSpecification().getApiKey();
     String secretKey = exchange.getExchangeSpecification().getSecretKey();
 
-    ClientConfig config = getClientConfig();
-    ClientConfigUtil.addBasicAuthCredentials(config, apiKey, secretKey);
+    ClientConfigCustomizer clientConfigCustomizer =
+        config -> ClientConfigUtil.addBasicAuthCredentials(config, apiKey, secretKey);
     hitbtc =
-        RestProxyFactory.createProxy(
-            HitbtcAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), config);
+        ExchangeRestProxyBuilder.forInterface(
+                HitbtcAuthenticated.class, exchange.getExchangeSpecification())
+            .clientConfigCustomizer(clientConfigCustomizer)
+            .build();
   }
 }

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/HuobiBaseService.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/HuobiBaseService.java
@@ -2,6 +2,7 @@ package org.knowm.xchange.huobi.service;
 
 import java.io.IOException;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.huobi.Huobi;
 import org.knowm.xchange.huobi.dto.HuobiResult;
@@ -11,7 +12,6 @@ import org.knowm.xchange.huobi.dto.marketdata.results.HuobiAssetsResult;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class HuobiBaseService extends BaseExchangeService implements BaseService {
 
@@ -21,8 +21,8 @@ public class HuobiBaseService extends BaseExchangeService implements BaseService
   public HuobiBaseService(Exchange exchange) {
     super(exchange);
     huobi =
-        RestProxyFactory.createProxy(
-            Huobi.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Huobi.class, exchange.getExchangeSpecification())
+            .build();
     signatureCreator =
         HuobiDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }

--- a/xchange-idex/src/main/java/org/knowm/xchange/idex/IdexAccountService.java
+++ b/xchange-idex/src/main/java/org/knowm/xchange/idex/IdexAccountService.java
@@ -8,6 +8,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.dto.account.AccountInfo;
 import org.knowm.xchange.dto.account.Balance;
@@ -15,7 +16,12 @@ import org.knowm.xchange.dto.account.FundingRecord;
 import org.knowm.xchange.dto.account.FundingRecord.Status;
 import org.knowm.xchange.dto.account.FundingRecord.Type;
 import org.knowm.xchange.dto.account.Wallet;
-import org.knowm.xchange.idex.dto.*;
+import org.knowm.xchange.idex.dto.CompleteBalancesReq;
+import org.knowm.xchange.idex.dto.DepositsWithdrawalsReq;
+import org.knowm.xchange.idex.dto.ReturnCompleteBalancesResponse;
+import org.knowm.xchange.idex.dto.ReturnDepositsWithdrawalsResponse;
+import org.knowm.xchange.idex.dto.WithdrawReq;
+import org.knowm.xchange.idex.dto.WithdrawResponse;
 import org.knowm.xchange.idex.service.ReturnCompleteBalancesApi;
 import org.knowm.xchange.idex.service.ReturnDepositsWithdrawalsApi;
 import org.knowm.xchange.idex.service.WithdrawApi;
@@ -23,43 +29,37 @@ import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.account.AccountService;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.WithdrawFundsParams;
-import si.mazi.rescu.RestProxyFactory;
 
 public class IdexAccountService extends BaseExchangeService implements AccountService {
 
-  private ReturnCompleteBalancesApi returnCompleteBalancesApi;
-
-  private ReturnDepositsWithdrawalsApi returnDepositsWithdrawalsApi;
-
-  private WithdrawApi withdrawApi;
-
-  private String apiKey;
+  private final ReturnCompleteBalancesApi returnCompleteBalancesApi;
+  private final ReturnDepositsWithdrawalsApi returnDepositsWithdrawalsApi;
+  private final WithdrawApi withdrawApi;
+  private final String apiKey;
 
   public IdexAccountService(IdexExchange idexExchange) {
 
     super(idexExchange);
 
     returnCompleteBalancesApi =
-        RestProxyFactory.createProxy(
-            ReturnCompleteBalancesApi.class,
-            idexExchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                ReturnCompleteBalancesApi.class, idexExchange.getExchangeSpecification())
+            .build();
 
     returnDepositsWithdrawalsApi =
-        RestProxyFactory.createProxy(
-            ReturnDepositsWithdrawalsApi.class,
-            idexExchange.getDefaultExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                ReturnDepositsWithdrawalsApi.class, idexExchange.getExchangeSpecification())
+            .build();
 
     withdrawApi =
-        RestProxyFactory.createProxy(
-            WithdrawApi.class,
-            idexExchange.getDefaultExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                WithdrawApi.class, idexExchange.getExchangeSpecification())
+            .build();
 
     apiKey = exchange.getExchangeSpecification().getApiKey();
   }
 
+  @Override
   public AccountInfo getAccountInfo() {
     AccountInfo ret = null;
     try {
@@ -90,6 +90,7 @@ public class IdexAccountService extends BaseExchangeService implements AccountSe
     return ret;
   }
 
+  @Override
   public String requestDepositAddress(Currency currency, String... args) {
     return exchange.getExchangeSpecification().getApiKey();
   }
@@ -112,7 +113,7 @@ public class IdexAccountService extends BaseExchangeService implements AccountSe
     return ret;
   }
 
-  private final List<FundingRecord> mutableList(
+  private List<FundingRecord> mutableList(
       ReturnDepositsWithdrawalsResponse returnDepositsWithdrawalsPost) {
 
     return Arrays.asList(
@@ -154,10 +155,12 @@ public class IdexAccountService extends BaseExchangeService implements AccountSe
         .collect(Collectors.toList());
   }
 
+  @Override
   public TradeHistoryParams createFundingHistoryParams() {
     return new IdexDepositsWithdrawalsParams(apiKey);
   }
 
+  @Override
   public String withdrawFunds(WithdrawFundsParams w) {
     String ret = "error";
     if (w instanceof IdexWithdraw) {

--- a/xchange-idex/src/main/java/org/knowm/xchange/idex/IdexExchange.java
+++ b/xchange-idex/src/main/java/org/knowm/xchange/idex/IdexExchange.java
@@ -11,6 +11,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import org.knowm.xchange.BaseExchange;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.meta.CurrencyMetaData;
@@ -23,7 +24,6 @@ import org.knowm.xchange.idex.dto.ReturnCurrenciesResponse;
 import org.knowm.xchange.idex.dto.ReturnNextNonceResponse;
 import org.knowm.xchange.idex.dto.ReturnTickerRequestedWithNull;
 import org.knowm.xchange.idex.service.ReturnNextNonceApi;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 public class IdexExchange extends BaseExchange {
@@ -36,6 +36,7 @@ public class IdexExchange extends BaseExchange {
     return unavailableCPMeta;
   }
 
+  @Override
   public final ExchangeMetaData getExchangeMetaData() {
 
     ReturnCurrenciesResponse allCurrenciesStatic = null;
@@ -78,21 +79,25 @@ public class IdexExchange extends BaseExchange {
   public ReturnNextNonceApi getNextNonceApi() {
     if (null == nextNonceApi) {
       nextNonceApi =
-          RestProxyFactory.createProxy(ReturnNextNonceApi.class, exchangeSpecification.getSslUri());
+          ExchangeRestProxyBuilder.forInterface(ReturnNextNonceApi.class, exchangeSpecification)
+              .build();
     }
     return nextNonceApi;
   }
 
+  @Override
   public IdexAccountService getAccountService() {
     if (null == idexAccountService) idexAccountService = new IdexAccountService(this);
     return idexAccountService;
   }
 
+  @Override
   public IdexMarketDataService getMarketDataService() {
     if (null == idexMarketDataService) idexMarketDataService = new IdexMarketDataService(this);
     return idexMarketDataService;
   }
 
+  @Override
   public IdexTradeService getTradeService() {
     if (null == idexTradeService) idexTradeService = new IdexTradeService(this);
     return idexTradeService;

--- a/xchange-idex/src/main/java/org/knowm/xchange/idex/IdexMarketDataService.java
+++ b/xchange-idex/src/main/java/org/knowm/xchange/idex/IdexMarketDataService.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import javax.net.ssl.HttpsURLConnection;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
@@ -21,43 +22,44 @@ import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trade;
 import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.dto.trade.LimitOrder;
-import org.knowm.xchange.idex.dto.*;
+import org.knowm.xchange.idex.dto.IdexBuySell;
+import org.knowm.xchange.idex.dto.Market;
+import org.knowm.xchange.idex.dto.OrderBookReq;
+import org.knowm.xchange.idex.dto.ReturnCurrenciesResponse;
+import org.knowm.xchange.idex.dto.ReturnOrderBookResponse;
+import org.knowm.xchange.idex.dto.ReturnTickerRequestedWithNull;
+import org.knowm.xchange.idex.dto.ReturnTickerResponse;
+import org.knowm.xchange.idex.dto.TradeHistoryReq;
 import org.knowm.xchange.idex.service.ReturnOrderBookApi;
 import org.knowm.xchange.idex.service.ReturnTickerApi;
 import org.knowm.xchange.idex.service.ReturnTradeHistoryApi;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.marketdata.MarketDataService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class IdexMarketDataService extends BaseExchangeService implements MarketDataService {
 
-  private ReturnTickerApi returnTickerApi;
-
-  private ReturnOrderBookApi returnOrderBookApi;
-
-  private ReturnTradeHistoryApi returnTradeHistoryApi;
+  private final ReturnTickerApi returnTickerApi;
+  private final ReturnOrderBookApi returnOrderBookApi;
+  private final ReturnTradeHistoryApi returnTradeHistoryApi;
 
   public IdexMarketDataService(IdexExchange idexExchange) {
 
     super(idexExchange);
 
     returnTickerApi =
-        RestProxyFactory.createProxy(
-            ReturnTickerApi.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                ReturnTickerApi.class, exchange.getExchangeSpecification())
+            .build();
 
     returnOrderBookApi =
-        RestProxyFactory.createProxy(
-            ReturnOrderBookApi.class,
-            exchange.getDefaultExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                ReturnOrderBookApi.class, exchange.getExchangeSpecification())
+            .build();
 
     returnTradeHistoryApi =
-        RestProxyFactory.createProxy(
-            ReturnTradeHistoryApi.class,
-            exchange.getDefaultExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                ReturnTradeHistoryApi.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   @Override

--- a/xchange-idex/src/main/java/org/knowm/xchange/idex/IdexTradeService.java
+++ b/xchange-idex/src/main/java/org/knowm/xchange/idex/IdexTradeService.java
@@ -10,21 +10,40 @@ import static org.knowm.xchange.idex.IdexSignature.generateSignature;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.MathContext;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
 import java.util.stream.Collectors;
 import org.bouncycastle.util.encoders.Hex;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.marketdata.Trade;
 import org.knowm.xchange.dto.marketdata.Trades;
-import org.knowm.xchange.dto.trade.*;
+import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.LimitOrder.Builder;
+import org.knowm.xchange.dto.trade.MarketOrder;
+import org.knowm.xchange.dto.trade.OpenOrders;
+import org.knowm.xchange.dto.trade.StopOrder;
+import org.knowm.xchange.dto.trade.UserTrade;
+import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.idex.IdexExchange.Companion.IdexCurrencyMeta;
-import org.knowm.xchange.idex.dto.*;
-import org.knowm.xchange.idex.service.*;
+import org.knowm.xchange.idex.dto.IdexBuySell;
+import org.knowm.xchange.idex.dto.OpenOrdersReq;
+import org.knowm.xchange.idex.dto.OrderReq;
+import org.knowm.xchange.idex.dto.ReturnContractAddressResponse;
+import org.knowm.xchange.idex.dto.ReturnOpenOrdersResponse;
+import org.knowm.xchange.idex.dto.TradeHistoryReq;
+import org.knowm.xchange.idex.service.CancelApi;
+import org.knowm.xchange.idex.service.OrderApi;
+import org.knowm.xchange.idex.service.ReturnContractAddressApi;
+import org.knowm.xchange.idex.service.ReturnOpenOrdersApi;
+import org.knowm.xchange.idex.service.ReturnTradeHistoryApi;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.trade.TradeService;
 import org.knowm.xchange.service.trade.params.CancelOrderParams;
@@ -32,7 +51,6 @@ import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
 import org.web3j.crypto.Sign.SignatureData;
-import si.mazi.rescu.RestProxyFactory;
 
 public class IdexTradeService extends BaseExchangeService implements TradeService {
 
@@ -52,30 +70,27 @@ public class IdexTradeService extends BaseExchangeService implements TradeServic
     super(idexExchange);
 
     returnOpenOrdersApi =
-        RestProxyFactory.createProxy(
-            ReturnOpenOrdersApi.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                ReturnOpenOrdersApi.class, exchange.getExchangeSpecification())
+            .build();
 
     cancelApi =
-        RestProxyFactory.createProxy(
-            CancelApi.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(CancelApi.class, exchange.getExchangeSpecification())
+            .build();
 
     returnTradeHistoryApi =
-        RestProxyFactory.createProxy(
-            ReturnTradeHistoryApi.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                ReturnTradeHistoryApi.class, exchange.getExchangeSpecification())
+            .build();
 
     orderApi =
-        RestProxyFactory.createProxy(
-            OrderApi.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(OrderApi.class, exchange.getExchangeSpecification())
+            .build();
 
     returnContractAddressApi =
-        RestProxyFactory.createProxy(
-            ReturnContractAddressApi.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                ReturnContractAddressApi.class, exchange.getExchangeSpecification())
+            .build();
 
     apiKey = exchange.getExchangeSpecification().getApiKey();
   }

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveAccountServiceRaw.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveAccountServiceRaw.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Date;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.independentreserve.IndependentReserveAuthenticated;
 import org.knowm.xchange.independentreserve.dto.IndependentReserveHttpStatusException;
@@ -18,7 +19,6 @@ import org.knowm.xchange.independentreserve.dto.trade.IndependentReserveTransact
 import org.knowm.xchange.independentreserve.dto.trade.IndependentReserveTransactionsRequest;
 import org.knowm.xchange.independentreserve.dto.trade.IndependentReserveTransactionsResponse;
 import org.knowm.xchange.independentreserve.util.ExchangeEndpoint;
-import si.mazi.rescu.RestProxyFactory;
 
 /** Author: Kamil Zbikowski Date: 4/10/15 */
 public class IndependentReserveAccountServiceRaw extends IndependentReserveBaseService {
@@ -36,10 +36,9 @@ public class IndependentReserveAccountServiceRaw extends IndependentReserveBaseS
     super(exchange);
 
     this.independentReserveAuthenticated =
-        RestProxyFactory.createProxy(
-            IndependentReserveAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                IndependentReserveAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.signatureCreator =
         IndependentReserveDigest.createInstance(
             exchange.getExchangeSpecification().getSecretKey(),

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveMarketDataServiceRaw.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveMarketDataServiceRaw.java
@@ -2,10 +2,10 @@ package org.knowm.xchange.independentreserve.service;
 
 import java.io.IOException;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.independentreserve.IndependentReserve;
 import org.knowm.xchange.independentreserve.dto.marketdata.IndependentReserveOrderBook;
 import org.knowm.xchange.independentreserve.dto.marketdata.IndependentReserveTicker;
-import si.mazi.rescu.RestProxyFactory;
 
 /** Author: Kamil Zbikowski Date: 4/9/15 */
 public class IndependentReserveMarketDataServiceRaw extends IndependentReserveBaseService {
@@ -14,10 +14,9 @@ public class IndependentReserveMarketDataServiceRaw extends IndependentReserveBa
   public IndependentReserveMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
     this.independentReserve =
-        RestProxyFactory.createProxy(
-            IndependentReserve.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                IndependentReserve.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public IndependentReserveTicker getIndependentReserveTicker(

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveTradeServiceRaw.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveTradeServiceRaw.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Date;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.exceptions.CurrencyPairNotValidException;
@@ -25,7 +26,6 @@ import org.knowm.xchange.independentreserve.dto.trade.IndependentReserveTransact
 import org.knowm.xchange.independentreserve.dto.trade.IndependentReserveTransactionsResponse;
 import org.knowm.xchange.independentreserve.util.ExchangeEndpoint;
 import org.knowm.xchange.instrument.Instrument;
-import si.mazi.rescu.RestProxyFactory;
 
 /** Author: Kamil Zbikowski Date: 4/13/15 */
 public class IndependentReserveTradeServiceRaw extends IndependentReserveBaseService {
@@ -43,10 +43,9 @@ public class IndependentReserveTradeServiceRaw extends IndependentReserveBaseSer
     super(exchange);
 
     this.independentReserveAuthenticated =
-        RestProxyFactory.createProxy(
-            IndependentReserveAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                IndependentReserveAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.signatureCreator =
         IndependentReserveDigest.createInstance(
             exchange.getExchangeSpecification().getSecretKey(),

--- a/xchange-itbit/src/main/java/org/knowm/xchange/itbit/service/ItBitBaseService.java
+++ b/xchange-itbit/src/main/java/org/knowm/xchange/itbit/service/ItBitBaseService.java
@@ -1,12 +1,12 @@
 package org.knowm.xchange.itbit.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.itbit.ItBit;
 import org.knowm.xchange.itbit.ItBitAuthenticated;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class ItBitBaseService extends BaseExchangeService implements BaseService {
 
@@ -28,20 +28,21 @@ public class ItBitBaseService extends BaseExchangeService implements BaseService
 
     super(exchange);
 
+    final String baseUrl =
+        (String) exchange.getExchangeSpecification().getExchangeSpecificParametersItem("authHost");
     this.itBitAuthenticated =
-        RestProxyFactory.createProxy(
-            ItBitAuthenticated.class,
-            (String)
-                exchange.getExchangeSpecification().getExchangeSpecificParametersItem("authHost"),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                ItBitAuthenticated.class, exchange.getExchangeSpecification())
+            .baseUrl(baseUrl)
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =
         ItBitHmacPostBodyDigest.createInstance(
             apiKey, exchange.getExchangeSpecification().getSecretKey());
 
     this.itBitPublic =
-        RestProxyFactory.createProxy(
-            ItBit.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(ItBit.class, exchange.getExchangeSpecification())
+            .build();
 
     this.userId =
         (String) exchange.getExchangeSpecification().getExchangeSpecificParametersItem("userId");

--- a/xchange-koineks/src/main/java/org/knowm/xchange/koineks/service/KoineksMarketDataServiceRaw.java
+++ b/xchange-koineks/src/main/java/org/knowm/xchange/koineks/service/KoineksMarketDataServiceRaw.java
@@ -2,9 +2,9 @@ package org.knowm.xchange.koineks.service;
 
 import java.io.IOException;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.koineks.Koineks;
 import org.knowm.xchange.koineks.dto.marketdata.KoineksTicker;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author semihunaldi */
 public class KoineksMarketDataServiceRaw extends KoineksBaseService {
@@ -15,8 +15,8 @@ public class KoineksMarketDataServiceRaw extends KoineksBaseService {
 
     super(exchange);
     this.koineks =
-        RestProxyFactory.createProxy(
-            Koineks.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Koineks.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public KoineksTicker getKoineksTicker() throws IOException {

--- a/xchange-koinim/src/main/java/org/knowm/xchange/koinim/service/KoinimMarketDataServiceRaw.java
+++ b/xchange-koinim/src/main/java/org/knowm/xchange/koinim/service/KoinimMarketDataServiceRaw.java
@@ -2,9 +2,9 @@ package org.knowm.xchange.koinim.service;
 
 import java.io.IOException;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.koinim.Koinim;
 import org.knowm.xchange.koinim.dto.marketdata.KoinimTicker;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author ahmet.oz */
 public class KoinimMarketDataServiceRaw extends KoinimBaseService {
@@ -15,8 +15,8 @@ public class KoinimMarketDataServiceRaw extends KoinimBaseService {
 
     super(exchange);
     this.koinim =
-        RestProxyFactory.createProxy(
-            Koinim.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Koinim.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public KoinimTicker getKoinimTicker() throws IOException {

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenBaseService.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenBaseService.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.IOrderFlags;
@@ -29,7 +30,6 @@ import org.knowm.xchange.kraken.dto.trade.KrakenOrderFlags;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class KrakenBaseService extends BaseExchangeService implements BaseService {
 
@@ -46,10 +46,9 @@ public class KrakenBaseService extends BaseExchangeService implements BaseServic
     super(exchange);
 
     kraken =
-        RestProxyFactory.createProxy(
-            KrakenAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                KrakenAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     signatureCreator =
         KrakenDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinBaseService.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinBaseService.java
@@ -1,10 +1,21 @@
 package org.knowm.xchange.kucoin;
 
 import com.google.common.base.Strings;
-import org.knowm.xchange.kucoin.service.*;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
+import org.knowm.xchange.kucoin.service.AccountAPI;
+import org.knowm.xchange.kucoin.service.DepositAPI;
+import org.knowm.xchange.kucoin.service.FillAPI;
+import org.knowm.xchange.kucoin.service.HistOrdersAPI;
+import org.knowm.xchange.kucoin.service.HistoryAPI;
+import org.knowm.xchange.kucoin.service.KucoinApiException;
+import org.knowm.xchange.kucoin.service.KucoinDigest;
+import org.knowm.xchange.kucoin.service.OrderAPI;
+import org.knowm.xchange.kucoin.service.OrderBookAPI;
+import org.knowm.xchange.kucoin.service.SymbolAPI;
+import org.knowm.xchange.kucoin.service.WebsocketAPI;
+import org.knowm.xchange.kucoin.service.WithdrawalAPI;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 public class KucoinBaseService extends BaseExchangeService<KucoinExchange> implements BaseService {
@@ -47,8 +58,8 @@ public class KucoinBaseService extends BaseExchangeService<KucoinExchange> imple
   }
 
   private <T> T service(KucoinExchange exchange, Class<T> clazz) {
-    return RestProxyFactory.createProxy(
-        clazz, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+    return ExchangeRestProxyBuilder.forInterface(clazz, exchange.getExchangeSpecification())
+        .build();
   }
 
   protected void checkAuthenticated() {

--- a/xchange-kuna/src/main/java/org/knowm/xchange/kuna/service/KunaBaseService.java
+++ b/xchange-kuna/src/main/java/org/knowm/xchange/kuna/service/KunaBaseService.java
@@ -1,17 +1,17 @@
 package org.knowm.xchange.kuna.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.kuna.Kuna;
 import org.knowm.xchange.kuna.KunaAuthenticated;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author Dat Bui */
 public class KunaBaseService extends BaseExchangeService implements BaseService {
 
-  private Kuna kuna;
-  private KunaAuthenticated kunaAuthenticated;
+  private final Kuna kuna;
+  private final KunaAuthenticated kunaAuthenticated;
 
   /**
    * Constructor.
@@ -21,13 +21,12 @@ public class KunaBaseService extends BaseExchangeService implements BaseService 
   protected KunaBaseService(Exchange exchange) {
     super(exchange);
     kuna =
-        RestProxyFactory.createProxy(
-            Kuna.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Kuna.class, exchange.getExchangeSpecification())
+            .build();
     kunaAuthenticated =
-        RestProxyFactory.createProxy(
-            KunaAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                KunaAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   protected Kuna getKuna() {

--- a/xchange-lakebtc/src/main/java/org/knowm/xchange/lakebtc/service/LakeBTCBaseService.java
+++ b/xchange-lakebtc/src/main/java/org/knowm/xchange/lakebtc/service/LakeBTCBaseService.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.lakebtc.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.lakebtc.LakeBTC;
 import org.knowm.xchange.lakebtc.LakeBTCAuthenticated;
@@ -9,7 +10,6 @@ import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import org.knowm.xchange.utils.Assert;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author kpysniak */
 public class LakeBTCBaseService extends BaseExchangeService implements BaseService {
@@ -33,18 +33,17 @@ public class LakeBTCBaseService extends BaseExchangeService implements BaseServi
         "Exchange specification URI cannot be null");
 
     this.lakeBTCAuthenticated =
-        RestProxyFactory.createProxy(
-            LakeBTCAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                LakeBTCAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.signatureCreator =
         LakeBTCDigest.createInstance(
             exchange.getExchangeSpecification().getUserName(),
             exchange.getExchangeSpecification().getSecretKey());
 
     this.lakeBTC =
-        RestProxyFactory.createProxy(
-            LakeBTC.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(LakeBTC.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public static <T extends LakeBTCResponse> T checkResult(T returnObject) {

--- a/xchange-latoken/src/main/java/org/knowm/xchange/latoken/LatokenExchange.java
+++ b/xchange-latoken/src/main/java/org/knowm/xchange/latoken/LatokenExchange.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import org.knowm.xchange.BaseExchange;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.meta.CurrencyMetaData;
@@ -16,14 +17,10 @@ import org.knowm.xchange.latoken.service.LatokenAccountService;
 import org.knowm.xchange.latoken.service.LatokenMarketDataService;
 import org.knowm.xchange.latoken.service.LatokenTradeService;
 import org.knowm.xchange.utils.AuthUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 public class LatokenExchange extends BaseExchange {
 
-  private static final Logger LOG = LoggerFactory.getLogger(LatokenExchange.class);
   private static final int PRECISION = 8;
 
   private LatokenAuthenticated latoken;
@@ -31,8 +28,9 @@ public class LatokenExchange extends BaseExchange {
   @Override
   protected void initServices() {
     this.latoken =
-        RestProxyFactory.createProxy(
-            LatokenAuthenticated.class, getExchangeSpecification().getSslUri());
+        ExchangeRestProxyBuilder.forInterface(
+                LatokenAuthenticated.class, getExchangeSpecification())
+            .build();
     this.marketDataService = new LatokenMarketDataService(this);
     this.tradeService = new LatokenTradeService(this);
     this.accountService = new LatokenAccountService(this);

--- a/xchange-latoken/src/main/java/org/knowm/xchange/latoken/service/LatokenBaseService.java
+++ b/xchange-latoken/src/main/java/org/knowm/xchange/latoken/service/LatokenBaseService.java
@@ -1,13 +1,13 @@
 package org.knowm.xchange.latoken.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.latoken.LatokenAuthenticated;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class LatokenBaseService extends BaseExchangeService<Exchange> implements BaseService {
 
@@ -21,10 +21,9 @@ public class LatokenBaseService extends BaseExchangeService<Exchange> implements
 
     super(exchange);
     this.latoken =
-        RestProxyFactory.createProxy(
-            LatokenAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                LatokenAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =
         LatokenHmacDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());

--- a/xchange-lgo/src/main/java/org/knowm/xchange/lgo/service/LgoBaseService.java
+++ b/xchange-lgo/src/main/java/org/knowm/xchange/lgo/service/LgoBaseService.java
@@ -1,10 +1,10 @@
 package org.knowm.xchange.lgo.service;
 
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.lgo.Lgo;
 import org.knowm.xchange.lgo.LgoExchange;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class LgoBaseService extends BaseExchangeService<LgoExchange> implements BaseService {
 
@@ -13,7 +13,7 @@ public class LgoBaseService extends BaseExchangeService<LgoExchange> implements 
   protected LgoBaseService(LgoExchange exchange) {
     super(exchange);
     proxy =
-        RestProxyFactory.createProxy(
-            Lgo.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Lgo.class, exchange.getExchangeSpecification())
+            .build();
   }
 }

--- a/xchange-lgo/src/main/java/org/knowm/xchange/lgo/service/LgoKeyService.java
+++ b/xchange-lgo/src/main/java/org/knowm/xchange/lgo/service/LgoKeyService.java
@@ -4,12 +4,12 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.lgo.CertificateAuthority;
 import org.knowm.xchange.lgo.LgoAdapters;
 import org.knowm.xchange.lgo.LgoEnv;
 import org.knowm.xchange.lgo.dto.key.LgoKey;
-import si.mazi.rescu.RestProxyFactory;
 
 public class LgoKeyService {
 
@@ -17,10 +17,12 @@ public class LgoKeyService {
   private LgoKey currentKey;
 
   public LgoKeyService(ExchangeSpecification exchangeSpecification) {
+    final String baseUrl =
+        exchangeSpecification.getExchangeSpecificParametersItem(LgoEnv.KEYS_URL).toString();
     proxy =
-        RestProxyFactory.createProxy(
-            CertificateAuthority.class,
-            exchangeSpecification.getExchangeSpecificParametersItem(LgoEnv.KEYS_URL).toString());
+        ExchangeRestProxyBuilder.forInterface(CertificateAuthority.class, exchangeSpecification)
+            .baseUrl(baseUrl)
+            .build();
   }
 
   public LgoKey selectKey() {

--- a/xchange-luno/src/main/java/org/knowm/xchange/luno/LunoAPIImpl.java
+++ b/xchange-luno/src/main/java/org/knowm/xchange/luno/LunoAPIImpl.java
@@ -5,6 +5,8 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.luno.dto.LunoBoolean;
 import org.knowm.xchange.luno.dto.LunoException;
 import org.knowm.xchange.luno.dto.account.LunoAccount;
@@ -26,20 +28,22 @@ import org.knowm.xchange.luno.dto.trade.LunoPostOrder;
 import org.knowm.xchange.luno.dto.trade.OrderType;
 import org.knowm.xchange.luno.dto.trade.State;
 import si.mazi.rescu.BasicAuthCredentials;
-import si.mazi.rescu.ClientConfig;
-import si.mazi.rescu.RestProxyFactory;
 
 public class LunoAPIImpl implements LunoAPI {
 
   private static final Set<String> VALID_TYPES =
-      new HashSet<String>(Arrays.asList("ZAR_EFT", "NAD_EFT", "KES_MPESA", "MYR_IBG", "IDR_LLG"));
+      new HashSet<>(Arrays.asList("ZAR_EFT", "NAD_EFT", "KES_MPESA", "MYR_IBG", "IDR_LLG"));
   private final LunoAuthenticated luno;
   private final BasicAuthCredentials auth;
 
-  public LunoAPIImpl(String key, String secret, String uri, ClientConfig clientConfig) {
+  public LunoAPIImpl(ExchangeSpecification exchangeSpecification) {
 
-    luno = RestProxyFactory.createProxy(LunoAuthenticated.class, uri, clientConfig);
-    auth = new BasicAuthCredentials(key, secret);
+    luno =
+        ExchangeRestProxyBuilder.forInterface(LunoAuthenticated.class, exchangeSpecification)
+            .build();
+    auth =
+        new BasicAuthCredentials(
+            exchangeSpecification.getApiKey(), exchangeSpecification.getSecretKey());
   }
 
   @Override

--- a/xchange-luno/src/main/java/org/knowm/xchange/luno/service/LunoBaseService.java
+++ b/xchange-luno/src/main/java/org/knowm/xchange/luno/service/LunoBaseService.java
@@ -11,13 +11,7 @@ public class LunoBaseService extends BaseExchangeService implements BaseService 
   protected final LunoAPI lunoAPI;
 
   public LunoBaseService(Exchange exchange) {
-
     super(exchange);
-    lunoAPI =
-        new LunoAPIImpl(
-            exchange.getExchangeSpecification().getApiKey(),
-            exchange.getExchangeSpecification().getSecretKey(),
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+    lunoAPI = new LunoAPIImpl(exchange.getExchangeSpecification());
   }
 }

--- a/xchange-lykke/src/main/java/org/knowm/xchange/lykke/service/LykkeBaseService.java
+++ b/xchange-lykke/src/main/java/org/knowm/xchange/lykke/service/LykkeBaseService.java
@@ -1,11 +1,11 @@
 package org.knowm.xchange.lykke.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.lykke.Lykke;
 import org.knowm.xchange.lykke.LykkeAuthenticated;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class LykkeBaseService extends BaseExchangeService implements BaseService {
 
@@ -16,13 +16,14 @@ public class LykkeBaseService extends BaseExchangeService implements BaseService
   protected LykkeBaseService(Exchange exchange) {
     super(exchange);
     this.lykke =
-        RestProxyFactory.createProxy(
-            LykkeAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                LykkeAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.lykkePublic =
-        RestProxyFactory.createProxy(
-            LykkeAuthenticated.class, "https://public-api.lykke.com/", getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                LykkeAuthenticated.class, exchange.getExchangeSpecification())
+            .baseUrl("https://public-api.lykke.com/")
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
   }
 }

--- a/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/service/MercadoBitcoinAccountServiceRaw.java
+++ b/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/service/MercadoBitcoinAccountServiceRaw.java
@@ -2,11 +2,11 @@ package org.knowm.xchange.mercadobitcoin.service;
 
 import java.io.IOException;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.mercadobitcoin.MercadoBitcoinAuthenticated;
 import org.knowm.xchange.mercadobitcoin.dto.MercadoBitcoinBaseTradeApiResult;
 import org.knowm.xchange.mercadobitcoin.dto.account.MercadoBitcoinAccountInfo;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author Felipe Micaroni Lalli */
 public class MercadoBitcoinAccountServiceRaw extends MercadoBitcoinBaseService {
@@ -23,30 +23,28 @@ public class MercadoBitcoinAccountServiceRaw extends MercadoBitcoinBaseService {
   protected MercadoBitcoinAccountServiceRaw(Exchange exchange) {
 
     super(exchange);
-
     this.mercadoBitcoinAuthenticated =
-        RestProxyFactory.createProxy(
-            MercadoBitcoinAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                MercadoBitcoinAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public MercadoBitcoinBaseTradeApiResult<MercadoBitcoinAccountInfo> getMercadoBitcoinAccountInfo()
       throws IOException {
 
     String method = GET_ACCOUNT_INFO;
-    long tonce = exchange.getNonceFactory().createValue();
+    long nonce = exchange.getNonceFactory().createValue();
 
     MercadoBitcoinDigest signatureCreator =
         MercadoBitcoinDigest.createInstance(
             method,
             exchange.getExchangeSpecification().getPassword(),
             exchange.getExchangeSpecification().getSecretKey(),
-            tonce);
+            nonce);
 
     MercadoBitcoinBaseTradeApiResult<MercadoBitcoinAccountInfo> accountInfo =
         mercadoBitcoinAuthenticated.getInfo(
-            exchange.getExchangeSpecification().getApiKey(), signatureCreator, method, tonce);
+            exchange.getExchangeSpecification().getApiKey(), signatureCreator, method, nonce);
 
     if (accountInfo.getSuccess() == 0) {
       throw new ExchangeException("Error getting account info: " + accountInfo.getError());

--- a/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/service/MercadoBitcoinMarketDataServiceRaw.java
+++ b/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/service/MercadoBitcoinMarketDataServiceRaw.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.mercadobitcoin.service;
 import java.io.IOException;
 import java.math.BigDecimal;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.mercadobitcoin.MercadoBitcoin;
@@ -10,7 +11,6 @@ import org.knowm.xchange.mercadobitcoin.MercadoBitcoinUtils;
 import org.knowm.xchange.mercadobitcoin.dto.marketdata.MercadoBitcoinOrderBook;
 import org.knowm.xchange.mercadobitcoin.dto.marketdata.MercadoBitcoinTicker;
 import org.knowm.xchange.mercadobitcoin.dto.marketdata.MercadoBitcoinTransaction;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author Felipe Micaroni Lalli */
 public class MercadoBitcoinMarketDataServiceRaw extends MercadoBitcoinBaseService {
@@ -23,13 +23,11 @@ public class MercadoBitcoinMarketDataServiceRaw extends MercadoBitcoinBaseServic
    * @param exchange
    */
   public MercadoBitcoinMarketDataServiceRaw(Exchange exchange) {
-
     super(exchange);
     this.mercadoBitcoin =
-        RestProxyFactory.createProxy(
-            MercadoBitcoin.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                MercadoBitcoin.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public MercadoBitcoinOrderBook getMercadoBitcoinOrderBook(CurrencyPair currencyPair)

--- a/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/service/MercadoBitcoinTradeServiceRaw.java
+++ b/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/service/MercadoBitcoinTradeServiceRaw.java
@@ -5,13 +5,13 @@ import java.math.BigDecimal;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.mercadobitcoin.MercadoBitcoinAuthenticated;
 import org.knowm.xchange.mercadobitcoin.dto.MercadoBitcoinBaseTradeApiResult;
 import org.knowm.xchange.mercadobitcoin.dto.trade.MercadoBitcoinCancelOrderResult;
 import org.knowm.xchange.mercadobitcoin.dto.trade.MercadoBitcoinPlaceLimitOrderResult;
 import org.knowm.xchange.mercadobitcoin.dto.trade.MercadoBitcoinUserOrders;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author Felipe Micaroni Lalli */
 public class MercadoBitcoinTradeServiceRaw extends MercadoBitcoinBaseService {
@@ -31,10 +31,9 @@ public class MercadoBitcoinTradeServiceRaw extends MercadoBitcoinBaseService {
 
     super(exchange);
     this.mercadoBitcoinAuthenticated =
-        RestProxyFactory.createProxy(
-            MercadoBitcoinAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                MercadoBitcoinAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public MercadoBitcoinBaseTradeApiResult<MercadoBitcoinUserOrders> getMercadoBitcoinUserOrders(

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OKCoinBaseTradeService.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OKCoinBaseTradeService.java
@@ -1,12 +1,12 @@
 package org.knowm.xchange.okcoin.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.okcoin.OkCoin;
 import org.knowm.xchange.okcoin.OkCoinDigest;
 import org.knowm.xchange.okcoin.OkCoinUtils;
 import org.knowm.xchange.okcoin.dto.trade.OkCoinErrorResult;
-import si.mazi.rescu.RestProxyFactory;
 
 public class OKCoinBaseTradeService extends OkCoinBaseService {
 
@@ -24,8 +24,8 @@ public class OKCoinBaseTradeService extends OkCoinBaseService {
     super(exchange);
 
     okCoin =
-        RestProxyFactory.createProxy(
-            OkCoin.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(OkCoin.class, exchange.getExchangeSpecification())
+            .build();
     apikey = exchange.getExchangeSpecification().getApiKey();
     secretKey = exchange.getExchangeSpecification().getSecretKey();
   }

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinMarketDataServiceRaw.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinMarketDataServiceRaw.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.okcoin.FuturesContract;
 import org.knowm.xchange.okcoin.OkCoin;
@@ -16,7 +17,6 @@ import org.knowm.xchange.okcoin.dto.marketdata.OkCoinKline;
 import org.knowm.xchange.okcoin.dto.marketdata.OkCoinKlineType;
 import org.knowm.xchange.okcoin.dto.marketdata.OkCoinTickerResponse;
 import org.knowm.xchange.okcoin.dto.marketdata.OkCoinTrade;
-import si.mazi.rescu.RestProxyFactory;
 
 public class OkCoinMarketDataServiceRaw extends OkCoinBaseService {
 
@@ -32,8 +32,8 @@ public class OkCoinMarketDataServiceRaw extends OkCoinBaseService {
     super(exchange);
 
     okCoin =
-        RestProxyFactory.createProxy(
-            OkCoin.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(OkCoin.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   /**

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/v3/service/OkexBaseService.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/v3/service/OkexBaseService.java
@@ -1,12 +1,12 @@
 package org.knowm.xchange.okcoin.v3.service;
 
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.okcoin.OkexDigestV3;
 import org.knowm.xchange.okcoin.OkexExchangeV3;
 import org.knowm.xchange.okcoin.OkexV3;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class OkexBaseService extends BaseExchangeService<OkexExchangeV3> implements BaseService {
 
@@ -20,7 +20,7 @@ public class OkexBaseService extends BaseExchangeService<OkexExchangeV3> impleme
   public OkexBaseService(OkexExchangeV3 exchange) {
     super(exchange);
     final ExchangeSpecification spec = exchange.getExchangeSpecification();
-    okex = RestProxyFactory.createProxy(OkexV3.class, spec.getSslUri(), getClientConfig());
+    okex = ExchangeRestProxyBuilder.forInterface(OkexV3.class, spec).build();
     apikey = spec.getApiKey();
     passphrase = (String) spec.getExchangeSpecificParametersItem("passphrase");
 

--- a/xchange-openexchangerates/src/main/java/org/knowm/xchange/oer/service/OERMarketDataServiceRaw.java
+++ b/xchange-openexchangerates/src/main/java/org/knowm/xchange/oer/service/OERMarketDataServiceRaw.java
@@ -2,12 +2,12 @@ package org.knowm.xchange.oer.service;
 
 import java.io.IOException;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.oer.OER;
 import org.knowm.xchange.oer.dto.marketdata.OERRates;
 import org.knowm.xchange.oer.dto.marketdata.OERTickers;
-import si.mazi.rescu.RestProxyFactory;
 
 /** @author timmolter */
 public class OERMarketDataServiceRaw extends OERBaseService {
@@ -23,8 +23,8 @@ public class OERMarketDataServiceRaw extends OERBaseService {
 
     super(exchange);
     this.openExchangeRates =
-        RestProxyFactory.createProxy(
-            OER.class, exchange.getExchangeSpecification().getPlainTextUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(OER.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public OERRates getOERTicker(CurrencyPair pair) throws IOException {

--- a/xchange-paribu/src/main/java/org/knowm/xchange/paribu/service/ParibuMarketDataServiceRaw.java
+++ b/xchange-paribu/src/main/java/org/knowm/xchange/paribu/service/ParibuMarketDataServiceRaw.java
@@ -2,9 +2,9 @@ package org.knowm.xchange.paribu.service;
 
 import java.io.IOException;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.paribu.Paribu;
 import org.knowm.xchange.paribu.dto.marketdata.ParibuTicker;
-import si.mazi.rescu.RestProxyFactory;
 
 /** Created by semihunaldi on 27/11/2017 */
 public class ParibuMarketDataServiceRaw extends ParibuBaseService {
@@ -15,8 +15,8 @@ public class ParibuMarketDataServiceRaw extends ParibuBaseService {
 
     super(exchange);
     this.paribu =
-        RestProxyFactory.createProxy(
-            Paribu.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Paribu.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public ParibuTicker getParibuTicker() throws IOException {

--- a/xchange-paymium/src/main/java/org/knowm/xchange/paymium/service/PaymiumAccountServiceRaw.java
+++ b/xchange-paymium/src/main/java/org/knowm/xchange/paymium/service/PaymiumAccountServiceRaw.java
@@ -4,10 +4,10 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.paymium.PaymiumAuthenticated;
 import org.knowm.xchange.paymium.dto.account.PaymiumBalance;
 import org.knowm.xchange.paymium.dto.account.PaymiumOrder;
-import si.mazi.rescu.RestProxyFactory;
 
 public class PaymiumAccountServiceRaw extends PaymiumBaseService {
 
@@ -22,10 +22,10 @@ public class PaymiumAccountServiceRaw extends PaymiumBaseService {
     super(exchange);
 
     this.paymiumAuthenticated =
-        RestProxyFactory.createProxy(
-            org.knowm.xchange.paymium.PaymiumAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                org.knowm.xchange.paymium.PaymiumAuthenticated.class,
+                exchange.getExchangeSpecification())
+            .build();
   }
 
   public PaymiumBalance getPaymiumBalances() throws IOException {

--- a/xchange-paymium/src/main/java/org/knowm/xchange/paymium/service/PaymiumBaseService.java
+++ b/xchange-paymium/src/main/java/org/knowm/xchange/paymium/service/PaymiumBaseService.java
@@ -1,12 +1,12 @@
 package org.knowm.xchange.paymium.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.paymium.Paymium;
 import org.knowm.xchange.paymium.PaymiumAuthenticated;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class PaymiumBaseService extends BaseExchangeService implements BaseService {
 
@@ -28,14 +28,13 @@ public class PaymiumBaseService extends BaseExchangeService implements BaseServi
     super(exchange);
 
     this.paymium =
-        RestProxyFactory.createProxy(
-            Paymium.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Paymium.class, exchange.getExchangeSpecification())
+            .build();
 
     this.paymiumAuthenticated =
-        RestProxyFactory.createProxy(
-            PaymiumAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                PaymiumAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
 
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =

--- a/xchange-paymium/src/main/java/org/knowm/xchange/paymium/service/PaymiumTradeServiceRaw.java
+++ b/xchange-paymium/src/main/java/org/knowm/xchange/paymium/service/PaymiumTradeServiceRaw.java
@@ -4,9 +4,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.paymium.PaymiumAuthenticated;
 import org.knowm.xchange.paymium.dto.account.PaymiumOrder;
-import si.mazi.rescu.RestProxyFactory;
 
 public class PaymiumTradeServiceRaw extends PaymiumBaseService {
 
@@ -17,10 +17,10 @@ public class PaymiumTradeServiceRaw extends PaymiumBaseService {
     super(exchange);
 
     this.paymiumAuthenticated =
-        RestProxyFactory.createProxy(
-            org.knowm.xchange.paymium.PaymiumAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                org.knowm.xchange.paymium.PaymiumAuthenticated.class,
+                exchange.getExchangeSpecification())
+            .build();
   }
 
   public List<PaymiumOrder> getPaymiumOrders(Long offset, Integer limit) throws IOException {

--- a/xchange-quoine/src/main/java/org/knowm/xchange/quoine/service/QuoineBaseService.java
+++ b/xchange-quoine/src/main/java/org/knowm/xchange/quoine/service/QuoineBaseService.java
@@ -2,6 +2,7 @@ package org.knowm.xchange.quoine.service;
 
 import java.io.IOException;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.quoine.QuoineAuthenticated;
@@ -9,7 +10,6 @@ import org.knowm.xchange.quoine.QuoineExchange;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import si.mazi.rescu.HttpStatusIOException;
-import si.mazi.rescu.RestProxyFactory;
 
 public class QuoineBaseService extends BaseExchangeService implements BaseService {
 
@@ -30,10 +30,9 @@ public class QuoineBaseService extends BaseExchangeService implements BaseServic
     super(exchange);
 
     quoine =
-        RestProxyFactory.createProxy(
-            QuoineAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                QuoineAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
 
     this.tokenID = exchange.getExchangeSpecification().getApiKey();
     this.secret = exchange.getExchangeSpecification().getSecretKey();

--- a/xchange-ripple/src/main/java/org/knowm/xchange/ripple/service/RippleBaseService.java
+++ b/xchange-ripple/src/main/java/org/knowm/xchange/ripple/service/RippleBaseService.java
@@ -1,11 +1,11 @@
 package org.knowm.xchange.ripple.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.ripple.RippleAuthenticated;
 import org.knowm.xchange.ripple.RipplePublic;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
-import si.mazi.rescu.RestProxyFactory;
 
 public class RippleBaseService extends BaseExchangeService implements BaseService {
 
@@ -26,8 +26,15 @@ public class RippleBaseService extends BaseExchangeService implements BaseServic
     } else {
       throw new IllegalStateException("either SSL or plain text URI must be specified");
     }
-    ripplePublic = RestProxyFactory.createProxy(RipplePublic.class, uri, getClientConfig());
+    ripplePublic =
+        ExchangeRestProxyBuilder.forInterface(
+                RipplePublic.class, exchange.getExchangeSpecification())
+            .baseUrl(uri)
+            .build();
     rippleAuthenticated =
-        RestProxyFactory.createProxy(RippleAuthenticated.class, uri, getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                RippleAuthenticated.class, exchange.getExchangeSpecification())
+            .baseUrl(uri)
+            .build();
   }
 }

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingExchange.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingExchange.java
@@ -14,11 +14,10 @@ import java.util.stream.Stream;
 import org.knowm.xchange.binance.BinanceAuthenticated;
 import org.knowm.xchange.binance.BinanceExchange;
 import org.knowm.xchange.binance.service.BinanceMarketDataService;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.CurrencyPair;
-import org.knowm.xchange.service.BaseExchangeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import si.mazi.rescu.RestProxyFactory;
 
 public class BinanceStreamingExchange extends BinanceExchange implements StreamingExchange {
 
@@ -89,10 +88,9 @@ public class BinanceStreamingExchange extends BinanceExchange implements Streami
 
       LOG.info("Connecting to authenticated web socket");
       BinanceAuthenticated binance =
-          RestProxyFactory.createProxy(
-              BinanceAuthenticated.class,
-              getExchangeSpecification().getSslUri(),
-              new BaseExchangeService<BinanceExchange>(this) {}.getClientConfig());
+          ExchangeRestProxyBuilder.forInterface(
+                  BinanceAuthenticated.class, getExchangeSpecification())
+              .build();
       userDataChannel =
           new BinanceUserDataChannel(binance, exchangeSpecification.getApiKey(), onApiCall);
       try {

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockAccountServiceRaw.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockAccountServiceRaw.java
@@ -6,6 +6,7 @@ import java.util.Date;
 import java.util.List;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.therock.TheRockAuthenticated;
 import org.knowm.xchange.therock.dto.TheRockException;
@@ -13,7 +14,6 @@ import org.knowm.xchange.therock.dto.account.TheRockBalance;
 import org.knowm.xchange.therock.dto.account.TheRockWithdrawal;
 import org.knowm.xchange.therock.dto.account.TheRockWithdrawalResponse;
 import org.knowm.xchange.therock.dto.trade.TheRockTransactions;
-import si.mazi.rescu.RestProxyFactory;
 
 public class TheRockAccountServiceRaw extends TheRockBaseService {
 
@@ -27,8 +27,7 @@ public class TheRockAccountServiceRaw extends TheRockBaseService {
     super(exchange);
     final ExchangeSpecification spec = exchange.getExchangeSpecification();
     this.theRockAuthenticated =
-        RestProxyFactory.createProxy(
-            TheRockAuthenticated.class, spec.getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(TheRockAuthenticated.class, spec).build();
     apiKey = spec.getApiKey();
     this.signatureCreator = new TheRockDigest(spec.getSecretKey());
   }

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockMarketDataServiceRaw.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockMarketDataServiceRaw.java
@@ -3,12 +3,12 @@ package org.knowm.xchange.therock.service;
 import java.io.IOException;
 import java.util.Date;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.therock.TheRock;
 import org.knowm.xchange.therock.dto.TheRockException;
 import org.knowm.xchange.therock.dto.marketdata.TheRockOrderBook;
 import org.knowm.xchange.therock.dto.marketdata.TheRockTicker;
 import org.knowm.xchange.therock.dto.marketdata.TheRockTrades;
-import si.mazi.rescu.RestProxyFactory;
 
 public class TheRockMarketDataServiceRaw extends TheRockBaseService {
 
@@ -17,8 +17,8 @@ public class TheRockMarketDataServiceRaw extends TheRockBaseService {
   public TheRockMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
     this.theRock =
-        RestProxyFactory.createProxy(
-            TheRock.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(TheRock.class, exchange.getExchangeSpecification())
+            .build();
   }
 
   public TheRockTicker getTheRockTicker(TheRock.Pair currencyPair)

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockTradeServiceRaw.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockTradeServiceRaw.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 import java.util.Date;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.therock.TheRock;
@@ -14,7 +15,6 @@ import org.knowm.xchange.therock.dto.trade.TheRockOrder;
 import org.knowm.xchange.therock.dto.trade.TheRockOrders;
 import org.knowm.xchange.therock.dto.trade.TheRockTransaction;
 import org.knowm.xchange.therock.dto.trade.TheRockUserTrades;
-import si.mazi.rescu.RestProxyFactory;
 
 public class TheRockTradeServiceRaw extends TheRockBaseService {
 
@@ -25,8 +25,7 @@ public class TheRockTradeServiceRaw extends TheRockBaseService {
     super(exchange);
     final ExchangeSpecification spec = exchange.getExchangeSpecification();
     this.theRockAuthenticated =
-        RestProxyFactory.createProxy(
-            TheRockAuthenticated.class, spec.getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(TheRockAuthenticated.class, spec).build();
     this.signatureCreator = new TheRockDigest(spec.getSecretKey());
   }
 

--- a/xchange-tradeogre/src/main/java/org/knowm/xchange/tradeogre/service/TradeOgreBaseService.java
+++ b/xchange-tradeogre/src/main/java/org/knowm/xchange/tradeogre/service/TradeOgreBaseService.java
@@ -1,12 +1,12 @@
 package org.knowm.xchange.tradeogre.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ClientConfigCustomizer;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import org.knowm.xchange.tradeogre.TradeOgreAuthenticated;
-import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.ClientConfigUtil;
-import si.mazi.rescu.RestProxyFactory;
 
 public class TradeOgreBaseService extends BaseExchangeService implements BaseService {
 
@@ -19,10 +19,12 @@ public class TradeOgreBaseService extends BaseExchangeService implements BaseSer
     String apiKey = exchange.getExchangeSpecification().getApiKey();
     String secretKey = exchange.getExchangeSpecification().getSecretKey();
 
-    ClientConfig config = getClientConfig();
-    ClientConfigUtil.addBasicAuthCredentials(config, apiKey, secretKey);
+    ClientConfigCustomizer clientConfigCustomizer =
+        config -> ClientConfigUtil.addBasicAuthCredentials(config, apiKey, secretKey);
     tradeOgre =
-        RestProxyFactory.createProxy(
-            TradeOgreAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), config);
+        ExchangeRestProxyBuilder.forInterface(
+                TradeOgreAuthenticated.class, exchange.getExchangeSpecification())
+            .clientConfigCustomizer(clientConfigCustomizer)
+            .build();
   }
 }

--- a/xchange-truefx/src/main/java/org/knowm/xchange/truefx/service/TrueFxMarketDataServiceRaw.java
+++ b/xchange-truefx/src/main/java/org/knowm/xchange/truefx/service/TrueFxMarketDataServiceRaw.java
@@ -6,12 +6,12 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import java.io.IOException;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ClientConfigCustomizer;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.truefx.TrueFxPublic;
 import org.knowm.xchange.truefx.dto.marketdata.TrueFxTicker;
-import si.mazi.rescu.ClientConfig;
-import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.serialization.jackson.DefaultJacksonObjectMapperFactory;
 import si.mazi.rescu.serialization.jackson.JacksonObjectMapperFactory;
 
@@ -40,12 +40,13 @@ public class TrueFxMarketDataServiceRaw extends BaseExchangeService {
   protected TrueFxMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
 
-    final ClientConfig config = getClientConfig();
-    config.setJacksonObjectMapperFactory(factory);
-
+    ClientConfigCustomizer clientConfigCustomizer =
+        config -> config.setJacksonObjectMapperFactory(factory);
     trueFx =
-        RestProxyFactory.createProxy(
-            TrueFxPublic.class, exchange.getExchangeSpecification().getPlainTextUri(), config);
+        ExchangeRestProxyBuilder.forInterface(
+                TrueFxPublic.class, exchange.getExchangeSpecification())
+            .clientConfigCustomizer(clientConfigCustomizer)
+            .build();
   }
 
   public TrueFxTicker getTicker(CurrencyPair pair) throws IOException {

--- a/xchange-upbit/src/main/java/org/knowm/xchange/upbit/service/UpbitBaseService.java
+++ b/xchange-upbit/src/main/java/org/knowm/xchange/upbit/service/UpbitBaseService.java
@@ -1,11 +1,11 @@
 package org.knowm.xchange.upbit.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import org.knowm.xchange.upbit.UpbitAuthenticated;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class UpbitBaseService extends BaseExchangeService implements BaseService {
 
@@ -23,8 +23,9 @@ public class UpbitBaseService extends BaseExchangeService implements BaseService
   public UpbitBaseService(Exchange exchange) {
     super(exchange);
     this.upbit =
-        RestProxyFactory.createProxy(
-            UpbitAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+        ExchangeRestProxyBuilder.forInterface(
+                UpbitAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.apiSecret = exchange.getExchangeSpecification().getSecretKey();
     this.url = exchange.getExchangeSpecification().getSslUri();

--- a/xchange-vaultoro/src/main/java/org/knowm/xchange/vaultoro/service/VaultoroBaseService.java
+++ b/xchange-vaultoro/src/main/java/org/knowm/xchange/vaultoro/service/VaultoroBaseService.java
@@ -1,11 +1,11 @@
 package org.knowm.xchange.vaultoro.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import org.knowm.xchange.vaultoro.VaultoroAuthenticated;
 import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class VaultoroBaseService extends BaseExchangeService implements BaseService {
 
@@ -23,10 +23,9 @@ public class VaultoroBaseService extends BaseExchangeService implements BaseServ
     super(exchange);
 
     this.vaultoro =
-        RestProxyFactory.createProxy(
-            VaultoroAuthenticated.class,
-            exchange.getExchangeSpecification().getSslUri(),
-            getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(
+                VaultoroAuthenticated.class, exchange.getExchangeSpecification())
+            .build();
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator =
         VaultoroDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());

--- a/xchange-yobit/src/main/java/org/knowm/xchange/yobit/service/YoBitBaseService.java
+++ b/xchange-yobit/src/main/java/org/knowm/xchange/yobit/service/YoBitBaseService.java
@@ -1,11 +1,11 @@
 package org.knowm.xchange.yobit.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import org.knowm.xchange.yobit.YoBit;
 import org.knowm.xchange.yobit.YoBitDigest;
-import si.mazi.rescu.RestProxyFactory;
 
 public class YoBitBaseService<T extends YoBit> extends BaseExchangeService implements BaseService {
   protected final T service;
@@ -19,7 +19,6 @@ public class YoBitBaseService<T extends YoBit> extends BaseExchangeService imple
             exchange.getExchangeSpecification().getSecretKey(),
             exchange.getExchangeSpecification().getApiKey());
     this.service =
-        RestProxyFactory.createProxy(
-            type, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(type, exchange.getExchangeSpecification()).build();
   }
 }

--- a/xchange-zaif/src/main/java/org/knowm/xchange/zaif/service/ZaifBaseService.java
+++ b/xchange-zaif/src/main/java/org/knowm/xchange/zaif/service/ZaifBaseService.java
@@ -1,10 +1,10 @@
 package org.knowm.xchange.zaif.service;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 import org.knowm.xchange.zaif.Zaif;
-import si.mazi.rescu.RestProxyFactory;
 
 public class ZaifBaseService extends BaseExchangeService implements BaseService {
 
@@ -18,7 +18,7 @@ public class ZaifBaseService extends BaseExchangeService implements BaseService 
   protected ZaifBaseService(Exchange exchange) {
     super(exchange);
     this.zaif =
-        RestProxyFactory.createProxy(
-            Zaif.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+        ExchangeRestProxyBuilder.forInterface(Zaif.class, exchange.getExchangeSpecification())
+            .build();
   }
 }


### PR DESCRIPTION
- All Exchanges (Rest proxy objects) built in the same way
- Removed deprecated method `BaseExchangeService.getClientConfig()` which is no longer needed