### PR TITLE
[performance] By default create Exchange and ExchangeSpecification by Class not class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Basic usage is very simple: Create an `Exchange` instance, get the appropriate s
 ## Example 1: Public Market Data
 
 ```java
-Exchange bitstamp = ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class.getName());
+Exchange bitstamp = ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class);
 MarketDataService marketDataService = bitstamp.getMarketDataService();
 Ticker ticker = marketDataService.getTicker(CurrencyPair.BTC_USD);
 System.out.println(ticker.toString());
@@ -58,7 +58,7 @@ You will need to import an additional dependency for the exchange you are using 
 
 ```java
 // Use StreamingExchangeFactory instead of ExchangeFactory
-StreamingExchange exchange = StreamingExchangeFactory.INSTANCE.createExchange(BitstampStreamingExchange.class.getName());
+StreamingExchange exchange = StreamingExchangeFactory.INSTANCE.createExchange(BitstampStreamingExchange.class);
 
 // Connect to the Exchange WebSocket API. Here we use a blocking wait.
 exchange.connect().blockingAwait();

--- a/xchange-bankera/src/main/java/org/knowm/xchange/bankera/BankeraExchange.java
+++ b/xchange-bankera/src/main/java/org/knowm/xchange/bankera/BankeraExchange.java
@@ -27,8 +27,7 @@ public class BankeraExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api-exchange.bankera.com");
     exchangeSpecification.setHost("api-exchange.bankera.com");
     exchangeSpecification.setPort(443);

--- a/xchange-bibox/src/main/java/org/knowm/xchange/bibox/BiboxExchange.java
+++ b/xchange-bibox/src/main/java/org/knowm/xchange/bibox/BiboxExchange.java
@@ -24,8 +24,7 @@ public class BiboxExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.bibox.com/");
     exchangeSpecification.setHost("bibox.com");
     exchangeSpecification.setPort(80);

