### PR TITLE
[Kraken][Streaming] - Restored original tradeId logic for userTrades stream

### DIFF
--- a/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingTradeService.java
+++ b/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingTradeService.java
@@ -190,7 +190,7 @@ public class KrakenStreamingTradeService implements StreamingTradeService {
         CurrencyPair currencyPair = new CurrencyPair(dto.pair);
         result.add(
             new UserTrade.Builder()
-                .id(dto.postxid)
+                .id(tradeId) // The tradeId should be the key of the map, postxid can be null and is not unique as required for a tradeId
                 .orderId(dto.ordertxid)
                 .currencyPair(currencyPair)
                 .timestamp(dto.time == null ? null : new Date((long) (dto.time * 1000L)))


### PR DESCRIPTION
As per the documentation at https://docs.kraken.com/websockets/#message-ownTrades , the tradeId should be the key of the map element. The current value ( dto.postxid ) is not unique and can be null.