### PR TITLE
[Binance] Add support to BUSD in Binance adapter. Fixes #3741

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAdapters.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAdapters.java
@@ -115,6 +115,8 @@ public class BinanceAdapters {
       return new CurrencyPair(symbol.substring(0, pairLength - 4), "TUSD");
     } else if (symbol.endsWith("USDS")) {
       return new CurrencyPair(symbol.substring(0, pairLength - 4), "USDS");
+    } else if (symbol.endsWith("BUSD")) {
+        return new CurrencyPair(symbol.substring(0, pairLength - 4), "BUSD");
     } else {
       return new CurrencyPair(
           symbol.substring(0, pairLength - 3), symbol.substring(pairLength - 3));


### PR DESCRIPTION
BinanceAdapters has special handling for pair extraction from binance's pair symbol. BUSD was not being handled correctly. For a pair such as "BTCBUSD", the resulting pair was "BTCB/USD" instead of "BTC/BUSD". This commit fixes this issue #3741 