### PR TITLE
Update StreamingTradeService.java

### DIFF
--- a/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingTradeService.java
+++ b/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingTradeService.java
@@ -1,8 +1,11 @@
 package info.bitrich.xchangestream.core;
 
+import java.util.Collection;
+
 import io.reactivex.Observable;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.dto.trade.UserTrade;
 import org.knowm.xchange.exceptions.ExchangeSecurityException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
@@ -55,6 +58,29 @@ public interface StreamingTradeService {
    * @return {@link Observable} that emits {@link UserTrade} when exchange sends the update.
    */
   default Observable<UserTrade> getUserTrades(CurrencyPair currencyPair, Object... args) {
+    throw new NotYetImplementedForExchangeException();
+  }
+
+  /**
+   * Get the changes of open orders for the logged-in user.
+   *
+   * <p><strong>Warning:</strong> there are currently no guarantees that messages will arrive in
+   * order, that messages will not be skipped, or that any initial state message will be sent on
+   * connection. Most exchanges have a recommended approach for managing this, involving timestamps,
+   * sequence numbers and a separate REST API for re-sync when inconsistencies appear. You should
+   * implement these approaches, if required, by combining calls to this method with {@link
+   * TradeService#getOpenOrders()}.
+   *
+   * <p><strong>Emits</strong> {@link
+   * info.bitrich.xchangestream.service.exception.NotConnectedException} When not connected to the
+   * WebSocket API.
+   *
+   * <p><strong>Immediately throws</strong> {@link ExchangeSecurityException} if called without
+   * authentication details
+   *
+   * @return {@link Observable} that emits {@link Order} when exchange sends the update.
+   */
+  default Observable<OpenOrders> getOpenOrders(Object... args) {
     throw new NotYetImplementedForExchangeException();
   }
 }


### PR DESCRIPTION
Not a duplicate of getOrderChanges(), which is not easy to use if we want to keep track of the active open orders.