### PR TITLE
Fix: [CryptoFacilities] stopPrice parameter is missing from sendOrder #3934

### DIFF
--- a/xchange-cryptofacilities/src/main/java/org/knowm/xchange/cryptofacilities/CryptoFacilitiesAuthenticated.java
+++ b/xchange-cryptofacilities/src/main/java/org/knowm/xchange/cryptofacilities/CryptoFacilitiesAuthenticated.java
@@ -45,7 +45,8 @@ public interface CryptoFacilitiesAuthenticated extends CryptoFacilities {
       @QueryParam("symbol") String symbol,
       @QueryParam("side") String side,
       @QueryParam("size") BigDecimal size,
-      @QueryParam("limitPrice") BigDecimal limitPrice)
+      @QueryParam("limitPrice") BigDecimal limitPrice,
+      @QueryParam("stopPrice") BigDecimal stopPrice)
       throws IOException;
 
   @POST

--- a/xchange-cryptofacilities/src/main/java/org/knowm/xchange/cryptofacilities/service/CryptoFacilitiesTradeServiceRaw.java
+++ b/xchange-cryptofacilities/src/main/java/org/knowm/xchange/cryptofacilities/service/CryptoFacilitiesTradeServiceRaw.java
@@ -53,7 +53,8 @@ public class CryptoFacilitiesTradeServiceRaw extends CryptoFacilitiesBaseService
             symbol,
             side,
             size,
-            limitPrice);
+            limitPrice,
+            null);
 
     if (ord.isSuccess()) {
       return ord;


### PR DESCRIPTION
Fixes issue #3934

* cryptofacilites fix: add missing stopPrice parameter to sendOrder