### PR TITLE
[Bitmex-Stream] Relax restriction that currency string must be >= 6

### DIFF
--- a/xchange-stream-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/dto/BitmexMarketDataEvent.java
+++ b/xchange-stream-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/dto/BitmexMarketDataEvent.java
@@ -28,7 +28,7 @@ public class BitmexMarketDataEvent {
 
   public CurrencyPair getCurrencyPair() {
     String base = symbol.substring(0, 3);
-    String counter = symbol.substring(3, 6);
+    String counter = symbol.substring(3);
     return new CurrencyPair(Currency.getInstance(base), Currency.getInstance(counter));
   }
 


### PR DESCRIPTION
The current implementation assumes that the currency string is always at least 6 characters. However, some symbols are less than 6 characters e.g. https://www.bitmex.com/app/index/.BXBT 
