### PR TITLE
UserTrade: added parameterless public static builder creation method

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/UserTrade.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/UserTrade.java
@@ -66,6 +66,10 @@ public class UserTrade extends Trade {
     this.orderUserReference = orderUserReference;
   }
 
+  public static UserTrade.Builder builder() {
+    return new UserTrade.Builder();
+  }
+
   public String getOrderId() {
 
     return orderId;


### PR DESCRIPTION
UserTrade: added missing parameterless public static builder creation method that returns a builder, so in this way UserTrade(builder) is compliant with mapstruct framework: https://mapstruct.org/documentation/stable/reference/html/#mapping-with-builders