### PR TITLE
[Binance] Add intervalNum field in RateLimit class

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/meta/exchangeinfo/RateLimit.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/meta/exchangeinfo/RateLimit.java
@@ -5,6 +5,8 @@ public class RateLimit {
 
   private String interval;
 
+  private String intervalNum;
+
   private String rateLimitType;
 
   public String getLimit() {
@@ -23,6 +25,14 @@ public class RateLimit {
     this.interval = interval;
   }
 
+  public String getIntervalNum() {
+    return intervalNum;
+  }
+
+  public void setIntervalNum(String intervalNum) {
+    this.intervalNum = intervalNum;
+  }
+
   public String getRateLimitType() {
     return rateLimitType;
   }
@@ -37,6 +47,8 @@ public class RateLimit {
         + limit
         + ", interval = "
         + interval
+        + ", intervalNum = "
+        + intervalNum
         + ", rateLimitType = "
         + rateLimitType
         + "]";


### PR DESCRIPTION
In the rate limit info of Binance, there is a field **intervalNum** that is not currently in the DTO. I use a custom Rate Limiter and this field is required for reliable validation.

See Binance API doc at https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#general-info-on-limits

**intervalNum describes the amount of the interval. For example, intervalNum 5 with intervalLetter M means "Every 5 minutes".**

Response from /api/v3/exchangeInfo
```
    "rateLimits": [
        {
            "rateLimitType": "REQUEST_WEIGHT",
            "interval": "MINUTE",
            "intervalNum": 1,
            "limit": 1200
        },
        {
            "rateLimitType": "ORDERS",
            "interval": "SECOND",
            "intervalNum": 10,     <-----------------------------
            "limit": 100
        },
        {
            "rateLimitType": "ORDERS",
            "interval": "DAY",
            "intervalNum": 1,
            "limit": 200000
        }
    ],
```