### PR TITLE
Official name was updated to just "sol" since 2015

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
@@ -188,7 +188,7 @@ public class Currency implements Comparable<Currency>, Serializable {
   public static final Currency OMG = createCurrency("OMG", "OmiseGO", null);
   public static final Currency OMR = createCurrency("OMR", "Omani Rial", null);
   public static final Currency PAB = createCurrency("PAB", "Panamanian Balboa", null);
-  public static final Currency PEN = createCurrency("PEN", "Peruvian Nuevo Sol", null);
+  public static final Currency PEN = createCurrency("PEN", "Peruvian Sol", null);
   public static final Currency PGK = createCurrency("PGK", "Papua New Guinean Kina", null);
   public static final Currency PHP = createCurrency("PHP", "Philippine Peso", null);
   public static final Currency PKR = createCurrency("PKR", "Pakistani Rupee", null);


### PR DESCRIPTION
Official name was changed from "nuevo sol" to simply "sol" in 2015 by congress ruling 30381[1]

1- https://www.bcrp.gob.pe/transparencia/datos-generales/marco-legal/ley-que-cambia-el-nombre-de-la-unidad-monetaria-de-nuevo-sol-a-sol.html