### PR TITLE
[core] Added rescu Interceptor(s) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 *.iml
 *.ipr
 *.ips
-.idea/
 
 # Eclipse
 .settings/
@@ -24,7 +23,6 @@ javadoc/
 bin/
 log/
 classes/
-META-INF/
 
 # Misc.
 .DS_Store

--- a/xchange-core/src/main/java/org/knowm/xchange/client/ExchangeRestProxyBuilder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/client/ExchangeRestProxyBuilder.java
@@ -1,9 +1,11 @@
 package org.knowm.xchange.client;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.interceptor.InterceptorProvider;
 import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.IRestProxyFactory;
 import si.mazi.rescu.Interceptor;
@@ -31,7 +33,8 @@ public final class ExchangeRestProxyBuilder<T> {
 
   public static <T> ExchangeRestProxyBuilder<T> forInterface(
       Class<T> restInterface, ExchangeSpecification exchangeSpecification) {
-    return new ExchangeRestProxyBuilder<>(restInterface, exchangeSpecification);
+    return new ExchangeRestProxyBuilder<>(restInterface, exchangeSpecification)
+        .customInterceptors(InterceptorProvider.provide());
   }
 
   public ExchangeRestProxyBuilder<T> clientConfig(ClientConfig value) {
@@ -52,6 +55,11 @@ public final class ExchangeRestProxyBuilder<T> {
 
   public ExchangeRestProxyBuilder<T> customInterceptor(Interceptor value) {
     this.customInterceptors.add(value);
+    return this;
+  }
+
+  public ExchangeRestProxyBuilder<T> customInterceptors(Collection<Interceptor> interceptors) {
+    customInterceptors.addAll(interceptors);
     return this;
   }
 

--- a/xchange-core/src/main/java/org/knowm/xchange/interceptor/InterceptorProvider.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/interceptor/InterceptorProvider.java
@@ -1,0 +1,24 @@
+package org.knowm.xchange.interceptor;
+
+import com.google.common.base.Suppliers;
+import java.util.Collection;
+import java.util.ServiceLoader;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import si.mazi.rescu.Interceptor;
+
+public class InterceptorProvider {
+
+  private static final Supplier<Collection<Interceptor>> INTERCEPTORS_SUPPLIER =
+      Suppliers.memoize(
+          () -> {
+            final ServiceLoader<Interceptor> serviceLoader = ServiceLoader.load(Interceptor.class);
+            return StreamSupport.stream(serviceLoader.spliterator(), false)
+                .collect(Collectors.toSet());
+          });
+
+  public static Collection<Interceptor> provide() {
+    return INTERCEPTORS_SUPPLIER.get();
+  }
+}

--- a/xchange-core/src/test/java/org/knowm/xchange/interceptor/InterceptorProviderTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/interceptor/InterceptorProviderTest.java
@@ -1,0 +1,18 @@
+package org.knowm.xchange.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import org.junit.Test;
+import si.mazi.rescu.Interceptor;
+
+public class InterceptorProviderTest {
+
+  @Test
+  public void testResolveInterceptors() {
+    final Collection<Interceptor> resolvedInterceptors = InterceptorProvider.provide();
+
+    assertThat(resolvedInterceptors).hasSize(1);
+    assertThat(resolvedInterceptors.iterator().next()).isInstanceOf(TestInterceptor.class);
+  }
+}

--- a/xchange-core/src/test/java/org/knowm/xchange/interceptor/TestInterceptor.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/interceptor/TestInterceptor.java
@@ -1,0 +1,15 @@
+package org.knowm.xchange.interceptor;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import si.mazi.rescu.Interceptor;
+
+public class TestInterceptor implements Interceptor {
+
+  @Override
+  public Object aroundInvoke(
+      InvocationHandler invocationHandler, Object proxy, Method method, Object[] args)
+      throws Throwable {
+    return invocationHandler.invoke(proxy, method, args);
+  }
+}

--- a/xchange-core/src/test/resources/META-INF/services/si.mazi.rescu.Interceptor
+++ b/xchange-core/src/test/resources/META-INF/services/si.mazi.rescu.Interceptor
@@ -1,0 +1,1 @@
+org.knowm.xchange.interceptor.TestInterceptor

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/interceptor/LoggingInterceptor.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/interceptor/LoggingInterceptor.java
@@ -1,0 +1,24 @@
+package org.knowm.xchange.examples.interceptor;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import lombok.extern.slf4j.Slf4j;
+import si.mazi.rescu.Interceptor;
+
+@Slf4j
+public class LoggingInterceptor implements Interceptor {
+
+  @Override
+  public Object aroundInvoke(
+      InvocationHandler invocationHandler, Object proxy, Method method, Object[] args)
+      throws Throwable {
+    long start = System.currentTimeMillis();
+    Object result = invocationHandler.invoke(proxy, method, args);
+    log.info(
+        "{}.{} took {} ms.",
+        method.getDeclaringClass().getName(),
+        method.getName(),
+        System.currentTimeMillis() - start);
+    return result;
+  }
+}

--- a/xchange-examples/src/main/resources/META-INF/services/si.mazi.rescu.Interceptor
+++ b/xchange-examples/src/main/resources/META-INF/services/si.mazi.rescu.Interceptor
@@ -1,0 +1,1 @@
+org.knowm.xchange.examples.interceptor.LoggingInterceptor


### PR DESCRIPTION
Added rescu Interceptor(s) support - added the possibility to use custom Interceptors.

Relates to #3272

Added rescu Interceptor(s) support to XChange library.
Based on Java ServiceLoader mechanism, so Interceptors can be easily added in client app by adding content to file:
```META-INF/services/si.mazi.rescu.Interceptor```