### PR TITLE
[bitfinex] added 'book' v2 api method

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexMarketDataServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexMarketDataServiceRaw.java
@@ -15,9 +15,14 @@ import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexSymbolDetail;
 import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexTicker;
 import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexTrade;
 import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexCandle;
+import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexFundingOrder;
+import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexFundingRawOrder;
 import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexPublicFundingTrade;
 import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexPublicTrade;
 import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexStats;
+import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexTradingOrder;
+import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexTradingRawOrder;
+import org.knowm.xchange.bitfinex.v2.dto.marketdata.BookPrecision;
 import org.knowm.xchange.bitfinex.v2.dto.marketdata.Status;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -183,4 +188,48 @@ public class BitfinexMarketDataServiceRaw extends BitfinexBaseService {
   public List<BitfinexStats> getStats(String key, String size, String symbol, String side, Integer sort, Long startTimestamp, Long endTimestamp, Integer limit) throws IOException {
     return bitfinexV2.getStats(key, size, symbol, side, sort, startTimestamp, endTimestamp, limit);
   }
+  
+  /**
+   * @see https://docs.bitfinex.com/reference#rest-public-book
+   * @param symbol The symbol you want information about. (e.g. tBTCUSD, tETHUSD, fUSD, fBTC)
+   * @param precision Level of price aggregation (P0, P1, P2, P3, P4, R0)
+   * @param len Number of price points ("1", "25", "100")
+   * @return list of orders in the book
+   * @throws IOException
+   */
+  public List<BitfinexTradingOrder> tradingBook(String symbol, BookPrecision precision, Integer len) throws IOException {
+    return bitfinexV2.tradingBook(symbol, precision, len);
+  }
+  /**
+   * @see https://docs.bitfinex.com/reference#rest-public-book
+   * @param symbol The symbol you want information about. (e.g. tBTCUSD, tETHUSD, fUSD, fBTC)
+   * @param len Number of price points ("1", "25", "100")
+   * @return list of orders in the book
+   * @throws IOException
+   */
+  public List<BitfinexTradingRawOrder> tradingBookRaw(String symbol, Integer len) throws IOException {
+      return bitfinexV2.tradingBookRaw(symbol, len);
+    }
+  
+  /**
+   * @see https://docs.bitfinex.com/reference#rest-public-book
+   * @param symbol The symbol you want information about. (e.g. tBTCUSD, tETHUSD, fUSD, fBTC)
+   * @param precision Level of price aggregation (P0, P1, P2, P3, P4, R0)
+   * @param len Number of price points ("1", "25", "100")
+   * @return list of orders in the book
+   * @throws IOException
+   */
+  public List<BitfinexFundingOrder> fundingBook(String symbol, BookPrecision precision, Integer len) throws IOException {
+    return bitfinexV2.fundingBook(symbol, precision, len);
+  }
+  /**
+   * @see https://docs.bitfinex.com/reference#rest-public-book
+   * @param symbol The symbol you want information about. (e.g. tBTCUSD, tETHUSD, fUSD, fBTC)
+   * @param len Number of price points ("1", "25", "100")
+   * @return list of orders in the book
+   * @throws IOException
+   */
+  public List<BitfinexFundingRawOrder> fundingBookRaw(String symbol, Integer len) throws IOException {
+      return bitfinexV2.fundingBookRaw(symbol, len);
+    }
 }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/Bitfinex.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/Bitfinex.java
@@ -1,6 +1,5 @@
 package org.knowm.xchange.bitfinex.v2;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.io.IOException;
 import java.util.List;
 import javax.ws.rs.GET;
@@ -11,10 +10,16 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import org.knowm.xchange.bitfinex.v2.dto.BitfinexExceptionV2;
 import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexCandle;
+import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexFundingOrder;
+import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexFundingRawOrder;
 import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexPublicFundingTrade;
 import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexPublicTrade;
 import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexStats;
+import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexTradingOrder;
+import org.knowm.xchange.bitfinex.v2.dto.marketdata.BitfinexTradingRawOrder;
+import org.knowm.xchange.bitfinex.v2.dto.marketdata.BookPrecision;
 import org.knowm.xchange.bitfinex.v2.dto.marketdata.Status;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 
 @Path("v2")
 @Produces(MediaType.APPLICATION_JSON)
@@ -82,4 +87,33 @@ public interface Bitfinex {
           @QueryParam("end") Long endTimestamp,
           @QueryParam("limit") Integer limit)
           throws IOException, BitfinexExceptionV2;
