### PR TITLE
Fix missing depth parameter in case of call from unsubscribe

### DIFF
--- a/xchange-stream-cexio/src/main/java/info/bitrich/xchangestream/cexio/CexioStreamingRawService.java
+++ b/xchange-stream-cexio/src/main/java/info/bitrich/xchangestream/cexio/CexioStreamingRawService.java
@@ -74,7 +74,10 @@ public class CexioStreamingRawService extends JsonNettyStreamingService {
       case ORDERBOOK:
         {
           CurrencyPair currencyPair = (CurrencyPair) args[0];
-          int depth = (Integer) args[1];
+          int depth = 0;
+          if (args.length > 1 && args[1] instanceof Integer) {
+            depth = (int) args[1];
+          }
           return new CexioWebSocketOrderBookSubscriptionData(currencyPair, isSubscribe, depth);
         }
       default:


### PR DESCRIPTION
When getSubscriptionData is called from

@Override
public String getUnsubscribeMessage(String channelName)

the "depth" parameter is missing, so this check is needed