### PR TITLE
[btcmarkets] - Restored service unit tests, added post only support

### DIFF
--- a/xchange-btcmarkets/pom.xml
+++ b/xchange-btcmarkets/pom.xml
@@ -30,7 +30,10 @@
             <version>${project.version}</version>
         </dependency>
 
-
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/dto/BTCMarketsOrderFlags.java
+++ b/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/dto/BTCMarketsOrderFlags.java
@@ -5,5 +5,6 @@ import org.knowm.xchange.dto.Order.IOrderFlags;
 public enum BTCMarketsOrderFlags implements IOrderFlags {
   // Time in force, see https://api.btcmarkets.net/doc/v3#tag/Timeinforce
   IOC,
-  FOK
+  FOK,
+  POST_ONLY
 }

--- a/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/dto/v3/trade/BTCMarketsPlaceOrderRequest.java
+++ b/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/dto/v3/trade/BTCMarketsPlaceOrderRequest.java
@@ -10,7 +10,7 @@ public class BTCMarketsPlaceOrderRequest {
   public final String triggerPrice;
   public final String targetAmount;
   public final String timeInForce;
-  public final String postOnly;
+  public final boolean postOnly;
   public final String selfTrade;
   public final String clientOrderId;
 
@@ -23,7 +23,7 @@ public class BTCMarketsPlaceOrderRequest {
       String triggerPrice,
       String targetAmount,
       String timeInForce,
-      String postOnly,
+      boolean postOnly,
       String selfTrade,
       String clientOrderId) {
     this.marketId = marketId;

--- a/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/BTCMarketsTradeService.java
+++ b/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/BTCMarketsTradeService.java
@@ -2,6 +2,7 @@ package org.knowm.xchange.btcmarkets.service;
 
 import static org.knowm.xchange.dto.Order.OrderType.BID;
 
+import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.*;
@@ -61,6 +62,12 @@ public class BTCMarketsTradeService extends BTCMarketsTradeServiceRaw implements
       BTCMarketsOrder.Type orderType,
       Set<Order.IOrderFlags> flags)
       throws IOException {
+    boolean postOnly = false;
+    if (flags.contains(BTCMarketsOrderFlags.POST_ONLY)) {
+      postOnly = true;
+      flags = Sets.filter(flags, flag -> flag != BTCMarketsOrderFlags.POST_ONLY);
+    }
+
     BTCMarketsOrder.Side side =
         orderSide == BID ? BTCMarketsOrder.Side.Bid : BTCMarketsOrder.Side.Ask;
     final String marketId = currencyPair.base.toString() + "-" + currencyPair.counter.toString();
@@ -73,7 +80,7 @@ public class BTCMarketsTradeService extends BTCMarketsTradeServiceRaw implements
       timeInForce = "GTC";
     }
     final BTCMarketsPlaceOrderResponse orderResponse =
-        placeBTCMarketsOrder(marketId, amount, price, side, orderType, timeInForce);
+        placeBTCMarketsOrder(marketId, amount, price, side, orderType, timeInForce, postOnly);
     return orderResponse.orderId;
   }
 

--- a/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/BTCMarketsTradeServiceRaw.java
+++ b/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/BTCMarketsTradeServiceRaw.java
@@ -24,7 +24,8 @@ public class BTCMarketsTradeServiceRaw extends BTCMarketsBaseService {
       BigDecimal price,
       BTCMarketsOrder.Side side,
       BTCMarketsOrder.Type type,
-      String timeInForce)
+      String timeInForce,
+      boolean postOnly)
       throws IOException {
     return btcmv3.placeOrder(
         exchange.getExchangeSpecification().getApiKey(),
@@ -39,7 +40,7 @@ public class BTCMarketsTradeServiceRaw extends BTCMarketsBaseService {
             null,
             null,
             timeInForce,
-            null,
+            postOnly,
             null,
             null));
   }

--- a/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/service/BTCMarketsAccountServiceTest.java
+++ b/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/service/BTCMarketsAccountServiceTest.java
@@ -1,247 +1,167 @@
 package org.knowm.xchange.btcmarkets.service;
 
