### PR TITLE
[Streaming][Kraken] Fixed bug that caused `invalid WebSocket Extension handshake` message.

### DIFF
--- a/xchange-stream-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/CoinbaseProStreamingService.java
+++ b/xchange-stream-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/CoinbaseProStreamingService.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import info.bitrich.xchangestream.coinbasepro.dto.CoinbaseProWebSocketSubscriptionMessage;
 import info.bitrich.xchangestream.coinbasepro.dto.CoinbaseProWebSocketTransaction;
-import info.bitrich.xchangestream.coinbasepro.netty.WebSocketClientCompressionAllowClientNoContextHandler;
+import info.bitrich.xchangestream.service.netty.WebSocketClientCompressionAllowClientNoContextHandler;
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.service.netty.JsonNettyStreamingService;
 import info.bitrich.xchangestream.service.netty.StreamingObjectMapperHelper;

--- a/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingService.java
+++ b/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingService.java
@@ -13,6 +13,7 @@ import info.bitrich.xchangestream.kraken.dto.enums.KrakenEventType;
 import info.bitrich.xchangestream.kraken.dto.enums.KrakenSubscriptionName;
 import info.bitrich.xchangestream.service.netty.JsonNettyStreamingService;
 import info.bitrich.xchangestream.service.netty.StreamingObjectMapperHelper;
+import info.bitrich.xchangestream.service.netty.WebSocketClientCompressionAllowClientNoContextHandler;
 import info.bitrich.xchangestream.service.netty.WebSocketClientHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
@@ -23,6 +24,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
+
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandler;
 import org.apache.commons.lang3.StringUtils;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.kraken.dto.account.KrakenWebsocketToken;
@@ -67,6 +70,11 @@ public class KrakenStreamingService extends JsonNettyStreamingService {
   @Override
   public boolean processArrayMessageSeparately() {
     return false;
+  }
+
+  @Override
+  protected WebSocketClientExtensionHandler getWebSocketClientExtensionHandler() {
+    return WebSocketClientCompressionAllowClientNoContextHandler.INSTANCE;
   }
 
   @Override

--- a/xchange-stream-service-netty/src/main/java/info/bitrich/xchangestream/service/netty/WebSocketClientCompressionAllowClientNoContextHandler.java
+++ b/xchange-stream-service-netty/src/main/java/info/bitrich/xchangestream/service/netty/WebSocketClientCompressionAllowClientNoContextHandler.java
@@ -1,4 +1,4 @@
-package info.bitrich.xchangestream.coinbasepro.netty;
+package info.bitrich.xchangestream.service.netty;
 
 import static io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateServerExtensionHandshaker.MAX_WINDOW_SIZE;
 


### PR DESCRIPTION
Fixed a bug in the Kraken streaming client that started today resulting in the following error

```
Caused by: io.netty.handler.codec.CodecException: invalid WebSocket Extension handshake for "permessage-deflate; client_no_context_takeover"
```
Relates to https://github.com/netty/netty/issues/10191 , this change reuses the existing CoinbasePro handler which i moved to streaming-core-netty.