--- a/xchange-bibox/src/test/java/org/knowm/xchange/bibox/service/marketdata/MarketDataServiceIntegration.java
+++ b/xchange-bibox/src/test/java/org/knowm/xchange/bibox/service/marketdata/MarketDataServiceIntegration.java
@@ -16,7 +16,7 @@ import org.knowm.xchange.service.marketdata.MarketDataService;
 public class MarketDataServiceIntegration {
 
   private static final Exchange BIBOX =
-      ExchangeFactory.INSTANCE.createExchange(BiboxExchange.class.getName());
+      ExchangeFactory.INSTANCE.createExchange(BiboxExchange.class);
   private static final CurrencyPair BIX_BTC = new CurrencyPair("BIX", "BTC");
 
   @Test

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceExchange.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceExchange.java
@@ -69,7 +69,7 @@ public class BinanceExchange extends BaseExchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification spec = new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification spec = new ExchangeSpecification(this.getClass());
     spec.setSslUri("https://api.binance.com");
     spec.setHost("www.binance.com");
     spec.setPort(80);

--- a/xchange-binance/src/test/java/org/knowm/xchange/binance/AbstractResilienceTest.java
+++ b/xchange-binance/src/test/java/org/knowm/xchange/binance/AbstractResilienceTest.java
@@ -32,8 +32,7 @@ public class AbstractResilienceTest {
   protected BinanceExchange createExchange(boolean retryEnabled, boolean rateLimiterEnabled) {
     BinanceExchange exchange =
         (BinanceExchange)
-            ExchangeFactory.INSTANCE.createExchangeWithoutSpecification(
-                BinanceExchange.class.getName());
+            ExchangeFactory.INSTANCE.createExchangeWithoutSpecification(BinanceExchange.class);
     ExchangeSpecification specification = exchange.getDefaultExchangeSpecification();
     specification.setHost("localhost");
     specification.setSslUri("http://localhost:" + wireMockRule.port() + "/");

--- a/xchange-binance/src/test/java/org/knowm/xchange/binance/service/account/AccountServiceIntegration.java
+++ b/xchange-binance/src/test/java/org/knowm/xchange/binance/service/account/AccountServiceIntegration.java
@@ -30,7 +30,7 @@ public class AccountServiceIntegration {
 
   @BeforeClass
   public static void beforeClass() {
-    exchange = ExchangeFactory.INSTANCE.createExchange(BinanceExchange.class.getName());
+    exchange = ExchangeFactory.INSTANCE.createExchange(BinanceExchange.class);
     accountService = exchange.getAccountService();
   }
 

--- a/xchange-binance/src/test/java/org/knowm/xchange/binance/service/marketdata/MarketDataServiceIntegration.java
+++ b/xchange-binance/src/test/java/org/knowm/xchange/binance/service/marketdata/MarketDataServiceIntegration.java
@@ -25,8 +25,7 @@ public class MarketDataServiceIntegration {
 
   @BeforeClass
   public static void beforeClass() {
-    exchange =
-        (BinanceExchange) ExchangeFactory.INSTANCE.createExchange(BinanceExchange.class.getName());
+    exchange = (BinanceExchange) ExchangeFactory.INSTANCE.createExchange(BinanceExchange.class);
     marketService = exchange.getMarketDataService();
   }
 

--- a/xchange-binance/src/test/java/org/knowm/xchange/binance/service/trade/TradeServiceIntegration.java
+++ b/xchange-binance/src/test/java/org/knowm/xchange/binance/service/trade/TradeServiceIntegration.java
@@ -30,7 +30,7 @@ public class TradeServiceIntegration {
 
   @BeforeClass
   public static void beforeClass() {
-    exchange = ExchangeFactory.INSTANCE.createExchange(BinanceExchange.class.getName());
+    exchange = ExchangeFactory.INSTANCE.createExchange(BinanceExchange.class);
     tradeService = (BinanceTradeService) exchange.getTradeService();
   }
 

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/BitbayExchange.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/BitbayExchange.java
@@ -17,8 +17,7 @@ public class BitbayExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://bitbay.net/API/");
     exchangeSpecification.setHost("bitbay.net");
     exchangeSpecification.setPort(80);

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/BitbayExchange.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/BitbayExchange.java
@@ -22,8 +22,7 @@ public class BitbayExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.bitbay.net");
     exchangeSpecification.setHost("api.bitbay.net");
     exchangeSpecification.setPort(443);

--- a/xchange-bitbay/src/test/java/org/knowm/xchange/bitbay/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-bitbay/src/test/java/org/knowm/xchange/bitbay/service/marketdata/TickerFetchIntegration.java
@@ -16,7 +16,7 @@ public class TickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitbayExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitbayExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "USD"));
     System.out.println(ticker.toString());

--- a/xchange-bitcoinaverage/src/main/java/org/knowm/xchange/bitcoinaverage/BitcoinAverageExchange.java
+++ b/xchange-bitcoinaverage/src/main/java/org/knowm/xchange/bitcoinaverage/BitcoinAverageExchange.java
@@ -23,8 +23,7 @@ public class BitcoinAverageExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://apiv2.bitcoinaverage.com");
     exchangeSpecification.setHost("bitcoinaverage.com");
     exchangeSpecification.setPort(80);

--- a/xchange-bitcoinaverage/src/test/java/org/knowm/xchange/bitcoinaverage/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-bitcoinaverage/src/test/java/org/knowm/xchange/bitcoinaverage/service/marketdata/TickerFetchIntegration.java
@@ -18,7 +18,7 @@ public class TickerFetchIntegration {
   public void tickerFetchTest() throws Exception {
 
     ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(BitcoinAverageExchange.class.getName());
+        new ExchangeSpecification(BitcoinAverageExchange.class);
     Exchange exchange = ExchangeFactory.INSTANCE.createExchange(exchangeSpecification);
     exchange.remoteInit();
     MarketDataService marketDataService = exchange.getMarketDataService();

--- a/xchange-bitcoincharts/src/main/java/org/knowm/xchange/bitcoincharts/BitcoinChartsExchange.java
+++ b/xchange-bitcoincharts/src/main/java/org/knowm/xchange/bitcoincharts/BitcoinChartsExchange.java
@@ -23,8 +23,7 @@ public class BitcoinChartsExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setPlainTextUri("http://api.bitcoincharts.com");
     exchangeSpecification.setHost("api.bitcoincharts.com");
     exchangeSpecification.setPort(80);

--- a/xchange-bitcoincharts/src/test/java/org/knowm/xchange/bitcoincharts/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-bitcoincharts/src/test/java/org/knowm/xchange/bitcoincharts/service/marketdata/TickerFetchIntegration.java
@@ -18,7 +18,7 @@ public class TickerFetchIntegration {
   public void tickerFetchTest() throws Exception {
 
     ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(BitcoinChartsExchange.class.getName());
+        new ExchangeSpecification(BitcoinChartsExchange.class);
     Exchange exchange = ExchangeFactory.INSTANCE.createExchange(exchangeSpecification);
     exchange.remoteInit();
     MarketDataService marketDataService = exchange.getMarketDataService();

--- a/xchange-bitcoincore/src/main/java/org/knowm/xchange/bitcoincore/BitcoinCoreWallet.java
+++ b/xchange-bitcoincore/src/main/java/org/knowm/xchange/bitcoincore/BitcoinCoreWallet.java
@@ -11,8 +11,7 @@ public class BitcoinCoreWallet extends BaseExchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification specification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification specification = new ExchangeSpecification(this.getClass());
     specification.setShouldLoadRemoteMetaData(false);
     specification.setPlainTextUri("http://localhost:8332/");
     specification.setExchangeName("BitcoinCore");

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/BitcoindeExchange.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/BitcoindeExchange.java
@@ -15,8 +15,7 @@ public class BitcoindeExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.bitcoin.de/v2/");
     exchangeSpecification.setHost("bitcoin.de");
     exchangeSpecification.setPort(80);

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeExchange.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeExchange.java
@@ -15,8 +15,7 @@ public class BitcoindeExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    final ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    final ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.bitcoin.de/");
     exchangeSpecification.setHost("bitcoin.de");
     exchangeSpecification.setPort(80);

--- a/xchange-bitcoinium/src/main/java/org/knowm/xchange/bitcoinium/BitcoiniumExchange.java
+++ b/xchange-bitcoinium/src/main/java/org/knowm/xchange/bitcoinium/BitcoiniumExchange.java
@@ -16,8 +16,7 @@ public class BitcoiniumExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://bitcoinium.com:443");
     exchangeSpecification.setHost("bitcoinium.com");
     exchangeSpecification.setPort(443);

--- a/xchange-bitcoinium/src/test/java/org/knowm/xchange/bitcoinium/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-bitcoinium/src/test/java/org/knowm/xchange/bitcoinium/service/marketdata/TickerFetchIntegration.java
@@ -18,7 +18,7 @@ public class TickerFetchIntegration {
   public void tickerFetchTest() throws Exception {
 
     ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(BitcoiniumExchange.class.getName());
+        new ExchangeSpecification(BitcoiniumExchange.class);
     exchangeSpecification.setApiKey("42djci5kmbtyzrvglfdw3e2dgmh5mr37");
     exchangeSpecification.setPlainTextUri("http://bitcoinium.com");
     System.out.println(exchangeSpecification.toString());

--- a/xchange-bitcointoyou/src/main/java/org/knowm/xchange/bitcointoyou/BitcointoyouExchange.java
+++ b/xchange-bitcointoyou/src/main/java/org/knowm/xchange/bitcointoyou/BitcointoyouExchange.java
@@ -35,8 +35,7 @@ public class BitcointoyouExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://www.bitcointoyou.com/");
     exchangeSpecification.setHost("www.bitcointoyou.com");
     exchangeSpecification.setPort(443);

--- a/xchange-bitcointoyou/src/test/java/org/knowm/xchange/bitcointoyou/BitcointoyouExchangeTest.java
+++ b/xchange-bitcointoyou/src/test/java/org/knowm/xchange/bitcointoyou/BitcointoyouExchangeTest.java
@@ -24,7 +24,7 @@ public class BitcointoyouExchangeTest {
 
   @Before
   public void setUp() throws Exception {
-    sut = ExchangeFactory.INSTANCE.createExchange(BitcointoyouExchange.class.getName());
+    sut = ExchangeFactory.INSTANCE.createExchange(BitcointoyouExchange.class);
   }
 
   @Test

--- a/xchange-bitcointoyou/src/test/java/org/knowm/xchange/bitcointoyou/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-bitcointoyou/src/test/java/org/knowm/xchange/bitcointoyou/service/marketdata/TickerFetchIntegration.java
@@ -24,8 +24,7 @@ public class TickerFetchIntegration {
   @BeforeClass
   public static void setUp() throws Exception {
 
-    Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(BitcointoyouExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitcointoyouExchange.class);
     exchange.remoteInit();
     MarketDataService marketDataService = exchange.getMarketDataService();
     ticker = marketDataService.getTicker(new CurrencyPair(Currency.BTC, Currency.BRL));

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/BitfinexExchange.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/BitfinexExchange.java
@@ -38,8 +38,7 @@ public class BitfinexExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.bitfinex.com/");
     exchangeSpecification.setHost("api.bitfinex.com");
     exchangeSpecification.setPort(80);

--- a/xchange-bitfinex/src/test/java/org/knowm/xchange/bitfinex/v1/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-bitfinex/src/test/java/org/knowm/xchange/bitfinex/v1/service/marketdata/TickerFetchIntegration.java
@@ -16,7 +16,7 @@ public class TickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitfinexExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitfinexExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "USD"));
     System.out.println(ticker.toString());

--- a/xchange-bitfinex/src/test/java/org/knowm/xchange/bitfinex/v1/service/trade/BitfinexTradeServiceIntegration.java
+++ b/xchange-bitfinex/src/test/java/org/knowm/xchange/bitfinex/v1/service/trade/BitfinexTradeServiceIntegration.java
@@ -32,7 +32,7 @@ public class BitfinexTradeServiceIntegration {
 
     exchange =
         ExchangeFactory.INSTANCE.createExchange(
-            BitfinexExchange.class.getName(), properties.getApiKey(), properties.getSecretKey());
+            BitfinexExchange.class, properties.getApiKey(), properties.getSecretKey());
   }
 
   @After

--- a/xchange-bitflyer/src/main/java/org/knowm/xchange/bitflyer/BitflyerExchange.java
+++ b/xchange-bitflyer/src/main/java/org/knowm/xchange/bitflyer/BitflyerExchange.java
@@ -29,8 +29,7 @@ public class BitflyerExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.bitflyer.jp/");
     exchangeSpecification.setHost("api.bitflyer.jp");
     exchangeSpecification.setPort(80);

--- a/xchange-bitflyer/src/test/java/org/knowm/xchange/bitflyer/service/BitflyerTickerIntegration.java
+++ b/xchange-bitflyer/src/test/java/org/knowm/xchange/bitflyer/service/BitflyerTickerIntegration.java
@@ -16,7 +16,7 @@ public class BitflyerTickerIntegration {
 
   @Test
   public void fetchTickerTest() throws IOException {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitflyerExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitflyerExchange.class);
     MarketDataService service = exchange.getMarketDataService();
 
     Ticker ticker = service.getTicker(CurrencyPair.BTC_JPY);

--- a/xchange-bithumb/src/main/java/org/knowm/xchange/bithumb/BithumbExchange.java
+++ b/xchange-bithumb/src/main/java/org/knowm/xchange/bithumb/BithumbExchange.java
@@ -24,8 +24,7 @@ public class BithumbExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.bithumb.com");
     exchangeSpecification.setHost("api.bithumb.com");
     exchangeSpecification.setPort(80);

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexExchange.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexExchange.java
@@ -62,8 +62,7 @@ public class BitmexExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://www.bitmex.com");
     exchangeSpecification.setHost("bitmex.com");
     exchangeSpecification.setPort(80);

--- a/xchange-bitmex/src/test/java/org/knowm/xchange/bitmex/service/marketdata/BitmexOrderBookFetchIntegration.java
+++ b/xchange-bitmex/src/test/java/org/knowm/xchange/bitmex/service/marketdata/BitmexOrderBookFetchIntegration.java
@@ -20,8 +20,7 @@ public class BitmexOrderBookFetchIntegration {
 
   @Before
   public void setUp() {
-    bitmexExchange =
-        (BitmexExchange) ExchangeFactory.INSTANCE.createExchange(BitmexExchange.class.getName());
+    bitmexExchange = (BitmexExchange) ExchangeFactory.INSTANCE.createExchange(BitmexExchange.class);
     marketDataService = bitmexExchange.getMarketDataService();
   }
 

--- a/xchange-bitmex/src/test/java/org/knowm/xchange/bitmex/service/marketdata/BitmexTickerFetchIntegration.java
+++ b/xchange-bitmex/src/test/java/org/knowm/xchange/bitmex/service/marketdata/BitmexTickerFetchIntegration.java
@@ -21,8 +21,7 @@ public class BitmexTickerFetchIntegration {
 
   @Before
   public void setUp() {
-    bitmexExchange =
-        (BitmexExchange) ExchangeFactory.INSTANCE.createExchange(BitmexExchange.class.getName());
+    bitmexExchange = (BitmexExchange) ExchangeFactory.INSTANCE.createExchange(BitmexExchange.class);
     marketDataService = bitmexExchange.getMarketDataService();
   }
 

--- a/xchange-bitmex/src/test/java/org/knowm/xchange/bitmex/service/marketdata/BitmexTradesFetchIntegration.java
+++ b/xchange-bitmex/src/test/java/org/knowm/xchange/bitmex/service/marketdata/BitmexTradesFetchIntegration.java
@@ -20,8 +20,7 @@ public class BitmexTradesFetchIntegration {
 
   @Before
   public void setUp() {
-    bitmexExchange =
-        (BitmexExchange) ExchangeFactory.INSTANCE.createExchange(BitmexExchange.class.getName());
+    bitmexExchange = (BitmexExchange) ExchangeFactory.INSTANCE.createExchange(BitmexExchange.class);
     marketDataService = bitmexExchange.getMarketDataService();
   }
 

--- a/xchange-bitso/src/main/java/org/knowm/xchange/bitso/BitsoExchange.java
+++ b/xchange-bitso/src/main/java/org/knowm/xchange/bitso/BitsoExchange.java
@@ -23,8 +23,7 @@ public class BitsoExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.bitso.com");
     exchangeSpecification.setHost("bitso.com");
     exchangeSpecification.setPort(80);

--- a/xchange-bitso/src/test/java/org/knowm/xchange/bitso/TickerFetchIntegration.java
+++ b/xchange-bitso/src/test/java/org/knowm/xchange/bitso/TickerFetchIntegration.java
@@ -14,7 +14,7 @@ public class TickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitsoExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitsoExchange.class);
     exchange.remoteInit();
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(CurrencyPair.BTC_MXN);

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampExchange.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampExchange.java
@@ -31,8 +31,7 @@ public class BitstampExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://www.bitstamp.net");
     exchangeSpecification.setHost("www.bitstamp.net");
     exchangeSpecification.setPort(80);

--- a/xchange-bitstamp/src/test/java/org/knowm/xchange/bitstamp/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-bitstamp/src/test/java/org/knowm/xchange/bitstamp/service/marketdata/TickerFetchIntegration.java
@@ -16,7 +16,7 @@ public class TickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "USD"));
     System.out.println(ticker.toString());

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/BittrexExchange.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/BittrexExchange.java
@@ -31,8 +31,7 @@ public class BittrexExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://bittrex.com/api/");
     exchangeSpecification.setExchangeSpecificParametersItem(
         "rest.v3.url", "https://api.bittrex.com/");

--- a/xchange-bittrex/src/test/java/org/knowm/xchange/bittrex/service/BaseMockedIntegrationTest.java
+++ b/xchange-bittrex/src/test/java/org/knowm/xchange/bittrex/service/BaseMockedIntegrationTest.java
@@ -14,8 +14,7 @@ public class BaseMockedIntegrationTest {
 
   public Exchange createExchange() {
     Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchangeWithoutSpecification(
-            BittrexExchange.class.getName());
+        ExchangeFactory.INSTANCE.createExchangeWithoutSpecification(BittrexExchange.class);
     ExchangeSpecification specification = exchange.getDefaultExchangeSpecification();
     specification.setHost("localhost");
     specification.setSslUri("http://localhost:" + wireMockRule.port() + "/api/");

--- a/xchange-bittrex/src/test/java/org/knowm/xchange/bittrex/service/MarketDataIntegration.java
+++ b/xchange-bittrex/src/test/java/org/knowm/xchange/bittrex/service/MarketDataIntegration.java
@@ -21,7 +21,7 @@ public class MarketDataIntegration {
 
   @BeforeClass
   public static void setUp() {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BittrexExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BittrexExchange.class);
     marketDataService = (BittrexMarketDataService) exchange.getMarketDataService();
   }
 

--- a/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexExchange.java
+++ b/xchange-bittrexV3/src/main/java/org/knowm/xchange/bittrex/BittrexExchange.java
@@ -31,8 +31,7 @@ public class BittrexExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.bittrex.com/");
     exchangeSpecification.setHost("bittrex.com");
     exchangeSpecification.setPort(80);

--- a/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/BaseMockedTestIntegration.java
+++ b/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/BaseMockedTestIntegration.java
@@ -15,8 +15,7 @@ public class BaseMockedTestIntegration {
 
   public Exchange createExchange() {
     Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchangeWithoutSpecification(
-            BittrexExchange.class.getName());
+        ExchangeFactory.INSTANCE.createExchangeWithoutSpecification(BittrexExchange.class);
     ExchangeSpecification specification = exchange.getDefaultExchangeSpecification();
     specification.setHost("localhost");
     specification.setSslUri("http://localhost:" + wireMockRule.port());

--- a/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/MarketDataTestIntegration.java
+++ b/xchange-bittrexV3/src/test/java/org/knowm/xchange/bittrex/service/MarketDataTestIntegration.java
@@ -21,7 +21,7 @@ public class MarketDataTestIntegration {
 
   @BeforeClass
   public static void setUp() {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BittrexExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BittrexExchange.class);
     marketDataService = (BittrexMarketDataService) exchange.getMarketDataService();
   }
 

--- a/xchange-bity/src/main/java/org/knowm/xchange/bity/BityExchange.java
+++ b/xchange-bity/src/main/java/org/knowm/xchange/bity/BityExchange.java
@@ -28,8 +28,7 @@ public class BityExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    final ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    final ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://bity.com");
     exchangeSpecification.setHost("bity.com");
     exchangeSpecification.setExchangeName("Bity");
@@ -38,6 +37,7 @@ public class BityExchange extends BaseExchange implements Exchange {
     return exchangeSpecification;
   }
 
+  @Override
   public SynchronizedValueFactory<Long> getNonceFactory() {
     return null;
   }

--- a/xchange-bitz/src/main/java/org/knowm/xchange/bitz/BitZExchange.java
+++ b/xchange-bitz/src/main/java/org/knowm/xchange/bitz/BitZExchange.java
@@ -29,8 +29,7 @@ public class BitZExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://www.bit-z.com");
     exchangeSpecification.setHost("http://www.bit-z.com");
     exchangeSpecification.setPort(80);

--- a/xchange-bitz/src/test/java/org/knowm/xchange/bitz/service/marketdata/BitzKlineFetchIntegration.java
+++ b/xchange-bitz/src/test/java/org/knowm/xchange/bitz/service/marketdata/BitzKlineFetchIntegration.java
@@ -15,7 +15,7 @@ public class BitzKlineFetchIntegration {
   public void ordersFetchTest() throws Exception {
     // Get Specific Exchange
     BitZExchange exchange =
-        (BitZExchange) ExchangeFactory.INSTANCE.createExchange(BitZExchange.class.getName());
+        (BitZExchange) ExchangeFactory.INSTANCE.createExchange(BitZExchange.class);
     BitZMarketDataService marketDataService =
         (BitZMarketDataService) exchange.getMarketDataService();
 

--- a/xchange-bitz/src/test/java/org/knowm/xchange/bitz/service/marketdata/BitzOrdersFetchIntegration.java
+++ b/xchange-bitz/src/test/java/org/knowm/xchange/bitz/service/marketdata/BitzOrdersFetchIntegration.java
@@ -15,7 +15,7 @@ public class BitzOrdersFetchIntegration {
   @Test
   public void ordersFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitZExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitZExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     OrderBook orders = marketDataService.getOrderBook(new CurrencyPair("LTC", "BTC"));
 

--- a/xchange-bitz/src/test/java/org/knowm/xchange/bitz/service/marketdata/BitzTickerAllFetchIntegration.java
+++ b/xchange-bitz/src/test/java/org/knowm/xchange/bitz/service/marketdata/BitzTickerAllFetchIntegration.java
@@ -15,7 +15,7 @@ public class BitzTickerAllFetchIntegration {
   public void tickerFetchTest() throws Exception {
     // Get Specific Exchange
     BitZExchange exchange =
-        (BitZExchange) ExchangeFactory.INSTANCE.createExchange(BitZExchange.class.getName());
+        (BitZExchange) ExchangeFactory.INSTANCE.createExchange(BitZExchange.class);
     BitZMarketDataService marketDataService =
         (BitZMarketDataService) exchange.getMarketDataService();
 

--- a/xchange-bitz/src/test/java/org/knowm/xchange/bitz/service/marketdata/BitzTickerFetchIntegration.java
+++ b/xchange-bitz/src/test/java/org/knowm/xchange/bitz/service/marketdata/BitzTickerFetchIntegration.java
@@ -15,7 +15,7 @@ public class BitzTickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitZExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitZExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(CurrencyPair.LTC_BTC);
 

--- a/xchange-bitz/src/test/java/org/knowm/xchange/bitz/service/marketdata/BitzTradesFetchIntegration.java
+++ b/xchange-bitz/src/test/java/org/knowm/xchange/bitz/service/marketdata/BitzTradesFetchIntegration.java
@@ -13,7 +13,7 @@ public class BitzTradesFetchIntegration {
   @Test
   public void tradesFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitZExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitZExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Trades trades = marketDataService.getTrades(new CurrencyPair("LTC", "BTC"));
 

--- a/xchange-bl3p/src/main/java/org/knowm/xchange/bl3p/Bl3pExchange.java
+++ b/xchange-bl3p/src/main/java/org/knowm/xchange/bl3p/Bl3pExchange.java
@@ -29,8 +29,7 @@ public class Bl3pExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.bl3p.eu/");
     exchangeSpecification.setHost("api.bl3p.eu");
     exchangeSpecification.setPort(80);

--- a/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/BleutradeExchange.java
+++ b/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/BleutradeExchange.java
@@ -45,8 +45,7 @@ public class BleutradeExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://bleutrade.com/api/");
     exchangeSpecification.setHost("bleutrade.com");
     exchangeSpecification.setPort(80);

--- a/xchange-bleutrade/src/test/java/org/knowm/xchange/bleutrade/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-bleutrade/src/test/java/org/knowm/xchange/bleutrade/service/marketdata/TickerFetchIntegration.java
@@ -19,7 +19,7 @@ public class TickerFetchIntegration {
 
     CertHelper.trustAllCerts();
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BleutradeExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BleutradeExchange.class);
     exchange.remoteInit();
     MarketDataService marketDataService = exchange.getMarketDataService();
     CurrencyPair market =

--- a/xchange-blockchain/src/main/java/org/knowm/xchange/blockchain/BlockchainExchange.java
+++ b/xchange-blockchain/src/main/java/org/knowm/xchange/blockchain/BlockchainExchange.java
@@ -11,8 +11,7 @@ public class BlockchainExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://blockchain.info");
     exchangeSpecification.setHost("www.blockchain.com");
     exchangeSpecification.setPort(80);

--- a/xchange-btcc/src/main/java/org/knowm/xchange/btcc/BTCCExchange.java
+++ b/xchange-btcc/src/main/java/org/knowm/xchange/btcc/BTCCExchange.java
@@ -26,8 +26,7 @@ public class BTCCExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.btcc.com");
     exchangeSpecification.setHost("api.btcc.com");
     exchangeSpecification.setPort(80);

--- a/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/BTCMarketsExchange.java
+++ b/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/BTCMarketsExchange.java
@@ -32,8 +32,7 @@ public class BTCMarketsExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.btcmarkets.net");
     exchangeSpecification.setHost("btcmarkets.net");
     exchangeSpecification.setPort(80);

--- a/xchange-btctrade/src/test/java/org/knowm/xchange/btctrade/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-btctrade/src/test/java/org/knowm/xchange/btctrade/service/marketdata/TickerFetchIntegration.java
@@ -16,7 +16,7 @@ public class TickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BTCTradeExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BTCTradeExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "USD"));
     System.out.println(ticker.toString());

--- a/xchange-btcturk/src/main/java/org/knowm/xchange/btcturk/BTCTurkExchange.java
+++ b/xchange-btcturk/src/main/java/org/knowm/xchange/btcturk/BTCTurkExchange.java
@@ -29,8 +29,7 @@ public class BTCTurkExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://www.btcturk.com");
     exchangeSpecification.setHost("www.btcturk.com");
     exchangeSpecification.setPort(80);

--- a/xchange-btcturk/src/test/java/org/knowm/xchange/btcturk/service/account/AccountDataFetchIntegration.java
+++ b/xchange-btcturk/src/test/java/org/knowm/xchange/btcturk/service/account/AccountDataFetchIntegration.java
@@ -26,7 +26,7 @@ public class AccountDataFetchIntegration {
   @Before
   public void InitExchange() throws IOException {
     if (BTCTurkDemoUtilsTest.BTCTURK_APIKEY.isEmpty())
-      btcTurk = ExchangeFactory.INSTANCE.createExchange(BTCTurkExchange.class.getName());
+      btcTurk = ExchangeFactory.INSTANCE.createExchange(BTCTurkExchange.class);
     else {
       ExchangeSpecification exSpec = new BTCTurkExchange().getDefaultExchangeSpecification();
       exSpec.setApiKey(BTCTurkDemoUtilsTest.BTCTURK_APIKEY);

--- a/xchange-btcturk/src/test/java/org/knowm/xchange/btcturk/service/marketdata/MarketDataFetchIntegration.java
+++ b/xchange-btcturk/src/test/java/org/knowm/xchange/btcturk/service/marketdata/MarketDataFetchIntegration.java
@@ -32,7 +32,7 @@ public class MarketDataFetchIntegration {
   @Before
   public void InitExchange() throws IOException {
     if (BTCTurkDemoUtilsTest.BTCTURK_APIKEY.isEmpty())
-      btcTurk = ExchangeFactory.INSTANCE.createExchange(BTCTurkExchange.class.getName());
+      btcTurk = ExchangeFactory.INSTANCE.createExchange(BTCTurkExchange.class);
     else {
       ExchangeSpecification exSpec = new BTCTurkExchange().getDefaultExchangeSpecification();
       exSpec.setApiKey(BTCTurkDemoUtilsTest.BTCTURK_APIKEY);

--- a/xchange-btcturk/src/test/java/org/knowm/xchange/btcturk/service/trade/TradeDataFetchIntegration.java
+++ b/xchange-btcturk/src/test/java/org/knowm/xchange/btcturk/service/trade/TradeDataFetchIntegration.java
@@ -30,7 +30,7 @@ public class TradeDataFetchIntegration {
   @Before
   public void InitExchange() throws IOException {
     if (BTCTurkDemoUtilsTest.BTCTURK_APIKEY.isEmpty())
-      btcTurk = ExchangeFactory.INSTANCE.createExchange(BTCTurkExchange.class.getName());
+      btcTurk = ExchangeFactory.INSTANCE.createExchange(BTCTurkExchange.class);
     else {
       ExchangeSpecification exSpec = new BTCTurkExchange().getDefaultExchangeSpecification();
       exSpec.setApiKey(BTCTurkDemoUtilsTest.BTCTURK_APIKEY);

--- a/xchange-bx/src/main/java/org/knowm/xchange/bx/BxExchange.java
+++ b/xchange-bx/src/main/java/org/knowm/xchange/bx/BxExchange.java
@@ -32,8 +32,7 @@ public class BxExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://bx.in.th");
     exchangeSpecification.setHost("bx.in.th");
     exchangeSpecification.setPort(80);

--- a/xchange-bx/src/test/java/org/knowm/xchange/bx/BxPrivateApiIntegration.java
+++ b/xchange-bx/src/test/java/org/knowm/xchange/bx/BxPrivateApiIntegration.java
@@ -25,7 +25,7 @@ public class BxPrivateApiIntegration {
     BxProperties properties = new BxProperties();
     Exchange exchange =
         ExchangeFactory.INSTANCE.createExchange(
-            BxExchange.class.getName(), properties.getApiKey(), properties.getSecretKey());
+            BxExchange.class, properties.getApiKey(), properties.getSecretKey());
 
     LimitOrder limitOrder =
         new LimitOrder(
@@ -57,7 +57,7 @@ public class BxPrivateApiIntegration {
     BxProperties properties = new BxProperties();
     Exchange exchange =
         ExchangeFactory.INSTANCE.createExchange(
-            BxExchange.class.getName(), properties.getApiKey(), properties.getSecretKey());
+            BxExchange.class, properties.getApiKey(), properties.getSecretKey());
     boolean result = exchange.getTradeService().cancelOrder("8221435");
     System.out.println(result);
     assertThat(result).isTrue();
@@ -68,7 +68,7 @@ public class BxPrivateApiIntegration {
     BxProperties properties = new BxProperties();
     Exchange exchange =
         ExchangeFactory.INSTANCE.createExchange(
-            BxExchange.class.getName(), properties.getApiKey(), properties.getSecretKey());
+            BxExchange.class, properties.getApiKey(), properties.getSecretKey());
     OpenOrders openOrders = exchange.getTradeService().getOpenOrders();
     System.out.println(openOrders.toString());
     assertThat(openOrders).isNotNull();
@@ -79,7 +79,7 @@ public class BxPrivateApiIntegration {
     BxProperties properties = new BxProperties();
     Exchange exchange =
         ExchangeFactory.INSTANCE.createExchange(
-            BxExchange.class.getName(), properties.getApiKey(), properties.getSecretKey());
+            BxExchange.class, properties.getApiKey(), properties.getSecretKey());
     Collection<Order> orders = exchange.getTradeService().getOrder("8200823", "8177040");
     System.out.println(orders.toString());
     assertThat(orders).isNotNull();
@@ -90,7 +90,7 @@ public class BxPrivateApiIntegration {
     BxProperties properties = new BxProperties();
     Exchange exchange =
         ExchangeFactory.INSTANCE.createExchange(
-            BxExchange.class.getName(), properties.getApiKey(), properties.getSecretKey());
+            BxExchange.class, properties.getApiKey(), properties.getSecretKey());
     TradeService tradeService = exchange.getTradeService();
     BxTradeHistoryParams params =
         new BxTradeHistoryParams("2018-03-01 00:00:00", "2018-03-31 23:59:59");
@@ -104,7 +104,7 @@ public class BxPrivateApiIntegration {
     BxProperties properties = new BxProperties();
     Exchange exchange =
         ExchangeFactory.INSTANCE.createExchange(
-            BxExchange.class.getName(), properties.getApiKey(), properties.getSecretKey());
+            BxExchange.class, properties.getApiKey(), properties.getSecretKey());
     TradeService tradeService = exchange.getTradeService();
     UserTrades trades = tradeService.getTradeHistory(null);
     System.out.println(trades);
@@ -116,7 +116,7 @@ public class BxPrivateApiIntegration {
     BxProperties properties = new BxProperties();
     Exchange exchange =
         ExchangeFactory.INSTANCE.createExchange(
-            BxExchange.class.getName(), properties.getApiKey(), properties.getSecretKey());
+            BxExchange.class, properties.getApiKey(), properties.getSecretKey());
     Balance balance =
         exchange.getAccountService().getAccountInfo().getWallet().getBalance(Currency.THB);
     System.out.println(balance.toString());

--- a/xchange-bx/src/test/java/org/knowm/xchange/bx/BxPublicApiIntegration.java
+++ b/xchange-bx/src/test/java/org/knowm/xchange/bx/BxPublicApiIntegration.java
@@ -16,7 +16,7 @@ public class BxPublicApiIntegration {
 
   @Test
   public void getTickerTest() throws IOException {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BxExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BxExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     CurrencyPair pair = new CurrencyPair("THB", "BTC");
     Ticker ticker = marketDataService.getTicker(pair);
@@ -30,7 +30,7 @@ public class BxPublicApiIntegration {
 
   @Test
   public void getExchangeSymbolsTest() {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BxExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BxExchange.class);
     List<CurrencyPair> pairs = exchange.getExchangeSymbols();
     System.out.println(Arrays.toString(pairs.toArray()));
     assertThat(pairs).isNotNull();

--- a/xchange-campbx/src/main/java/org/knowm/xchange/campbx/CampBXExchange.java
+++ b/xchange-campbx/src/main/java/org/knowm/xchange/campbx/CampBXExchange.java
@@ -32,8 +32,7 @@ public class CampBXExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://campbx.com");
     exchangeSpecification.setHost("campbx.com");
     exchangeSpecification.setPort(80);

--- a/xchange-campbx/src/test/java/org/knowm/xchange/campbx/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-campbx/src/test/java/org/knowm/xchange/campbx/service/marketdata/TickerFetchIntegration.java
@@ -16,7 +16,7 @@ public class TickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CampBXExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CampBXExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "USD"));
     System.out.println(ticker.toString());

--- a/xchange-ccex/src/main/java/org/knowm/xchange/ccex/CCEXExchange.java
+++ b/xchange-ccex/src/main/java/org/knowm/xchange/ccex/CCEXExchange.java
@@ -24,8 +24,7 @@ public class CCEXExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://c-cex.com");
     exchangeSpecification.setHost("c-cex.com");
     exchangeSpecification.setPort(80);

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/CexIOExchange.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/CexIOExchange.java
@@ -30,8 +30,7 @@ public class CexIOExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://cex.io");
     exchangeSpecification.setHost("cex.io");
     exchangeSpecification.setPort(80);

--- a/xchange-cexio/src/test/java/org/knowm/xchange/cexio/service/TradeServiceIntegration.java
+++ b/xchange-cexio/src/test/java/org/knowm/xchange/cexio/service/TradeServiceIntegration.java
@@ -31,7 +31,7 @@ public class TradeServiceIntegration {
       return;
     }
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CexIOExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CexIOExchange.class);
 
     ExchangeSpecification specification = exchange.getDefaultExchangeSpecification();
     specification.setApiKey(properties.getApiKey());

--- a/xchange-cexio/src/test/java/org/knowm/xchange/cexio/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-cexio/src/test/java/org/knowm/xchange/cexio/service/marketdata/TickerFetchIntegration.java
@@ -26,7 +26,7 @@ public class TickerFetchIntegration {
 
   @BeforeClass
   public static void setup() {
-    exchange = ExchangeFactory.INSTANCE.createExchange(CexIOExchange.class.getName());
+    exchange = ExchangeFactory.INSTANCE.createExchange(CexIOExchange.class);
   }
 
   @Test

--- a/xchange-cobinhood/src/main/java/org/knowm/xchange/cobinhood/CobinhoodExchange.java
+++ b/xchange-cobinhood/src/main/java/org/knowm/xchange/cobinhood/CobinhoodExchange.java
@@ -26,8 +26,7 @@ public class CobinhoodExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.cobinhood.com/");
     exchangeSpecification.setHost("cobinhood.com");
     exchangeSpecification.setPort(80);

--- a/xchange-cobinhood/src/test/java/org/knowm/xchange/cobinhood/service/CobinhoodMarketDataServiceIntegration.java
+++ b/xchange-cobinhood/src/test/java/org/knowm/xchange/cobinhood/service/CobinhoodMarketDataServiceIntegration.java
@@ -15,7 +15,7 @@ import org.knowm.xchange.service.marketdata.MarketDataService;
 public class CobinhoodMarketDataServiceIntegration {
 
   private static final Exchange COBINHOOD =
-      ExchangeFactory.INSTANCE.createExchange(CobinhoodExchange.class.getName());
+      ExchangeFactory.INSTANCE.createExchange(CobinhoodExchange.class);
 
   @Test
   public void testGetTicker() throws Exception {

--- a/xchange-coinbase/src/main/java/org/knowm/xchange/coinbase/CoinbaseExchange.java
+++ b/xchange-coinbase/src/main/java/org/knowm/xchange/coinbase/CoinbaseExchange.java
@@ -24,8 +24,7 @@ public class CoinbaseExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    final ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    final ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://coinbase.com");
     exchangeSpecification.setHost("coinbase.com");
     exchangeSpecification.setExchangeName("Coinbase");

--- a/xchange-coinbase/src/main/java/org/knowm/xchange/coinbase/v2/CoinbaseExchange.java
+++ b/xchange-coinbase/src/main/java/org/knowm/xchange/coinbase/v2/CoinbaseExchange.java
@@ -23,8 +23,7 @@ public class CoinbaseExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    final ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    final ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.coinbase.com/v2");
     exchangeSpecification.setHost("api.coinbase.com");
     exchangeSpecification.setExchangeName("Coinbase");

--- a/xchange-coinbase/src/test/java/org/knowm/xchange/coinbase/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-coinbase/src/test/java/org/knowm/xchange/coinbase/service/marketdata/TickerFetchIntegration.java
@@ -16,7 +16,7 @@ public class TickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "USD"));
     System.out.println(ticker.toString());

--- a/xchange-coinbase/src/test/java/org/knowm/xchange/coinbase/v2/services/AccountServiceIntegration.java
+++ b/xchange-coinbase/src/test/java/org/knowm/xchange/coinbase/v2/services/AccountServiceIntegration.java
@@ -24,7 +24,7 @@ public class AccountServiceIntegration {
 
   @BeforeClass
   public static void beforeClass() {
-    exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseExchange.class.getName());
+    exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseExchange.class);
     AuthUtils.setApiAndSecretKey(exchange.getExchangeSpecification());
     accountService = exchange.getAccountService();
   }

--- a/xchange-coinbase/src/test/java/org/knowm/xchange/coinbase/v2/services/BaseServiceIntegration.java
+++ b/xchange-coinbase/src/test/java/org/knowm/xchange/coinbase/v2/services/BaseServiceIntegration.java
@@ -18,9 +18,7 @@ public class BaseServiceIntegration {
 
   @BeforeClass
   public static void beforeClass() {
-    exchange =
-        (CoinbaseExchange)
-            ExchangeFactory.INSTANCE.createExchange(CoinbaseExchange.class.getName());
+    exchange = (CoinbaseExchange) ExchangeFactory.INSTANCE.createExchange(CoinbaseExchange.class);
     baseService = (CoinbaseBaseService) exchange.getMarketDataService();
   }
 

--- a/xchange-coinbase/src/test/java/org/knowm/xchange/coinbase/v2/services/MarketDataServiceIntegration.java
+++ b/xchange-coinbase/src/test/java/org/knowm/xchange/coinbase/v2/services/MarketDataServiceIntegration.java
@@ -26,7 +26,7 @@ public class MarketDataServiceIntegration {
 
   @BeforeClass
   public static void beforeClass() {
-    exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseExchange.class.getName());
+    exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseExchange.class);
     marketDataService = exchange.getMarketDataService();
   }
 

--- a/xchange-coinbase/src/test/java/org/knowm/xchange/coinbase/v2/services/TradeServiceIntegration.java
+++ b/xchange-coinbase/src/test/java/org/knowm/xchange/coinbase/v2/services/TradeServiceIntegration.java
@@ -26,7 +26,7 @@ public class TradeServiceIntegration {
 
   @BeforeClass
   public static void beforeClass() {
-    exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseExchange.class.getName());
+    exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseExchange.class);
     AuthUtils.setApiAndSecretKey(exchange.getExchangeSpecification());
     tradeService = exchange.getTradeService();
   }

--- a/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/CoinbaseProExchange.java
+++ b/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/CoinbaseProExchange.java
@@ -83,8 +83,7 @@ public class CoinbaseProExchange extends BaseExchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.pro.coinbase.com");
     exchangeSpecification.setHost("api.pro.coinbase.com");
     exchangeSpecification.setPort(80);

--- a/xchange-coinbasepro/src/test/java/org/knowm/xchange/coinbasepro/CoinbaseProExchangeIntegration.java
+++ b/xchange-coinbasepro/src/test/java/org/knowm/xchange/coinbasepro/CoinbaseProExchangeIntegration.java
@@ -44,7 +44,7 @@ public class CoinbaseProExchangeIntegration {
     final CurrencyPair currencyPair = new CurrencyPair("BTC", "EUR");
     final Exchange exchange;
 
-    exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseProExchange.class.getName());
+    exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseProExchange.class);
     marketDataService = exchange.getMarketDataService();
     marketDataServiceRaw = (CoinbaseProMarketDataServiceRaw) exchange.getMarketDataService();
 
@@ -66,8 +66,7 @@ public class CoinbaseProExchangeIntegration {
 
   @Test
   public void testExchangeMetaData() {
-    final Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(CoinbaseProExchange.class.getName());
+    final Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseProExchange.class);
 
     ExchangeMetaData exchangeMetaData = exchange.getExchangeMetaData();
 

--- a/xchange-coinbasepro/src/test/java/org/knowm/xchange/coinbasepro/service/marketdata/HistoricalCandlesIntegration.java
+++ b/xchange-coinbasepro/src/test/java/org/knowm/xchange/coinbasepro/service/marketdata/HistoricalCandlesIntegration.java
@@ -16,8 +16,7 @@ public class HistoricalCandlesIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(CoinbaseProExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseProExchange.class);
     CoinbaseProMarketDataService mds =
         (CoinbaseProMarketDataService) exchange.getMarketDataService();
     CoinbaseProCandle[] candles =

--- a/xchange-coinbasepro/src/test/java/org/knowm/xchange/coinbasepro/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-coinbasepro/src/test/java/org/knowm/xchange/coinbasepro/service/marketdata/TickerFetchIntegration.java
@@ -15,8 +15,7 @@ public class TickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(CoinbaseProExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseProExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "USD"));
     System.out.println(ticker.toString());

--- a/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/CoinbeneExchange.java
+++ b/xchange-coinbene/src/main/java/org/knowm/xchange/coinbene/CoinbeneExchange.java
@@ -30,8 +30,7 @@ public class CoinbeneExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.coinbene.com/");
     exchangeSpecification.setHost("coinbene.com");
     exchangeSpecification.setPort(80);

--- a/xchange-coinbene/src/test/java/org/knowm/xchange/coinbene/service/marketdata/CoinbeneMarketDataServiceIntegration.java
+++ b/xchange-coinbene/src/test/java/org/knowm/xchange/coinbene/service/marketdata/CoinbeneMarketDataServiceIntegration.java
@@ -19,7 +19,7 @@ import org.knowm.xchange.service.marketdata.MarketDataService;
 public class CoinbeneMarketDataServiceIntegration {
 
   private static final Exchange COINBENE =
-      ExchangeFactory.INSTANCE.createExchange(CoinbeneExchange.class.getName());
+      ExchangeFactory.INSTANCE.createExchange(CoinbeneExchange.class);
 
   @Test
   public void testGetTicker() throws Exception {

--- a/xchange-coindeal/src/main/java/org/knowm/xchange/coindeal/CoindealExchange.java
+++ b/xchange-coindeal/src/main/java/org/knowm/xchange/coindeal/CoindealExchange.java
@@ -28,8 +28,7 @@ public class CoindealExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://apigateway.coindeal.com");
     exchangeSpecification.setHost("www.coindeal.com");
     exchangeSpecification.setPort(80);

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/CoindirectExchange.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/CoindirectExchange.java
@@ -33,7 +33,7 @@ public class CoindirectExchange extends BaseExchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification spec = new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification spec = new ExchangeSpecification(this.getClass());
     spec.setSslUri("https://api.coindirect.com");
     spec.setHost("www.coindirect.com");
     spec.setPort(80);

--- a/xchange-coindirect/src/test/java/org/knowm/xchange/coindirect/ExchangeUtils.java
+++ b/xchange-coindirect/src/test/java/org/knowm/xchange/coindirect/ExchangeUtils.java
@@ -31,7 +31,7 @@ public class ExchangeUtils {
           "An exception occured while loading the configuration file from the classpath. "
               + "Returning exchange without keys.",
           e);
-      return ExchangeFactory.INSTANCE.createExchange(CoindirectExchange.class.getName());
+      return ExchangeFactory.INSTANCE.createExchange(CoindirectExchange.class);
     }
 
     return ExchangeFactory.INSTANCE.createExchange(exSpec);

--- a/xchange-coindirect/src/test/java/org/knowm/xchange/coindirect/service/CoindirectTickerFetchIntegration.java
+++ b/xchange-coindirect/src/test/java/org/knowm/xchange/coindirect/service/CoindirectTickerFetchIntegration.java
@@ -14,7 +14,7 @@ public class CoindirectTickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoindirectExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoindirectExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("ETH", "BTC"));
     System.out.println(ticker.toString());

--- a/xchange-coinegg/src/main/java/org/knowm/xchange/coinegg/CoinEggExchange.java
+++ b/xchange-coinegg/src/main/java/org/knowm/xchange/coinegg/CoinEggExchange.java
@@ -27,8 +27,7 @@ public class CoinEggExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.coinegg.com");
     exchangeSpecification.setHost("http://api.coinegg.com");
     exchangeSpecification.setPort(80);

--- a/xchange-coinegg/src/test/java/org/knowm/xchange/coinegg/service/marketdata/CoinEggOrdersFetchIntegration.java
+++ b/xchange-coinegg/src/test/java/org/knowm/xchange/coinegg/service/marketdata/CoinEggOrdersFetchIntegration.java
@@ -15,7 +15,7 @@ public class CoinEggOrdersFetchIntegration {
   @Test
   public void ordersFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinEggExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinEggExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     OrderBook orders = marketDataService.getOrderBook(CurrencyPair.ETH_BTC);
 
@@ -26,7 +26,7 @@ public class CoinEggOrdersFetchIntegration {
   @Test
   public void ordersFetchTest_BTC_USDT() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinEggExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinEggExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     OrderBook orders = marketDataService.getOrderBook(CurrencyPair.BTC_USDT);
 

--- a/xchange-coinegg/src/test/java/org/knowm/xchange/coinegg/service/marketdata/CoinEggTickerFetchIntegration.java
+++ b/xchange-coinegg/src/test/java/org/knowm/xchange/coinegg/service/marketdata/CoinEggTickerFetchIntegration.java
@@ -15,7 +15,7 @@ public class CoinEggTickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinEggExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinEggExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(CurrencyPair.ETH_BTC);
 

--- a/xchange-coinegg/src/test/java/org/knowm/xchange/coinegg/service/marketdata/CoinEggTradesFetchIntegration.java
+++ b/xchange-coinegg/src/test/java/org/knowm/xchange/coinegg/service/marketdata/CoinEggTradesFetchIntegration.java
@@ -15,7 +15,7 @@ public class CoinEggTradesFetchIntegration {
   @Test
   public void tradesFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinEggExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinEggExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Trades trades = marketDataService.getTrades(CurrencyPair.ETH_BTC);
 

--- a/xchange-coinex/src/main/java/org/knowm/xchange/coinex/CoinexExchange.java
+++ b/xchange-coinex/src/main/java/org/knowm/xchange/coinex/CoinexExchange.java
@@ -23,8 +23,7 @@ public class CoinexExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.coinex.com");
     exchangeSpecification.setHost("www.coinex.com");
     exchangeSpecification.setPort(80);

--- a/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/CoinfloorExchange.java
+++ b/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/CoinfloorExchange.java
@@ -14,8 +14,7 @@ public class CoinfloorExchange extends BaseExchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification specification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification specification = new ExchangeSpecification(this.getClass());
     specification.setShouldLoadRemoteMetaData(false);
     specification.setSslUri("https://webapi.coinfloor.co.uk:8090/");
     specification.setExchangeName("Coinfloor");

--- a/xchange-coinfloor/src/test/java/org/knowm/xchange/coinfloor/service/CoinfloorOrderBookIntegration.java
+++ b/xchange-coinfloor/src/test/java/org/knowm/xchange/coinfloor/service/CoinfloorOrderBookIntegration.java
@@ -17,7 +17,7 @@ public class CoinfloorOrderBookIntegration {
 
   @Test
   public void fetchOrderBookTest() throws IOException {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinfloorExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinfloorExchange.class);
     MarketDataService service = exchange.getMarketDataService();
 
     OrderBook orderBook = service.getOrderBook(CurrencyPair.BTC_GBP);

--- a/xchange-coinfloor/src/test/java/org/knowm/xchange/coinfloor/service/CoinfloorPublicTradesIntegration.java
+++ b/xchange-coinfloor/src/test/java/org/knowm/xchange/coinfloor/service/CoinfloorPublicTradesIntegration.java
@@ -18,7 +18,7 @@ public class CoinfloorPublicTradesIntegration {
 
   @Test
   public void fetchTransactionTest() throws IOException {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinfloorExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinfloorExchange.class);
     MarketDataService service = exchange.getMarketDataService();
 
     Trades trades = service.getTrades(CurrencyPair.BTC_GBP, CoinfloorInterval.HOUR);

--- a/xchange-coinfloor/src/test/java/org/knowm/xchange/coinfloor/service/CoinfloorTickerIntegration.java
+++ b/xchange-coinfloor/src/test/java/org/knowm/xchange/coinfloor/service/CoinfloorTickerIntegration.java
@@ -16,7 +16,7 @@ public class CoinfloorTickerIntegration {
 
   @Test
   public void fetchTickerTest() throws IOException {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinfloorExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinfloorExchange.class);
     MarketDataService service = exchange.getMarketDataService();
 
     Ticker ticker = service.getTicker(CurrencyPair.BTC_GBP);

--- a/xchange-coingi/src/main/java/org/knowm/xchange/coingi/CoingiExchange.java
+++ b/xchange-coingi/src/main/java/org/knowm/xchange/coingi/CoingiExchange.java
@@ -21,8 +21,7 @@ public class CoingiExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.coingi.com");
     exchangeSpecification.setHost("api.coingi.com");
     exchangeSpecification.setPort(80);

--- a/xchange-coingi/src/test/java/org/knowm/xchange/coingi/service/marketdata/CoingiExceptionIntegration.java
+++ b/xchange-coingi/src/test/java/org/knowm/xchange/coingi/service/marketdata/CoingiExceptionIntegration.java
@@ -14,7 +14,7 @@ import org.knowm.xchange.service.marketdata.MarketDataService;
 public class CoingiExceptionIntegration {
   @Test
   public void invalidCurrencyPairForTradesFetchTest() throws Exception {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoingiExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoingiExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
 
     Throwable exception =

--- a/xchange-coingi/src/test/java/org/knowm/xchange/coingi/service/marketdata/CoingiOrderBookFetchIntegration.java
+++ b/xchange-coingi/src/test/java/org/knowm/xchange/coingi/service/marketdata/CoingiOrderBookFetchIntegration.java
@@ -15,7 +15,7 @@ public class CoingiOrderBookFetchIntegration {
 
   @Test
   public void orderBookFetchTest() throws Exception {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoingiExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoingiExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
 
     CurrencyPair pair = CurrencyPair.BTC_EUR;

--- a/xchange-coinjar/src/main/java/org/knowm/xchange/coinjar/CoinjarExchange.java
+++ b/xchange-coinjar/src/main/java/org/knowm/xchange/coinjar/CoinjarExchange.java
@@ -28,8 +28,7 @@ public class CoinjarExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri(CoinjarBaseService.LIVE_URL);
     exchangeSpecification.setExchangeName("Coinjar");
     exchangeSpecification.setExchangeDescription("Coinjar");

--- a/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/deprecated/v2/CoinMarketCapExchange.java
+++ b/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/deprecated/v2/CoinMarketCapExchange.java
@@ -31,7 +31,7 @@ public class CoinMarketCapExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
     final ExchangeSpecification defaultExchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+        new ExchangeSpecification(this.getClass());
     defaultExchangeSpecification.setSslUri("https://api.coinmarketcap.com");
     defaultExchangeSpecification.setHost("coinmarketcap.com");
     defaultExchangeSpecification.setExchangeName("CoinMarketCap");

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateExchange.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateExchange.java
@@ -56,8 +56,7 @@ public class CoinmateExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://coinmate.io");
     exchangeSpecification.setHost("coinmate.io");
     exchangeSpecification.setPort(80);

--- a/xchange-coinmate/src/test/java/org/knowm/xchange/coinmate/service/CoinmateBaseServiceIntegration.java
+++ b/xchange-coinmate/src/test/java/org/knowm/xchange/coinmate/service/CoinmateBaseServiceIntegration.java
@@ -42,7 +42,7 @@ public class CoinmateBaseServiceIntegration {
   @Test
   public void tickerFetchTestBTC_EUR() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "EUR"));
     System.out.println(ticker.toString());
@@ -52,7 +52,7 @@ public class CoinmateBaseServiceIntegration {
   @Test
   public void tickerFetchTestBTC_CZK() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "CZK"));
     System.out.println(ticker.toString());
@@ -62,7 +62,7 @@ public class CoinmateBaseServiceIntegration {
   @Test
   public void tickerFetchTestLTC_BTC() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(CurrencyPair.LTC_BTC);
     System.out.println(ticker.toString());
@@ -72,7 +72,7 @@ public class CoinmateBaseServiceIntegration {
   @Test
   public void orderBookFetchTestBTC_EUR() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     OrderBook orderBook = marketDataService.getOrderBook(CurrencyPair.BTC_EUR);
     System.out.println(orderBook.toString());
@@ -82,7 +82,7 @@ public class CoinmateBaseServiceIntegration {
   @Test
   public void orderBookFetchTestBTC_CZK() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     OrderBook orderBook = marketDataService.getOrderBook(CurrencyPair.BTC_CZK);
     System.out.println(orderBook.toString());
@@ -92,7 +92,7 @@ public class CoinmateBaseServiceIntegration {
   @Test
   public void orderBookFetchTestLTC_BTC() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     OrderBook orderBook = marketDataService.getOrderBook(CurrencyPair.LTC_BTC);
     System.out.println(orderBook.toString());
@@ -102,7 +102,7 @@ public class CoinmateBaseServiceIntegration {
   @Test
   public void tradesFetchTestBTC_EUR() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Trades trades = marketDataService.getTrades(CurrencyPair.BTC_EUR);
     System.out.println(trades.getTrades().toString());
@@ -112,7 +112,7 @@ public class CoinmateBaseServiceIntegration {
   @Test
   public void tradesFetchTestBTC_CZK() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Trades trades = marketDataService.getTrades(CurrencyPair.BTC_CZK);
     System.out.println(trades.getTrades().toString());
@@ -122,7 +122,7 @@ public class CoinmateBaseServiceIntegration {
   @Test
   public void tradesFetchTestLTC_BTC() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Trades trades = marketDataService.getTrades(CurrencyPair.LTC_BTC);
     System.out.println(trades.getTrades().toString());
@@ -132,7 +132,7 @@ public class CoinmateBaseServiceIntegration {
   @Test
   public void tradesFetchTestXRP_CZK() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinmateExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Trades trades = marketDataService.getTrades(new CurrencyPair(Currency.XRP, Currency.CZK));
     System.out.println(trades.getTrades().toString());

--- a/xchange-coinone/src/main/java/org/knowm/xchange/coinone/CoinoneExchange.java
+++ b/xchange-coinone/src/main/java/org/knowm/xchange/coinone/CoinoneExchange.java
@@ -28,8 +28,7 @@ public class CoinoneExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.coinone.co.kr");
     exchangeSpecification.setHost("www.coinone.co.kr");
     exchangeSpecification.setExchangeName("Coinone");

--- a/xchange-coinsuper/src/main/java/org/knowm/xchange/coinsuper/CoinsuperExchange.java
+++ b/xchange-coinsuper/src/main/java/org/knowm/xchange/coinsuper/CoinsuperExchange.java
@@ -25,8 +25,7 @@ public class CoinsuperExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.coinsuper.com");
     exchangeSpecification.setHost("api.coinsuper.com");
     exchangeSpecification.setPort(80);

--- a/xchange-coinsuper/src/test/java/org/knowm/xchange/test/coinsuper/AccountServiceIntegration.java
+++ b/xchange-coinsuper/src/test/java/org/knowm/xchange/test/coinsuper/AccountServiceIntegration.java
@@ -28,7 +28,7 @@ public class AccountServiceIntegration {
     String apiKey = "00af0b38-11fb-4aab-bf19-45edd44a4adc";
     String secretKey = "fa3f0510-155f-4567-a3b3-3f386080efa3";
 
-    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class.getName());
+    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class);
 
     ExchangeSpecification exchangeSpecification = coinsuper.getExchangeSpecification();
     exchangeSpecification.setApiKey(apiKey);
@@ -62,7 +62,7 @@ public class AccountServiceIntegration {
     String apiKey = "00af0b38-11fb-4aab-bf19-45edd44a4adc";
     String secretKey = "fa3f0510-155f-4567-a3b3-3f386080efa3";
 
-    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class.getName());
+    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class);
 
     ExchangeSpecification exchangeSpecification = coinsuper.getExchangeSpecification();
     exchangeSpecification.setApiKey(apiKey);

--- a/xchange-coinsuper/src/test/java/org/knowm/xchange/test/coinsuper/MarketDataServiceIntegration.java
+++ b/xchange-coinsuper/src/test/java/org/knowm/xchange/test/coinsuper/MarketDataServiceIntegration.java
@@ -15,7 +15,7 @@ public class MarketDataServiceIntegration {
     String apiKey = "00af0b38-11fb-4aab-bf19-45edd44a4adc";
     String secretKey = "fa3f0510-155f-4567-a3b3-3f386080efa3";
 
-    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class.getName());
+    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class);
 
     ExchangeSpecification exchangeSpecification = coinsuper.getExchangeSpecification();
     exchangeSpecification.setApiKey(apiKey);

--- a/xchange-coinsuper/src/test/java/org/knowm/xchange/test/coinsuper/MarketDataServiceIntegrationOrderbook.java
+++ b/xchange-coinsuper/src/test/java/org/knowm/xchange/test/coinsuper/MarketDataServiceIntegrationOrderbook.java
@@ -23,7 +23,7 @@ public class MarketDataServiceIntegrationOrderbook {
     String apiKey = "00af0b38-11fb-4aab-bf19-45edd44a4adc";
     String secretKey = "fa3f0510-155f-4567-a3b3-3f386080efa3";
 
-    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class.getName());
+    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class);
 
     ExchangeSpecification exchangeSpecification = coinsuper.getExchangeSpecification();
     exchangeSpecification.setApiKey(apiKey);
@@ -62,7 +62,7 @@ public class MarketDataServiceIntegrationOrderbook {
   //	    String secretKey = "fa3f0510-155f-4567-a3b3-3f386080efa3";
   //
   //		Exchange coinsuper =
-  // ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class.getName());
+  // ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class);
   //
   //        ExchangeSpecification exchangeSpecification = coinsuper.getExchangeSpecification();
   //        exchangeSpecification.setApiKey(apiKey);

--- a/xchange-coinsuper/src/test/java/org/knowm/xchange/test/coinsuper/MarketDataServiceIntegrationPairs.java
+++ b/xchange-coinsuper/src/test/java/org/knowm/xchange/test/coinsuper/MarketDataServiceIntegrationPairs.java
@@ -26,7 +26,7 @@ public class MarketDataServiceIntegrationPairs {
     String apiKey = "00af0b38-11fb-4aab-bf19-45edd44a4adc";
     String secretKey = "fa3f0510-155f-4567-a3b3-3f386080efa3";
 
-    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class.getName());
+    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class);
 
     ExchangeSpecification exchangeSpecification = coinsuper.getExchangeSpecification();
     exchangeSpecification.setApiKey(apiKey);

--- a/xchange-coinsuper/src/test/java/org/knowm/xchange/test/coinsuper/MarketDataServiceIntegrationTicker.java
+++ b/xchange-coinsuper/src/test/java/org/knowm/xchange/test/coinsuper/MarketDataServiceIntegrationTicker.java
@@ -29,7 +29,7 @@ public class MarketDataServiceIntegrationTicker {
     String apiKey = "00af0b38-11fb-4aab-bf19-45edd44a4adc";
     String secretKey = "fa3f0510-155f-4567-a3b3-3f386080efa3";
 
-    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class.getName());
+    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class);
 
     ExchangeSpecification exchangeSpecification = coinsuper.getExchangeSpecification();
     exchangeSpecification.setApiKey(apiKey);
@@ -55,7 +55,7 @@ public class MarketDataServiceIntegrationTicker {
     String apiKey = "00af0b38-11fb-4aab-bf19-45edd44a4adc";
     String secretKey = "fa3f0510-155f-4567-a3b3-3f386080efa3";
 
-    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class.getName());
+    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class);
 
     ExchangeSpecification exchangeSpecification = coinsuper.getExchangeSpecification();
     exchangeSpecification.setApiKey(apiKey);

--- a/xchange-coinsuper/src/test/java/org/knowm/xchange/test/coinsuper/TradeServiceIntegrationTransactions.java
+++ b/xchange-coinsuper/src/test/java/org/knowm/xchange/test/coinsuper/TradeServiceIntegrationTransactions.java
@@ -28,7 +28,7 @@ public class TradeServiceIntegrationTransactions {
     String apiKey = "00af0b38-11fb-4aab-bf19-45edd44a4adc";
     String secretKey = "fa3f0510-155f-4567-a3b3-3f386080efa3";
 
-    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class.getName());
+    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class);
 
     ExchangeSpecification exchangeSpecification = coinsuper.getExchangeSpecification();
     exchangeSpecification.setApiKey(apiKey);
@@ -54,7 +54,7 @@ public class TradeServiceIntegrationTransactions {
     String apiKey = "00af0b38-11fb-4aab-bf19-45edd44a4adc";
     String secretKey = "fa3f0510-155f-4567-a3b3-3f386080efa3";
 
-    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class.getName());
+    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class);
 
     ExchangeSpecification exchangeSpecification = coinsuper.getExchangeSpecification();
     exchangeSpecification.setApiKey(apiKey);

--- a/xchange-coinsuper/src/test/java/org/knowm/xchange/test/coinsuper/TradeServiceIntegrationTransactionsCreateOrder.java
+++ b/xchange-coinsuper/src/test/java/org/knowm/xchange/test/coinsuper/TradeServiceIntegrationTransactionsCreateOrder.java
@@ -32,7 +32,7 @@ public class TradeServiceIntegrationTransactionsCreateOrder {
     String apiKey = "00af0b38-11fb-4aab-bf19-45edd44a4adc";
     String secretKey = "fa3f0510-155f-4567-a3b3-3f386080efa3";
 
-    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class.getName());
+    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class);
 
     ExchangeSpecification exchangeSpecification = coinsuper.getExchangeSpecification();
     exchangeSpecification.setApiKey(apiKey);
@@ -64,7 +64,7 @@ public class TradeServiceIntegrationTransactionsCreateOrder {
     String apiKey = "00af0b38-11fb-4aab-bf19-45edd44a4adc";
     String secretKey = "fa3f0510-155f-4567-a3b3-3f386080efa3";
 
-    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class.getName());
+    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class);
 
     ExchangeSpecification exchangeSpecification = coinsuper.getExchangeSpecification();
     exchangeSpecification.setApiKey(apiKey);
@@ -99,7 +99,7 @@ public class TradeServiceIntegrationTransactionsCreateOrder {
     String apiKey = "00af0b38-11fb-4aab-bf19-45edd44a4adc";
     String secretKey = "fa3f0510-155f-4567-a3b3-3f386080efa3";
 
-    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class.getName());
+    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class);
 
     ExchangeSpecification exchangeSpecification = coinsuper.getExchangeSpecification();
     exchangeSpecification.setApiKey(apiKey);
@@ -123,7 +123,7 @@ public class TradeServiceIntegrationTransactionsCreateOrder {
     String apiKey = "00af0b38-11fb-4aab-bf19-45edd44a4adc";
     String secretKey = "fa3f0510-155f-4567-a3b3-3f386080efa3";
 
-    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class.getName());
+    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class);
 
     ExchangeSpecification exchangeSpecification = coinsuper.getExchangeSpecification();
     exchangeSpecification.setApiKey(apiKey);
@@ -164,7 +164,7 @@ public class TradeServiceIntegrationTransactionsCreateOrder {
     String apiKey = "00af0b38-11fb-4aab-bf19-45edd44a4adc";
     String secretKey = "fa3f0510-155f-4567-a3b3-3f386080efa3";
 
-    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class.getName());
+    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class);
 
     ExchangeSpecification exchangeSpecification = coinsuper.getExchangeSpecification();
     exchangeSpecification.setApiKey(apiKey);
@@ -188,7 +188,7 @@ public class TradeServiceIntegrationTransactionsCreateOrder {
     String apiKey = "00af0b38-11fb-4aab-bf19-45edd44a4adc";
     String secretKey = "fa3f0510-155f-4567-a3b3-3f386080efa3";
 
-    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class.getName());
+    Exchange coinsuper = ExchangeFactory.INSTANCE.createExchange(CoinsuperExchange.class);
 
     ExchangeSpecification exchangeSpecification = coinsuper.getExchangeSpecification();
     exchangeSpecification.setApiKey(apiKey);

--- a/xchange-core/src/main/java/org/knowm/xchange/ExchangeClassUtils.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/ExchangeClassUtils.java
@@ -1,0 +1,25 @@
+package org.knowm.xchange;
+
+import org.knowm.xchange.exceptions.ExchangeException;
+
+public final class ExchangeClassUtils {
+
+  private ExchangeClassUtils() {}
+
+  public static Class<? extends Exchange> exchangeClassForName(String exchangeClassName) {
+    // Attempt to create an instance of the exchange provider
+    try {
+      Class<?> exchangeProviderClass = Class.forName(exchangeClassName);
+
+      // Test that the class implements Exchange
+      if (Exchange.class.isAssignableFrom(exchangeProviderClass)) {
+        return (Class<? extends Exchange>) exchangeProviderClass;
+      } else {
+        throw new ExchangeException(
+            "Class '" + exchangeClassName + "' does not implement Exchange");
+      }
+    } catch (ClassNotFoundException e) {
+      throw new ExchangeException("Problem creating Exchange (class not found)", e);
+    }
+  }
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/ExchangeFactory.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/ExchangeFactory.java
@@ -1,5 +1,7 @@
 package org.knowm.xchange;
 
+import static org.knowm.xchange.ExchangeClassUtils.exchangeClassForName;
+
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.utils.Assert;
 import org.slf4j.Logger;
@@ -123,8 +125,8 @@ public enum ExchangeFactory {
 
     log.debug("Creating exchange from specification");
 
-    String exchangeClassName = exchangeSpecification.getExchangeClassName();
-    Exchange exchange = createExchangeWithoutSpecification(exchangeClassName);
+    final Class<? extends Exchange> exchangeClass = exchangeSpecification.getExchangeClass();
+    Exchange exchange = createExchangeWithoutSpecification(exchangeClass);
     exchange.applySpecification(exchangeSpecification);
     return exchange;
   }
@@ -140,28 +142,9 @@ public enum ExchangeFactory {
    *     org.knowm.xchange.ExchangeSpecification}
    */
   public Exchange createExchangeWithoutSpecification(String exchangeClassName) {
-
     Assert.notNull(exchangeClassName, "exchangeClassName cannot be null");
-
     log.debug("Creating default exchange from class name");
-    // Attempt to create an instance of the exchange provider
-    try {
-
-      // Attempt to locate the exchange provider on the classpath
-
-      Class exchangeProviderClass = Class.forName(exchangeClassName);
-
-      // Test that the class implements Exchange
-      if (Exchange.class.isAssignableFrom(exchangeProviderClass)) {
-        // Instantiate through the default constructor and use the default exchange specification
-        return createExchangeWithoutSpecification(exchangeProviderClass);
-      } else {
-        throw new ExchangeException(
-            "Class '" + exchangeClassName + "' does not implement Exchange");
-      }
-    } catch (ClassNotFoundException e) {
-      throw new ExchangeException("Problem creating Exchange (class not found)", e);
-    }
+    return createExchangeWithoutSpecification(exchangeClassForName(exchangeClassName));
   }
 
   /**

--- a/xchange-core/src/main/java/org/knowm/xchange/ExchangeSpecification.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/ExchangeSpecification.java
@@ -1,5 +1,7 @@
 package org.knowm.xchange;
 
+import static org.knowm.xchange.ExchangeClassUtils.exchangeClassForName;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -13,7 +15,7 @@ import java.util.Map;
  */
 public class ExchangeSpecification {
 
-  private final String exchangeClassName;
+  private final Class<? extends Exchange> exchangeClass;
   private String exchangeName;
   private String exchangeDescription;
   private String userName;
@@ -39,10 +41,11 @@ public class ExchangeSpecification {
    *
    * @param exchangeClassName The exchange class name (e.g.
    *     "org.knowm.xchange.mtgox.v1.MtGoxExchange")
+   * @deprecated use constructor with exchange class for better performance
    */
+  @Deprecated
   public ExchangeSpecification(String exchangeClassName) {
-
-    this.exchangeClassName = exchangeClassName;
+    this(exchangeClassForName(exchangeClassName));
   }
 
   /**
@@ -51,14 +54,22 @@ public class ExchangeSpecification {
    * @param exchangeClass The exchange class
    */
   public ExchangeSpecification(Class<? extends Exchange> exchangeClass) {
-
-    this.exchangeClassName = exchangeClass.getCanonicalName();
+    this.exchangeClass = exchangeClass;
   }
 
-  /** @return The exchange class name for loading at runtime */
-  public String getExchangeClassName() {
+  /** @return The exchange class for loading at runtime */
+  public Class<? extends Exchange> getExchangeClass() {
+    return exchangeClass;
+  }
 
-    return exchangeClassName;
+  /**
+   * @return The exchange class name for loading at runtime
+   * @see this#getExchangeClass
+   * @deprecated use getExchangeClass
+   */
+  @Deprecated
+  public String getExchangeClassName() {
+    return exchangeClass.getName();
   }
 
   /**

--- a/xchange-cryptofacilities/src/main/java/org/knowm/xchange/cryptofacilities/CryptoFacilitiesExchange.java
+++ b/xchange-cryptofacilities/src/main/java/org/knowm/xchange/cryptofacilities/CryptoFacilitiesExchange.java
@@ -24,8 +24,7 @@ public class CryptoFacilitiesExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://www.cryptofacilities.com/derivatives");
     exchangeSpecification.setHost("www.cryptofacilities.com");
     exchangeSpecification.setPort(443);

--- a/xchange-cryptonit/src/main/java/org/knowm/xchange/cryptonit2/CryptonitExchange.java
+++ b/xchange-cryptonit/src/main/java/org/knowm/xchange/cryptonit2/CryptonitExchange.java
@@ -25,8 +25,7 @@ public class CryptonitExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.cryptonit2.net");
     exchangeSpecification.setHost("www.cryptonit2.net");
     exchangeSpecification.setPort(80);

--- a/xchange-cryptonit/src/test/java/org/knowm/xchange/cryptonit2/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-cryptonit/src/test/java/org/knowm/xchange/cryptonit2/service/marketdata/TickerFetchIntegration.java
@@ -16,7 +16,7 @@ public class TickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CryptonitExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CryptonitExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "USD"));
     System.out.println(ticker.toString());

--- a/xchange-cryptonit/src/test/test/java/org/knowm/xchange/cryptonit2/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-cryptonit/src/test/test/java/org/knowm/xchange/cryptonit2/service/marketdata/TickerFetchIntegration.java
@@ -16,7 +16,7 @@ public class TickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CryptonitExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CryptonitExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "USD"));
     System.out.println(ticker.toString());

--- a/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/CryptopiaExchange.java
+++ b/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/CryptopiaExchange.java
@@ -40,8 +40,7 @@ public class CryptopiaExchange extends BaseExchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://www.cryptopia.co.nz");
     exchangeSpecification.setHost("www.cryptopia.co.nz");
     exchangeSpecification.setPort(80);

--- a/xchange-cryptopia/src/test/java/org/knowm/xchange/cryptopia/service/CryptopiaMarketDataServiceIntegration.java
+++ b/xchange-cryptopia/src/test/java/org/knowm/xchange/cryptopia/service/CryptopiaMarketDataServiceIntegration.java
@@ -25,7 +25,7 @@ public class CryptopiaMarketDataServiceIntegration {
 
   @BeforeClass
   public static void setupExchange() {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CryptopiaExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CryptopiaExchange.class);
 
     marketDataService = exchange.getMarketDataService();
   }

--- a/xchange-cryptowatch/src/main/java/org/knowm/xchange/cryptowatch/CryptowatchExchange.java
+++ b/xchange-cryptowatch/src/main/java/org/knowm/xchange/cryptowatch/CryptowatchExchange.java
@@ -29,8 +29,7 @@ public class CryptowatchExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.cryptowat.ch");
     exchangeSpecification.setHost("api.cryptowat.ch");
     exchangeSpecification.setPort(80);

--- a/xchange-cryptowatch/src/test/java/org/knowm/xchange/cryptowatch/service/CryptowatchMarketDataServiceIntegration.java
+++ b/xchange-cryptowatch/src/test/java/org/knowm/xchange/cryptowatch/service/CryptowatchMarketDataServiceIntegration.java
@@ -17,8 +17,7 @@ public class CryptowatchMarketDataServiceIntegration {
 
   @Before
   public void setUp() {
-    Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(CryptowatchExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CryptowatchExchange.class);
     marketDataService = (CryptowatchMarketDataService) exchange.getMarketDataService();
   }
 

--- a/xchange-cryptowatch/src/test/java/org/knowm/xchange/cryptowatch/service/CryptowatchMarketDataServiceRawIntegration.java
+++ b/xchange-cryptowatch/src/test/java/org/knowm/xchange/cryptowatch/service/CryptowatchMarketDataServiceRawIntegration.java
@@ -24,8 +24,7 @@ public class CryptowatchMarketDataServiceRawIntegration {
 
   @Before
   public void setUp() {
-    Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(CryptowatchExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CryptowatchExchange.class);
     marketDataService = (CryptowatchMarketDataServiceRaw) exchange.getMarketDataService();
   }
 

--- a/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/DeribitExchange.java
+++ b/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/DeribitExchange.java
@@ -44,8 +44,7 @@ public class DeribitExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://www.deribit.com");
     exchangeSpecification.setHost("deribit.com");
     //    exchangeSpecification.setPort(80);
@@ -56,8 +55,7 @@ public class DeribitExchange extends BaseExchange implements Exchange {
 
   public ExchangeSpecification getSandboxExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://test.deribit.com/");
     exchangeSpecification.setHost("test.deribit.com");
     //    exchangeSpecification.setPort(80);

--- a/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/DragonexExchange.java
+++ b/xchange-dragonex/src/main/java/org/knowm/xchange/dragonex/DragonexExchange.java
@@ -95,7 +95,7 @@ public class DragonexExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification spec = new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification spec = new ExchangeSpecification(this.getClass());
     spec.setSslUri("https://openapi.dragonex.io/");
     spec.setHost("openapi.dragonex.io");
     spec.setPort(80);

--- a/xchange-dsx/src/main/java/org/knowm/xchange/dsx/DsxExchange.java
+++ b/xchange-dsx/src/main/java/org/knowm/xchange/dsx/DsxExchange.java
@@ -83,8 +83,7 @@ public class DsxExchange extends BaseExchange implements org.knowm.xchange.Excha
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.dsxglobal.com/");
     exchangeSpecification.setHost("dsx.com");
     exchangeSpecification.setPort(80);

--- a/xchange-dsx/src/test/java/org/knowm/xchange/dsx/AuthenticatedBaseTestCase.java
+++ b/xchange-dsx/src/test/java/org/knowm/xchange/dsx/AuthenticatedBaseTestCase.java
@@ -22,8 +22,7 @@ public class AuthenticatedBaseTestCase {
     String apiKey = System.getProperty(API_KEY_LOOKUP);
     String secretValue = System.getProperty(SECRET_KEY_LOOKUP);
 
-    EXCHANGE =
-        ExchangeFactory.INSTANCE.createExchange(DsxExchange.class.getName(), apiKey, secretValue);
+    EXCHANGE = ExchangeFactory.INSTANCE.createExchange(DsxExchange.class, apiKey, secretValue);
     EXCHANGE.remoteInit();
   }
 }

--- a/xchange-dvchain/src/main/java/org/knowm/xchange/dvchain/DVChainExchange.java
+++ b/xchange-dvchain/src/main/java/org/knowm/xchange/dvchain/DVChainExchange.java
@@ -25,8 +25,7 @@ public class DVChainExchange extends BaseExchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://trade.dvchain.co");
     exchangeSpecification.setHost("trade.dvchain.co");
     exchangeSpecification.setPort(80);

--- a/xchange-dvchain/src/test/java/org/knowm/xchange/dvchain/v4/DVChainExchangeIntegration.java
+++ b/xchange-dvchain/src/test/java/org/knowm/xchange/dvchain/v4/DVChainExchangeIntegration.java
@@ -38,7 +38,7 @@ public class DVChainExchangeIntegration {
   @Test
   public void testExchangeMarketData() {
     final Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(DVChainExchange.class.getName(), secret, secret);
+        ExchangeFactory.INSTANCE.createExchange(DVChainExchange.class, secret, secret);
     ExchangeSpecification exchangeSpecification = exchange.getExchangeSpecification();
     exchangeSpecification.setSslUri("https://sandbox.trade.dvchain.co");
     exchangeSpecification.setHost("sandbox.trade.dvchain.co");
@@ -61,7 +61,7 @@ public class DVChainExchangeIntegration {
   public void testMarketOrder() {
 
     final Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(DVChainExchange.class.getName(), secret, secret);
+        ExchangeFactory.INSTANCE.createExchange(DVChainExchange.class, secret, secret);
     ExchangeSpecification exchangeSpecification = exchange.getExchangeSpecification();
     exchangeSpecification.setSslUri("https://sandbox.trade.dvchain.co");
     exchangeSpecification.setHost("sandbox.trade.dvchain.co");
@@ -82,7 +82,7 @@ public class DVChainExchangeIntegration {
   @Test
   public void testLimitOrder() {
     final Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(DVChainExchange.class.getName(), secret, secret);
+        ExchangeFactory.INSTANCE.createExchange(DVChainExchange.class, secret, secret);
     ExchangeSpecification exchangeSpecification = exchange.getExchangeSpecification();
     exchangeSpecification.setSslUri("https://sandbox.trade.dvchain.co");
     exchangeSpecification.setHost("sandbox.trade.dvchain.co");
@@ -108,7 +108,7 @@ public class DVChainExchangeIntegration {
   @Test
   public void testOrders() {
     final Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(DVChainExchange.class.getName(), secret, secret);
+        ExchangeFactory.INSTANCE.createExchange(DVChainExchange.class, secret, secret);
     ExchangeSpecification exchangeSpecification = exchange.getExchangeSpecification();
     exchangeSpecification.setSslUri("https://sandbox.trade.dvchain.co");
     exchangeSpecification.setHost("sandbox.trade.dvchain.co");
@@ -126,7 +126,7 @@ public class DVChainExchangeIntegration {
   @Test
   public void testTrades() {
     final Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(DVChainExchange.class.getName(), secret, secret);
+        ExchangeFactory.INSTANCE.createExchange(DVChainExchange.class, secret, secret);
     ExchangeSpecification exchangeSpecification = exchange.getExchangeSpecification();
     exchangeSpecification.setSslUri("https://sandbox.trade.dvchain.co");
     exchangeSpecification.setHost("sandbox.trade.dvchain.co");

--- a/xchange-enigma/src/main/java/org/knowm/xchange/enigma/EnigmaExchange.java
+++ b/xchange-enigma/src/main/java/org/knowm/xchange/enigma/EnigmaExchange.java
@@ -28,8 +28,7 @@ public class EnigmaExchange extends BaseExchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri(SSL_URI);
     exchangeSpecification.setHost(HOST);
     exchangeSpecification.setPort(443);

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bibox/marketdata/BiboxMarketDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bibox/marketdata/BiboxMarketDataDemo.java
@@ -22,7 +22,7 @@ public class BiboxMarketDataDemo {
 
   public static void main(String[] args) throws IOException {
 
-    exchange = ExchangeFactory.INSTANCE.createExchange(BiboxExchange.class.getName());
+    exchange = ExchangeFactory.INSTANCE.createExchange(BiboxExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
 
     System.out.println(Arrays.toString(exchange.getExchangeSymbols().toArray()));

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/binance/BinanceDemoUtils.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/binance/BinanceDemoUtils.java
@@ -8,7 +8,7 @@ public class BinanceDemoUtils {
 
   public static Exchange createExchange() {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BinanceExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BinanceExchange.class);
     return exchange;
   }
 }

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitbay/BitBayMetaDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitbay/BitBayMetaDataDemo.java
@@ -10,7 +10,7 @@ public class BitBayMetaDataDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get bitbay exchange API using default settings
-    Exchange anx = ExchangeFactory.INSTANCE.createExchange(BitbayExchange.class.getName());
+    Exchange anx = ExchangeFactory.INSTANCE.createExchange(BitbayExchange.class);
 
     System.out.println(anx.getExchangeMetaData().toString());
   }

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitbay/marketdata/BitbayTickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitbay/marketdata/BitbayTickerDemo.java
@@ -13,7 +13,7 @@ public class BitbayTickerDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get ANX exchange API using default settings
-    Exchange anx = ExchangeFactory.INSTANCE.createExchange(BitbayExchange.class.getName());
+    Exchange anx = ExchangeFactory.INSTANCE.createExchange(BitbayExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = anx.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoinaverage/BitcoinAverageMetaDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoinaverage/BitcoinAverageMetaDataDemo.java
@@ -9,8 +9,7 @@ public class BitcoinAverageMetaDataDemo {
 
   public static void main(String[] args) throws IOException {
 
-    Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(BitcoinAverageExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitcoinAverageExchange.class);
     exchange.remoteInit();
 
     System.out.println(exchange.getExchangeMetaData().toString());

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoinaverage/BitcoinAverageTickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoinaverage/BitcoinAverageTickerDemo.java
@@ -16,7 +16,7 @@ public class BitcoinAverageTickerDemo {
 
     // Use the factory to get the BitcoinAverage exchange API using default settings
     Exchange bitcoinAverageExchange =
-        ExchangeFactory.INSTANCE.createExchange(BitcoinAverageExchange.class.getName());
+        ExchangeFactory.INSTANCE.createExchange(BitcoinAverageExchange.class);
     bitcoinAverageExchange.remoteInit();
     generic(bitcoinAverageExchange);
     raw(bitcoinAverageExchange);

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoincharts/BitcoinChartsMetaDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoincharts/BitcoinChartsMetaDataDemo.java
@@ -9,8 +9,7 @@ public class BitcoinChartsMetaDataDemo {
 
   public static void main(String[] args) throws IOException {
 
-    Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(BitcoinChartsExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitcoinChartsExchange.class);
     exchange.remoteInit();
     System.out.println(exchange.getExchangeMetaData().toString());
   }

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoincharts/BitcoinChartsRawDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoincharts/BitcoinChartsRawDataDemo.java
@@ -19,7 +19,7 @@ public class BitcoinChartsRawDataDemo {
 
     // Use the factory to get BitcoinCharts exchange API using default settings
     Exchange bitcoinChartsExchange =
-        ExchangeFactory.INSTANCE.createExchange(BitcoinChartsExchange.class.getName());
+        ExchangeFactory.INSTANCE.createExchange(BitcoinChartsExchange.class);
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = bitcoinChartsExchange.getMarketDataService();
 

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoincharts/BitcoinChartsTickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoincharts/BitcoinChartsTickerDemo.java
@@ -19,7 +19,7 @@ public class BitcoinChartsTickerDemo {
 
     // Use the factory to get BitcoinCharts exchange API using default settings
     Exchange bitcoinChartsExchange =
-        ExchangeFactory.INSTANCE.createExchange(BitcoinChartsExchange.class.getName());
+        ExchangeFactory.INSTANCE.createExchange(BitcoinChartsExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = bitcoinChartsExchange.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoinium/BitcoiniumMarketDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoinium/BitcoiniumMarketDataDemo.java
@@ -19,7 +19,7 @@ public class BitcoiniumMarketDataDemo {
   public static void main(String[] args) throws Exception {
 
     ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(BitcoiniumExchange.class.getName());
+        new ExchangeSpecification(BitcoiniumExchange.class);
     exchangeSpecification.setApiKey("42djci5kmbtyzrvglfdw3e2dgmh5mr37");
     System.out.println(exchangeSpecification.toString());
     Exchange bitcoiniumExchange = ExchangeFactory.INSTANCE.createExchange(exchangeSpecification);

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoinium/BitcoiniumOrderBookChartDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoinium/BitcoiniumOrderBookChartDemo.java
@@ -27,7 +27,7 @@ public class BitcoiniumOrderBookChartDemo {
   public static void main(String[] args) throws Exception {
 
     ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(BitcoiniumExchange.class.getName());
+        new ExchangeSpecification(BitcoiniumExchange.class);
     // exchangeSpecification.setPlainTextUri("http://openexchangerates.org");
     exchangeSpecification.setApiKey("42djci5kmbtyzrvglfdw3e2dgmh5mr37");
     System.out.println(exchangeSpecification.toString());

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoinium/BitcoiniumRealtimeOrderbookDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoinium/BitcoiniumRealtimeOrderbookDemo.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
-import javax.swing.JFrame;
+import javax.swing.*;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeFactory;
 import org.knowm.xchange.ExchangeSpecification;
@@ -66,7 +66,7 @@ public class BitcoiniumRealtimeOrderbookDemo {
   private void go() throws IOException {
 
     ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(BitcoiniumExchange.class.getName());
+        new ExchangeSpecification(BitcoiniumExchange.class);
     // exchangeSpecification.setPlainTextUri("http://openexchangerates.org");
     exchangeSpecification.setApiKey("42djci5kmbtyzrvglfdw3e2dgmh5mr37");
     System.out.println(exchangeSpecification.toString());

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoinium/BitcoiniumRealtimeTickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoinium/BitcoiniumRealtimeTickerDemo.java
@@ -6,7 +6,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
-import javax.swing.JFrame;
+import javax.swing.*;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeFactory;
 import org.knowm.xchange.ExchangeSpecification;
@@ -45,7 +45,7 @@ public class BitcoiniumRealtimeTickerDemo {
   private void go() throws IOException {
 
     ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(BitcoiniumExchange.class.getName());
+        new ExchangeSpecification(BitcoiniumExchange.class);
     // exchangeSpecification.setPlainTextUri("http://openexchangerates.org");
     exchangeSpecification.setApiKey("42djci5kmbtyzrvglfdw3e2dgmh5mr37");
     System.out.println(exchangeSpecification.toString());

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoinium/BitcoiniumTickerHistoryDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitcoinium/BitcoiniumTickerHistoryDemo.java
@@ -28,7 +28,7 @@ public class BitcoiniumTickerHistoryDemo {
   public static void main(String[] args) throws Exception {
 
     ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(BitcoiniumExchange.class.getName());
+        new ExchangeSpecification(BitcoiniumExchange.class);
     // exchangeSpecification.setPlainTextUri("http://openexchangerates.org");
     exchangeSpecification.setApiKey("42djci5kmbtyzrvglfdw3e2dgmh5mr37");
     System.out.println(exchangeSpecification.toString());

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitfinex/BitfinexDemoUtils.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitfinex/BitfinexDemoUtils.java
@@ -10,7 +10,7 @@ public class BitfinexDemoUtils {
   public static Exchange createExchange() {
 
     // Use the factory to get BFX exchange API using default settings
-    Exchange bfx = ExchangeFactory.INSTANCE.createExchange(BitfinexExchange.class.getName());
+    Exchange bfx = ExchangeFactory.INSTANCE.createExchange(BitfinexExchange.class);
 
     ExchangeSpecification bfxSpec = bfx.getDefaultExchangeSpecification();
 

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitfinex/marketdata/BitfinexDepthDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitfinex/marketdata/BitfinexDepthDemo.java
@@ -16,7 +16,7 @@ public class BitfinexDepthDemo {
   public static void main(String[] args) throws Exception {
 
     // Use the factory to get BTC-E exchange API using default settings
-    Exchange bitfinex = ExchangeFactory.INSTANCE.createExchange(BitfinexExchange.class.getName());
+    Exchange bitfinex = ExchangeFactory.INSTANCE.createExchange(BitfinexExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = bitfinex.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitfinex/marketdata/LendDepthDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitfinex/marketdata/LendDepthDemo.java
@@ -13,7 +13,7 @@ public class LendDepthDemo {
   public static void main(String[] args) throws Exception {
 
     // Use the factory to get BFX exchange API using default settings
-    Exchange bfx = ExchangeFactory.INSTANCE.createExchange(BitfinexExchange.class.getName());
+    Exchange bfx = ExchangeFactory.INSTANCE.createExchange(BitfinexExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = bfx.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitfinex/marketdata/SymbolsDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitfinex/marketdata/SymbolsDemo.java
@@ -14,7 +14,7 @@ public class SymbolsDemo {
   public static void main(String[] args) throws Exception {
 
     // Use the factory to get Bitfinex exchange API using default settings
-    Exchange bitfinex = ExchangeFactory.INSTANCE.createExchange(BitfinexExchange.class.getName());
+    Exchange bitfinex = ExchangeFactory.INSTANCE.createExchange(BitfinexExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = bitfinex.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitfinex/marketdata/TickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitfinex/marketdata/TickerDemo.java
@@ -16,7 +16,7 @@ public class TickerDemo {
   public static void main(String[] args) throws Exception {
 
     // Use the factory to get Bitfinex exchange API using default settings
-    Exchange bitfinex = ExchangeFactory.INSTANCE.createExchange(BitfinexExchange.class.getName());
+    Exchange bitfinex = ExchangeFactory.INSTANCE.createExchange(BitfinexExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = bitfinex.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitfinex/marketdata/TradesDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitfinex/marketdata/TradesDemo.java
@@ -17,7 +17,7 @@ public class TradesDemo {
   public static void main(String[] args) throws Exception {
 
     // Use the factory to get BTC-E exchange API using default settings
-    Exchange bitfinex = ExchangeFactory.INSTANCE.createExchange(BitfinexExchange.class.getName());
+    Exchange bitfinex = ExchangeFactory.INSTANCE.createExchange(BitfinexExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = bitfinex.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitflyer/BitflyerDemoUtils.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitflyer/BitflyerDemoUtils.java
@@ -10,7 +10,7 @@ public class BitflyerDemoUtils {
   public static Exchange createExchange() {
 
     // Use the factory to get BitFlyer exchange API using default settings
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitflyerExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitflyerExchange.class);
 
     ExchangeSpecification bfxSpec = exchange.getDefaultExchangeSpecification();
 

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bithumb/BithumbDemoUtils.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bithumb/BithumbDemoUtils.java
@@ -8,7 +8,7 @@ import org.knowm.xchange.bithumb.BithumbExchange;
 public class BithumbDemoUtils {
   public static Exchange createExchange() {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BithumbExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BithumbExchange.class);
 
     ExchangeSpecification bithumbSpec = exchange.getDefaultExchangeSpecification();
 

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitmex/BitmexDemoUtils.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitmex/BitmexDemoUtils.java
@@ -10,7 +10,7 @@ public class BitmexDemoUtils {
   public static Exchange createExchange() {
 
     // Use the factory to get Bitmex exchange API using default settings
-    Exchange bitmex = ExchangeFactory.INSTANCE.createExchange(BitmexExchange.class.getName());
+    Exchange bitmex = ExchangeFactory.INSTANCE.createExchange(BitmexExchange.class);
 
     ExchangeSpecification bitmexSpec = bitmex.getDefaultExchangeSpecification();
 

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitso/marketdata/BitsoMarketDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitso/marketdata/BitsoMarketDataDemo.java
@@ -25,7 +25,7 @@ public class BitsoMarketDataDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Bitso exchange API using default settings
-    Exchange bitso = ExchangeFactory.INSTANCE.createExchange(BitsoExchange.class.getName());
+    Exchange bitso = ExchangeFactory.INSTANCE.createExchange(BitsoExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = bitso.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitstamp/marketdata/BitstampTickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitstamp/marketdata/BitstampTickerDemo.java
@@ -19,7 +19,7 @@ public class BitstampTickerDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Bitstamp exchange API using default settings
-    Exchange bitstamp = ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class.getName());
+    Exchange bitstamp = ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = bitstamp.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitstamp/marketdata/DepthChartDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitstamp/marketdata/DepthChartDemo.java
@@ -25,8 +25,7 @@ public class DepthChartDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get the version 1 Bitstamp exchange API using default settings
-    Exchange bitstampExchange =
-        ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class.getName());
+    Exchange bitstampExchange = ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = bitstampExchange.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitstamp/marketdata/DepthDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitstamp/marketdata/DepthDemo.java
@@ -16,7 +16,7 @@ public class DepthDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Bitstamp exchange API using default settings
-    Exchange bitstamp = ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class.getName());
+    Exchange bitstamp = ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = bitstamp.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitstamp/marketdata/TradesDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitstamp/marketdata/TradesDemo.java
@@ -17,7 +17,7 @@ public class TradesDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Bitstamp exchange API using default settings
-    Exchange bitstamp = ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class.getName());
+    Exchange bitstamp = ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = bitstamp.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bittrex/marketdata/BittrexMarketDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bittrex/marketdata/BittrexMarketDataDemo.java
@@ -29,7 +29,7 @@ public class BittrexMarketDataDemo {
 
   public static void main(String[] args) throws IOException {
 
-    exchange = ExchangeFactory.INSTANCE.createExchange(BittrexExchange.class.getName());
+    exchange = ExchangeFactory.INSTANCE.createExchange(BittrexExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
 
     System.out.println(Arrays.toString(exchange.getExchangeSymbols().toArray()));

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitz/BitZTickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitz/BitZTickerDemo.java
@@ -18,7 +18,7 @@ public class BitZTickerDemo {
   public static void main(String[] args) throws IOException {
 
     // Create Default BitZ Instance
-    Exchange bitZ = ExchangeFactory.INSTANCE.createExchange(BitZExchange.class.getName());
+    Exchange bitZ = ExchangeFactory.INSTANCE.createExchange(BitZExchange.class);
 
     // Get The Public Market Data Service
     MarketDataService marketDataService = bitZ.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bleutrade/BleutradeDemoUtils.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bleutrade/BleutradeDemoUtils.java
@@ -9,7 +9,7 @@ public class BleutradeDemoUtils {
 
   public static Exchange getExchange() {
 
-    Exchange bleutrade = ExchangeFactory.INSTANCE.createExchange(BleutradeExchange.class.getName());
+    Exchange bleutrade = ExchangeFactory.INSTANCE.createExchange(BleutradeExchange.class);
     ExchangeSpecification exchangeSpecification = bleutrade.getDefaultExchangeSpecification();
     exchangeSpecification.setApiKey("");
     exchangeSpecification.setSecretKey("");

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bleutrade/marketdata/BleutradeMarketDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bleutrade/marketdata/BleutradeMarketDataDemo.java
@@ -17,7 +17,7 @@ public class BleutradeMarketDataDemo {
 
     //    Exchange bleutrade = BleutradeDemoUtils.getExchange();
     ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(BleutradeExchange.class.getName());
+        new ExchangeSpecification(BleutradeExchange.class);
     Exchange bleutrade = ExchangeFactory.INSTANCE.createExchange(exchangeSpecification);
 
     MarketDataService dataService = bleutrade.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/blockchain/BlockchainAddressDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/blockchain/BlockchainAddressDemo.java
@@ -15,7 +15,7 @@ public class BlockchainAddressDemo {
   public static void main(String[] args) throws IOException {
 
     Exchange blockchainExchangexchange =
-        ExchangeFactory.INSTANCE.createExchange(BlockchainExchange.class.getName());
+        ExchangeFactory.INSTANCE.createExchange(BlockchainExchange.class);
     Blockchain blockchain =
         ExchangeRestProxyBuilder.forInterface(
                 Blockchain.class, blockchainExchangexchange.getExchangeSpecification())

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/btcmarkets/BTCMarketsExampleUtils.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/btcmarkets/BTCMarketsExampleUtils.java
@@ -10,8 +10,7 @@ public class BTCMarketsExampleUtils {
   private BTCMarketsExampleUtils() {}
 
   public static Exchange createTestExchange() {
-    Exchange btcMarketsExchange =
-        ExchangeFactory.INSTANCE.createExchange(BTCMarketsExchange.class.getName());
+    Exchange btcMarketsExchange = ExchangeFactory.INSTANCE.createExchange(BTCMarketsExchange.class);
     ExchangeSpecification spec = btcMarketsExchange.getExchangeSpecification();
 
     // Set your actual credentials here for the demos to work.

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/btcmarkets/BTCMarketsMarketDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/btcmarkets/BTCMarketsMarketDataDemo.java
@@ -15,8 +15,7 @@ public class BTCMarketsMarketDataDemo {
 
   public static void main(String[] args) throws IOException {
     // Use the factory to get BTCMarkets exchange API using default settings
-    Exchange btcMarketsExchange =
-        ExchangeFactory.INSTANCE.createExchange(BTCMarketsExchange.class.getName());
+    Exchange btcMarketsExchange = ExchangeFactory.INSTANCE.createExchange(BTCMarketsExchange.class);
     generic(btcMarketsExchange);
     raw(btcMarketsExchange);
   }

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/btctrade/marketdata/DepthDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/btctrade/marketdata/DepthDemo.java
@@ -16,7 +16,7 @@ public class DepthDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get BTCTrade exchange API using default settings.
-    Exchange btcTrade = ExchangeFactory.INSTANCE.createExchange(BTCTradeExchange.class.getName());
+    Exchange btcTrade = ExchangeFactory.INSTANCE.createExchange(BTCTradeExchange.class);
     generic(btcTrade);
     raw(btcTrade);
   }

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/btctrade/marketdata/TickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/btctrade/marketdata/TickerDemo.java
@@ -16,7 +16,7 @@ public class TickerDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get BTC-E exchange API using default settings.
-    Exchange btcTrade = ExchangeFactory.INSTANCE.createExchange(BTCTradeExchange.class.getName());
+    Exchange btcTrade = ExchangeFactory.INSTANCE.createExchange(BTCTradeExchange.class);
     generic(btcTrade);
     raw(btcTrade);
   }

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/btctrade/marketdata/TradesDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/btctrade/marketdata/TradesDemo.java
@@ -17,7 +17,7 @@ public class TradesDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get BTCTrade exchange API using the default settings.
-    Exchange btcTrade = ExchangeFactory.INSTANCE.createExchange(BTCTradeExchange.class.getName());
+    Exchange btcTrade = ExchangeFactory.INSTANCE.createExchange(BTCTradeExchange.class);
     generic(btcTrade);
     raw(btcTrade);
   }

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/campbx/account/CampBXAccountDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/campbx/account/CampBXAccountDataDemo.java
@@ -15,7 +15,7 @@ public class CampBXAccountDataDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Campbx exchange API using default settings
-    Exchange campbx = ExchangeFactory.INSTANCE.createExchange(CampBXExchange.class.getName());
+    Exchange campbx = ExchangeFactory.INSTANCE.createExchange(CampBXExchange.class);
 
     campbx.getExchangeSpecification().setUserName("XChange");
     campbx.getExchangeSpecification().setPassword("The Java API");

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/campbx/marketdata/CampBXMarketDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/campbx/marketdata/CampBXMarketDataDemo.java
@@ -18,8 +18,7 @@ public class CampBXMarketDataDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get CampBX exchange API using default settings
-    Exchange campBXExchange =
-        ExchangeFactory.INSTANCE.createExchange(CampBXExchange.class.getName());
+    Exchange campBXExchange = ExchangeFactory.INSTANCE.createExchange(CampBXExchange.class);
     generic(campBXExchange);
     raw(campBXExchange);
   }

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/campbx/trade/CampBXTradeDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/campbx/trade/CampBXTradeDemo.java
@@ -24,7 +24,7 @@ public class CampBXTradeDemo {
 
   public static void main(String[] args) throws IOException {
 
-    Exchange campbx = ExchangeFactory.INSTANCE.createExchange(CampBXExchange.class.getName());
+    Exchange campbx = ExchangeFactory.INSTANCE.createExchange(CampBXExchange.class);
 
     ExchangeSpecification exSpec = campbx.getExchangeSpecification();
     exSpec.setUserName("XChange");

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/ccex/CCEXExchangeDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/ccex/CCEXExchangeDemo.java
@@ -9,7 +9,7 @@ public class CCEXExchangeDemo {
 
   public static void main(String[] args) throws IOException {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CCEXExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CCEXExchange.class);
 
     System.out.println("ExchangeMetaData toString(): " + exchange.getExchangeMetaData().toString());
     System.out.println(

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/ccex/marketdata/DepthChartDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/ccex/marketdata/DepthChartDemo.java
@@ -25,7 +25,7 @@ public class DepthChartDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get the version 1 Bitstamp exchange API using default settings
-    Exchange ccexExchange = ExchangeFactory.INSTANCE.createExchange(CCEXExchange.class.getName());
+    Exchange ccexExchange = ExchangeFactory.INSTANCE.createExchange(CCEXExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = ccexExchange.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/ccex/marketdata/OrderBookDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/ccex/marketdata/OrderBookDemo.java
@@ -14,7 +14,7 @@ public class OrderBookDemo {
 
   public static void main(String[] args) throws IOException {
 
-    Exchange ccexExchange = ExchangeFactory.INSTANCE.createExchange(CCEXExchange.class.getName());
+    Exchange ccexExchange = ExchangeFactory.INSTANCE.createExchange(CCEXExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = ccexExchange.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/ccex/marketdata/TickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/ccex/marketdata/TickerDemo.java
@@ -13,7 +13,7 @@ public class TickerDemo {
 
   public static void main(String[] args) throws IOException {
 
-    Exchange ccexExchange = ExchangeFactory.INSTANCE.createExchange(CCEXExchange.class.getName());
+    Exchange ccexExchange = ExchangeFactory.INSTANCE.createExchange(CCEXExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = ccexExchange.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/cexio/marketdata/DepthDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/cexio/marketdata/DepthDemo.java
@@ -15,7 +15,7 @@ public class DepthDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Cex.IO exchange API using default settings
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CexIOExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CexIOExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = exchange.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/cexio/marketdata/TickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/cexio/marketdata/TickerDemo.java
@@ -15,7 +15,7 @@ public class TickerDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Cex.IO exchange API using default settings
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CexIOExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CexIOExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = exchange.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/cexio/marketdata/TradesDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/cexio/marketdata/TradesDemo.java
@@ -15,7 +15,7 @@ public class TradesDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Cex.IO exchange API using default settings
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CexIOExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CexIOExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = exchange.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/cobinhood/CobinhoodDemoUtils.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/cobinhood/CobinhoodDemoUtils.java
@@ -7,6 +7,6 @@ import org.knowm.xchange.cobinhood.CobinhoodExchange;
 public class CobinhoodDemoUtils {
 
   public static Exchange createExchange() {
-    return ExchangeFactory.INSTANCE.createExchange(CobinhoodExchange.class.getName());
+    return ExchangeFactory.INSTANCE.createExchange(CobinhoodExchange.class);
   }
 }

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/coinbase/marketdata/CoinbaseMarketDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/coinbase/marketdata/CoinbaseMarketDataDemo.java
@@ -22,8 +22,7 @@ public class CoinbaseMarketDataDemo {
 
   public static void main(String[] args) throws IOException {
 
-    Exchange coinbaseExchange =
-        ExchangeFactory.INSTANCE.createExchange(CoinbaseExchange.class.getName());
+    Exchange coinbaseExchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseExchange.class);
     MarketDataService marketDataService = coinbaseExchange.getMarketDataService();
 
     generic(marketDataService);

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/coinbase/v2/CoinbaseDemoUtils.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/coinbase/v2/CoinbaseDemoUtils.java
@@ -8,7 +8,7 @@ import org.knowm.xchange.utils.AuthUtils;
 public class CoinbaseDemoUtils {
 
   public static Exchange createExchange() {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseExchange.class);
     AuthUtils.setApiAndSecretKey(exchange.getExchangeSpecification(), "coinbase");
     return exchange;
   }

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/coinbase/v2/marketdata/CoinbaseMarketDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/coinbase/v2/marketdata/CoinbaseMarketDataDemo.java
@@ -18,8 +18,7 @@ public class CoinbaseMarketDataDemo {
 
   public static void main(String[] args) throws IOException, ParseException {
 
-    Exchange coinbaseExchange =
-        ExchangeFactory.INSTANCE.createExchange(CoinbaseExchange.class.getName());
+    Exchange coinbaseExchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseExchange.class);
     CoinbaseMarketDataService marketDataService =
         (CoinbaseMarketDataService) coinbaseExchange.getMarketDataService();
 

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/coinbasepro/CoinbaseProDepthDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/coinbasepro/CoinbaseProDepthDemo.java
@@ -15,8 +15,7 @@ public class CoinbaseProDepthDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Coinbase Pro exchange API using default settings
-    Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(CoinbaseProExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseProExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = exchange.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/coinbasepro/CoinbaseProHistoricalCandlesDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/coinbasepro/CoinbaseProHistoricalCandlesDemo.java
@@ -12,8 +12,7 @@ import org.knowm.xchange.currency.CurrencyPair;
 public class CoinbaseProHistoricalCandlesDemo {
 
   public static void main(String[] args) throws IOException {
-    Exchange coinbasePro =
-        ExchangeFactory.INSTANCE.createExchange(CoinbaseProExchange.class.getName());
+    Exchange coinbasePro = ExchangeFactory.INSTANCE.createExchange(CoinbaseProExchange.class);
     CoinbaseProMarketDataService mds =
         (CoinbaseProMarketDataService) coinbasePro.getMarketDataService();
     CoinbaseProCandle[] candles =

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/coinbasepro/CoinbaseproTradesDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/coinbasepro/CoinbaseproTradesDemo.java
@@ -15,8 +15,7 @@ public class CoinbaseproTradesDemo {
 
   public static void main(String[] args) throws IOException {
 
-    Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(CoinbaseProExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CoinbaseProExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
 
     generic(marketDataService);

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/coinbene/CoinbeneDemoUtils.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/coinbene/CoinbeneDemoUtils.java
@@ -7,6 +7,6 @@ import org.knowm.xchange.coinbene.CoinbeneExchange;
 public class CoinbeneDemoUtils {
 
   public static Exchange createExchange() {
-    return ExchangeFactory.INSTANCE.createExchange(CoinbeneExchange.class.getName());
+    return ExchangeFactory.INSTANCE.createExchange(CoinbeneExchange.class);
   }
 }

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/coindirect/CoindirectDemoUtils.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/coindirect/CoindirectDemoUtils.java
@@ -14,10 +14,9 @@ public class CoindirectDemoUtils {
 
     if (apiKey != null && apiSecret != null) {
       exchange =
-          ExchangeFactory.INSTANCE.createExchange(
-              CoindirectExchange.class.getName(), apiKey, apiSecret);
+          ExchangeFactory.INSTANCE.createExchange(CoindirectExchange.class, apiKey, apiSecret);
     } else {
-      exchange = ExchangeFactory.INSTANCE.createExchange(CoindirectExchange.class.getName());
+      exchange = ExchangeFactory.INSTANCE.createExchange(CoindirectExchange.class);
     }
 
     /** substitute this with an exchange with your credentials to test authenticated services */

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/coinegg/CoinEggTickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/coinegg/CoinEggTickerDemo.java
@@ -13,7 +13,7 @@ public class CoinEggTickerDemo {
   public static void main(String[] args) throws IOException {
 
     // Create Default BitZ Instance
-    Exchange coinEgg = ExchangeFactory.INSTANCE.createExchange(CoinEggExchange.class.getName());
+    Exchange coinEgg = ExchangeFactory.INSTANCE.createExchange(CoinEggExchange.class);
 
     // Get The Public Market Data Service
     MarketDataService marketDataService = coinEgg.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/coinone/marketdata/CoinoneOrderBookDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/coinone/marketdata/CoinoneOrderBookDemo.java
@@ -14,7 +14,7 @@ public class CoinoneOrderBookDemo {
   public static void main(String[] args) throws IOException {
 
     // Create Default BitZ Instance
-    Exchange coinone = ExchangeFactory.INSTANCE.createExchange(CoinoneExchange.class.getName());
+    Exchange coinone = ExchangeFactory.INSTANCE.createExchange(CoinoneExchange.class);
 
     // Get The Public Market Data Service
     MarketDataService marketDataService = coinone.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/coinone/marketdata/CoinoneTickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/coinone/marketdata/CoinoneTickerDemo.java
@@ -14,7 +14,7 @@ public class CoinoneTickerDemo {
   public static void main(String[] args) throws IOException {
 
     // Create Default BitZ Instance
-    Exchange coinEgg = ExchangeFactory.INSTANCE.createExchange(CoinEggExchange.class.getName());
+    Exchange coinEgg = ExchangeFactory.INSTANCE.createExchange(CoinEggExchange.class);
 
     // Get The Public Market Data Service
     MarketDataService marketDataService = coinEgg.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/core/utils/RetriesDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/core/utils/RetriesDemo.java
@@ -22,7 +22,7 @@ public class RetriesDemo {
       };
 
   public static void main(String[] args) throws Exception {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitsoExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(BitsoExchange.class);
     MarketDataService service = exchange.getMarketDataService();
     CurrencyPair cp = new CurrencyPair("BTC", "MXN");
 

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/cryptonit2/marketdata/CryptonitTickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/cryptonit2/marketdata/CryptonitTickerDemo.java
@@ -19,7 +19,7 @@ public class CryptonitTickerDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Bitstamp exchange API using default settings
-    Exchange cryptonit = ExchangeFactory.INSTANCE.createExchange(CryptonitExchange.class.getName());
+    Exchange cryptonit = ExchangeFactory.INSTANCE.createExchange(CryptonitExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = cryptonit.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/cryptonit2/marketdata/DepthChartDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/cryptonit2/marketdata/DepthChartDemo.java
@@ -25,8 +25,7 @@ public class DepthChartDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get the version 1 Bitstamp exchange API using default settings
-    Exchange bitstampExchange =
-        ExchangeFactory.INSTANCE.createExchange(CryptonitExchange.class.getName());
+    Exchange bitstampExchange = ExchangeFactory.INSTANCE.createExchange(CryptonitExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = bitstampExchange.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/cryptonit2/marketdata/DepthDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/cryptonit2/marketdata/DepthDemo.java
@@ -16,7 +16,7 @@ public class DepthDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Bitstamp exchange API using default settings
-    Exchange bitstamp = ExchangeFactory.INSTANCE.createExchange(CryptonitExchange.class.getName());
+    Exchange bitstamp = ExchangeFactory.INSTANCE.createExchange(CryptonitExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = bitstamp.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/cryptonit2/marketdata/TradesDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/cryptonit2/marketdata/TradesDemo.java
@@ -17,7 +17,7 @@ public class TradesDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Bitstamp exchange API using default settings
-    Exchange bitstamp = ExchangeFactory.INSTANCE.createExchange(CryptonitExchange.class.getName());
+    Exchange bitstamp = ExchangeFactory.INSTANCE.createExchange(CryptonitExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = bitstamp.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/cryptopia/marketdata/CryptopiaTickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/cryptopia/marketdata/CryptopiaTickerDemo.java
@@ -18,7 +18,7 @@ public class CryptopiaTickerDemo {
 
   public static void main(String[] args) throws IOException {
     // Use the factory to get Cryptopia exchange API using default settings
-    Exchange cryptopia = ExchangeFactory.INSTANCE.createExchange(CryptopiaExchange.class.getName());
+    Exchange cryptopia = ExchangeFactory.INSTANCE.createExchange(CryptopiaExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = cryptopia.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/cryptopia/marketdata/DepthChartDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/cryptopia/marketdata/DepthChartDemo.java
@@ -23,7 +23,7 @@ public class DepthChartDemo {
 
   public static void main(String[] args) throws IOException {
     // Use the factory to get Cryptopia exchange API using default settings
-    Exchange cryptopia = ExchangeFactory.INSTANCE.createExchange(CryptopiaExchange.class.getName());
+    Exchange cryptopia = ExchangeFactory.INSTANCE.createExchange(CryptopiaExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = cryptopia.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/cryptopia/marketdata/DepthDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/cryptopia/marketdata/DepthDemo.java
@@ -15,7 +15,7 @@ public class DepthDemo {
 
   public static void main(String[] args) throws IOException {
     // Use the factory to get Cryptopia exchange API using default settings
-    Exchange cryptopia = ExchangeFactory.INSTANCE.createExchange(CryptopiaExchange.class.getName());
+    Exchange cryptopia = ExchangeFactory.INSTANCE.createExchange(CryptopiaExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = cryptopia.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/cryptopia/marketdata/TradesDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/cryptopia/marketdata/TradesDemo.java
@@ -16,7 +16,7 @@ public class TradesDemo {
 
   public static void main(String[] args) throws IOException {
     // Use the factory to get Cryptopia exchange API using default settings
-    Exchange cryptopia = ExchangeFactory.INSTANCE.createExchange(CryptopiaExchange.class.getName());
+    Exchange cryptopia = ExchangeFactory.INSTANCE.createExchange(CryptopiaExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = cryptopia.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/dvchain/DVChainMarketDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/dvchain/DVChainMarketDataDemo.java
@@ -15,7 +15,7 @@ public class DVChainMarketDataDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get DVChain exchange API using default settings
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(DVChainExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(DVChainExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = exchange.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/dvchain/DVChainNewLimitOrderDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/dvchain/DVChainNewLimitOrderDemo.java
@@ -17,7 +17,7 @@ public class DVChainNewLimitOrderDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get DVChain exchange API using default settings
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(DVChainExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(DVChainExchange.class);
 
     // Interested in the public market data feed (no authentication)
     TradeService tradeService = exchange.getTradeService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/gateio/GateioExchangeDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/gateio/GateioExchangeDemo.java
@@ -9,7 +9,7 @@ public class GateioExchangeDemo {
 
   public static void main(String[] args) throws IOException {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(GateioExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(GateioExchange.class);
 
     System.out.println("ExchangeMetaData toString(): " + exchange.getExchangeMetaData().toString());
     System.out.println(

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/gateio/marketdata/GateioMarketDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/gateio/marketdata/GateioMarketDataDemo.java
@@ -24,7 +24,7 @@ public class GateioMarketDataDemo {
 
   public static void main(String[] args) throws IOException {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(GateioExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(GateioExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
 
     generic(marketDataService);

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/huobi/HuobiDemoUtils.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/huobi/HuobiDemoUtils.java
@@ -6,7 +6,7 @@ import org.knowm.xchange.huobi.HuobiExchange;
 
 public class HuobiDemoUtils {
   public static Exchange createExchange() {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(HuobiExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(HuobiExchange.class);
     return exchange;
   }
 }

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/independentreserve/marketdata/DepthDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/independentreserve/marketdata/DepthDemo.java
@@ -17,7 +17,7 @@ public class DepthDemo {
 
     // Use the factory to get IndependentReserve exchange API using default settings
     Exchange independentReserve =
-        ExchangeFactory.INSTANCE.createExchange(IndependentReserveExchange.class.getName());
+        ExchangeFactory.INSTANCE.createExchange(IndependentReserveExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = independentReserve.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/independentreserve/marketdata/DepthDemoEth.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/independentreserve/marketdata/DepthDemoEth.java
@@ -20,7 +20,7 @@ public class DepthDemoEth {
 
     // Use the factory to get IndependentReserve exchange API using default settings
     Exchange independentReserve =
-        ExchangeFactory.INSTANCE.createExchange(IndependentReserveExchange.class.getName());
+        ExchangeFactory.INSTANCE.createExchange(IndependentReserveExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = independentReserve.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/itbit/market/ItBitOrderBookDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/itbit/market/ItBitOrderBookDemo.java
@@ -14,7 +14,7 @@ import org.knowm.xchange.service.marketdata.MarketDataService;
 /** Created by joseph on 6/15/17. */
 public class ItBitOrderBookDemo {
   public static void main(String[] args) throws IOException {
-    Exchange xchange = ExchangeFactory.INSTANCE.createExchange(ItBitExchange.class.getName());
+    Exchange xchange = ExchangeFactory.INSTANCE.createExchange(ItBitExchange.class);
 
     MarketDataService marketDataService = xchange.getMarketDataService();
 

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/itbit/market/ItBitTickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/itbit/market/ItBitTickerDemo.java
@@ -14,7 +14,7 @@ import org.knowm.xchange.service.marketdata.MarketDataService;
 public class ItBitTickerDemo {
   public static void main(String[] args) throws IOException {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(ItBitExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(ItBitExchange.class);
 
     MarketDataService marketDataService = exchange.getMarketDataService();
 

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/itbit/market/ItBitTradesDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/itbit/market/ItBitTradesDemo.java
@@ -12,7 +12,7 @@ import org.knowm.xchange.service.marketdata.MarketDataService;
 /** Created by joseph on 6/15/17. */
 public class ItBitTradesDemo {
   public static void main(String[] args) throws IOException {
-    Exchange xchange = ExchangeFactory.INSTANCE.createExchange(ItBitExchange.class.getName());
+    Exchange xchange = ExchangeFactory.INSTANCE.createExchange(ItBitExchange.class);
 
     MarketDataService marketDataService = xchange.getMarketDataService();
 

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/kraken/KrakenExampleUtils.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/kraken/KrakenExampleUtils.java
@@ -10,8 +10,7 @@ public class KrakenExampleUtils {
 
   public static Exchange createTestExchange() {
 
-    Exchange krakenExchange =
-        ExchangeFactory.INSTANCE.createExchange(KrakenExchange.class.getName());
+    Exchange krakenExchange = ExchangeFactory.INSTANCE.createExchange(KrakenExchange.class);
     krakenExchange.getExchangeSpecification().setApiKey("API Key");
     krakenExchange.getExchangeSpecification().setSecretKey("Secret==");
     krakenExchange.getExchangeSpecification().setUserName("user");

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/kraken/marketdata/KrakenDepthDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/kraken/marketdata/KrakenDepthDemo.java
@@ -15,8 +15,7 @@ public class KrakenDepthDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Kraken exchange API using default settings
-    Exchange krakenExchange =
-        ExchangeFactory.INSTANCE.createExchange(KrakenExchange.class.getName());
+    Exchange krakenExchange = ExchangeFactory.INSTANCE.createExchange(KrakenExchange.class);
 
     generic(krakenExchange);
     raw(krakenExchange);

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/kraken/marketdata/KrakenExchangeSymbolsDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/kraken/marketdata/KrakenExchangeSymbolsDemo.java
@@ -15,8 +15,7 @@ public class KrakenExchangeSymbolsDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Kraken exchange API using default settings
-    Exchange krakenExchange =
-        ExchangeFactory.INSTANCE.createExchange(KrakenExchange.class.getName());
+    Exchange krakenExchange = ExchangeFactory.INSTANCE.createExchange(KrakenExchange.class);
 
     generic(krakenExchange);
     raw(krakenExchange);

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/kraken/marketdata/KrakenMarketDataRawSpecificDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/kraken/marketdata/KrakenMarketDataRawSpecificDemo.java
@@ -15,8 +15,7 @@ public class KrakenMarketDataRawSpecificDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Kraken exchange API using default settings
-    Exchange krakenExchange =
-        ExchangeFactory.INSTANCE.createExchange(KrakenExchange.class.getName());
+    Exchange krakenExchange = ExchangeFactory.INSTANCE.createExchange(KrakenExchange.class);
 
     // Interested in the public market data feed (no authentication)
     KrakenMarketDataServiceRaw krakenMarketDataService =

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/kraken/marketdata/KrakenTickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/kraken/marketdata/KrakenTickerDemo.java
@@ -16,8 +16,7 @@ public class KrakenTickerDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Kraken exchange API using default settings
-    Exchange krakenExchange =
-        ExchangeFactory.INSTANCE.createExchange(KrakenExchange.class.getName());
+    Exchange krakenExchange = ExchangeFactory.INSTANCE.createExchange(KrakenExchange.class);
 
     generic(krakenExchange);
     raw(krakenExchange);

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/kraken/marketdata/KrakenTradesDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/kraken/marketdata/KrakenTradesDemo.java
@@ -15,8 +15,7 @@ public class KrakenTradesDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Kraken exchange API using default settings
-    Exchange krakenExchange =
-        ExchangeFactory.INSTANCE.createExchange(KrakenExchange.class.getName());
+    Exchange krakenExchange = ExchangeFactory.INSTANCE.createExchange(KrakenExchange.class);
 
     generic(krakenExchange);
     //    raw(krakenExchange);

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/kucoin/marketdata/KucoinMarketDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/kucoin/marketdata/KucoinMarketDataDemo.java
@@ -25,7 +25,7 @@ public class KucoinMarketDataDemo {
 
   public static void main(String[] args) throws IOException {
 
-    exchange = ExchangeFactory.INSTANCE.createExchange(KucoinExchange.class.getName());
+    exchange = ExchangeFactory.INSTANCE.createExchange(KucoinExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
 
     System.out.println(Arrays.toString(exchange.getExchangeSymbols().toArray()));

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/lakebtc/LakeBTCExamplesUtils.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/lakebtc/LakeBTCExamplesUtils.java
@@ -11,8 +11,7 @@ public class LakeBTCExamplesUtils {
 
   public static Exchange createTestExchange() {
 
-    Exchange lakeBtcExchange =
-        ExchangeFactory.INSTANCE.createExchange(LakeBTCExchange.class.getName());
+    Exchange lakeBtcExchange = ExchangeFactory.INSTANCE.createExchange(LakeBTCExchange.class);
 
     //    lakeBtcExchange.getExchangeSpecification().setSslUri("https://www.LakeBTC.com");
     //    lakeBtcExchange.getExchangeSpecification().setHost("https://lakebtc.com");

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/livecoin/LivecoinExchangeDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/livecoin/LivecoinExchangeDemo.java
@@ -9,7 +9,7 @@ public class LivecoinExchangeDemo {
 
   public static void main(String[] args) throws IOException {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(LivecoinExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(LivecoinExchange.class);
 
     System.out.println("ExchangeMetaData toString(): " + exchange.getExchangeMetaData().toString());
     System.out.println(

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/livecoin/marketdata/OrderBookDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/livecoin/marketdata/OrderBookDemo.java
@@ -14,8 +14,7 @@ public class OrderBookDemo {
 
   public static void main(String[] args) throws IOException {
 
-    Exchange livecoinExchange =
-        ExchangeFactory.INSTANCE.createExchange(LivecoinExchange.class.getName());
+    Exchange livecoinExchange = ExchangeFactory.INSTANCE.createExchange(LivecoinExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = livecoinExchange.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/livecoin/marketdata/TradeDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/livecoin/marketdata/TradeDemo.java
@@ -14,8 +14,7 @@ public class TradeDemo {
 
   public static void main(String[] args) throws IOException {
 
-    Exchange livecoinExchange =
-        ExchangeFactory.INSTANCE.createExchange(LivecoinExchange.class.getName());
+    Exchange livecoinExchange = ExchangeFactory.INSTANCE.createExchange(LivecoinExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = livecoinExchange.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/mercadobitcoin/InteractiveAuthenticatedExchange.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/mercadobitcoin/InteractiveAuthenticatedExchange.java
@@ -10,8 +10,7 @@ import org.knowm.xchange.mercadobitcoin.MercadoBitcoinExchange;
 public class InteractiveAuthenticatedExchange {
 
   public static Exchange createInstanceFromDefaultInput() {
-    Exchange mercadoBitcoin =
-        ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class.getName());
+    Exchange mercadoBitcoin = ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class);
     ExchangeSpecification exchangeSpecification = mercadoBitcoin.getExchangeSpecification();
 
     Scanner s = new Scanner(System.in);

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/mercadobitcoin/marketdata/btc/DepthChartDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/mercadobitcoin/marketdata/btc/DepthChartDemo.java
@@ -30,7 +30,7 @@ public class DepthChartDemo {
 
     // Use the factory to get the version 1 Mercado Bitcoin exchange API using default settings
     Exchange mercadoExchange =
-        ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class.getName());
+        ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = mercadoExchange.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/mercadobitcoin/marketdata/btc/DepthDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/mercadobitcoin/marketdata/btc/DepthDemo.java
@@ -20,8 +20,7 @@ public class DepthDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Mercado Bitcoin exchange API using default settings
-    Exchange mercadoBitcoin =
-        ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class.getName());
+    Exchange mercadoBitcoin = ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = mercadoBitcoin.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/mercadobitcoin/marketdata/btc/TickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/mercadobitcoin/marketdata/btc/TickerDemo.java
@@ -21,8 +21,7 @@ public class TickerDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Mercado Bitcoin exchange API using default settings
-    Exchange mercadoBitcoin =
-        ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class.getName());
+    Exchange mercadoBitcoin = ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = mercadoBitcoin.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/mercadobitcoin/marketdata/btc/TradesDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/mercadobitcoin/marketdata/btc/TradesDemo.java
@@ -22,8 +22,7 @@ public class TradesDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Mercado Bitcoin exchange API using default settings
-    Exchange mercadoBitcoin =
-        ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class.getName());
+    Exchange mercadoBitcoin = ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = mercadoBitcoin.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/mercadobitcoin/marketdata/ltc/DepthChartDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/mercadobitcoin/marketdata/ltc/DepthChartDemo.java
@@ -31,7 +31,7 @@ public class DepthChartDemo {
 
     // Use the factory to get the version 1 Mercado Bitcoin exchange API using default settings
     Exchange mercadoExchange =
-        ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class.getName());
+        ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = mercadoExchange.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/mercadobitcoin/marketdata/ltc/DepthDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/mercadobitcoin/marketdata/ltc/DepthDemo.java
@@ -21,8 +21,7 @@ public class DepthDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Mercado Bitcoin exchange API using default settings
-    Exchange mercadoBitcoin =
-        ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class.getName());
+    Exchange mercadoBitcoin = ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = mercadoBitcoin.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/mercadobitcoin/marketdata/ltc/TickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/mercadobitcoin/marketdata/ltc/TickerDemo.java
@@ -22,8 +22,7 @@ public class TickerDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Mercado Bitcoin exchange API using default settings
-    Exchange mercadoBitcoin =
-        ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class.getName());
+    Exchange mercadoBitcoin = ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = mercadoBitcoin.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/mercadobitcoin/marketdata/ltc/TradesDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/mercadobitcoin/marketdata/ltc/TradesDemo.java
@@ -23,8 +23,7 @@ public class TradesDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Mercado Bitcoin exchange API using default settings
-    Exchange mercadoBitcoin =
-        ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class.getName());
+    Exchange mercadoBitcoin = ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = mercadoBitcoin.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/okcoin/OkCoinExampleUtils.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/okcoin/OkCoinExampleUtils.java
@@ -10,8 +10,7 @@ public class OkCoinExampleUtils {
 
   public static Exchange createTestExchange() {
 
-    Exchange okcoinExchange =
-        ExchangeFactory.INSTANCE.createExchange(OkCoinExchange.class.getName());
+    Exchange okcoinExchange = ExchangeFactory.INSTANCE.createExchange(OkCoinExchange.class);
     okcoinExchange.getExchangeSpecification().setApiKey("");
     okcoinExchange.getExchangeSpecification().setSecretKey("");
     okcoinExchange.getExchangeSpecification().setUserName("");

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/openexchangerates/marketdata/TickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/openexchangerates/marketdata/TickerDemo.java
@@ -17,8 +17,7 @@ public class TickerDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get the Open Exchange Rates exchange API
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(OERExchange.class.getName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(OERExchange.class);
     exchangeSpecification.setPlainTextUri("http://openexchangerates.org");
     exchangeSpecification.setApiKey("ab32c922bca749ec9345b4717914ee1f");
 

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/paymium/PaymiumMarketDataExample.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/paymium/PaymiumMarketDataExample.java
@@ -12,8 +12,7 @@ public class PaymiumMarketDataExample {
 
   public static void main(String[] args) throws IOException {
 
-    Exchange btcCentralExchange =
-        ExchangeFactory.INSTANCE.createExchange(PaymiumExchange.class.getName());
+    Exchange btcCentralExchange = ExchangeFactory.INSTANCE.createExchange(PaymiumExchange.class);
     PaymiumMarketDataServiceRaw btcCentralMarketDataServiceRaw =
         (PaymiumMarketDataServiceRaw) btcCentralExchange.getMarketDataService();
 

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/poloniex/PoloniexMetaDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/poloniex/PoloniexMetaDataDemo.java
@@ -11,7 +11,7 @@ public class PoloniexMetaDataDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Poloniex exchange API using default settings
-    Exchange anx = ExchangeFactory.INSTANCE.createExchange(PoloniexExchange.class.getName());
+    Exchange anx = ExchangeFactory.INSTANCE.createExchange(PoloniexExchange.class);
     ExchangeMetaData exchangeMetaData = anx.getExchangeMetaData();
     System.out.println(exchangeMetaData.toJSONString());
     System.out.println(

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/poloniex/marketdata/PoloniexExchangeInfoDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/poloniex/marketdata/PoloniexExchangeInfoDemo.java
@@ -15,7 +15,7 @@ public class PoloniexExchangeInfoDemo {
 
     CertHelper.trustAllCerts();
 
-    Exchange poloniex = ExchangeFactory.INSTANCE.createExchange(PoloniexExchange.class.getName());
+    Exchange poloniex = ExchangeFactory.INSTANCE.createExchange(PoloniexExchange.class);
 
     final Map<CurrencyPair, CurrencyPairMetaData> currencyPairs =
         poloniex.getExchangeMetaData().getCurrencyPairs();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/poloniex/marketdata/PoloniexMarketDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/poloniex/marketdata/PoloniexMarketDataDemo.java
@@ -20,7 +20,7 @@ public class PoloniexMarketDataDemo {
 
     //    CertHelper.trustAllCerts();
 
-    poloniex = ExchangeFactory.INSTANCE.createExchange(PoloniexExchange.class.getName());
+    poloniex = ExchangeFactory.INSTANCE.createExchange(PoloniexExchange.class);
     MarketDataService dataService = poloniex.getMarketDataService();
     currencyPair = new CurrencyPair("BTC", "USDT");
     //    currencyPair = new CurrencyPair("ETH", "BTC");

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/quoine/marketdata/OrderBookDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/quoine/marketdata/OrderBookDemo.java
@@ -15,8 +15,7 @@ public class OrderBookDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Quoine exchange API using default settings
-    Exchange quoineExchange =
-        ExchangeFactory.INSTANCE.createExchange(QuoineExchange.class.getName());
+    Exchange quoineExchange = ExchangeFactory.INSTANCE.createExchange(QuoineExchange.class);
 
     generic(quoineExchange);
     raw(quoineExchange);

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/quoine/marketdata/QuoineProductsDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/quoine/marketdata/QuoineProductsDemo.java
@@ -17,7 +17,7 @@ public class QuoineProductsDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Quoine exchange API using default settings
-    Exchange quoine = ExchangeFactory.INSTANCE.createExchange(QuoineExchange.class.getName());
+    Exchange quoine = ExchangeFactory.INSTANCE.createExchange(QuoineExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = quoine.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/quoine/marketdata/TickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/quoine/marketdata/TickerDemo.java
@@ -19,7 +19,7 @@ public class TickerDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get Quoine exchange API using default settings
-    Exchange quoine = ExchangeFactory.INSTANCE.createExchange(QuoineExchange.class.getName());
+    Exchange quoine = ExchangeFactory.INSTANCE.createExchange(QuoineExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = quoine.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/ripple/marketdata/RippleOrderBookDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/ripple/marketdata/RippleOrderBookDemo.java
@@ -19,7 +19,7 @@ public class RippleOrderBookDemo {
 
   public static void main(final String[] args) throws IOException {
     // Use the factory to get Riiple exchange API using default settings
-    final Exchange ripple = ExchangeFactory.INSTANCE.createExchange(RippleExchange.class.getName());
+    final Exchange ripple = ExchangeFactory.INSTANCE.createExchange(RippleExchange.class);
 
     // Interested in the public market data feed (no authentication)
     final MarketDataService marketDataService = ripple.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/therock/TheRockExampleUtils.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/therock/TheRockExampleUtils.java
@@ -9,7 +9,7 @@ public class TheRockExampleUtils {
   private TheRockExampleUtils() {}
 
   public static Exchange createTestExchange() {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(TheRockExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(TheRockExchange.class);
     exchange.getExchangeSpecification().setApiKey("API Key");
     exchange.getExchangeSpecification().setSecretKey("Secret==");
     exchange.getExchangeSpecification().setUserName("user");

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/therock/TheRockMetaDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/therock/TheRockMetaDataDemo.java
@@ -12,7 +12,7 @@ public class TheRockMetaDataDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get The Rock exchange API using default settings
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(TheRockExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(TheRockExchange.class);
     ExchangeMetaData exchangeMetaData = exchange.getExchangeMetaData();
     System.out.println(exchangeMetaData.toString());
 

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/therock/marketdata/TheRockMarketDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/therock/marketdata/TheRockMarketDataDemo.java
@@ -12,8 +12,7 @@ public class TheRockMarketDataDemo {
   public static void main(String[] args) throws IOException {
 
     // Use the factory to get TheRock exchange API using default settings
-    Exchange theRockExchange =
-        ExchangeFactory.INSTANCE.createExchange(TheRockExchange.class.getName());
+    Exchange theRockExchange = ExchangeFactory.INSTANCE.createExchange(TheRockExchange.class);
 
     generic(theRockExchange);
   }

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/upbit/marketdata/UpbitOrderBookDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/upbit/marketdata/UpbitOrderBookDemo.java
@@ -14,7 +14,7 @@ public class UpbitOrderBookDemo {
   public static void main(String[] args) throws IOException {
 
     // Create Default Upbit Instance
-    Exchange upbit = ExchangeFactory.INSTANCE.createExchange(CoinoneExchange.class.getName());
+    Exchange upbit = ExchangeFactory.INSTANCE.createExchange(CoinoneExchange.class);
 
     // Get The Public Market Data Service
     MarketDataService marketDataService = upbit.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/upbit/marketdata/UpbitTickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/upbit/marketdata/UpbitTickerDemo.java
@@ -14,7 +14,7 @@ public class UpbitTickerDemo {
   public static void main(String[] args) throws IOException {
 
     // Create Default Upbit Instance
-    Exchange upbit = ExchangeFactory.INSTANCE.createExchange(UpbitExchange.class.getName());
+    Exchange upbit = ExchangeFactory.INSTANCE.createExchange(UpbitExchange.class);
 
     // Get The Public Market Data Service
     MarketDataService marketDataService = upbit.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/yobit/YoBitExchangeDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/yobit/YoBitExchangeDemo.java
@@ -9,7 +9,7 @@ public class YoBitExchangeDemo {
 
   public static void main(String[] args) throws IOException {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(YoBitExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(YoBitExchange.class);
 
     System.out.println("ExchangeMetaData toString(): " + exchange.getExchangeMetaData().toString());
     System.out.println(

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/yobit/marketdata/YoBitBookDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/yobit/marketdata/YoBitBookDemo.java
@@ -14,7 +14,7 @@ public class YoBitBookDemo {
 
   public static void main(String[] args) throws IOException {
 
-    Exchange yoBitExchange = ExchangeFactory.INSTANCE.createExchange(YoBitExchange.class.getName());
+    Exchange yoBitExchange = ExchangeFactory.INSTANCE.createExchange(YoBitExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = yoBitExchange.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/yobit/marketdata/YoBitTradeDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/yobit/marketdata/YoBitTradeDemo.java
@@ -14,7 +14,7 @@ public class YoBitTradeDemo {
 
   public static void main(String[] args) throws IOException {
 
-    Exchange yoBitExchange = ExchangeFactory.INSTANCE.createExchange(YoBitExchange.class.getName());
+    Exchange yoBitExchange = ExchangeFactory.INSTANCE.createExchange(YoBitExchange.class);
 
     // Interested in the public market data feed (no authentication)
     MarketDataService marketDataService = yoBitExchange.getMarketDataService();

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/zaif/market/ZaifMarketDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/zaif/market/ZaifMarketDataDemo.java
@@ -19,7 +19,7 @@ public class ZaifMarketDataDemo {
 
   public static void main(String[] args) throws IOException {
 
-    exchange = ExchangeFactory.INSTANCE.createExchange(ZaifExchange.class.getName());
+    exchange = ExchangeFactory.INSTANCE.createExchange(ZaifExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
 
     System.out.println(Arrays.toString(exchange.getExchangeSymbols().toArray()));

--- a/xchange-exmo/src/main/java/org/knowm/xchange/exmo/ExmoExchange.java
+++ b/xchange-exmo/src/main/java/org/knowm/xchange/exmo/ExmoExchange.java
@@ -31,8 +31,7 @@ public class ExmoExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setShouldLoadRemoteMetaData(false);
     exchangeSpecification.setSslUri("https://api.exmo.com");
     exchangeSpecification.setHost("exmo.com");

--- a/xchange-exx/src/main/java/org/knowm/xchange/exx/EXXExchange.java
+++ b/xchange-exx/src/main/java/org/knowm/xchange/exx/EXXExchange.java
@@ -28,8 +28,7 @@ public class EXXExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
 
     exchangeSpecification.setSslUri("https://api.exx.com");
     exchangeSpecification.setHost("api.exx.com");

--- a/xchange-exx/src/test/java/org/knowm/xchange/test/exx/AccountServiceIntegration.java
+++ b/xchange-exx/src/test/java/org/knowm/xchange/test/exx/AccountServiceIntegration.java
@@ -26,7 +26,7 @@ public class AccountServiceIntegration {
     String apiKey = "";
     String secretKey = "";
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(EXXExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(EXXExchange.class);
 
     ExchangeSpecification exchangeSpecification = exchange.getDefaultExchangeSpecification();
     exchangeSpecification.setSslUri("https://trade.exx.com");

--- a/xchange-exx/src/test/java/org/knowm/xchange/test/exx/MarketDataServiceIntegration.java
+++ b/xchange-exx/src/test/java/org/knowm/xchange/test/exx/MarketDataServiceIntegration.java
@@ -113,7 +113,7 @@ public class MarketDataServiceIntegration {
   }
 
   private static Exchange getExchange() throws IOException {
-    Exchange exx = ExchangeFactory.INSTANCE.createExchange(EXXExchange.class.getName());
+    Exchange exx = ExchangeFactory.INSTANCE.createExchange(EXXExchange.class);
 
     return exx;
   }

--- a/xchange-exx/src/test/java/org/knowm/xchange/test/exx/TradeServiceIntegration.java
+++ b/xchange-exx/src/test/java/org/knowm/xchange/test/exx/TradeServiceIntegration.java
@@ -112,7 +112,7 @@ public class TradeServiceIntegration {
   }
 
   private static Exchange getExchange() throws IOException {
-    Exchange exx = ExchangeFactory.INSTANCE.createExchange(EXXExchange.class.getName());
+    Exchange exx = ExchangeFactory.INSTANCE.createExchange(EXXExchange.class);
 
     ExchangeSpecification exchangeSpecification = exx.getExchangeSpecification();
     exchangeSpecification.setSslUri("https://trade.exx.com");

--- a/xchange-fcoin/src/main/java/org/knowm/xchange/fcoin/FCoinExchange.java
+++ b/xchange-fcoin/src/main/java/org/knowm/xchange/fcoin/FCoinExchange.java
@@ -21,8 +21,7 @@ public class FCoinExchange extends BaseExchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.fcoin.com");
     exchangeSpecification.setHost("api.fcoin.com");
     exchangeSpecification.setExchangeName("FCoin");

--- a/xchange-gateio/src/main/java/org/knowm/xchange/gateio/GateioExchange.java
+++ b/xchange-gateio/src/main/java/org/knowm/xchange/gateio/GateioExchange.java
@@ -26,8 +26,7 @@ public class GateioExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://data.gate.io");
     exchangeSpecification.setHost("gate.io");
     exchangeSpecification.setExchangeName("Gateio");

--- a/xchange-gateio/src/test/java/org/knowm/xchange/gateio/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-gateio/src/test/java/org/knowm/xchange/gateio/service/marketdata/TickerFetchIntegration.java
@@ -16,7 +16,7 @@ public class TickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(GateioExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(GateioExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "USDT"));
     System.out.println(ticker.toString());

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/GeminiExchange.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/GeminiExchange.java
@@ -46,8 +46,7 @@ public class GeminiExchange extends BaseExchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.Gemini.com/");
     exchangeSpecification.setHost("api.Gemini.com");
     exchangeSpecification.setPort(80);

--- a/xchange-gemini/src/test/java/org/knowm/xchange/gemini/v1/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-gemini/src/test/java/org/knowm/xchange/gemini/v1/service/marketdata/TickerFetchIntegration.java
@@ -21,7 +21,7 @@ public class TickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(GeminiExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(GeminiExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "USD"));
     System.out.println(ticker.toString());
@@ -31,7 +31,7 @@ public class TickerFetchIntegration {
   @Test
   public void candleFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(GeminiExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(GeminiExchange.class);
     GeminiMarketDataServiceRaw mds = (GeminiMarketDataServiceRaw) exchange.getMarketDataService();
     GeminiCandle[] candles = mds.getCandles(CurrencyPair.BTC_USD, Duration.ofHours(1));
     System.out.println(Arrays.toString(candles));
@@ -41,7 +41,7 @@ public class TickerFetchIntegration {
   @Test
   public void ticker2FetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(GeminiExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(GeminiExchange.class);
     GeminiMarketDataServiceRaw mds = (GeminiMarketDataServiceRaw) exchange.getMarketDataService();
     GeminiTicker2 ticker = mds.getTicker2(CurrencyPair.BTC_USD);
     System.out.println(ticker);

--- a/xchange-globitex/src/main/java/org/knowm/xchange/globitex/GlobitexExchange.java
+++ b/xchange-globitex/src/main/java/org/knowm/xchange/globitex/GlobitexExchange.java
@@ -33,8 +33,7 @@ public class GlobitexExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.globitex.com");
     exchangeSpecification.setHost("api.globitex.com");
     exchangeSpecification.setPort(80);

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/HitbtcExchange.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/HitbtcExchange.java
@@ -83,8 +83,7 @@ public class HitbtcExchange extends BaseExchange implements org.knowm.xchange.Ex
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.hitbtc.com");
     exchangeSpecification.setHost("hitbtc.com");
     exchangeSpecification.setPort(80);

--- a/xchange-hitbtc/src/test/java/org/knowm/xchange/hitbtc/v2/AuthenticatedBaseTestCase.java
+++ b/xchange-hitbtc/src/test/java/org/knowm/xchange/hitbtc/v2/AuthenticatedBaseTestCase.java
@@ -23,9 +23,7 @@ public class AuthenticatedBaseTestCase {
     String apiKey = System.getProperty(API_KEY_LOOKUP);
     String secretValue = System.getProperty(SECRET_KEY_LOOKUP);
 
-    EXCHANGE =
-        ExchangeFactory.INSTANCE.createExchange(
-            HitbtcExchange.class.getName(), apiKey, secretValue);
+    EXCHANGE = ExchangeFactory.INSTANCE.createExchange(HitbtcExchange.class, apiKey, secretValue);
     EXCHANGE.remoteInit();
   }
 }

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/HuobiExchange.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/HuobiExchange.java
@@ -27,8 +27,7 @@ public class HuobiExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.huobi.pro");
     exchangeSpecification.setHost("api.huobi.pro");
     exchangeSpecification.setPort(80);

--- a/xchange-huobi/src/test/java/org/knowm/xchange/huobi/HuobiPrivateApiIntegration.java
+++ b/xchange-huobi/src/test/java/org/knowm/xchange/huobi/HuobiPrivateApiIntegration.java
@@ -34,7 +34,7 @@ public class HuobiPrivateApiIntegration {
 
     exchange =
         ExchangeFactory.INSTANCE.createExchange(
-            HuobiExchange.class.getName(), properties.getApiKey(), properties.getSecretKey());
+            HuobiExchange.class, properties.getApiKey(), properties.getSecretKey());
   }
 
   @After

--- a/xchange-huobi/src/test/java/org/knowm/xchange/huobi/HuobiPublicApiIntegration.java
+++ b/xchange-huobi/src/test/java/org/knowm/xchange/huobi/HuobiPublicApiIntegration.java
@@ -18,7 +18,7 @@ public class HuobiPublicApiIntegration {
 
   @Before
   public void setup() {
-    exchange = ExchangeFactory.INSTANCE.createExchange(HuobiExchange.class.getName());
+    exchange = ExchangeFactory.INSTANCE.createExchange(HuobiExchange.class);
   }
 
   @Test

--- a/xchange-idex/src/test/java/org/knowm/xchange/idex/IdexExchangeIntegration.java
+++ b/xchange-idex/src/test/java/org/knowm/xchange/idex/IdexExchangeIntegration.java
@@ -12,7 +12,7 @@ public class IdexExchangeIntegration {
 
   @Test
   public void shouldRunWithoutExceptionWhenCallGetMetadata() {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(IdexExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(IdexExchange.class);
 
     ExchangeMetaData metaData = exchange.getExchangeMetaData();
     Assert.assertNotNull(metaData);
@@ -20,7 +20,7 @@ public class IdexExchangeIntegration {
 
   @Test
   public void shouldRunWithoutExceptionWhenCallGetExchangeSymbols() {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(IdexExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(IdexExchange.class);
 
     List<CurrencyPair> marketCurrencyPairs = exchange.getExchangeSymbols();
     Assert.assertNotNull(marketCurrencyPairs);

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/IndependentReserveExchange.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/IndependentReserveExchange.java
@@ -24,8 +24,7 @@ public class IndependentReserveExchange extends BaseExchange implements Exchange
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.independentreserve.com");
     exchangeSpecification.setHost("https://api.independentreserve.com");
     exchangeSpecification.setPort(80);

--- a/xchange-independentreserve/src/test/java/org/knowm/xchange/independentreserve/service/IndependentReserveAccountServiceIntegration.java
+++ b/xchange-independentreserve/src/test/java/org/knowm/xchange/independentreserve/service/IndependentReserveAccountServiceIntegration.java
@@ -16,7 +16,7 @@ public class IndependentReserveAccountServiceIntegration {
 
   @BeforeClass
   public static void beforeClass() {
-    exchange = ExchangeFactory.INSTANCE.createExchange(IndependentReserveExchange.class.getName());
+    exchange = ExchangeFactory.INSTANCE.createExchange(IndependentReserveExchange.class);
     AuthUtils.setApiAndSecretKey(exchange.getExchangeSpecification());
     exchange = ExchangeFactory.INSTANCE.createExchange(exchange.getExchangeSpecification());
     accountService = (IndependentReserveAccountService) exchange.getAccountService();

--- a/xchange-independentreserve/src/test/java/org/knowm/xchange/independentreserve/service/IndependentReserveTradeServiceIntegration.java
+++ b/xchange-independentreserve/src/test/java/org/knowm/xchange/independentreserve/service/IndependentReserveTradeServiceIntegration.java
@@ -20,7 +20,7 @@ public class IndependentReserveTradeServiceIntegration {
 
   @BeforeClass
   public static void beforeClass() {
-    exchange = ExchangeFactory.INSTANCE.createExchange(IndependentReserveExchange.class.getName());
+    exchange = ExchangeFactory.INSTANCE.createExchange(IndependentReserveExchange.class);
     AuthUtils.setApiAndSecretKey(exchange.getExchangeSpecification());
     exchange = ExchangeFactory.INSTANCE.createExchange(exchange.getExchangeSpecification());
     tradeService = (IndependentReserveTradeService) exchange.getTradeService();

--- a/xchange-itbit/src/main/java/org/knowm/xchange/itbit/ItBitExchange.java
+++ b/xchange-itbit/src/main/java/org/knowm/xchange/itbit/ItBitExchange.java
@@ -23,8 +23,7 @@ public class ItBitExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.itbit.com");
     exchangeSpecification.setHost("api.itbit.com");
     exchangeSpecification.setPort(443);

--- a/xchange-itbit/src/test/java/org/knowm/xchange/itbit/service/marketdata/OrderBookFetchIntegration.java
+++ b/xchange-itbit/src/test/java/org/knowm/xchange/itbit/service/marketdata/OrderBookFetchIntegration.java
@@ -16,7 +16,7 @@ public class OrderBookFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(ItBitExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(ItBitExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     OrderBook orderBook = marketDataService.getOrderBook(new CurrencyPair("XBT", "USD"));
     //    System.out.println(orderBook.toString());

--- a/xchange-koineks/src/main/java/org/knowm/xchange/koineks/KoineksExchange.java
+++ b/xchange-koineks/src/main/java/org/knowm/xchange/koineks/KoineksExchange.java
@@ -21,8 +21,7 @@ public class KoineksExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://koineks.com");
     exchangeSpecification.setHost("www.koineks.com");
     exchangeSpecification.setPort(80);

--- a/xchange-koineks/src/test/java/org/knowm/xchange/koineks/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-koineks/src/test/java/org/knowm/xchange/koineks/service/marketdata/TickerFetchIntegration.java
@@ -15,7 +15,7 @@ public class TickerFetchIntegration {
 
   @Test
   public void tickerFetchTest() throws Exception {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(KoineksExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(KoineksExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "TRY"));
     System.out.println(ticker.toString());

--- a/xchange-koinim/src/main/java/org/knowm/xchange/koinim/KoinimExchange.java
+++ b/xchange-koinim/src/main/java/org/knowm/xchange/koinim/KoinimExchange.java
@@ -21,8 +21,7 @@ public class KoinimExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://www.koinim.com");
     exchangeSpecification.setHost("www.koinim.com");
     exchangeSpecification.setPort(80);

--- a/xchange-koinim/src/test/java/org/knowm/xchange/koinim/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-koinim/src/test/java/org/knowm/xchange/koinim/service/marketdata/TickerFetchIntegration.java
@@ -15,7 +15,7 @@ public class TickerFetchIntegration {
 
   @Test
   public void tickerFetchTest() throws Exception {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(KoinimExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(KoinimExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "TRY"));
     System.out.println(ticker.toString());

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenExchange.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenExchange.java
@@ -28,8 +28,7 @@ public class KrakenExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.kraken.com");
     exchangeSpecification.setHost("api.kraken.com");
     exchangeSpecification.setPort(80);

--- a/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/marketdata/TickerFetchIntegration.java
@@ -15,7 +15,7 @@ public class TickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(KrakenExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(KrakenExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "USD"));
     System.out.println(ticker.toString());

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinExchange.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinExchange.java
@@ -56,8 +56,7 @@ public class KucoinExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri(LIVE_URI);
     exchangeSpecification.setHost(LIVE_HOST);
     exchangeSpecification.setPort(80);

--- a/xchange-kuna/src/main/java/org/knowm/xchange/kuna/KunaExchange.java
+++ b/xchange-kuna/src/main/java/org/knowm/xchange/kuna/KunaExchange.java
@@ -36,8 +36,7 @@ public class KunaExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri(KUNA_URL);
     exchangeSpecification.setHost(KUNA_HOST);
     exchangeSpecification.setPort(KUNA_PORT);

--- a/xchange-kuna/src/test/java/org/knowm/xchange/kuna/BaseKunaTest.java
+++ b/xchange-kuna/src/test/java/org/knowm/xchange/kuna/BaseKunaTest.java
@@ -11,7 +11,7 @@ public class BaseKunaTest {
 
   @BeforeClass
   public static void beforeClass() {
-    exchange = ExchangeFactory.INSTANCE.createExchange(KunaExchange.class.getName());
+    exchange = ExchangeFactory.INSTANCE.createExchange(KunaExchange.class);
   }
 
   protected static Exchange getExchange() {

--- a/xchange-kuna/src/test/java/org/knowm/xchange/kuna/service/KunaMarketDataServiceTest.java
+++ b/xchange-kuna/src/test/java/org/knowm/xchange/kuna/service/KunaMarketDataServiceTest.java
@@ -11,6 +11,6 @@ public class KunaMarketDataServiceTest {
 
   @Before
   public static void beforeClass() {
-    exchange = ExchangeFactory.INSTANCE.createExchange(KunaExchange.class.getName());
+    exchange = ExchangeFactory.INSTANCE.createExchange(KunaExchange.class);
   }
 }

--- a/xchange-lakebtc/src/main/java/org/knowm/xchange/lakebtc/LakeBTCExchange.java
+++ b/xchange-lakebtc/src/main/java/org/knowm/xchange/lakebtc/LakeBTCExchange.java
@@ -26,8 +26,7 @@ public class LakeBTCExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.lakebtc.com/");
     exchangeSpecification.setHost("https://lakebtc.com");
     exchangeSpecification.setPort(80);

--- a/xchange-lakebtc/src/test/java/org/knowm/xchange/lakebtc/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-lakebtc/src/test/java/org/knowm/xchange/lakebtc/service/marketdata/TickerFetchIntegration.java
@@ -16,7 +16,7 @@ public class TickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(LakeBTCExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(LakeBTCExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "USD"));
     System.out.println(ticker.toString());

--- a/xchange-latoken/src/main/java/org/knowm/xchange/latoken/LatokenExchange.java
+++ b/xchange-latoken/src/main/java/org/knowm/xchange/latoken/LatokenExchange.java
@@ -47,7 +47,7 @@ public class LatokenExchange extends BaseExchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification spec = new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification spec = new ExchangeSpecification(this.getClass());
     spec.setSslUri("https://api.latoken.com");
     spec.setHost("www.latoken.com");
     spec.setPort(80);

--- a/xchange-latoken/src/test/java/org/knowm/xchange/latoken/service/LatokenMarketDataServiceIntegration.java
+++ b/xchange-latoken/src/test/java/org/knowm/xchange/latoken/service/LatokenMarketDataServiceIntegration.java
@@ -26,7 +26,7 @@ public class LatokenMarketDataServiceIntegration {
 
   @BeforeClass
   public static void beforeClass() {
-    exchange = ExchangeFactory.INSTANCE.createExchange(LatokenExchange.class.getName());
+    exchange = ExchangeFactory.INSTANCE.createExchange(LatokenExchange.class);
     marketService = exchange.getMarketDataService();
   }
 

--- a/xchange-latoken/src/test/java/org/knowm/xchange/latoken/service/LatokenTradeServiceIntegration.java
+++ b/xchange-latoken/src/test/java/org/knowm/xchange/latoken/service/LatokenTradeServiceIntegration.java
@@ -30,7 +30,7 @@ public class LatokenTradeServiceIntegration {
   public static void beforeClass() {
     exchange =
         ExchangeFactory.INSTANCE.createExchange(
-            LatokenExchange.class.getName(), "api-v1-XXX", "api-v1-secret-YYY");
+            LatokenExchange.class, "api-v1-XXX", "api-v1-secret-YYY");
     tradeService = (LatokenTradeService) exchange.getTradeService();
   }
 

--- a/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/LivecoinExchange.java
+++ b/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/LivecoinExchange.java
@@ -38,8 +38,7 @@ public class LivecoinExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.livecoin.net");
     exchangeSpecification.setHost("api.livecoin.net");
     exchangeSpecification.setExchangeName("Livecoin");

--- a/xchange-livecoin/src/test/java/org/knowm/xchange/livecoin/service/BaseMockedIntegrationTest.java
+++ b/xchange-livecoin/src/test/java/org/knowm/xchange/livecoin/service/BaseMockedIntegrationTest.java
@@ -14,8 +14,7 @@ public class BaseMockedIntegrationTest {
 
   public Exchange createExchange() {
     Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchangeWithoutSpecification(
-            LivecoinExchange.class.getName());
+        ExchangeFactory.INSTANCE.createExchangeWithoutSpecification(LivecoinExchange.class);
     ExchangeSpecification specification = exchange.getDefaultExchangeSpecification();
     specification.setHost("localhost");
     specification.setSslUri("http://localhost:" + wireMockRule.port());

--- a/xchange-livecoin/src/test/java/org/knowm/xchange/livecoin/service/MarketDataIntegration.java
+++ b/xchange-livecoin/src/test/java/org/knowm/xchange/livecoin/service/MarketDataIntegration.java
@@ -22,7 +22,7 @@ public class MarketDataIntegration {
 
   @BeforeClass
   public static void setUp() {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(LivecoinExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(LivecoinExchange.class);
     marketDataService = (LivecoinMarketDataService) exchange.getMarketDataService();
   }
 

--- a/xchange-luno/src/main/java/org/knowm/xchange/luno/LunoExchange.java
+++ b/xchange-luno/src/main/java/org/knowm/xchange/luno/LunoExchange.java
@@ -23,8 +23,7 @@ public class LunoExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.mybitx.com");
     exchangeSpecification.setHost("api.mybitx.com");
     exchangeSpecification.setPort(443);

--- a/xchange-lykke/src/main/java/org/knowm/xchange/lykke/LykkeExchange.java
+++ b/xchange-lykke/src/main/java/org/knowm/xchange/lykke/LykkeExchange.java
@@ -42,8 +42,7 @@ public class LykkeExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://hft-api.lykke.com/");
     exchangeSpecification.setHost("lykke.com");
     exchangeSpecification.setPort(80);

--- a/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/MercadoBitcoinExchange.java
+++ b/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/MercadoBitcoinExchange.java
@@ -17,8 +17,7 @@ public class MercadoBitcoinExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://www.mercadobitcoin.net");
     exchangeSpecification.setHost("www.mercadobitcoin.net");
     exchangeSpecification.setPort(80);

--- a/xchange-mercadobitcoin/src/test/java/org/knowm/xchange/mercadobitcoin/service/marketdata/OrderBookFetchIntegration.java
+++ b/xchange-mercadobitcoin/src/test/java/org/knowm/xchange/mercadobitcoin/service/marketdata/OrderBookFetchIntegration.java
@@ -16,8 +16,7 @@ public class OrderBookFetchIntegration {
   @Test
   public void orderbookFetchTest() throws Exception {
 
-    Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
 
     OrderBook orderBook;

--- a/xchange-mercadobitcoin/src/test/java/org/knowm/xchange/mercadobitcoin/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-mercadobitcoin/src/test/java/org/knowm/xchange/mercadobitcoin/service/marketdata/TickerFetchIntegration.java
@@ -17,8 +17,7 @@ public class TickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
 
     Ticker ticker;

--- a/xchange-mercadobitcoin/src/test/java/org/knowm/xchange/mercadobitcoin/service/marketdata/TradesFetchIntegration.java
+++ b/xchange-mercadobitcoin/src/test/java/org/knowm/xchange/mercadobitcoin/service/marketdata/TradesFetchIntegration.java
@@ -16,8 +16,7 @@ public class TradesFetchIntegration {
   @Test
   public void orderbookFetchTest() throws Exception {
 
-    Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(MercadoBitcoinExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
 
     Trades trades;

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinExchange.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinExchange.java
@@ -113,8 +113,7 @@ public class OkCoinExchange extends BaseExchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://www.okex.com/api");
     exchangeSpecification.setHost("www.okex.com");
     exchangeSpecification.setExchangeName("OKCoin");

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkexExchangeV3.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkexExchangeV3.java
@@ -19,7 +19,7 @@ public class OkexExchangeV3 extends BaseExchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification spec = new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification spec = new ExchangeSpecification(this.getClass());
     spec.setSslUri("https://www.okex.com");
     spec.setHost("www.okex.com");
     spec.setExchangeName("OKEx");

--- a/xchange-openexchangerates/src/main/java/org/knowm/xchange/oer/OERExchange.java
+++ b/xchange-openexchangerates/src/main/java/org/knowm/xchange/oer/OERExchange.java
@@ -16,8 +16,7 @@ public class OERExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setPlainTextUri("http://openexchangerates.org");
     exchangeSpecification.setHost("openexchangerates.org");
     exchangeSpecification.setPort(80);

--- a/xchange-openexchangerates/src/test/java/org/knowm/xchange/oer/service/OERMarketDataServiceRawTest.java
+++ b/xchange-openexchangerates/src/test/java/org/knowm/xchange/oer/service/OERMarketDataServiceRawTest.java
@@ -17,7 +17,7 @@ public class OERMarketDataServiceRawTest {
 
   @Test
   public void testProxyIsCalledWithCorrectParameters() throws IOException {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(OERExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(OERExchange.class);
     OERMarketDataServiceRaw serviceRaw = new OERMarketDataServiceRaw(exchange);
     OER oerMock = Mockito.mock(OER.class);
     OERTickers tickers = new OERTickers(new OERRates(), 0L);

--- a/xchange-openexchangerates/src/test/java/org/knowm/xchange/oer/service/OERMarketDataServiceTest.java
+++ b/xchange-openexchangerates/src/test/java/org/knowm/xchange/oer/service/OERMarketDataServiceTest.java
@@ -17,7 +17,7 @@ public class OERMarketDataServiceTest {
 
   @Test
   public void testTakesCorrectValueFromOERRates() throws IOException {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(OERExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(OERExchange.class);
 
     OERMarketDataService marketDataService =
         new OERMarketDataService(exchange) {

--- a/xchange-paribu/src/main/java/org/knowm/xchange/paribu/ParibuExchange.java
+++ b/xchange-paribu/src/main/java/org/knowm/xchange/paribu/ParibuExchange.java
@@ -21,8 +21,7 @@ public class ParibuExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://www.paribu.com");
     exchangeSpecification.setHost("www.paribu.com");
     exchangeSpecification.setPort(80);

--- a/xchange-paribu/src/test/java/org/knowm/xchange/paribu/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-paribu/src/test/java/org/knowm/xchange/paribu/service/marketdata/TickerFetchIntegration.java
@@ -15,7 +15,7 @@ public class TickerFetchIntegration {
 
   @Test
   public void tickerFetchTest() throws Exception {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(ParibuExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(ParibuExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "TRY"));
     System.out.println(ticker.toString());

--- a/xchange-paymium/src/main/java/org/knowm/xchange/paymium/PaymiumExchange.java
+++ b/xchange-paymium/src/main/java/org/knowm/xchange/paymium/PaymiumExchange.java
@@ -14,8 +14,7 @@ public class PaymiumExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://paymium.com/api/v1");
     exchangeSpecification.setHost("paymium.com");
     exchangeSpecification.setPort(443);

--- a/xchange-paymium/src/test/java/org/knowm/xchange/paymium/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-paymium/src/test/java/org/knowm/xchange/paymium/service/marketdata/TickerFetchIntegration.java
@@ -16,7 +16,7 @@ public class TickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(PaymiumExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(PaymiumExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "EUR"));
     System.out.println(ticker.toString());

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexExchange.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexExchange.java
@@ -30,8 +30,7 @@ public class PoloniexExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://poloniex.com/");
     exchangeSpecification.setHost("poloniex.com");
     exchangeSpecification.setPort(80);

--- a/xchange-poloniex/src/test/java/org/knowm/xchange/poloniex/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-poloniex/src/test/java/org/knowm/xchange/poloniex/service/marketdata/TickerFetchIntegration.java
@@ -16,7 +16,7 @@ public class TickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(PoloniexExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(PoloniexExchange.class);
     exchange.remoteInit();
     MarketDataService marketDataService = exchange.getMarketDataService();
     CurrencyPair currencyPair =

--- a/xchange-quoine/src/main/java/org/knowm/xchange/quoine/QuoineExchange.java
+++ b/xchange-quoine/src/main/java/org/knowm/xchange/quoine/QuoineExchange.java
@@ -34,8 +34,7 @@ public class QuoineExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.liquid.com");
     exchangeSpecification.setExchangeName("Quoine");
     exchangeSpecification.setExchangeSpecificParametersItem("Use_Margin", false);

--- a/xchange-ripple/README.md
+++ b/xchange-ripple/README.md
@@ -38,7 +38,7 @@ running locally and listening only on the localhost interface. There are instruc
 configured using the XChange initialisation:
 
 ```
-	ExchangeSpecification specification = new ExchangeSpecification(RippleExchange.class.getName());
+	ExchangeSpecification specification = new ExchangeSpecification(RippleExchange.class);
     specification.setSslUri(""); // remove the default api.ripple.com connection
     specification.setPlainTextUri(RippleExchange.REST_API_LOCALHOST_PLAIN_TEXT);
     specification.setSecretKey("s****************************");
@@ -51,7 +51,7 @@ then this must be explicitly enabled to prevent an exception being thrown on cre
 in the XChange specification, e.g.
 
 ```
-    ExchangeSpecification specification = new ExchangeSpecification(RippleExchange.class.getName());
+    ExchangeSpecification specification = new ExchangeSpecification(RippleExchange.class);
     specification.setSslUri(RippleExchange.REST_API_RIPPLE_LABS);
     specification.setSecretKey("s****************************");
     specification.setExchangeSpecificParametersItem(RippleExchange.TRUST_API_RIPPLE_COM, true);

--- a/xchange-ripple/src/main/java/org/knowm/xchange/ripple/RippleExchange.java
+++ b/xchange-ripple/src/main/java/org/knowm/xchange/ripple/RippleExchange.java
@@ -65,8 +65,7 @@ public class RippleExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    final ExchangeSpecification specification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    final ExchangeSpecification specification = new ExchangeSpecification(this.getClass());
     specification.setSslUri(REST_API_RIPPLE_LABS);
     specification.setExchangeName("Ripple");
     specification.setExchangeDescription(

--- a/xchange-ripple/src/main/java/org/knowm/xchange/ripple/service/RippleTradeService.java
+++ b/xchange-ripple/src/main/java/org/knowm/xchange/ripple/service/RippleTradeService.java
@@ -57,8 +57,7 @@ public class RippleTradeService extends RippleTradeServiceRaw implements TradeSe
     if (order instanceof RippleLimitOrder) {
       return placeOrder((RippleLimitOrder) order, ripple.validateOrderRequests());
     } else {
-      throw new IllegalArgumentException(
-          "order must be of type: " + RippleLimitOrder.class.getName());
+      throw new IllegalArgumentException("order must be of type: " + RippleLimitOrder.class);
     }
   }
 

--- a/xchange-ripple/src/test/java/org/knowm/xchange/ripple/RippleServerTrustTest.java
+++ b/xchange-ripple/src/test/java/org/knowm/xchange/ripple/RippleServerTrustTest.java
@@ -15,8 +15,7 @@ public class RippleServerTrustTest {
    */
   @Test
   public void noSecretKeyTest() {
-    final Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(RippleExchange.class.getName());
+    final Exchange exchange = ExchangeFactory.INSTANCE.createExchange(RippleExchange.class);
     assertThat(exchange).isInstanceOf(RippleExchange.class);
     assertThat(exchange.getExchangeSpecification().getSecretKey()).isNull();
     assertThat(exchange.getExchangeSpecification().getSslUri())
@@ -30,8 +29,7 @@ public class RippleServerTrustTest {
    */
   @Test(expected = IllegalStateException.class)
   public void safetyNetTest() {
-    final ExchangeSpecification specification =
-        new ExchangeSpecification(RippleExchange.class.getName());
+    final ExchangeSpecification specification = new ExchangeSpecification(RippleExchange.class);
     specification.setSslUri(RippleExchange.REST_API_RIPPLE_LABS);
     specification.setSecretKey("s****************************");
     ExchangeFactory.INSTANCE.createExchange(specification);
@@ -43,8 +41,7 @@ public class RippleServerTrustTest {
    */
   @Test
   public void localServerTest() {
-    final ExchangeSpecification specification =
-        new ExchangeSpecification(RippleExchange.class.getName());
+    final ExchangeSpecification specification = new ExchangeSpecification(RippleExchange.class);
     specification.setSslUri(""); // remove the default api.ripple.com connection
     specification.setPlainTextUri(RippleExchange.REST_API_LOCALHOST_PLAIN_TEXT);
     specification.setSecretKey("s****************************");
@@ -65,8 +62,7 @@ public class RippleServerTrustTest {
    */
   @Test
   public void breakGlassTest() {
-    final ExchangeSpecification specification =
-        new ExchangeSpecification(RippleExchange.class.getName());
+    final ExchangeSpecification specification = new ExchangeSpecification(RippleExchange.class);
     specification.setSslUri(RippleExchange.REST_API_RIPPLE_LABS);
     specification.setSecretKey("s****************************");
     specification.setExchangeSpecificParametersItem(

--- a/xchange-ripple/src/test/java/org/knowm/xchange/ripple/dto/account/RippleAccountIntegration.java
+++ b/xchange-ripple/src/test/java/org/knowm/xchange/ripple/dto/account/RippleAccountIntegration.java
@@ -13,8 +13,7 @@ public class RippleAccountIntegration {
 
   @Test
   public void accountSettingsTest() throws IOException {
-    final Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(RippleExchange.class.getName());
+    final Exchange exchange = ExchangeFactory.INSTANCE.createExchange(RippleExchange.class);
     final RippleAccountServiceRaw accountService =
         (RippleAccountServiceRaw) exchange.getAccountService();
     final RippleSettings settings =

--- a/xchange-ripple/src/test/java/org/knowm/xchange/ripple/dto/account/trade/RippleTradeHistoryIntegration.java
+++ b/xchange-ripple/src/test/java/org/knowm/xchange/ripple/dto/account/trade/RippleTradeHistoryIntegration.java
@@ -24,8 +24,7 @@ public class RippleTradeHistoryIntegration {
 
   @Test
   public void getTradeHistoryTest() throws Exception {
-    final Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(RippleExchange.class.getName());
+    final Exchange exchange = ExchangeFactory.INSTANCE.createExchange(RippleExchange.class);
     final TradeService tradeService = exchange.getTradeService();
 
     final RippleTradeHistoryParams params =

--- a/xchange-ripple/src/test/java/org/knowm/xchange/ripple/dto/account/trade/RippleTransactioFeeIntegration.java
+++ b/xchange-ripple/src/test/java/org/knowm/xchange/ripple/dto/account/trade/RippleTransactioFeeIntegration.java
@@ -13,8 +13,7 @@ public class RippleTransactioFeeIntegration {
 
   @Test
   public void getTransactionFeeTest() {
-    final Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(RippleExchange.class.getName());
+    final Exchange exchange = ExchangeFactory.INSTANCE.createExchange(RippleExchange.class);
     final RippleTradeService tradeService = (RippleTradeService) exchange.getTradeService();
 
     final BigDecimal transactionFee = tradeService.getTransactionFee();

--- a/xchange-ripple/src/test/java/org/knowm/xchange/ripple/service/marketdata/RippleOrderBookIntegration.java
+++ b/xchange-ripple/src/test/java/org/knowm/xchange/ripple/service/marketdata/RippleOrderBookIntegration.java
@@ -20,8 +20,7 @@ public class RippleOrderBookIntegration {
   public void getOrderBookTest() throws Exception {
     final int depthLimit = 15;
 
-    final Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(RippleExchange.class.getName());
+    final Exchange exchange = ExchangeFactory.INSTANCE.createExchange(RippleExchange.class);
     final MarketDataService marketDataService = exchange.getMarketDataService();
 
     final RippleMarketDataParams params = new RippleMarketDataParams();
@@ -59,8 +58,7 @@ public class RippleOrderBookIntegration {
   public void invalidOrderBookTest() throws Exception {
     final int depthLimit = 15;
 
-    final Exchange exchange =
-        ExchangeFactory.INSTANCE.createExchange(RippleExchange.class.getName());
+    final Exchange exchange = ExchangeFactory.INSTANCE.createExchange(RippleExchange.class);
     final MarketDataService marketDataService = exchange.getMarketDataService();
 
     final RippleMarketDataParams params = new RippleMarketDataParams();

--- a/xchange-simulated/src/main/java/org/knowm/xchange/simulated/SimulatedExchange.java
+++ b/xchange-simulated/src/main/java/org/knowm/xchange/simulated/SimulatedExchange.java
@@ -71,8 +71,7 @@ public class SimulatedExchange extends BaseExchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setExchangeName("Simulated");
     exchangeSpecification.setExchangeDescription(
         "A simulated exchange for integration testing purposes.");

--- a/xchange-stream-bankera/src/test/java/info/bitrich/xchangestream/bankera/BankeraManualExample.java
+++ b/xchange-stream-bankera/src/test/java/info/bitrich/xchangestream/bankera/BankeraManualExample.java
@@ -11,7 +11,7 @@ public class BankeraManualExample {
 
   public static void main(String[] args) {
     StreamingExchange exchange =
-        StreamingExchangeFactory.INSTANCE.createExchange(BankeraStreamingExchange.class.getName());
+        StreamingExchangeFactory.INSTANCE.createExchange(BankeraStreamingExchange.class);
 
     exchange.connect().blockingAwait();
     exchange

--- a/xchange-stream-binance/src/test/java/info/bitrich/xchangestream/binance/BinanceManualExample.java
+++ b/xchange-stream-binance/src/test/java/info/bitrich/xchangestream/binance/BinanceManualExample.java
@@ -20,7 +20,7 @@ public class BinanceManualExample {
 
     ExchangeSpecification spec =
         StreamingExchangeFactory.INSTANCE
-            .createExchange(BinanceStreamingExchange.class.getName())
+            .createExchange(BinanceStreamingExchange.class)
             .getDefaultExchangeSpecification();
     spec.setApiKey(apiKey);
     spec.setSecretKey(apiSecret);

--- a/xchange-stream-binance/src/test/java/info/bitrich/xchangestream/binance/BinanceTest.java
+++ b/xchange-stream-binance/src/test/java/info/bitrich/xchangestream/binance/BinanceTest.java
@@ -15,8 +15,7 @@ public class BinanceTest {
   public void channelCreateUrlTest() {
     BinanceStreamingExchange exchange =
         (BinanceStreamingExchange)
-            StreamingExchangeFactory.INSTANCE.createExchange(
-                BinanceStreamingExchange.class.getName());
+            StreamingExchangeFactory.INSTANCE.createExchange(BinanceStreamingExchange.class);
     ProductSubscription.ProductSubscriptionBuilder builder = ProductSubscription.create();
     builder.addTicker(CurrencyPair.BTC_USD).addTicker(CurrencyPair.DASH_BTC);
     String buildSubscriptionStreams = exchange.buildSubscriptionStreams(builder.build());
@@ -40,7 +39,7 @@ public class BinanceTest {
         .addOrderbook(CurrencyPair.ETH_BTC);
     ExchangeSpecification spec =
         StreamingExchangeFactory.INSTANCE
-            .createExchange(BinanceStreamingExchange.class.getName())
+            .createExchange(BinanceStreamingExchange.class)
             .getDefaultExchangeSpecification();
     spec.setExchangeSpecificParametersItem(USE_HIGHER_UPDATE_FREQUENCY, true);
     BinanceStreamingExchange exchange =

--- a/xchange-stream-bitfinex/src/test/java/info/bitrich/xchangestream/bitfinex/BitfinexManualAuthExample.java
+++ b/xchange-stream-bitfinex/src/test/java/info/bitrich/xchangestream/bitfinex/BitfinexManualAuthExample.java
@@ -22,7 +22,7 @@ public class BitfinexManualAuthExample {
 
     ExchangeSpecification spec =
         StreamingExchangeFactory.INSTANCE
-            .createExchange(BitfinexStreamingExchange.class.getName())
+            .createExchange(BitfinexStreamingExchange.class)
             .getDefaultExchangeSpecification();
     spec.setApiKey(apiKey);
     spec.setSecretKey(apiSecret);

--- a/xchange-stream-bitflyer/src/test/java/info/bitrich/xchangestream/bitflyer/BitflyerManualExample.java
+++ b/xchange-stream-bitflyer/src/test/java/info/bitrich/xchangestream/bitflyer/BitflyerManualExample.java
@@ -12,7 +12,7 @@ public class BitflyerManualExample {
 
   public static void main(String[] args) {
     StreamingExchange exchange =
-        StreamingExchangeFactory.INSTANCE.createExchange(BitflyerStreamingExchange.class.getName());
+        StreamingExchangeFactory.INSTANCE.createExchange(BitflyerStreamingExchange.class);
     exchange.connect().blockingAwait();
 
     // Note that, the receiving first order book snapshot takes several seconds or minutes!

--- a/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexAuthenticatedExample.java
+++ b/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexAuthenticatedExample.java
@@ -16,7 +16,7 @@ public class BitmexAuthenticatedExample {
   public static void main(String[] args) throws Exception {
     CertHelper.trustAllCerts();
     StreamingExchange exchange =
-        StreamingExchangeFactory.INSTANCE.createExchange(BitmexStreamingExchange.class.getName());
+        StreamingExchangeFactory.INSTANCE.createExchange(BitmexStreamingExchange.class);
     ExchangeSpecification defaultExchangeSpecification = exchange.getDefaultExchangeSpecification();
     //
     // defaultExchangeSpecification.setExchangeSpecificParametersItem(StreamingExchange.SOCKS_PROXY_HOST, "localhost");

--- a/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexManualExample.java
+++ b/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexManualExample.java
@@ -14,8 +14,7 @@ public class BitmexManualExample {
   public static void main(String[] args) {
     BitmexStreamingExchange exchange =
         (BitmexStreamingExchange)
-            StreamingExchangeFactory.INSTANCE.createExchange(
-                BitmexStreamingExchange.class.getName());
+            StreamingExchangeFactory.INSTANCE.createExchange(BitmexStreamingExchange.class);
     exchange.connect().blockingAwait();
 
     exchange.messageDelay().subscribe(delay -> LOG.info("Message delay: " + delay));

--- a/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexOrderIT.java
+++ b/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexOrderIT.java
@@ -50,8 +50,7 @@ public class BitmexOrderIT {
         PropsLoader.loadKeys("bitmex.secret.keys", "bitmex.secret.keys.origin", "bitmex");
     exchange =
         (BitmexStreamingExchange)
-            StreamingExchangeFactory.INSTANCE.createExchange(
-                BitmexStreamingExchange.class.getName());
+            StreamingExchangeFactory.INSTANCE.createExchange(BitmexStreamingExchange.class);
 
     exchange.applySpecification(
         BitmexTestsCommons.getExchangeSpecification(

--- a/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexTest.java
+++ b/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexTest.java
@@ -31,8 +31,7 @@ public class BitmexTest {
 
   @Before
   public void setup() {
-    exchange =
-        StreamingExchangeFactory.INSTANCE.createExchange(BitmexStreamingExchange.class.getName());
+    exchange = StreamingExchangeFactory.INSTANCE.createExchange(BitmexStreamingExchange.class);
     awaitCompletable(exchange.connect());
     streamingMarketDataService =
         (BitmexStreamingMarketDataService) exchange.getStreamingMarketDataService();

--- a/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexWithProxyIT.java
+++ b/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexWithProxyIT.java
@@ -28,8 +28,7 @@ public class BitmexWithProxyIT {
     proxyUtil.startProxy();
     LocalExchangeConfig localConfig =
         PropsLoader.loadKeys("bitmex.secret.keys", "bitmex.secret.keys.origin", "bitmex");
-    exchange =
-        StreamingExchangeFactory.INSTANCE.createExchange(BitmexStreamingExchange.class.getName());
+    exchange = StreamingExchangeFactory.INSTANCE.createExchange(BitmexStreamingExchange.class);
 
     ExchangeSpecification exchangeSpecification =
         BitmexTestsCommons.getExchangeSpecification(

--- a/xchange-stream-cexio/src/test/java/info/bitrich/xchangestream/cexio/CexioManualExample.java
+++ b/xchange-stream-cexio/src/test/java/info/bitrich/xchangestream/cexio/CexioManualExample.java
@@ -12,8 +12,7 @@ public class CexioManualExample {
   public static void main(String[] args) throws IOException {
     CexioStreamingExchange exchange =
         (CexioStreamingExchange)
-            StreamingExchangeFactory.INSTANCE.createExchange(
-                CexioStreamingExchange.class.getName());
+            StreamingExchangeFactory.INSTANCE.createExchange(CexioStreamingExchange.class);
 
     CexioProperties properties = new CexioProperties();
     exchange.setCredentials(properties.getApiKey(), properties.getSecretKey());

--- a/xchange-stream-coinbasepro/src/test/java/info/bitrich/xchangestream/coinbasepro/CoinbaseProManualExample.java
+++ b/xchange-stream-coinbasepro/src/test/java/info/bitrich/xchangestream/coinbasepro/CoinbaseProManualExample.java
@@ -29,7 +29,7 @@ public class CoinbaseProManualExample {
 
     ExchangeSpecification spec =
         StreamingExchangeFactory.INSTANCE
-            .createExchange(CoinbaseProStreamingExchange.class.getName())
+            .createExchange(CoinbaseProStreamingExchange.class)
             .getDefaultExchangeSpecification();
     spec.setApiKey(apiKey);
     spec.setSecretKey(apiSecret);

--- a/xchange-stream-coinmate/src/test/java/info/bitrich/xchangestream/coinmate/CoinmateManualExample.java
+++ b/xchange-stream-coinmate/src/test/java/info/bitrich/xchangestream/coinmate/CoinmateManualExample.java
@@ -12,7 +12,7 @@ public class CoinmateManualExample {
   public static void main(String[] args) {
 
     StreamingExchange exchange =
-        StreamingExchangeFactory.INSTANCE.createExchange(CoinmateStreamingExchange.class.getName());
+        StreamingExchangeFactory.INSTANCE.createExchange(CoinmateStreamingExchange.class);
     exchange.connect().blockingAwait();
 
     exchange

--- a/xchange-stream-gemini/src/test/java/info/bitrich/xchangestream/gemini/GeminiManualExample.java
+++ b/xchange-stream-gemini/src/test/java/info/bitrich/xchangestream/gemini/GeminiManualExample.java
@@ -12,7 +12,7 @@ public class GeminiManualExample {
 
   public static void main(String[] args) {
     StreamingExchange exchange =
-        StreamingExchangeFactory.INSTANCE.createExchange(GeminiStreamingExchange.class.getName());
+        StreamingExchangeFactory.INSTANCE.createExchange(GeminiStreamingExchange.class);
     exchange.connect().blockingAwait();
 
     exchange

--- a/xchange-stream-hitbtc/src/test/java/info/bitrich/xchangestream/hitbtc/HitbtcManualExample.java
+++ b/xchange-stream-hitbtc/src/test/java/info/bitrich/xchangestream/hitbtc/HitbtcManualExample.java
@@ -13,7 +13,7 @@ public class HitbtcManualExample {
 
   public static void main(String[] args) {
     StreamingExchange exchange =
-        StreamingExchangeFactory.INSTANCE.createExchange(HitbtcStreamingExchange.class.getName());
+        StreamingExchangeFactory.INSTANCE.createExchange(HitbtcStreamingExchange.class);
 
     exchange.connect().blockingAwait();
     Disposable orderBookObserver =

--- a/xchange-stream-huobi/src/test/java/info/bitrich/xchangestream/huobi/HuobiManualExample.java
+++ b/xchange-stream-huobi/src/test/java/info/bitrich/xchangestream/huobi/HuobiManualExample.java
@@ -16,7 +16,7 @@ public class HuobiManualExample {
 
   public static void main(String[] args) {
     StreamingExchange exchange =
-        StreamingExchangeFactory.INSTANCE.createExchange(HuobiStreamingExchange.class.getName());
+        StreamingExchangeFactory.INSTANCE.createExchange(HuobiStreamingExchange.class);
 
     exchange.connect().blockingAwait();
 

--- a/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingExchange.java
+++ b/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingExchange.java
@@ -110,18 +110,19 @@ public class KrakenStreamingExchange extends KrakenExchange implements Streaming
   }
 
   /**
-   * Gets a WebSocketToken following https://support.kraken.com/hc/en-us/articles/360034664311-How-to-subscribe-to-the-Kraken-WebSocket-private-feeds
+   * Gets a WebSocketToken following
+   * https://support.kraken.com/hc/en-us/articles/360034664311-How-to-subscribe-to-the-Kraken-WebSocket-private-feeds
    *
-   * <p>Token requests should be made before any Websocket reconnection to avoid cases where the token has
-   * become invalid due to issues on the Kraken side.
+   * <p>Token requests should be made before any Websocket reconnection to avoid cases where the
+   * token has become invalid due to issues on the Kraken side.
    *
    * <p>From Kraken support:
    *
-   *    <p>In theory WebSocket authentication tokens can last indefinitely, but in reality they do
-   *    sometimes expire causing an invalid session error. As an example, during a recent WebSocket
-   *    API upgrade, many authentication tokens became invalid (for no apparent reason to the token
-   *    owners), causing unexpected invalid session errors upon reconnecting/resubscribing after the
-   *    upgrade.
+   * <p>In theory WebSocket authentication tokens can last indefinitely, but in reality they do
+   * sometimes expire causing an invalid session error. As an example, during a recent WebSocket API
+   * upgrade, many authentication tokens became invalid (for no apparent reason to the token
+   * owners), causing unexpected invalid session errors upon reconnecting/resubscribing after the
+   * upgrade.
    *
    * @param accountServiceRaw account service to query new token against
    * @return token retrieved

--- a/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingMarketDataService.java
+++ b/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingMarketDataService.java
@@ -179,7 +179,7 @@ public class KrakenStreamingMarketDataService implements StreamingMarketDataServ
       LOG.error(
           "Order book size param type {} is invalid. Expected: {}. Default order book size has been used {}",
           obSizeParam.getClass().getName(),
-          Number.class.getName(),
+          Number.class,
           ORDER_BOOK_SIZE_DEFAULT);
       return ORDER_BOOK_SIZE_DEFAULT;
     }

--- a/xchange-stream-okcoin/src/test/java/info/bitrich/xchangestream/okcoin/OkCoinManualExample.java
+++ b/xchange-stream-okcoin/src/test/java/info/bitrich/xchangestream/okcoin/OkCoinManualExample.java
@@ -11,7 +11,7 @@ public class OkCoinManualExample {
 
   public static void main(String[] args) {
     StreamingExchange exchange =
-        StreamingExchangeFactory.INSTANCE.createExchange(OkCoinStreamingExchange.class.getName());
+        StreamingExchangeFactory.INSTANCE.createExchange(OkCoinStreamingExchange.class);
     exchange.connect().blockingAwait();
 
     exchange

--- a/xchange-stream-okcoin/src/test/java/info/bitrich/xchangestream/okcoin/OkExFuturesManualExample.java
+++ b/xchange-stream-okcoin/src/test/java/info/bitrich/xchangestream/okcoin/OkExFuturesManualExample.java
@@ -12,8 +12,7 @@ public class OkExFuturesManualExample {
 
   public static void main(String[] args) {
     StreamingExchange exchange =
-        StreamingExchangeFactory.INSTANCE.createExchange(
-            OkExFuturesStreamingExchange.class.getName());
+        StreamingExchangeFactory.INSTANCE.createExchange(OkExFuturesStreamingExchange.class);
     exchange.connect().blockingAwait();
 
     exchange

--- a/xchange-stream-okcoin/src/test/java/info/bitrich/xchangestream/okcoin/OkExManualExample.java
+++ b/xchange-stream-okcoin/src/test/java/info/bitrich/xchangestream/okcoin/OkExManualExample.java
@@ -13,7 +13,7 @@ public class OkExManualExample {
 
   public static void main(String[] args) {
     StreamingExchange exchange =
-        StreamingExchangeFactory.INSTANCE.createExchange(OkExStreamingExchange.class.getName());
+        StreamingExchangeFactory.INSTANCE.createExchange(OkExStreamingExchange.class);
     exchange.connect().blockingAwait();
 
     CurrencyPair btcUsdt = new CurrencyPair(new Currency("BTC"), new Currency("USDT"));

--- a/xchange-stream-poloniex/src/test/java/info/bitrich/xchangestream/poloniex/PoloniexManualExample.java
+++ b/xchange-stream-poloniex/src/test/java/info/bitrich/xchangestream/poloniex/PoloniexManualExample.java
@@ -11,7 +11,7 @@ public class PoloniexManualExample {
 
   public static void main(String[] args) {
     StreamingExchange exchange =
-        StreamingExchangeFactory.INSTANCE.createExchange(PoloniexStreamingExchange.class.getName());
+        StreamingExchangeFactory.INSTANCE.createExchange(PoloniexStreamingExchange.class);
     exchange.connect().blockingAwait();
 
     //

--- a/xchange-stream-poloniex2/src/test/java/info/bitrich/xchangestream/poloniex2/PoloniexManualExample.java
+++ b/xchange-stream-poloniex2/src/test/java/info/bitrich/xchangestream/poloniex2/PoloniexManualExample.java
@@ -17,7 +17,7 @@ public class PoloniexManualExample {
     //
     //        CertHelper.trustAllCerts();
     StreamingExchange exchange =
-        StreamingExchangeFactory.INSTANCE.createExchange(PoloniexStreamingExchange.class.getName());
+        StreamingExchangeFactory.INSTANCE.createExchange(PoloniexStreamingExchange.class);
     ExchangeSpecification defaultExchangeSpecification = exchange.getDefaultExchangeSpecification();
     //
     // defaultExchangeSpecification.setExchangeSpecificParametersItem(StreamingExchange.SOCKS_PROXY_HOST, "localhost");

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/TheRockExchange.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/TheRockExchange.java
@@ -32,8 +32,7 @@ public class TheRockExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.therocktrading.com");
     exchangeSpecification.setHost("api.therocktrading.com");
     exchangeSpecification.setPort(80);

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockTradeService.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockTradeService.java
@@ -137,8 +137,7 @@ public class TheRockTradeService extends TheRockTradeServiceRaw implements Trade
   @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
     if (!(params instanceof TradeHistoryParamCurrencyPair)) {
-      throw new ExchangeException(
-          "TheRock API recquires " + TradeHistoryParamCurrencyPair.class.getName());
+      throw new ExchangeException("TheRock API recquires " + TradeHistoryParamCurrencyPair.class);
     }
 
     TradeHistoryParamCurrencyPair pairParams = (TradeHistoryParamCurrencyPair) params;

--- a/xchange-therock/src/test/java/org/knowm/xchange/therock/service/trade/AbstractTheRockTradeServiceIntegration.java
+++ b/xchange-therock/src/test/java/org/knowm/xchange/therock/service/trade/AbstractTheRockTradeServiceIntegration.java
@@ -12,7 +12,7 @@ public abstract class AbstractTheRockTradeServiceIntegration {
    * @return an instance of class TheRockExchange
    */
   protected static Exchange createExchange() {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(TheRockExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(TheRockExchange.class);
     exchange.getExchangeSpecification().setApiKey("ApiKey");
     exchange.getExchangeSpecification().setSecretKey("SecretKey");
     exchange.getExchangeSpecification().setUserName("UserName");

--- a/xchange-tradeogre/src/main/java/org/knowm/xchange/tradeogre/TradeOgreExchange.java
+++ b/xchange-tradeogre/src/main/java/org/knowm/xchange/tradeogre/TradeOgreExchange.java
@@ -25,8 +25,7 @@ public class TradeOgreExchange extends BaseExchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://tradeogre.com/api/v1");
     exchangeSpecification.setHost("tradeogre.com");
     exchangeSpecification.setPort(80);

--- a/xchange-truefx/src/main/java/org/knowm/xchange/truefx/TrueFxExchange.java
+++ b/xchange-truefx/src/main/java/org/knowm/xchange/truefx/TrueFxExchange.java
@@ -11,8 +11,7 @@ public class TrueFxExchange extends BaseExchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification specification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification specification = new ExchangeSpecification(this.getClass());
     specification.setShouldLoadRemoteMetaData(false);
     specification.setPlainTextUri("http://webrates.truefx.com/");
     specification.setExchangeName("TrueFX");

--- a/xchange-truefx/src/test/java/org/knowm/xchange/truefx/TrueFxAdaptersTest.java
+++ b/xchange-truefx/src/test/java/org/knowm/xchange/truefx/TrueFxAdaptersTest.java
@@ -20,7 +20,7 @@ public class TrueFxAdaptersTest {
   public void adaptTickerTest() throws JsonParseException, JsonMappingException, IOException {
     InputStream is = getClass().getResourceAsStream("/marketdata/example-ticker.csv");
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(TrueFxExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(TrueFxExchange.class);
     TrueFxMarketDataServiceRaw rawService =
         (TrueFxMarketDataServiceRaw) exchange.getMarketDataService();
     ObjectMapper mapper = rawService.createObjectMapper();

--- a/xchange-truefx/src/test/java/org/knowm/xchange/truefx/dto/marketdata/TrueFxTickerTest.java
+++ b/xchange-truefx/src/test/java/org/knowm/xchange/truefx/dto/marketdata/TrueFxTickerTest.java
@@ -18,7 +18,7 @@ public class TrueFxTickerTest {
 
   @Test
   public void unmarshalTest1() throws IOException {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(TrueFxExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(TrueFxExchange.class);
     TrueFxMarketDataServiceRaw rawService =
         (TrueFxMarketDataServiceRaw) exchange.getMarketDataService();
     ObjectMapper mapper = rawService.createObjectMapper();

--- a/xchange-truefx/src/test/java/org/knowm/xchange/truefx/service/TrueFxTickerIntegration.java
+++ b/xchange-truefx/src/test/java/org/knowm/xchange/truefx/service/TrueFxTickerIntegration.java
@@ -16,7 +16,7 @@ public class TrueFxTickerIntegration {
 
   @Test
   public void fetchTickerTest() throws IOException {
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(TrueFxExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(TrueFxExchange.class);
     MarketDataService service = exchange.getMarketDataService();
 
     Ticker ticker = service.getTicker(CurrencyPair.GBP_USD);

--- a/xchange-upbit/src/main/java/org/knowm/xchange/upbit/UpbitExchange.java
+++ b/xchange-upbit/src/main/java/org/knowm/xchange/upbit/UpbitExchange.java
@@ -23,8 +23,7 @@ public class UpbitExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.upbit.com");
     exchangeSpecification.setHost("www.upbit.co.kr");
     exchangeSpecification.setExchangeName("Upbit");

--- a/xchange-vaultoro/src/main/java/org/knowm/xchange/vaultoro/VaultoroExchange.java
+++ b/xchange-vaultoro/src/main/java/org/knowm/xchange/vaultoro/VaultoroExchange.java
@@ -33,8 +33,7 @@ public class VaultoroExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.vaultoro.com");
     exchangeSpecification.setExchangeName("Vaultoro");
 

--- a/xchange-yobit/src/main/java/org/knowm/xchange/yobit/YoBitExchange.java
+++ b/xchange-yobit/src/main/java/org/knowm/xchange/yobit/YoBitExchange.java
@@ -24,8 +24,7 @@ public class YoBitExchange extends BaseExchange implements Exchange {
 
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://yobit.net");
     exchangeSpecification.setHost("yobit.net");
     exchangeSpecification.setPort(80);

--- a/xchange-yobit/src/test/java/org/knowm/xchange/yobit/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-yobit/src/test/java/org/knowm/xchange/yobit/service/marketdata/TickerFetchIntegration.java
@@ -15,7 +15,7 @@ public class TickerFetchIntegration {
   @Test
   public void tickerFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(YoBitExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(YoBitExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("LTC", "BTC"));
     System.out.println(ticker.toString());

--- a/xchange-zaif/src/main/java/org/knowm/xchange/zaif/ZaifExchange.java
+++ b/xchange-zaif/src/main/java/org/knowm/xchange/zaif/ZaifExchange.java
@@ -28,8 +28,7 @@ public class ZaifExchange extends BaseExchange implements Exchange {
   @Override
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification =
-        new ExchangeSpecification(this.getClass().getCanonicalName());
+    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
     exchangeSpecification.setSslUri("https://api.zaif.jp/");
     exchangeSpecification.setHost("api.zaif.jp");
     exchangeSpecification.setPort(80);

--- a/xchange-zaif/src/test/java/org/knowm/xchange/zaif/marketdata/MarketDataFetchIntegration.java
+++ b/xchange-zaif/src/test/java/org/knowm/xchange/zaif/marketdata/MarketDataFetchIntegration.java
@@ -15,7 +15,7 @@ public class MarketDataFetchIntegration {
   @Test
   public void depthFetchTest() throws Exception {
 
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(ZaifExchange.class.getName());
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(ZaifExchange.class);
     MarketDataService marketDataService = exchange.getMarketDataService();
 
     OrderBook orderBook = marketDataService.getOrderBook(CurrencyPair.BTC_JPY);


### PR DESCRIPTION
By default create Exchange and ExchangeSpecification by Class, not by String for better performance (to avoid frequently using Class.forName).

Creating exchange by Class name marked as deprecated.

- [X] backward compatibility 
