### PR TITLE
[ftx] fix adapter for futures

### DIFF
--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/FtxAdapters.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/FtxAdapters.java
@@ -12,6 +12,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
@@ -314,9 +316,10 @@ public class FtxAdapters {
     return ftxOrderSide == FtxOrderSide.buy ? Order.OrderType.BID : Order.OrderType.ASK;
   }
 
+  private static final Pattern FUTURES_PATTERN = Pattern.compile("PERP|[0-9]+");
+  
   public static String adaptCurrencyPairToFtxMarket(CurrencyPair currencyPair) {
-    if (currencyPair.counter.getCurrencyCode().contains("PERP")
-        || currencyPair.counter.getCurrencyCode().contains("[0-9]+")) {
+    if (FUTURES_PATTERN.matcher(currencyPair.counter.getCurrencyCode()).matches()) {
       return currencyPair.base + "-" + currencyPair.counter;
     } else {
       return currencyPair.toString();

--- a/xchange-ftx/src/test/java/org/knowm/xchange/ftx/FtxAdapterTest.java
+++ b/xchange-ftx/src/test/java/org/knowm/xchange/ftx/FtxAdapterTest.java
@@ -16,11 +16,15 @@ public class FtxAdapterTest {
 
   @Test
   public void adaptCurrencyPairToFtxPair() {
-    String market = "BTC-PERP";
-    CurrencyPair currencyPair = new CurrencyPair(market);
+    assertPair("BTC-USD", "BTC/USD", "BTC/USD");
+    assertPair("BTC-PERP", "BTC/PERP", "BTC-PERP");
+    assertPair("BTC-0625", "BTC/0625", "BTC-0625");
+  }
 
-    assertThat(currencyPair.toString()).isEqualTo("BTC/PERP");
-    assertThat(FtxAdapters.adaptCurrencyPairToFtxMarket(currencyPair)).isEqualTo("BTC-PERP");
+  private void assertPair(String market, String expString, String expAdapted) {
+    CurrencyPair currencyPair = new CurrencyPair(market);
+    assertThat(currencyPair.toString()).isEqualTo(expString);
+    assertThat(FtxAdapters.adaptCurrencyPairToFtxMarket(currencyPair)).isEqualTo(expAdapted);
   }
 
   @Test


### PR DESCRIPTION
The FTX adapter does not work for expiring futures, such as BTC-0625.