+  
+  @GET
+  @Path("book/{symbol}/{precision}")
+  List<BitfinexTradingOrder> tradingBook(
+          @PathParam("symbol") String symbol,
+          @PathParam("precision") BookPrecision precision,
+          @QueryParam("len") Integer len)
+          throws IOException, BitfinexExceptionV2;
+  @GET
+  @Path("book/{symbol}/R0")
+  List<BitfinexTradingRawOrder> tradingBookRaw(
+          @PathParam("symbol") String symbol,
+          @QueryParam("len") Integer len)
+          throws IOException, BitfinexExceptionV2;
+  
+  @GET
+  @Path("book/{symbol}/{precision}")
+  List<BitfinexFundingOrder> fundingBook(
+          @PathParam("symbol") String symbol,
+          @PathParam("precision") BookPrecision precision,
+          @QueryParam("len") Integer len)
+          throws IOException, BitfinexExceptionV2;
+  @GET
+  @Path("book/{symbol}/R0")
+  List<BitfinexFundingRawOrder> fundingBookRaw(
+          @PathParam("symbol") String symbol,
+          @QueryParam("len") Integer len)
+          throws IOException, BitfinexExceptionV2;
+  
 }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexFundingOrder.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexFundingOrder.java
@@ -1,0 +1,29 @@
+package org.knowm.xchange.bitfinex.v2.dto.marketdata;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+
+/**
+ * @see https://docs.bitfinex.com/reference#rest-public-book
+ */
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@Value
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+public class BitfinexFundingOrder {
+  /** Rate level */
+  BigDecimal rate;
+  /** Period level */
+  int period;
+  /** Number of orders at that price level */
+  int count;
+  /**
+   * Total amount available at that price level.
+   * if AMOUNT > 0 then ask else bid.
+   */
+  BigDecimal amount;
+}

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexFundingRawOrder.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexFundingRawOrder.java
@@ -1,0 +1,30 @@
+package org.knowm.xchange.bitfinex.v2.dto.marketdata;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+
+/**
+ * @see https://docs.bitfinex.com/reference#rest-public-book
+ * funding order on raw books (precision of R0)
+ */
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@Value
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+public class BitfinexFundingRawOrder {
+  /** Order ID */
+  long orderId;
+  /** Period level */
+  int period;
+  /** Rate level */
+  BigDecimal rate;
+  /**
+   * Total amount available at that price level.
+   * if AMOUNT > 0 then ask else bid.
+   */
+  BigDecimal amount;
+}

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexTradingOrder.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexTradingOrder.java
@@ -1,0 +1,27 @@
+package org.knowm.xchange.bitfinex.v2.dto.marketdata;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+
+/**
+ * @see https://docs.bitfinex.com/reference#rest-public-book
+ */
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@Value
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+public class BitfinexTradingOrder {
+  /** Price level  */
+  BigDecimal price;
+  /** Number of orders at that price level */
+  int count;
+  /**
+   * Total amount available at that price level.
+   * if AMOUNT > 0 then bid else as
+   */
+  BigDecimal amount;
+}

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexTradingRawOrder.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexTradingRawOrder.java
@@ -1,0 +1,28 @@
+package org.knowm.xchange.bitfinex.v2.dto.marketdata;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+
+/**
+ * @see https://docs.bitfinex.com/reference#rest-public-book
+ * trading order on raw books (precision of R0)
+ */
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@Value
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+public class BitfinexTradingRawOrder {
+  /** Order ID */
+  long orderId;
+  /** Price level */
+  BigDecimal price;
+  /**
+   * Total amount available at that price level.
+   * if AMOUNT > 0 then bid else ask.
+   */
+  BigDecimal amount;
+}

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BookPrecision.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BookPrecision.java
@@ -1,0 +1,14 @@
+package org.knowm.xchange.bitfinex.v2.dto.marketdata;
+
+/**
+ * Level of price aggregation
+ *  Precision Level  Number of significant figures
+ *  P0               5
+ *  P1               4
+ *  P2               3
+ *  P3               2
+ *  P4               1
+ */
+public enum BookPrecision {
+    P0, P1, P2, P3, P4;
+}


### PR DESCRIPTION
see api doc https://docs.bitfinex.com/reference#rest-public-book
unfortunatelly i had to separate the method, and make actually 4 different methods, depending on the input parameters
we differ between funding and trading books
we differ between raw (R0) and "aggrgated" (P0 ... P4) books

it would be difficult to handle those in one method, since the structure of the response depends on those input parameters

if, some one has a better idea, how to handle the different structures, would be happy to improve my implementation