### PR TITLE
Add possibility to skip generating sources and javadocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -531,9 +531,6 @@
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <skipSource>false</skipSource>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -549,7 +546,6 @@
         </executions>
         <configuration>
           <quiet>true</quiet>
-          <skip>false</skip>
           <doclint>none</doclint>
           <source>${version.java}</source>
         </configuration>


### PR DESCRIPTION
Currently, by misconfiguration, it is not possible to skip generating sources and javadocs, because the configuration is hardcoded, so properties `maven.source.skip` and `maven.javadoc.skip` are ignored.

In this PR hardcoded config is removed. After this PR default generating sources and javadocs will be still enabled, but it will be possible to disable it.

Here are the results of building a project with 1 core (1 thread) without tests:
`mvn clean install -DskipTests -Dmaven.source.skip=true -Dmaven.javadoc.skip=true`

`Total time:  02:38 min`

vs

`mvn clean install -DskipTests`

`Total time:  13:13 min`  


So with skipping generating sources and javadocs build witout tests is 80% faster. It is very useful for development.