### PR TITLE
[CoinbasePro] CoinbaseProException - return original exchange message for getMessage()

### DIFF
--- a/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/dto/CoinbaseProException.java
+++ b/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/dto/CoinbaseProException.java
@@ -5,7 +5,15 @@ import si.mazi.rescu.HttpStatusExceptionSupport;
 
 public class CoinbaseProException extends HttpStatusExceptionSupport {
 
-  public CoinbaseProException(@JsonProperty("message") String reason) {
-    super(reason);
+  private final String message;
+
+  public CoinbaseProException(@JsonProperty("message") String message) {
+    super(message);
+    this.message = message;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
   }
 }


### PR DESCRIPTION
CoinbaseProException does not return original exchange message for `getMessage()`. It returns default `HttpStatusExceptionSupport.getMessage()`.
So `CoinbaseProException` currently returns:
`Invalid API Key  (HTTP status code: 401)`
instead of
`Invalid API Key`.

If we need to obtain http status code we can use: `HttpStatusExceptionSupport.getHttpStatusCode()`

This PR is fixing it.