-// Note:
-//    I tried my best to get powermock to work after adding a logback.xml file to suppress verbose
-// logging but there are some Java 9* issues
-//    arising with powermock that I just cannot resolve. Therefore I decided to comment out all the
-// powermock code in this module since it's the
-//    only module using powermock. The dependencies have also been removed from the project.
-// Hopefully someone will upgrade all these test to use
-//    Mokito.
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
-// import static org.assertj.core.api.Assertions.assertThat;
-// import static org.mockito.ArgumentMatchers.any;
-// import static org.mockito.ArgumentMatchers.eq;
-// import static org.mockito.BDDMockito.given;
-// import static org.powermock.api.mockito.PowerMockito.mock;
-// import static org.powermock.api.mockito.PowerMockito.when;
-//
-// import java.io.IOException;
-// import java.math.BigDecimal;
-// import java.util.Arrays;
-// import java.util.Date;
-// import java.util.List;
-//
-// import org.junit.Before;
-// import org.junit.Test;
-// import org.junit.runner.RunWith;
-// import org.knowm.xchange.ExchangeFactory;
-// import org.knowm.xchange.ExchangeSpecification;
-// import org.knowm.xchange.btcmarkets.BTCMarkets;
-// import org.knowm.xchange.btcmarkets.BTCMarketsAuthenticated;
-// import org.knowm.xchange.btcmarkets.BTCMarketsAuthenticatedV3;
-// import org.knowm.xchange.btcmarkets.BTCMarketsExchange;
-// import org.knowm.xchange.btcmarkets.BtcMarketsAssert;
-// import org.knowm.xchange.btcmarkets.dto.account.BTCMarketsBalance;
-// import org.knowm.xchange.btcmarkets.dto.account.BTCMarketsFundtransfer;
-// import org.knowm.xchange.btcmarkets.dto.account.BTCMarketsFundtransferHistoryResponse;
-// import org.knowm.xchange.btcmarkets.dto.trade.BTCMarketsWithdrawCryptoRequest;
-// import org.knowm.xchange.btcmarkets.dto.trade.BTCMarketsWithdrawCryptoResponse;
-// import org.knowm.xchange.btcmarkets.dto.v3.account.BTCMarketsAddressesResponse;
-// import org.knowm.xchange.client.ExchangeRestProxyBuilder;
-// import org.knowm.xchange.currency.Currency;
-// import org.knowm.xchange.dto.account.AccountInfo;
-// import org.knowm.xchange.dto.account.FundingRecord;
-// import org.knowm.xchange.service.trade.params.RippleWithdrawFundsParams;
-// import org.mockito.ArgumentCaptor;
-// import org.mockito.Mockito;
-// import org.powermock.api.mockito.PowerMockito;
-// import org.powermock.core.classloader.annotations.PrepareForTest;
-// import org.powermock.modules.junit4.PowerMockRunner;
-//
-// import si.mazi.rescu.SynchronizedValueFactory;
-//
-// @RunWith(PowerMockRunner.class)
-// @PrepareForTest(ExchangeRestProxyBuilder.class)
-public class BTCMarketsAccountServiceTest extends BTCMarketsTestSupport {
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import org.junit.Test;
+import org.knowm.xchange.btcmarkets.BtcMarketsAssert;
+import org.knowm.xchange.btcmarkets.dto.account.BTCMarketsBalance;
+import org.knowm.xchange.btcmarkets.dto.account.BTCMarketsFundtransfer;
+import org.knowm.xchange.btcmarkets.dto.account.BTCMarketsFundtransferHistoryResponse;
+import org.knowm.xchange.btcmarkets.dto.trade.BTCMarketsWithdrawCryptoRequest;
+import org.knowm.xchange.btcmarkets.dto.trade.BTCMarketsWithdrawCryptoResponse;
+import org.knowm.xchange.btcmarkets.dto.v3.account.BTCMarketsAddressesResponse;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.dto.account.AccountInfo;
+import org.knowm.xchange.dto.account.FundingRecord;
+import org.knowm.xchange.service.trade.params.RippleWithdrawFundsParams;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import si.mazi.rescu.SynchronizedValueFactory;
 
-  //  private BTCMarketsAuthenticated btcm;
-  //  private BTCMarketsAuthenticatedV3 btcmv3;
-  //  private BTCMarkets btcMarkets;
-  //  private BTCMarketsAccountService accountService;
-  //
-  //  @Before
-  //  public void setUp() {
-  //    btcm = mock(BTCMarketsAuthenticated.class);
-  //    btcmv3 = mock(BTCMarketsAuthenticatedV3.class);
-  //    PowerMockito.mockStatic(ExchangeRestProxyBuilder.class);
-  //
-  //    final ExchangeSpecification defaultExchangeSpecification =
-  //        new BTCMarketsExchange().getDefaultExchangeSpecification();
-  //
-  //    ExchangeRestProxyBuilder<BTCMarketsAuthenticated> exchangeRestProxyBuilderMock =
-  //        mock(ExchangeRestProxyBuilder.class);
-  //    given(
-  //            ExchangeRestProxyBuilder.forInterface(
-  //                eq(BTCMarketsAuthenticated.class), eq(defaultExchangeSpecification)))
-  //        .willReturn(exchangeRestProxyBuilderMock);
-  //    ExchangeRestProxyBuilder<BTCMarketsAuthenticatedV3> exchangeRestProxyBuilderV3Mock =
-  //        mock(ExchangeRestProxyBuilder.class);
-  //    ExchangeRestProxyBuilder<BTCMarkets> exchangeRestProxyBuilderBTCMarketsMock =
-  //        mock(ExchangeRestProxyBuilder.class);
-  //
-  //    given(ExchangeRestProxyBuilder.forInterface(eq(BTCMarketsAuthenticated.class), any()))
-  //        .willReturn(exchangeRestProxyBuilderMock);
-  //    given(ExchangeRestProxyBuilder.forInterface(eq(BTCMarketsAuthenticatedV3.class), any()))
-  //        .willReturn(exchangeRestProxyBuilderV3Mock);
-  //    given(ExchangeRestProxyBuilder.forInterface(eq(BTCMarkets.class), any()))
-  //        .willReturn(exchangeRestProxyBuilderBTCMarketsMock);
-  //
-  //    when(exchangeRestProxyBuilderMock.build()).thenReturn(btcm);
-  //    when(exchangeRestProxyBuilderV3Mock.build()).thenReturn(btcmv3);
-  //    when(exchangeRestProxyBuilderBTCMarketsMock.build()).thenReturn(btcMarkets);
-  //    BTCMarketsExchange exchange =
-  //        (BTCMarketsExchange)
-  //
-  // ExchangeFactory.INSTANCE.createExchange(BTCMarketsExchange.class.getCanonicalName());
-  //    ExchangeSpecification specification = exchange.getExchangeSpecification();
-  //    specification.setUserName(SPECIFICATION_USERNAME);
-  //    specification.setApiKey(SPECIFICATION_API_KEY);
-  //    specification.setSecretKey(SPECIFICATION_SECRET_KEY);
-  //
-  //    accountService = new BTCMarketsAccountService(exchange);
-  //  }
-  //
-  //  @Test
-  //  public void shouldCreateAccountInfo() throws IOException {
-  //    // given
-  //    BTCMarketsBalance balance = parse(BTCMarketsBalance.class);
-  //
-  //    PowerMockito.when(
-  //            btcm.getBalance(
-  //                Mockito.eq(SPECIFICATION_API_KEY),
-  //                Mockito.any(SynchronizedValueFactory.class),
-  //                Mockito.any(BTCMarketsDigest.class)))
-  //        .thenReturn(Arrays.asList(balance));
-  //
-  //    // when
-  //    AccountInfo accountInfo = accountService.getAccountInfo();
-  //
-  //    // then
-  //    assertThat(accountInfo.getUsername()).isEqualTo(SPECIFICATION_USERNAME);
-  //    assertThat(accountInfo.getTradingFee()).isNull();
-  //    assertThat(accountInfo.getWallets()).hasSize(1);
-  //
-  //    BtcMarketsAssert.assertEquals(
-  //        accountInfo.getWallet().getBalance(Currency.BTC), EXPECTED_BALANCE);
-  //  }
-  //
-  //  @Test
-  //  public void withdrawFundsShouldReturnNull() throws IOException {
-  //
-  //    String status = "the-status"; // maybe the id would be more useful?
-  //    BTCMarketsWithdrawCryptoResponse response =
-  //        new BTCMarketsWithdrawCryptoResponse(
-  //            true, null, null, status, "id", "desc", "ccy", BigDecimal.ONE, BigDecimal.ONE, 0L);
-  //
-  //    PowerMockito.when(
-  //            btcm.withdrawCrypto(
-  //                Mockito.eq(SPECIFICATION_API_KEY),
-  //                Mockito.any(SynchronizedValueFactory.class),
-  //                Mockito.any(BTCMarketsDigest.class),
-  //                Mockito.any(BTCMarketsWithdrawCryptoRequest.class)))
-  //        .thenReturn(response);
-  //
-  //    // when
-  //    String result = accountService.withdrawFunds(Currency.BTC, BigDecimal.TEN, "any address");
-  //
-  //    assertThat(result).isNull();
-  //  }
-  //
-  //  @Test
-  //  public void withdrawFundsShouldAppendRippleTag() throws IOException {
-  //
-  //    String status = "the-status"; // maybe the id would be more useful?
-  //    BTCMarketsWithdrawCryptoResponse response =
-  //        new BTCMarketsWithdrawCryptoResponse(
-  //            true, null, null, status, "id", "desc", "ccy", BigDecimal.ONE, BigDecimal.ONE, 0L);
-  //    ArgumentCaptor<BTCMarketsWithdrawCryptoRequest> captor =
-  //        ArgumentCaptor.forClass(BTCMarketsWithdrawCryptoRequest.class);
-  //
-  //    PowerMockito.when(
-  //            btcm.withdrawCrypto(
-  //                Mockito.eq(SPECIFICATION_API_KEY),
-  //                Mockito.any(SynchronizedValueFactory.class),
-  //                Mockito.any(BTCMarketsDigest.class),
-  //                captor.capture()))
-  //        .thenReturn(response);
-  //
-  //    // when
-  //    RippleWithdrawFundsParams params =
-  //        new RippleWithdrawFundsParams("any address", Currency.BTC, BigDecimal.TEN, "12345");
-  //    String result = accountService.withdrawFunds(params);
-  //    assertThat(captor.getValue().address).isEqualTo("any address?dt=12345");
-  //    assertThat(result).isNull();
-  //  }
-  //
-  //  @Test
-  //  public void shouldRequestDepositAddress() throws IOException {
-  //    BTCMarketsAddressesResponse response = new BTCMarketsAddressesResponse("address");
-  //
-  //    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-  //
-  //    PowerMockito.when(
-  //            btcmv3.depositAddress(
-  //                Mockito.eq(SPECIFICATION_API_KEY),
-  //                Mockito.any(SynchronizedValueFactory.class),
-  //                Mockito.any(BTCMarketsDigestV3.class),
-  //                captor.capture()))
-  //        .thenReturn(response);
-  //    // when
-  //    String address = accountService.requestDepositAddress(Currency.BTC);
-  //
-  //    // then
-  //    assertThat(captor.getValue()).isEqualTo("BTC");
-  //    assertThat(address).isEqualTo("address");
-  //  }
-  //
-  //  @Test
-  //  public void getFundingHistoryShouldReturnFundingRecors() throws IOException {
-  //    Date creationTime = new Date();
-  //    Date lastUpdate = new Date();
-  //    BTCMarketsFundtransfer fundtransfer =
-  //        new BTCMarketsFundtransfer(
-  //            "Complete",
-  //            lastUpdate,
-  //            BigDecimal.ONE,
-  //            "desc",
-  //            null,
-  //            creationTime,
-  //            12345L,
-  //            new BTCMarketsFundtransfer.CryptoPaymentDetail("tx1", "address"),
-  //            "BTC",
-  //            BigDecimal.valueOf(123.45),
-  //            "DEPOSIT");
-  //
-  //    BTCMarketsFundtransferHistoryResponse response =
-  //        new BTCMarketsFundtransferHistoryResponse(
-  //            true,
-  //            null,
-  //            null,
-  //            Arrays.asList(fundtransfer),
-  //            new BTCMarketsFundtransferHistoryResponse.Paging("12345", "12345"));
-  //
-  //    PowerMockito.when(
-  //            btcm.fundtransferHistory(
-  //                Mockito.eq(SPECIFICATION_API_KEY),
-  //                Mockito.any(SynchronizedValueFactory.class),
-  //                Mockito.any(BTCMarketsDigest.class)))
-  //        .thenReturn(response);
-  //
-  //    // when
-  //    List<FundingRecord> result =
-  //        accountService.getFundingHistory(accountService.createFundingHistoryParams());
-  //    assertThat(result).hasSize(1);
-  //    assertThat(result.get(0).getType()).isEqualTo(FundingRecord.Type.DEPOSIT);
-  //    assertThat(result.get(0).getStatus()).isEqualTo(FundingRecord.Status.COMPLETE);
-  //    assertThat(result.get(0).getCurrency()).isEqualTo(Currency.BTC);
-  //    assertThat(result.get(0).getInternalId()).isEqualTo("12345");
-  //    assertThat(result.get(0).getFee()).isEqualTo(BigDecimal.ONE);
-  //    assertThat(result.get(0).getDescription()).isEqualTo("desc");
-  //    assertThat(result.get(0).getDate()).isEqualTo(creationTime);
-  //    assertThat(result.get(0).getBlockchainTransactionHash()).isEqualTo("tx1");
-  //    assertThat(result.get(0).getBalance()).isNull();
-  //    assertThat(result.get(0).getAmount()).isEqualTo(BigDecimal.valueOf(123.45));
-  //    assertThat(result.get(0).getAddress()).isEqualTo("address");
-  //  }
+public class BTCMarketsAccountServiceTest extends BTCMarketsServiceTest {
+
+  @Test
+  public void shouldCreateAccountInfo() throws IOException {
+    // given
+    BTCMarketsBalance balance = parse(BTCMarketsBalance.class);
+
+    when(btcMarketsAuthenticated.getBalance(
+            Mockito.eq(SPECIFICATION_API_KEY),
+            Mockito.any(SynchronizedValueFactory.class),
+            Mockito.any(BTCMarketsDigest.class)))
+        .thenReturn(Arrays.asList(balance));
+
+    // when
+    AccountInfo accountInfo = btcMarketsAccountService.getAccountInfo();
+
+    // then
+    assertThat(accountInfo.getTradingFee()).isNull();
+    assertThat(accountInfo.getWallets()).hasSize(1);
+
+    BtcMarketsAssert.assertEquals(
+        accountInfo.getWallet().getBalance(Currency.BTC), EXPECTED_BALANCE);
+  }
+
+  @Test
+  public void withdrawFundsShouldReturnNull() throws IOException {
+
+    String status = "the-status"; // maybe the id would be more useful?
+    BTCMarketsWithdrawCryptoResponse response =
+        new BTCMarketsWithdrawCryptoResponse(
+            true, null, null, status, "id", "desc", "ccy", BigDecimal.ONE, BigDecimal.ONE, 0L);
+
+    when(btcMarketsAuthenticated.withdrawCrypto(
+            Mockito.eq(SPECIFICATION_API_KEY),
+            Mockito.any(SynchronizedValueFactory.class),
+            Mockito.any(BTCMarketsDigest.class),
+            Mockito.any(BTCMarketsWithdrawCryptoRequest.class)))
+        .thenReturn(response);
+
+    // when
+    String result =
+        btcMarketsAccountService.withdrawFunds(Currency.BTC, BigDecimal.TEN, "any address");
+
+    assertThat(result).isNull();
+  }
+
+  @Test
+  public void withdrawFundsShouldAppendRippleTag() throws IOException {
+
+    String status = "the-status"; // maybe the id would be more useful?
+    BTCMarketsWithdrawCryptoResponse response =
+        new BTCMarketsWithdrawCryptoResponse(
+            true, null, null, status, "id", "desc", "ccy", BigDecimal.ONE, BigDecimal.ONE, 0L);
+    ArgumentCaptor<BTCMarketsWithdrawCryptoRequest> captor =
+        ArgumentCaptor.forClass(BTCMarketsWithdrawCryptoRequest.class);
+
+    when(btcMarketsAuthenticated.withdrawCrypto(
+            Mockito.eq(SPECIFICATION_API_KEY),
+            Mockito.any(SynchronizedValueFactory.class),
+            Mockito.any(BTCMarketsDigest.class),
+            captor.capture()))
+        .thenReturn(response);
+
+    // when
+    RippleWithdrawFundsParams params =
+        new RippleWithdrawFundsParams("any address", Currency.BTC, BigDecimal.TEN, "12345");
+    String result = btcMarketsAccountService.withdrawFunds(params);
+    assertThat(captor.getValue().address).isEqualTo("any address?dt=12345");
+    assertThat(result).isNull();
+  }
+
+  @Test
+  public void shouldRequestDepositAddress() throws IOException {
+    BTCMarketsAddressesResponse response = new BTCMarketsAddressesResponse("address");
+
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+
+    when(btcMarketsAuthenticatedV3.depositAddress(
+            Mockito.eq(SPECIFICATION_API_KEY),
+            Mockito.any(SynchronizedValueFactory.class),
+            Mockito.any(BTCMarketsDigestV3.class),
+            captor.capture()))
+        .thenReturn(response);
+    // when
+    String address = btcMarketsAccountService.requestDepositAddress(Currency.BTC);
+
+    // then
+    assertThat(captor.getValue()).isEqualTo("BTC");
+    assertThat(address).isEqualTo("address");
+  }
+
+  @Test
+  public void getFundingHistoryShouldReturnFundingRecors() throws IOException {
+    Date creationTime = new Date();
+    Date lastUpdate = new Date();
+    BTCMarketsFundtransfer fundtransfer =
+        new BTCMarketsFundtransfer(
+            "Complete",
+            lastUpdate,
+            BigDecimal.ONE,
+            "desc",
+            null,
+            creationTime,
+            12345L,
+            new BTCMarketsFundtransfer.CryptoPaymentDetail("tx1", "address"),
+            "BTC",
+            BigDecimal.valueOf(123.45),
+            "DEPOSIT");
+
+    BTCMarketsFundtransferHistoryResponse response =
+        new BTCMarketsFundtransferHistoryResponse(
+            true,
+            null,
+            null,
+            Arrays.asList(fundtransfer),
+            new BTCMarketsFundtransferHistoryResponse.Paging("12345", "12345"));
+
+    when(btcMarketsAuthenticated.fundtransferHistory(
+            Mockito.eq(SPECIFICATION_API_KEY),
+            Mockito.any(SynchronizedValueFactory.class),
+            Mockito.any(BTCMarketsDigest.class)))
+        .thenReturn(response);
+
+    // when
+    List<FundingRecord> result =
+        btcMarketsAccountService.getFundingHistory(
+            btcMarketsAccountService.createFundingHistoryParams());
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getType()).isEqualTo(FundingRecord.Type.DEPOSIT);
+    assertThat(result.get(0).getStatus()).isEqualTo(FundingRecord.Status.COMPLETE);
+    assertThat(result.get(0).getCurrency()).isEqualTo(Currency.BTC);
+    assertThat(result.get(0).getInternalId()).isEqualTo("12345");
+    assertThat(result.get(0).getFee()).isEqualTo(BigDecimal.ONE);
+    assertThat(result.get(0).getDescription()).isEqualTo("desc");
+    assertThat(result.get(0).getDate()).isEqualTo(creationTime);
+    assertThat(result.get(0).getBlockchainTransactionHash()).isEqualTo("tx1");
+    assertThat(result.get(0).getBalance()).isNull();
+    assertThat(result.get(0).getAmount()).isEqualTo(BigDecimal.valueOf(123.45));
+    assertThat(result.get(0).getAddress()).isEqualTo("address");
+  }
 }

