### PR TITLE
Fix for Issue #4021 Bitfinex init exception and #4024 [Bitstamp] Some Currency Metadata and CurrencyPair Metadata are null

### DIFF
--- a/xchange-bitstamp/src/main/resources/bitstamp.json
+++ b/xchange-bitstamp/src/main/resources/bitstamp.json
@@ -1,81 +1,5 @@
 {
-  "currency_pairs": {
-    "BTC/USD": {
-      "price_scale": 2,
-      "trading_fee": 0.0025,
-      "min_amount": 0.00085000
-    },
-    "BTC/EUR": {
-      "price_scale": 2,
-      "trading_fee": 0.0025,
-      "min_amount": 0.00085000
-    },
-    "EUR/USD": {
-      "price_scale": 5,
-      "trading_fee": 0.0020,
-      "min_amount": 5.00
-    },
-    "XRP/USD": {
-      "price_scale": 5,
-      "trading_fee": 0.0025,
-      "min_amount": 10.00000000
-    },
-    "XRP/EUR": {
-      "price_scale": 5,
-      "trading_fee": 0.0025,
-      "min_amount": 11.00000000
-    },
-    "XRP/BTC": {
-      "price_scale": 8,
-      "trading_fee": 0.0025,
-      "min_amount": 15.00000000
-    },
-    "LTC/USD": {
-      "price_scale": 2,
-      "trading_fee": 0.0025,
-      "min_amount": 0.04000000
-    },
-    "LTC/EUR": {
-      "price_scale": 2,
-      "trading_fee": 0.0025,
-      "min_amount": 0.04500000
-    },
-    "LTC/BTC": {
-      "price_scale": 8,
-      "trading_fee": 0.0025,
-      "min_amount": 0.06000000
-    },
-    "ETH/EUR": {
-      "price_scale": 2,
-      "trading_fee": 0.0025,
-      "min_amount": 0.01500000
-    },
-    "ETH/USD": {
-      "price_scale": 2,
-      "trading_fee": 0.0025,
-      "min_amount": 0.01500000
-    },
-    "ETH/BTC": {
-      "price_scale": 8,
-      "trading_fee": 0.0025,
-      "min_amount": 0.02000000
-    },
-    "BCH/EUR": {
-      "price_scale": 2,
-      "trading_fee": 0.0025,
-      "min_amount": 0.00700000
-    },
-    "BCH/USD": {
-      "price_scale": 2,
-      "trading_fee": 0.0025,
-      "min_amount": 0.00600000
-    },
-    "BCH/BTC": {
-      "price_scale": 8,
-      "trading_fee": 0.0025,
-      "min_amount": 0.01000000
-    }
-  },
+  "currency_pairs": {},
   "currencies": {
     "BTC": {
       "scale": 8,
@@ -86,6 +10,10 @@
       "withdrawal_fee": 0
     },
     "EUR": {
+      "scale": 2,
+      "withdrawal_fee": 0
+    },
+    "GBP": {
       "scale": 2,
       "withdrawal_fee": 0
     },
@@ -104,6 +32,62 @@
     "BCH": {
       "scale": 8,
       "withdrawal_fee": 0.0001
+    },
+    "XLM": {
+      "scale": 8,
+      "withdrawal_fee": 0.005
+    },
+    "PAX": {
+      "scale": 8,
+      "withdrawal_fee": 20.0
+    },
+    "LINK": {
+      "scale": 8,
+      "withdrawal_fee": 1.0
+    },
+    "OMG": {
+      "scale": 8,
+      "withdrawal_fee": 3.0
+    },
+    "USDC": {
+      "scale": 8,
+      "withdrawal_fee": 20.0
+    },
+    "AAVE": {
+      "scale": 8,
+      "withdrawal_fee": 0.07
+    },
+    "BAT": {
+      "scale": 8,
+      "withdrawal_fee": 5.0
+    },
+    "UMA": {
+      "scale": 8,
+      "withdrawal_fee": 0.2
+    },
+    "DAI": {
+      "scale": 8,
+      "withdrawal_fee": 1.0
+    },
+    "KNC": {
+      "scale": 8,
+      "withdrawal_fee": 1.75
+    },
+    "MKR": {
+      "scale": 8,
+      "withdrawal_fee": 0.005
+    },
+    "ZRX": {
+      "scale": 8,
+      "withdrawal_fee": 3.0
+    },
+    "GUSD": {
+      "scale": 8,
+      "withdrawal_fee": 1.0
+    },
+    "ETH2": {
+      "scale": 8,
+      "withdrawal_fee": 0
     }
   },
   "private_rate_limits": [

--- a/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
@@ -83,9 +83,9 @@ public class Currency implements Comparable<Currency>, Serializable {
   public static final Currency DGB = createCurrency("DGB", "DigiByte", null);
   public static final Currency DJF = createCurrency("DJF", "Djiboutian Franc", null);
   public static final Currency DKK = createCurrency("DKK", "Danish Krone", null);
-  public static final Currency DOGE = createCurrency("DOGE", "Dogecoin", null, "XDC", "XDG");
-  public static final Currency XDC = getInstance("XDC");
+  public static final Currency DOGE = createCurrency("DOGE", "Dogecoin", null, "XDG");
   public static final Currency XDG = getInstance("XDG");
+  public static final Currency XDC = createCurrency("XDC", "XinFin Network", null);
   public static final Currency DOP = createCurrency("DOP", "Dominican Peso", null);
   public static final Currency DGC = createCurrency("DGC", "Digitalcoin", null);
   public static final Currency DVC = createCurrency("DVC", "Devcoin", null);


### PR DESCRIPTION
As discussed in the issue, it's a simple fix that

Defines Doge as DOGE or XDG (not XDC)
And add a Currency for XinFin Network called XDC

As you can see on CMC : https://coinmarketcap.com/currencies/xinfin-network/
XDC is the official symbol of XinFin Network

And you can see on https://www.kraken.com/prices?quote=USD that the Kraken symbol for Doge is XDG (not XDC)