### PR TITLE
Allow to override web socket client extention handler

### DIFF
--- a/xchange-stream-service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
+++ b/xchange-stream-service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
@@ -61,6 +61,8 @@ public abstract class NettyStreamingService<T> extends ConnectableService {
   protected static final Duration DEFAULT_RETRY_DURATION = Duration.ofSeconds(15);
   protected static final int DEFAULT_IDLE_TIMEOUT = 15;
 
+  private static final WebSocketClientExtensionHandler DEFAULT_WEB_SOCKET_HANDLER = WebSocketClientCompressionHandler.INSTANCE;
+
   protected class Subscription {
 
     final ObservableEmitter<T> emitter;
@@ -88,6 +90,7 @@ public abstract class NettyStreamingService<T> extends ConnectableService {
   private volatile NioEventLoopGroup eventLoopGroup;
   protected final Map<String, Subscription> channels = new ConcurrentHashMap<>();
   private boolean compressedMessages = false;
+  private WebSocketClientExtensionHandler webSocketClientExtensionHandler;
 
   private final Subject<Throwable> reconnFailEmitters = PublishSubject.create();
   private final Subject<Object> connectionSuccessEmitters = PublishSubject.create();
@@ -135,6 +138,7 @@ public abstract class NettyStreamingService<T> extends ConnectableService {
     this.retryDuration = retryDuration;
     this.connectionTimeout = connectionTimeout;
     this.idleTimeoutSeconds = idleTimeoutSeconds;
+    this.webSocketClientExtensionHandler = DEFAULT_WEB_SOCKET_HANDLER;
     try {
       this.uri = new URI(apiUrl);
     } catch (URISyntaxException e) {
@@ -508,8 +512,12 @@ public abstract class NettyStreamingService<T> extends ConnectableService {
     emitter.onError(t);
   }
 
+  public void setWebSocketClientExtensionHandler(WebSocketClientExtensionHandler webSocketClientExtensionHandler) {
+    this.webSocketClientExtensionHandler = webSocketClientExtensionHandler;
+  }
+
   protected WebSocketClientExtensionHandler getWebSocketClientExtensionHandler() {
-    return WebSocketClientCompressionHandler.INSTANCE;
+    return webSocketClientExtensionHandler;
   }
 
   protected WebSocketClientHandler getWebSocketClientHandler(


### PR DESCRIPTION
Today I faced with issue that binance exchange start to force 'server_no_context_takeover' flag for handshaker and i received
`io.netty.handler.codec.CodecException: invalid WebSocket Extension handshake for "permessage-deflate; server_no_context_takeover; client_max_window_bits=15"`
I checked sources and there is no way how I can change that behaviour without copy and edit all sources for binance, so I suggest to add method for set custom handler if that needed.