--- a/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/service/BTCMarketsMarketDataServiceTest.java
+++ b/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/service/BTCMarketsMarketDataServiceTest.java
@@ -1,143 +1,71 @@
 package org.knowm.xchange.btcmarkets.service;
 
-// Note:
-//    I tried my best to get powermock to work after adding a logback.xml file to suppress verbose
-// logging but there are some Java 9* issues
-//    arising with powermock that I just cannot resolve. Therefore I decided to comment out all the
-// powermock code in this module since it's the
-//    only module using powermock. The dependencies have also been removed from the project.
-// Hopefully someone will upgrade all these test to use
-//    Mokito.
-// import static org.assertj.core.api.Assertions.assertThat;
-// import static org.assertj.core.api.Assertions.fail;
-// import static org.mockito.ArgumentMatchers.any;
-// import static org.mockito.ArgumentMatchers.eq;
-// import static org.mockito.BDDMockito.given;
-// import static org.powermock.api.mockito.PowerMockito.mock;
-//
-// import java.io.IOException;
-// import java.util.List;
-// import org.junit.Before;
-// import org.junit.Test;
-// import org.junit.runner.RunWith;
-// import org.knowm.xchange.ExchangeFactory;
-// import org.knowm.xchange.ExchangeSpecification;
-// import org.knowm.xchange.btcmarkets.BTCMarkets;
-// import org.knowm.xchange.btcmarkets.BTCMarketsAuthenticated;
-// import org.knowm.xchange.btcmarkets.BTCMarketsAuthenticatedV3;
-// import org.knowm.xchange.btcmarkets.BTCMarketsExchange;
-// import org.knowm.xchange.btcmarkets.BtcMarketsAssert;
-// import org.knowm.xchange.btcmarkets.dto.marketdata.BTCMarketsOrderBook;
-// import org.knowm.xchange.client.ExchangeRestProxyBuilder;
-// import org.knowm.xchange.currency.CurrencyPair;
-// import org.knowm.xchange.dto.marketdata.OrderBook;
-// import org.knowm.xchange.dto.marketdata.Ticker;
-// import org.knowm.xchange.dto.trade.LimitOrder;
-// import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
-// import org.powermock.api.mockito.PowerMockito;
-// import org.powermock.core.classloader.annotations.PrepareForTest;
-// import org.powermock.modules.junit4.PowerMockRunner;
-//
-// @RunWith(PowerMockRunner.class)
-// @PrepareForTest(ExchangeRestProxyBuilder.class)
-public class BTCMarketsMarketDataServiceTest extends BTCMarketsTestSupport {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.when;
 
-  //  private BTCMarkets btcmarkets;
-  //  private BTCMarketsMarketDataService marketDataService;
-  //
-  //  @Before
-  //  public void setUp() {
-  //    btcmarkets = mock(BTCMarkets.class);
-  //    BTCMarketsAuthenticated btcMarketsAuthenticated = mock(BTCMarketsAuthenticated.class);
-  //    BTCMarketsAuthenticatedV3 btcMarketsAuthenticatedV3 = mock(BTCMarketsAuthenticatedV3.class);
-  //    PowerMockito.mockStatic(ExchangeRestProxyBuilder.class);
-  //
-  //    ExchangeRestProxyBuilder<BTCMarkets> exchangeRestProxyBuilderBtcMarketsMock =
-  //        mock(ExchangeRestProxyBuilder.class);
-  //    given(ExchangeRestProxyBuilder.forInterface(eq(BTCMarkets.class), any()))
-  //        .willReturn(exchangeRestProxyBuilderBtcMarketsMock);
-  //    given(exchangeRestProxyBuilderBtcMarketsMock.build()).willReturn(btcmarkets);
-  //
-  //    ExchangeRestProxyBuilder<BTCMarketsAuthenticated>
-  //        exchangeRestProxyBuilderBTCMarketsAuthenticatedMock =
-  // mock(ExchangeRestProxyBuilder.class);
-  //    given(ExchangeRestProxyBuilder.forInterface(eq(BTCMarketsAuthenticated.class), any()))
-  //        .willReturn(exchangeRestProxyBuilderBTCMarketsAuthenticatedMock);
-  //    given(exchangeRestProxyBuilderBTCMarketsAuthenticatedMock.build())
-  //        .willReturn(btcMarketsAuthenticated);
-  //
-  //    ExchangeRestProxyBuilder<BTCMarketsAuthenticatedV3>
-  //        exchangeRestProxyBuilderBTCMarketsAuthenticatedV3Mock =
-  //            mock(ExchangeRestProxyBuilder.class);
-  //    given(ExchangeRestProxyBuilder.forInterface(eq(BTCMarketsAuthenticatedV3.class), any()))
-  //        .willReturn(exchangeRestProxyBuilderBTCMarketsAuthenticatedV3Mock);
-  //    given(exchangeRestProxyBuilderBTCMarketsAuthenticatedV3Mock.build())
-  //        .willReturn(btcMarketsAuthenticatedV3);
-  //
-  //    BTCMarketsExchange exchange =
-  //        (BTCMarketsExchange)
-  //
-  // ExchangeFactory.INSTANCE.createExchange(BTCMarketsExchange.class.getCanonicalName());
-  //    ExchangeSpecification specification = exchange.getExchangeSpecification();
-  //    specification.setUserName(SPECIFICATION_USERNAME);
-  //    specification.setApiKey(SPECIFICATION_API_KEY);
-  //    specification.setSecretKey(SPECIFICATION_SECRET_KEY);
-  //
-  //    marketDataService = new BTCMarketsMarketDataService(exchange);
-  //  }
-  //
-  //  @Test
-  //  public void shouldGetTicker() throws IOException {
-  //    // given
-  //    PowerMockito.when(btcmarkets.getTicker("BTC",
-  // "AUD")).thenReturn(EXPECTED_BTC_MARKETS_TICKER);
-  //
-  //    // when
-  //    Ticker ticker = marketDataService.getTicker(CurrencyPair.BTC_AUD);
-  //
-  //    // then
-  //    BtcMarketsAssert.assertEquals(ticker, EXPECTED_TICKER);
-  //  }
-  //
-  //  @Test
-  //  public void shouldGetOrderBook() throws IOException {
-  //    // given
-  //    final LimitOrder[] expectedAsks = expectedAsks();
-  //    final LimitOrder[] expectedBids = expectedBids();
-  //
-  //    BTCMarketsOrderBook orderBookMock =
-  //        parse("org/knowm/xchange/btcmarkets/dto/" + "ShortOrderBook",
-  // BTCMarketsOrderBook.class);
-  //
-  //    PowerMockito.when(btcmarkets.getOrderBook("BTC", "AUD")).thenReturn(orderBookMock);
-  //
-  //    // when
-  //    OrderBook orderBook = marketDataService.getOrderBook(CurrencyPair.BTC_AUD);
-  //
-  //    // then
-  //    assertThat(orderBook.getTimeStamp().getTime()).isEqualTo(1442997827000L);
-  //
-  //    List<LimitOrder> asks = orderBook.getAsks();
-  //    assertThat(asks).hasSize(3);
-  //    for (int i = 0; i < asks.size(); i++) {
-  //      BtcMarketsAssert.assertEquals(asks.get(i), expectedAsks[i]);
-  //    }
-  //
-  //    List<LimitOrder> bids = orderBook.getBids();
-  //    assertThat(bids).hasSize(2);
-  //    for (int i = 0; i < bids.size(); i++) {
-  //      BtcMarketsAssert.assertEquals(bids.get(i), expectedBids[i]);
-  //    }
-  //  }
-  //
-  //  @Test(expected = NotYetImplementedForExchangeException.class)
-  //  public void shouldFailWhenGetTrades() throws IOException {
-  //    // when
-  //    marketDataService.getTrades(CurrencyPair.BTC_AUD);
-  //
-  //    // then
-  //    fail(
-  //        "BTCMarketsMarketDataService should throw NotYetImplementedForExchangeException when
-  // call getTrades");
-  //  }
+import java.io.IOException;
+import java.util.List;
+import org.junit.Test;
+import org.knowm.xchange.btcmarkets.BtcMarketsAssert;
+import org.knowm.xchange.btcmarkets.dto.marketdata.BTCMarketsOrderBook;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.marketdata.Ticker;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
+
+public class BTCMarketsMarketDataServiceTest extends BTCMarketsServiceTest {
+
+  @Test
+  public void shouldGetTicker() throws IOException {
+    // given
+    when(btcMarkets.getTicker("BTC", "AUD")).thenReturn(EXPECTED_BTC_MARKETS_TICKER);
+
+    // when
+    Ticker ticker = btcMarketsMarketDataService.getTicker(CurrencyPair.BTC_AUD);
+
+    // then
+    BtcMarketsAssert.assertEquals(ticker, EXPECTED_TICKER);
+  }
+
+  @Test
+  public void shouldGetOrderBook() throws IOException {
+    // given
+    final LimitOrder[] expectedAsks = expectedAsks();
+    final LimitOrder[] expectedBids = expectedBids();
+
+    BTCMarketsOrderBook orderBookMock =
+        parse("org/knowm/xchange/btcmarkets/dto/" + "ShortOrderBook", BTCMarketsOrderBook.class);
+
+    when(btcMarkets.getOrderBook("BTC", "AUD")).thenReturn(orderBookMock);
+
+    // when
+    OrderBook orderBook = btcMarketsMarketDataService.getOrderBook(CurrencyPair.BTC_AUD);
+
+    // then
+    assertThat(orderBook.getTimeStamp().getTime()).isEqualTo(1442997827000L);
+
+    List<LimitOrder> asks = orderBook.getAsks();
+    assertThat(asks).hasSize(3);
+    for (int i = 0; i < asks.size(); i++) {
+      BtcMarketsAssert.assertEquals(asks.get(i), expectedAsks[i]);
+    }
+
+    List<LimitOrder> bids = orderBook.getBids();
+    assertThat(bids).hasSize(2);
+    for (int i = 0; i < bids.size(); i++) {
+      BtcMarketsAssert.assertEquals(bids.get(i), expectedBids[i]);
+    }
+  }
+
+  @Test(expected = NotYetImplementedForExchangeException.class)
+  public void shouldFailWhenGetTrades() throws IOException {
+    // when
+    btcMarketsMarketDataService.getTrades(CurrencyPair.BTC_AUD);
+
+    // then
+    fail(
+        "BTCMarketsMarketDataService should throw NotYetImplementedForExchangeException when call getTrades");
+  }
 }

--- a/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/service/BTCMarketsServiceTest.java
+++ b/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/service/BTCMarketsServiceTest.java
@@ -1,0 +1,63 @@
+package org.knowm.xchange.btcmarkets.service;
+
+import org.junit.Before;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.btcmarkets.BTCMarkets;
+import org.knowm.xchange.btcmarkets.BTCMarketsAuthenticated;
+import org.knowm.xchange.btcmarkets.BTCMarketsAuthenticatedV3;
+import org.knowm.xchange.btcmarkets.BTCMarketsExchange;
+import org.mockito.Mockito;
+
+abstract class BTCMarketsServiceTest extends BTCMarketsTestSupport {
+  protected BTCMarketsExchange exchange;
+  protected BTCMarketsTradeService btcMarketsTradeService;
+  protected BTCMarketsAccountService btcMarketsAccountService;
+  protected BTCMarketsMarketDataService btcMarketsMarketDataService;
+
+  protected BTCMarketsAuthenticatedV3 btcMarketsAuthenticatedV3;
+  protected BTCMarketsAuthenticated btcMarketsAuthenticated;
+  protected BTCMarkets btcMarkets;
+
+  @Before
+  public void setUp() throws Exception {
+    ExchangeSpecification specification =
+        ExchangeFactory.INSTANCE
+            .createExchange(BTCMarketsExchange.class)
+            .getDefaultExchangeSpecification();
+    specification.setApiKey(SPECIFICATION_API_KEY);
+    specification.setSecretKey(SPECIFICATION_SECRET_KEY);
+    exchange = (BTCMarketsExchange) ExchangeFactory.INSTANCE.createExchange(specification);
+
+    btcMarketsTradeService = (BTCMarketsTradeService) exchange.getTradeService();
+    btcMarketsAccountService = (BTCMarketsAccountService) exchange.getAccountService();
+    btcMarketsMarketDataService = (BTCMarketsMarketDataService) exchange.getMarketDataService();
+
+    btcMarketsAuthenticatedV3 = Mockito.mock(BTCMarketsAuthenticatedV3.class);
+    btcMarketsAuthenticated = Mockito.mock(BTCMarketsAuthenticated.class);
+    btcMarkets = Mockito.mock(BTCMarkets.class);
+
+    setMock(
+        BTCMarketsBaseService.class.getDeclaredField("btcmv3"),
+        btcMarketsTradeService,
+        btcMarketsAuthenticatedV3);
+    setMock(
+        BTCMarketsBaseService.class.getDeclaredField("btcm"),
+        btcMarketsTradeService,
+        btcMarketsAuthenticated);
+
+    setMock(
+        BTCMarketsBaseService.class.getDeclaredField("btcmv3"),
+        btcMarketsAccountService,
+        btcMarketsAuthenticatedV3);
+    setMock(
+        BTCMarketsBaseService.class.getDeclaredField("btcm"),
+        btcMarketsAccountService,
+        btcMarketsAuthenticated);
+
+    setMock(
+        BTCMarketsBaseService.class.getDeclaredField("btcmPublic"),
+        btcMarketsMarketDataService,
+        btcMarkets);
+  }
+}

--- a/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/service/BTCMarketsTestSupport.java
+++ b/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/service/BTCMarketsTestSupport.java
@@ -1,5 +1,6 @@
 package org.knowm.xchange.btcmarkets.service;
 
+import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,7 +26,11 @@ import org.knowm.xchange.dto.trade.UserTrade;
 /** Test utilities for btnmarkets tests. */
 public class BTCMarketsTestSupport extends BTCMarketsDtoTestSupport {
 
-  protected static final String SPECIFICATION_USERNAME = "admin";
+  static void setMock(Field field, Object instance, Object newValue) throws Exception {
+    field.setAccessible(true);
+    field.set(instance, newValue);
+  }
+
   protected static final String SPECIFICATION_API_KEY =
       Base64.getEncoder().encodeToString("publicKey".getBytes());
   protected static final String SPECIFICATION_SECRET_KEY =

--- a/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/service/BTCMarketsTradeServiceTest.java
+++ b/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/service/BTCMarketsTradeServiceTest.java
@@ -1,208 +1,193 @@
 package org.knowm.xchange.btcmarkets.service;
 
-// Note:
-//    I tried my best to get powermock to work after adding a logback.xml file to suppress verbose
-// logging but there are some Java 9* issues
-//    arising with powermock that I just cannot resolve. Therefore I decided to comment out all the
-// powermock code in this module since it's the
-//    only module using powermock. The dependencies have also been removed from the project.
-// Hopefully someone will upgrade all these test to use
-//    Mokito.
-// import static org.assertj.core.api.Assertions.assertThat;
-// import static org.powermock.api.mockito.PowerMockito.mock;
-//
-// import java.io.IOException;
-// import java.math.BigDecimal;
-// import java.util.*;
-// import org.junit.Before;
-// import org.junit.Test;
-// import org.junit.runner.RunWith;
-// import org.knowm.xchange.ExchangeFactory;
-// import org.knowm.xchange.btcmarkets.BTCMarketsAuthenticated;
-// import org.knowm.xchange.btcmarkets.BTCMarketsAuthenticatedV3;
-// import org.knowm.xchange.btcmarkets.BTCMarketsExchange;
-// import org.knowm.xchange.btcmarkets.dto.BTCMarketsException;
-// import org.knowm.xchange.btcmarkets.dto.trade.*;
-// import org.knowm.xchange.btcmarkets.dto.v3.trade.BTCMarketsPlaceOrderRequest;
-// import org.knowm.xchange.btcmarkets.dto.v3.trade.BTCMarketsPlaceOrderResponse;
-// import org.knowm.xchange.currency.CurrencyPair;
-// import org.knowm.xchange.dto.Order;
-// import org.knowm.xchange.dto.trade.LimitOrder;
-// import org.knowm.xchange.dto.trade.MarketOrder;
-// import org.mockito.Matchers;
-// import org.mockito.Mockito;
-// import org.powermock.api.mockito.PowerMockito;
-// import org.powermock.core.classloader.annotations.PowerMockIgnore;
-// import org.powermock.core.classloader.annotations.PrepareForTest;
-// import org.powermock.modules.junit4.PowerMockRunner;
-// import org.powermock.reflect.Whitebox;
-// import si.mazi.rescu.SynchronizedValueFactory;
-//
-// @RunWith(PowerMockRunner.class)
-// @PrepareForTest({
-//  BTCMarketsAuthenticated.class,
-//  BTCMarketsOpenOrdersRequest.class,
-//  BTCMarketsCancelOrderRequest.class,
-//  BTCMarketsOrder.class
-// })
-// @PowerMockIgnore("javax.crypto.*")
-public class BTCMarketsTradeServiceTest extends BTCMarketsTestSupport {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
-  //  private BTCMarketsExchange exchange;
-  //  private BTCMarketsTradeService marketsTradeService;
-  //
-  //  @Before
-  //  public void setUp() {
-  //    exchange =
-  //        (BTCMarketsExchange)
-  //
-  // ExchangeFactory.INSTANCE.createExchange(BTCMarketsExchange.class.getCanonicalName());
-  //
-  //    exchange.getExchangeSpecification().getExchangeSpecificParameters();
-  //    exchange.getExchangeSpecification().setUserName(SPECIFICATION_USERNAME);
-  //    exchange.getExchangeSpecification().setApiKey(SPECIFICATION_API_KEY);
-  //    exchange.getExchangeSpecification().setSecretKey(SPECIFICATION_SECRET_KEY);
-  //
-  //    marketsTradeService = new BTCMarketsTradeService(exchange);
-  //  }
-  //
-  //  @Test
-  //  public void shouldPlaceMarketOrder() throws IOException {
-  //    // given
-  //    MarketOrder marketOrder =
-  //        new MarketOrder(Order.OrderType.BID, new BigDecimal("10.00000000"),
-  // CurrencyPair.BTC_AUD);
-  //
-  //    BTCMarketsPlaceOrderRequest btcMarketsOrder =
-  //        new BTCMarketsPlaceOrderRequest(
-  //            "BTC-AUD", "0", "10.00000000", "Market", "Bid", null, null, "GTC", null, null,
-  // null);
-  //
-  //    BTCMarketsPlaceOrderResponse orderResponse = new BTCMarketsPlaceOrderResponse("11111");
-  //
-  //    BTCMarketsAuthenticatedV3 btcm = mock(BTCMarketsAuthenticatedV3.class);
-  //    PowerMockito.when(
-  //            btcm.placeOrder(
-  //                Mockito.eq(SPECIFICATION_API_KEY),
-  //                Mockito.any(SynchronizedValueFactory.class),
-  //                Mockito.any(BTCMarketsDigestV3.class),
-  //                Mockito.refEq(btcMarketsOrder)))
-  //        .thenReturn(orderResponse);
-  //
-  //    Whitebox.setInternalState(marketsTradeService, "btcmv3", btcm);
-  //
-  //    // when
-  //    String placed = marketsTradeService.placeMarketOrder(marketOrder);
-  //
-  //    // then
-  //    assertThat(placed).isEqualTo("11111");
-  //  }
-  //
-  //  @Test
-  //  public void shouldPlaceLimitOrder() throws IOException {
-  //    // given
-  //    LimitOrder limitOrder =
-  //        new LimitOrder(
-  //            Order.OrderType.ASK,
-  //            new BigDecimal("10.00000000"),
-  //            CurrencyPair.BTC_AUD,
-  //            "11111",
-  //            new Date(1234567890L),
-  //            new BigDecimal("20.00000000"));
-  //
-  //    BTCMarketsPlaceOrderRequest request =
-  //        new BTCMarketsPlaceOrderRequest(
-  //            "BTC-AUD",
-  //            "20.00000000",
-  //            "10.00000000",
-  //            "Limit",
-  //            "Ask",
-  //            null,
-  //            null,
-  //            "GTC",
-  //            null,
-  //            null,
-  //            null);
-  //
-  //    BTCMarketsPlaceOrderResponse orderResponse = new BTCMarketsPlaceOrderResponse("11111");
-  //
-  //    BTCMarketsAuthenticatedV3 btcm = mock(BTCMarketsAuthenticatedV3.class);
-  //    PowerMockito.when(
-  //            btcm.placeOrder(
-  //                Mockito.eq(SPECIFICATION_API_KEY),
-  //                Mockito.any(SynchronizedValueFactory.class),
-  //                Mockito.any(BTCMarketsDigestV3.class),
-  //                Mockito.refEq(request)))
-  //        .thenReturn(orderResponse);
-  //
-  //    Whitebox.setInternalState(marketsTradeService, "btcmv3", btcm);
-  //
-  //    // when
-  //    String placed = marketsTradeService.placeLimitOrder(limitOrder);
-  //
-  //    // then
-  //    assertThat(placed).isEqualTo("11111");
-  //  }
-  //
-  //  @Test
-  //  public void shouldCancelOrder() throws IOException {
-  //    // given
-  //    BTCMarketsCancelOrderRequest cancelOrderRequest = new BTCMarketsCancelOrderRequest(111L);
-  //
-  //    BTCMarketsCancelOrderResponse orderResponse =
-  //        new BTCMarketsCancelOrderResponse(
-  //            true,
-  //            null,
-  //            0,
-  //            Arrays.asList(new BTCMarketsException(true, null, 0, "12345", 111L, null)));
-  //
-  //    BTCMarketsAuthenticated btcm = mock(BTCMarketsAuthenticated.class);
-  //    PowerMockito.when(
-  //            btcm.cancelOrder(
-  //                Mockito.eq(SPECIFICATION_API_KEY),
-  //                Mockito.any(SynchronizedValueFactory.class),
-  //                Mockito.any(BTCMarketsDigest.class),
-  //                Mockito.refEq(cancelOrderRequest)))
-  //        .thenReturn(orderResponse);
-  //    Whitebox.setInternalState(marketsTradeService, "btcm", btcm);
-  //
-  //    // when
-  //    boolean cancelled = marketsTradeService.cancelOrder("111");
-  //
-  //    // then
-  //    assertThat(cancelled).isTrue();
-  //  }
-  //
-  //  @Test
-  //  public void shouldCreateHistoryParams() {
-  //    // when
-  //    BTCMarketsTradeService.HistoryParams historyParams =
-  //        marketsTradeService.createTradeHistoryParams();
-  //
-  //    // then
-  //    assertThat(historyParams.getPageLength()).isEqualTo(200);
-  //  }
-  //
-  //  @Test
-  //  public void shouldGetOrderDetails() throws IOException {
-  //    // given
-  //    List<Long> orderIds = new ArrayList<>();
-  //    orderIds.add(1000L);
-  //    BTCMarketsOrderDetailsRequest btcMarketsOrderDetailsRequest =
-  //        new BTCMarketsOrderDetailsRequest(orderIds);
-  //    BTCMarketsOrders btcMarketsOrders = new BTCMarketsOrders(true, "", 0, new ArrayList<>());
-  //
-  //    BTCMarketsAuthenticated btcm = mock(BTCMarketsAuthenticated.class);
-  //    PowerMockito.when(
-  //            btcm.getOrderDetails(
-  //                Mockito.eq(SPECIFICATION_API_KEY),
-  //                Mockito.any(SynchronizedValueFactory.class),
-  //                Mockito.any(BTCMarketsDigest.class),
-  //                Matchers.eq(btcMarketsOrderDetailsRequest)))
-  //        .thenReturn(btcMarketsOrders);
-  //    Whitebox.setInternalState(marketsTradeService, "btcm", btcm);
-  //    // when
-  //    Collection<Order> orders = marketsTradeService.getOrder("1000");
-  //    assertThat(orders).hasSize(0);
-  //  }
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.*;
+import org.junit.Test;
+import org.knowm.xchange.btcmarkets.dto.BTCMarketsException;
+import org.knowm.xchange.btcmarkets.dto.BTCMarketsOrderFlags;
+import org.knowm.xchange.btcmarkets.dto.trade.BTCMarketsCancelOrderRequest;
+import org.knowm.xchange.btcmarkets.dto.trade.BTCMarketsCancelOrderResponse;
+import org.knowm.xchange.btcmarkets.dto.trade.BTCMarketsOrderDetailsRequest;
+import org.knowm.xchange.btcmarkets.dto.trade.BTCMarketsOrders;
+import org.knowm.xchange.btcmarkets.dto.v3.trade.BTCMarketsPlaceOrderRequest;
+import org.knowm.xchange.btcmarkets.dto.v3.trade.BTCMarketsPlaceOrderResponse;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.dto.trade.MarketOrder;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+import si.mazi.rescu.SynchronizedValueFactory;
+
+public class BTCMarketsTradeServiceTest extends BTCMarketsServiceTest {
+
+  @Test
+  public void shouldPlaceMarketOrder() throws IOException {
+    MarketOrder marketOrder =
+        new MarketOrder(Order.OrderType.BID, new BigDecimal("10.00000000"), CurrencyPair.BTC_AUD);
+
+    BTCMarketsPlaceOrderRequest btcMarketsOrder =
+        new BTCMarketsPlaceOrderRequest(
+            "BTC-AUD", "0", "10.00000000", "Market", "Bid", null, null, "GTC", false, null, null);
+
+    BTCMarketsPlaceOrderResponse orderResponse = new BTCMarketsPlaceOrderResponse("11111");
+
+    when(btcMarketsAuthenticatedV3.placeOrder(
+            Mockito.eq(SPECIFICATION_API_KEY),
+            Mockito.any(SynchronizedValueFactory.class),
+            Mockito.any(BTCMarketsDigestV3.class),
+            Mockito.refEq(btcMarketsOrder)))
+        .thenReturn(orderResponse);
+
+    // when
+    String placed = btcMarketsTradeService.placeMarketOrder(marketOrder);
+
+    // then
+    assertThat(placed).isEqualTo("11111");
+  }
+
+  @Test
+  public void shouldPlaceLimitOrder() throws IOException {
+    // given
+    LimitOrder limitOrder =
+        new LimitOrder(
+            Order.OrderType.ASK,
+            new BigDecimal("10.00000000"),
+            CurrencyPair.BTC_AUD,
+            "11111",
+            new Date(1234567890L),
+            new BigDecimal("20.00000000"));
+
+    BTCMarketsPlaceOrderRequest request =
+        new BTCMarketsPlaceOrderRequest(
+            "BTC-AUD",
+            "20.00000000",
+            "10.00000000",
+            "Limit",
+            "Ask",
+            null,
+            null,
+            "GTC",
+            false,
+            null,
+            null);
+
+    BTCMarketsPlaceOrderResponse orderResponse = new BTCMarketsPlaceOrderResponse("11111");
+
+    when(btcMarketsAuthenticatedV3.placeOrder(
+            Mockito.eq(SPECIFICATION_API_KEY),
+            Mockito.any(SynchronizedValueFactory.class),
+            Mockito.any(BTCMarketsDigestV3.class),
+            Mockito.refEq(request)))
+        .thenReturn(orderResponse);
+
+    // when
+    String placed = btcMarketsTradeService.placeLimitOrder(limitOrder);
+
+    // then
+    assertThat(placed).isEqualTo("11111");
+  }
+
+  @Test
+  public void shouldPlaceLimitOrderWithPostOnlyFlag() throws IOException {
+    // given
+    LimitOrder limitOrder =
+        new LimitOrder(
+            Order.OrderType.ASK,
+            new BigDecimal("10.00000000"),
+            CurrencyPair.BTC_AUD,
+            "11111",
+            new Date(1234567890L),
+            new BigDecimal("20.00000000"));
+    limitOrder.getOrderFlags().add(BTCMarketsOrderFlags.POST_ONLY);
+
+    BTCMarketsPlaceOrderRequest expectedRequest =
+        new BTCMarketsPlaceOrderRequest(
+            "BTC-AUD",
+            "20.00000000",
+            "10.00000000",
+            "Limit",
+            "Ask",
+            null,
+            null,
+            "GTC",
+            true,
+            null,
+            null);
+
+    BTCMarketsPlaceOrderResponse orderResponse = new BTCMarketsPlaceOrderResponse("11111");
+
+    when(btcMarketsAuthenticatedV3.placeOrder(
+            Mockito.eq(SPECIFICATION_API_KEY),
+            Mockito.any(SynchronizedValueFactory.class),
+            Mockito.any(BTCMarketsDigestV3.class),
+            Mockito.refEq(expectedRequest)))
+        .thenReturn(orderResponse);
+
+    // when
+    String placed = btcMarketsTradeService.placeLimitOrder(limitOrder);
+
+    // then
+    assertThat(placed).isEqualTo("11111");
+  }
+
+  @Test
+  public void shouldCancelOrder() throws IOException {
+    // given
+    BTCMarketsCancelOrderRequest cancelOrderRequest = new BTCMarketsCancelOrderRequest(111L);
+
+    BTCMarketsCancelOrderResponse orderResponse =
+        new BTCMarketsCancelOrderResponse(
+            true,
+            null,
+            0,
+            Arrays.asList(new BTCMarketsException(true, null, 0, "12345", 111L, null)));
+
+    when(btcMarketsAuthenticated.cancelOrder(
+            Mockito.eq(SPECIFICATION_API_KEY),
+            Mockito.any(SynchronizedValueFactory.class),
+            Mockito.any(BTCMarketsDigest.class),
+            Mockito.refEq(cancelOrderRequest)))
+        .thenReturn(orderResponse);
+
+    // when
+    boolean cancelled = btcMarketsTradeService.cancelOrder("111");
+
+    // then
+    assertThat(cancelled).isTrue();
+  }
+
+  @Test
+  public void shouldCreateHistoryParams() {
+    // when
+    BTCMarketsTradeService.HistoryParams historyParams =
+        btcMarketsTradeService.createTradeHistoryParams();
+
+    // then
+    assertThat(historyParams.getPageLength()).isEqualTo(200);
+  }
+
+  @Test
+  public void shouldGetOrderDetails() throws IOException {
+    // given
+    List<Long> orderIds = new ArrayList<>();
+    orderIds.add(1000L);
+    BTCMarketsOrderDetailsRequest btcMarketsOrderDetailsRequest =
+        new BTCMarketsOrderDetailsRequest(orderIds);
+    BTCMarketsOrders btcMarketsOrders = new BTCMarketsOrders(true, "", 0, new ArrayList<>());
+
+    when(btcMarketsAuthenticated.getOrderDetails(
+            Mockito.eq(SPECIFICATION_API_KEY),
+            Mockito.any(SynchronizedValueFactory.class),
+            Mockito.any(BTCMarketsDigest.class),
+            Matchers.eq(btcMarketsOrderDetailsRequest)))
+        .thenReturn(btcMarketsOrders);
+    // when
+    Collection<Order> orders = btcMarketsTradeService.getOrder("1000");
+    assertThat(orders).hasSize(0);
+  }
 }


### PR DESCRIPTION
- Added support for POST_ONLY order flag
- Restored tests disabled by @timmolter earlier this year