### PR TITLE
[Binance] ticker map closetime

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/marketdata/BinanceTicker24h.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/marketdata/BinanceTicker24h.java
@@ -1,8 +1,9 @@
 package org.knowm.xchange.binance.dto.marketdata;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
 import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.knowm.xchange.binance.BinanceAdapters;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.Ticker;
@@ -194,6 +195,7 @@ public final class BinanceTicker24h {
               .askSize(askQty)
               .bidSize(bidQty)
               .quoteVolume(quoteVolume)
+              .timestamp(closeTime > 0 ? new Date(closeTime) : null)
               .percentageChange(priceChangePercent)
               .build();
     }


### PR DESCRIPTION
Add the closetime to the ticker, Binance is getting old tickers for markets that doesn't exist anymore and there is no way to know if they are good or not unless we have the time