### PR TITLE
change default order book size from 0 to 1

### DIFF
--- a/xchange-stream-gemini/src/main/java/info/bitrich/xchangestream/gemini/GeminiStreamingMarketDataService.java
+++ b/xchange-stream-gemini/src/main/java/info/bitrich/xchangestream/gemini/GeminiStreamingMarketDataService.java
@@ -22,13 +22,9 @@ import org.knowm.xchange.dto.marketdata.Trade;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.gemini.v1.dto.marketdata.GeminiTrade;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Created by Lukas Zaoralek on 15.11.17. */
 public class GeminiStreamingMarketDataService implements StreamingMarketDataService {
-  private static final Logger LOG = LoggerFactory.getLogger(GeminiStreamingMarketDataService.class);
-
   private final GeminiStreamingService service;
   private final Map<CurrencyPair, GeminiOrderbook> orderbooks = new HashMap<>();
 
@@ -58,7 +54,7 @@ public class GeminiStreamingMarketDataService implements StreamingMarketDataServ
   @Override
   public Observable<OrderBook> getOrderBook(CurrencyPair currencyPair, Object... args) {
 
-    int maxDepth = (int) MoreObjects.firstNonNull(args.length > 0 ? args[0] : null, 0);
+    int maxDepth = (int) MoreObjects.firstNonNull(args.length > 0 ? args[0] : null, 1);
 
     Observable<GeminiOrderbook> subscribedOrderbookSnapshot =
         service
@@ -114,7 +110,7 @@ public class GeminiStreamingMarketDataService implements StreamingMarketDataServ
                       LimitOrder firstAsk = orderBook.getAsks().iterator().next();
                       emitter.onNext(
                           new Ticker.Builder()
-                              .currencyPair(currencyPair)
+                              .instrument(currencyPair)
                               .bid(firstBid.getLimitPrice())
                               .bidSize(firstBid.getOriginalAmount())
                               .ask(firstAsk.getLimitPrice())


### PR DESCRIPTION
* Why would you ever want to fetch a zero-depth order book *by default*?
* Calling `getTicker()` fails with a NoSuchElementException because the order book is empty if you don't pass an argument to change it
* Changed a call to `currencyPair()` to `instrument()` to avoid using a deprecated method
* Removed logger and its dependencies because it is unused in this class