### PR TITLE
[bitstamp] do not hardcode currencies

### DIFF
--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAdapters.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAdapters.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+
 import org.knowm.xchange.bitstamp.dto.account.BitstampBalance;
 import org.knowm.xchange.bitstamp.dto.marketdata.BitstampOrderBook;
 import org.knowm.xchange.bitstamp.dto.marketdata.BitstampPairInfo;
@@ -300,80 +301,24 @@ public final class BitstampAdapters {
     return fundingRecords;
   }
 
-  private static CurrencyPair adaptCurrencyPair(BitstampOrderTransaction transaction) {
+  private static CurrencyPair adaptCurrencyPair(BitstampOrderTransaction transaction, List<CurrencyPair> exchangeSymbols) {
 
-    // USD section
-    if (transaction.getBtc() != null && transaction.getUsd() != null) return CurrencyPair.BTC_USD;
+    String[] keys = transaction.getAmounts().keySet().toArray(new String[0]);
+    if (keys.length != 2) {
+      throw new IllegalArgumentException("Amount size is not 2. Unable to calculate currency pair.");
+    }
 
-    if (transaction.getLtc() != null && transaction.getUsd() != null) return CurrencyPair.LTC_USD;
-
-    if (transaction.getEth() != null && transaction.getUsd() != null) return CurrencyPair.ETH_USD;
-
-    if (transaction.getXrp() != null && transaction.getUsd() != null) return CurrencyPair.XRP_USD;
-
-    if (transaction.getBch() != null && transaction.getUsd() != null) return CurrencyPair.BCH_USD;
-
-    // EUR section
-    if (transaction.getBtc() != null && transaction.getEur() != null) return CurrencyPair.BTC_EUR;
-
-    if (transaction.getLtc() != null && transaction.getEur() != null) return CurrencyPair.LTC_EUR;
-
-    if (transaction.getEth() != null && transaction.getEur() != null) return CurrencyPair.ETH_EUR;
-
-    if (transaction.getXrp() != null && transaction.getEur() != null) return CurrencyPair.XRP_EUR;
-
-    if (transaction.getBch() != null && transaction.getEur() != null) return CurrencyPair.BCH_EUR;
-
-    // BTC section
-    if (transaction.getLtc() != null && transaction.getBtc() != null) return CurrencyPair.LTC_BTC;
-
-    if (transaction.getEth() != null && transaction.getBtc() != null) return CurrencyPair.ETH_BTC;
-
-    if (transaction.getXrp() != null && transaction.getBtc() != null) return CurrencyPair.XRP_BTC;
-
-    if (transaction.getBch() != null && transaction.getBtc() != null) return CurrencyPair.BCH_BTC;
-
-    // XLM
-    if (transaction.getXlm() != null && transaction.getBtc() != null) return CurrencyPair.XLM_BTC;
-
-    if (transaction.getXlm() != null && transaction.getUsd() != null) return CurrencyPair.XLM_USD;
-
-    if (transaction.getXlm() != null && transaction.getEur() != null) return CurrencyPair.XLM_EUR;
-
-    if (transaction.getXlm() != null && transaction.getEth() != null) return CurrencyPair.XLM_ETH;
-
-    // LINK
-    if (transaction.getLink() != null && transaction.getBtc() != null) return CurrencyPair.LINK_BTC;
-
-    if (transaction.getLink() != null && transaction.getUsd() != null) return CurrencyPair.LINK_USD;
-
-    if (transaction.getLink() != null && transaction.getEur() != null) return CurrencyPair.LINK_EUR;
-
-    if (transaction.getLink() != null && transaction.getEth() != null) return CurrencyPair.LINK_ETH;
-
-    throw new NotYetImplementedForExchangeException();
+    if (exchangeSymbols.contains(new CurrencyPair(keys[0], keys[1]))) {
+      return new CurrencyPair(keys[0], keys[1]);
+    } else {
+      return new CurrencyPair(keys[1], keys[0]);
+    }
   }
 
   private static BigDecimal getBaseCurrencyAmountFromBitstampTransaction(
-      BitstampOrderTransaction bitstampTransaction) {
+      BitstampOrderTransaction bitstampTransaction, CurrencyPair currencyPair) {
 
-    CurrencyPair currencyPair = adaptCurrencyPair(bitstampTransaction);
-
-    if (currencyPair.base.equals(Currency.LTC)) return bitstampTransaction.getLtc();
-
-    if (currencyPair.base.equals(Currency.BTC)) return bitstampTransaction.getBtc();
-
-    if (currencyPair.base.equals(Currency.BCH)) return bitstampTransaction.getBch();
-
-    if (currencyPair.base.equals(Currency.ETH)) return bitstampTransaction.getEth();
-
-    if (currencyPair.base.equals(Currency.XRP)) return bitstampTransaction.getXrp();
-
-    if (currencyPair.base.equals(Currency.XLM)) return bitstampTransaction.getXlm();
-
-    if (currencyPair.base.equals(Currency.LINK)) return bitstampTransaction.getLink();
-
-    throw new NotYetImplementedForExchangeException();
+    return bitstampTransaction.getAmount(currencyPair.base.getCurrencyCode().toLowerCase());
   }
 
   public static Order.OrderStatus adaptOrderStatus(BitstampOrderStatus bitstampOrderStatus) {
@@ -392,17 +337,18 @@ public final class BitstampAdapters {
    * BitstampGenericOrder as a status
    *
    * @param bitstampOrderStatusResponse
+   * @param exchangeSymbols
    * @return
    */
   public static BitstampGenericOrder adaptOrder(
-      String orderId, BitstampOrderStatusResponse bitstampOrderStatusResponse) {
+          String orderId, BitstampOrderStatusResponse bitstampOrderStatusResponse, List<CurrencyPair> exchangeSymbols) {
 
     BitstampOrderTransaction[] bitstampTransactions = bitstampOrderStatusResponse.getTransactions();
 
     // Use only the first transaction, because we assume that for a single order id all transactions
     // will
     // be of the same currency pair
-    CurrencyPair currencyPair = adaptCurrencyPair(bitstampTransactions[0]);
+    CurrencyPair currencyPair = adaptCurrencyPair(bitstampTransactions[0], exchangeSymbols);
     Date date = bitstampTransactions[0].getDatetime();
 
     BigDecimal averagePrice =
@@ -414,7 +360,7 @@ public final class BitstampAdapters {
 
     BigDecimal cumulativeAmount =
         Arrays.stream(bitstampTransactions)
-            .map(t -> getBaseCurrencyAmountFromBitstampTransaction(t))
+            .map(t -> getBaseCurrencyAmountFromBitstampTransaction(t, currencyPair))
             .reduce((x, y) -> x.add(y))
             .get();
 

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAdapters.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAdapters.java
@@ -308,8 +308,9 @@ public final class BitstampAdapters {
       throw new IllegalArgumentException("Amount size is not 2. Unable to calculate currency pair.");
     }
 
-    if (exchangeSymbols.contains(new CurrencyPair(keys[0], keys[1]))) {
-      return new CurrencyPair(keys[0], keys[1]);
+    CurrencyPair currencyPair = new CurrencyPair(keys[0], keys[1]);
+    if (exchangeSymbols.contains(currencyPair)) {
+      return currencyPair;
     } else {
       return new CurrencyPair(keys[1], keys[0]);
     }

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/trade/BitstampOrderTransaction.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/trade/BitstampOrderTransaction.java
@@ -1,8 +1,12 @@
 package org.knowm.xchange.bitstamp.dto.trade;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.knowm.xchange.bitstamp.BitstampUtils;
 
 public class BitstampOrderTransaction {
@@ -10,15 +14,7 @@ public class BitstampOrderTransaction {
   private final Date datetime;
   private final long tid;
   private final BitstampUserTransaction.TransactionType type;
-  private final BigDecimal usd;
-  private final BigDecimal btc;
-  private final BigDecimal ltc;
-  private final BigDecimal eth;
-  private final BigDecimal eur;
-  private final BigDecimal xrp;
-  private final BigDecimal bch;
-  private final BigDecimal xlm;
-  private final BigDecimal link;
+  private final Map<String, BigDecimal> amounts = new HashMap<>();
   private final BigDecimal price;
   private final BigDecimal fee;
 
@@ -28,8 +24,6 @@ public class BitstampOrderTransaction {
    * @param datetime date and time of transaction
    * @param tid transaction id
    * @param type transaction type
-   * @param usd settled amoun
-   * @param btc traded amount
    * @param price transaction rate
    * @param fee transaction fee
    */
@@ -37,33 +31,21 @@ public class BitstampOrderTransaction {
       @JsonProperty("datetime") String datetime,
       @JsonProperty("tid") long tid,
       @JsonProperty("type") BitstampUserTransaction.TransactionType type,
-      @JsonProperty("usd") BigDecimal usd,
-      @JsonProperty("btc") BigDecimal btc,
-      @JsonProperty("ltc") BigDecimal ltc,
-      @JsonProperty("eth") BigDecimal eth,
-      @JsonProperty("eur") BigDecimal eur,
-      @JsonProperty("xrp") BigDecimal xrp,
-      @JsonProperty("bch") BigDecimal bch,
-      @JsonProperty("xlm") BigDecimal xlm,
-      @JsonProperty("link") BigDecimal link,
       @JsonProperty("price") BigDecimal price,
       @JsonProperty("fee") BigDecimal fee) {
 
     this.datetime = BitstampUtils.parseDate(datetime);
-    ;
     this.tid = tid;
     this.type = type;
-    this.usd = usd;
-    this.btc = btc;
     this.price = price;
     this.fee = fee;
-    this.ltc = ltc;
-    this.eth = eth;
-    this.eur = eur;
-    this.xrp = xrp;
-    this.bch = bch;
-    this.xlm = xlm;
-    this.link = link;
+  }
+
+  @JsonAnySetter
+  public void setDynamicProperty(String name, Object value) {
+    if (value != null) {
+      amounts.put(name, new BigDecimal(value.toString()));
+    }
   }
 
   public Date getDatetime() {
@@ -81,16 +63,6 @@ public class BitstampOrderTransaction {
     return type;
   }
 
-  public BigDecimal getUsd() {
-
-    return usd;
-  }
-
-  public BigDecimal getBtc() {
-
-    return btc;
-  }
-
   public BigDecimal getPrice() {
 
     return price;
@@ -101,31 +73,12 @@ public class BitstampOrderTransaction {
     return fee;
   }
 
-  public BigDecimal getLtc() {
-    return ltc;
+  public BigDecimal getAmount(String token) {
+    return amounts.get(token);
   }
 
-  public BigDecimal getEth() {
-    return eth;
+  public Map<String, BigDecimal> getAmounts() {
+    return amounts;
   }
 
-  public BigDecimal getEur() {
-    return eur;
-  }
-
-  public BigDecimal getXrp() {
-    return xrp;
-  }
-
-  public BigDecimal getBch() {
-    return bch;
-  }
-
-  public BigDecimal getXlm() {
-    return xlm;
-  }
-
-  public BigDecimal getLink() {
-    return link;
-  }
 }

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeService.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeService.java
@@ -181,7 +181,7 @@ public class BitstampTradeService extends BitstampTradeServiceRaw implements Tra
 
     for (String orderId : orderIds) {
       orders.add(
-          BitstampAdapters.adaptOrder(orderId, super.getBitstampOrder(Long.parseLong(orderId))));
+          BitstampAdapters.adaptOrder(orderId, super.getBitstampOrder(Long.parseLong(orderId)), exchange.getExchangeSymbols()));
     }
 
     return orders;

--- a/xchange-bitstamp/src/test/java/org/knowm/xchange/bitstamp/BitstampAdapterTest.java
+++ b/xchange-bitstamp/src/test/java/org/knowm/xchange/bitstamp/BitstampAdapterTest.java
@@ -7,15 +7,20 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.TimeZone;
 import org.junit.Test;
 import org.knowm.xchange.bitstamp.dto.account.BitstampBalance;
 import org.knowm.xchange.bitstamp.dto.marketdata.BitstampOrderBook;
 import org.knowm.xchange.bitstamp.dto.marketdata.BitstampTicker;
 import org.knowm.xchange.bitstamp.dto.marketdata.BitstampTransaction;
+import org.knowm.xchange.bitstamp.dto.trade.BitstampOrderStatusResponse;
 import org.knowm.xchange.bitstamp.dto.trade.BitstampUserTransaction;
+import org.knowm.xchange.bitstamp.order.dto.BitstampGenericOrder;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.account.AccountInfo;
 import org.knowm.xchange.dto.marketdata.OrderBook;
@@ -183,4 +188,58 @@ public class BitstampAdapterTest {
     String dateString = f.format(userTradeHistory.getTrades().get(0).getTimestamp());
     assertThat(dateString).isEqualTo("2013-09-02 13:17:49");
   }
+
+  @Test
+  public void testOrderAdapter() throws IOException {
+
+    // Read in the JSON from the example resources
+    String order = "{\"status\":\"Finished\",\"id\":1337944912351237,\"transactions\":[{\"datetime\":\"2020-09-01 05:55:04\",\"tid\":156881358,\"type\":2,\"usd\":null,\"btc\":0.00838324,\"ltc\":null,\"eth\":null,\"eur\":397.20059384,\"xrp\":null,\"bch\":null,\"xlm\":null,\"link\":null,\"price\":47380.32000000,\"fee\":0.43692}],\"error\":null}";
+
+    // Use Jackson to parse it
+    ObjectMapper mapper = new ObjectMapper();
+    BitstampOrderStatusResponse bitstampOrder = mapper.readValue(order, BitstampOrderStatusResponse.class);
+
+    List<CurrencyPair> currencyPairs = new ArrayList<>();
+    currencyPairs.add(CurrencyPair.BTC_USD);
+    currencyPairs.add(CurrencyPair.LTC_USD);
+    currencyPairs.add(CurrencyPair.ETH_USD);
+    currencyPairs.add(CurrencyPair.XRP_USD);
+    currencyPairs.add(CurrencyPair.BCH_USD);
+
+    currencyPairs.add(CurrencyPair.BTC_EUR);
+    currencyPairs.add(CurrencyPair.LTC_EUR);
+    currencyPairs.add(CurrencyPair.ETH_EUR);
+    currencyPairs.add(CurrencyPair.XRP_EUR);
+    currencyPairs.add(CurrencyPair.BCH_EUR);
+
+    currencyPairs.add(CurrencyPair.LTC_BTC);
+    currencyPairs.add(CurrencyPair.ETH_BTC);
+    currencyPairs.add(CurrencyPair.XRP_BTC);
+    currencyPairs.add(CurrencyPair.BCH_BTC);
+
+    currencyPairs.add(CurrencyPair.XLM_BTC);
+    currencyPairs.add(CurrencyPair.XLM_USD);
+    currencyPairs.add(CurrencyPair.XLM_EUR);
+    currencyPairs.add(CurrencyPair.XLM_ETH);
+
+    currencyPairs.add(CurrencyPair.LINK_BTC);
+    currencyPairs.add(CurrencyPair.LINK_USD);
+    currencyPairs.add(CurrencyPair.LINK_EUR);
+    currencyPairs.add(CurrencyPair.LINK_ETH);
+
+    BitstampGenericOrder genericOrder = BitstampAdapters.adaptOrder(String.valueOf(bitstampOrder.getId()), bitstampOrder, currencyPairs);
+
+    assertThat(genericOrder.getType()).isNull();
+    assertThat(genericOrder.getOriginalAmount()).isNull();
+    assertThat(genericOrder.getCurrencyPair()).isEqualTo(CurrencyPair.BTC_EUR);
+    assertThat(genericOrder.getId()).isEqualTo("1337944912351237");
+    assertThat(genericOrder.getTimestamp()).isEqualTo("2020-09-01T05:55:04Z");
+    assertThat(genericOrder.getAveragePrice()).isEqualTo(new BigDecimal("47380.32000000"));
+    assertThat(genericOrder.getCumulativeAmount()).isEqualTo(new BigDecimal("0.00838324"));
+    assertThat(genericOrder.getFee()).isEqualTo(new BigDecimal("0.43692"));
+    assertThat(genericOrder.getStatus()).isEqualTo(Order.OrderStatus.FILLED);
+
+  }
+
+
 }


### PR DESCRIPTION
Bitstamp had hardcoded set of currencies. 
Refactored using JsonAnySetter and list of markets form remoteInit.
