### PR TITLE
[security] Fixed CVE-2017-7656 + CVE-2017-7657

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
 
       <dependency>
         <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock</artifactId>
+        <artifactId>wiremock-jre8</artifactId>
         <version>2.27.2</version>
         <scope>test</scope>
       </dependency>

--- a/xchange-binance/pom.xml
+++ b/xchange-binance/pom.xml
@@ -33,7 +33,7 @@
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jre8</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/xchange-bittrex/pom.xml
+++ b/xchange-bittrex/pom.xml
@@ -32,7 +32,7 @@
 
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jre8</artifactId>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/xchange-bittrexV3/pom.xml
+++ b/xchange-bittrexV3/pom.xml
@@ -32,7 +32,7 @@
 
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jre8</artifactId>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/xchange-livecoin/pom.xml
+++ b/xchange-livecoin/pom.xml
@@ -26,7 +26,7 @@
         
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jre8</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Unfortunatelly XChange library is recognized as vulnerable library.

<img width="1109" alt="Screenshot 2020-10-09 at 12 06 38" src="https://user-images.githubusercontent.com/5555560/95571906-7652b200-0a29-11eb-9ee8-8ac87e0ce843.png">
<img width="1110" alt="Screenshot 2020-10-09 at 12 06 53" src="https://user-images.githubusercontent.com/5555560/95571922-7d79c000-0a29-11eb-9d72-7085af56aa8c.png">

It is caused by using wiremock (I know - only for test, by auditing tools recognise this lib as vulnerable) for Java 7, which has dependencies to old libraries. This lib is for at least Java 8, so wiremock-jre8 should be used.

Referneces to isssues:
https://nvd.nist.gov/vuln/detail/CVE-2017-7656
https://nvd.nist.gov/vuln/detail/CVE-2017-7657

This PR is fixing those issues.