### PR TITLE
Fix NPE, maxDepth default to zero instead of null when args is empty

### DIFF
--- a/xchange-stream-gemini/src/main/java/info/bitrich/xchangestream/gemini/GeminiStreamingMarketDataService.java
+++ b/xchange-stream-gemini/src/main/java/info/bitrich/xchangestream/gemini/GeminiStreamingMarketDataService.java
@@ -57,7 +57,7 @@ public class GeminiStreamingMarketDataService implements StreamingMarketDataServ
   @Override
   public Observable<OrderBook> getOrderBook(CurrencyPair currencyPair, Object... args) {
 
-    Integer maxDepth = args.length > 0 ? (Integer) args[0] : null;
+    int maxDepth = args.length > 0 ? (int) args[0] : 0;
 
     Observable<GeminiOrderbook> subscribedOrderbookSnapshot =
         service

--- a/xchange-stream-gemini/src/main/java/info/bitrich/xchangestream/gemini/GeminiStreamingMarketDataService.java
+++ b/xchange-stream-gemini/src/main/java/info/bitrich/xchangestream/gemini/GeminiStreamingMarketDataService.java
@@ -4,6 +4,7 @@ import static org.knowm.xchange.gemini.v1.GeminiAdapters.adaptTrades;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.MoreObjects;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
 import info.bitrich.xchangestream.gemini.dto.GeminiLimitOrder;
 import info.bitrich.xchangestream.gemini.dto.GeminiOrderbook;
@@ -57,7 +58,7 @@ public class GeminiStreamingMarketDataService implements StreamingMarketDataServ
   @Override
   public Observable<OrderBook> getOrderBook(CurrencyPair currencyPair, Object... args) {
 
-    int maxDepth = args.length > 0 ? (int) args[0] : 0;
+    int maxDepth = (int) MoreObjects.firstNonNull(args.length > 0 ? args[0] : null, 0);
 
     Observable<GeminiOrderbook> subscribedOrderbookSnapshot =
         service


### PR DESCRIPTION
Fix a null pointer exception in `GeminiStreamingMarketDataService` class, method `getOrderBook` caused by when `Object... args` is empty it will set `maxDepth` to null which would throw a NPE when we call `GeminiAdaptersX.toOrderbook(geminiOrderbook, maxDepth, new Date())` at the return for `getOrderBook`.

`toOrderBook` method signature is: `public static OrderBook toOrderbook(GeminiOrderbook geminiOrderbook, int maxLevels, Date timestamp)`

`maxLevels` is a primitive int, passing in a null here throws a NPE.

In the fix, instead of setting `maxDepth` to null we set it to zero.