### PR TITLE
Fix for #3991 bitstamp v2 API should be taking UUID nonces

### DIFF
--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAuthenticated.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAuthenticated.java
@@ -30,7 +30,7 @@ public interface BitstampAuthenticated {
 
   /**
    * @deprecated Use {@link BitstampAuthenticatedV2#getOpenOrders(String, ParamsDigest,
-   *     SynchronizedValueFactory, BitstampV2.Pair)}.
+   *     SynchronizedValueFactory, SynchronizedValueFactory, String, BitstampV2.Pair)}.
    */
   @POST
   @Path("open_orders/")

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAuthenticatedV2.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAuthenticatedV2.java
@@ -7,6 +7,7 @@ import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import org.knowm.xchange.bitstamp.dto.BitstampException;
@@ -22,33 +23,39 @@ import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 @Path("api/v2")
-@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 @Produces(MediaType.APPLICATION_JSON)
 public interface BitstampAuthenticatedV2 {
 
   @POST
   @Path("open_orders/all/")
   BitstampOrder[] getOpenOrders(
-      @FormParam("key") String apiKey,
-      @FormParam("signature") ParamsDigest signer,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce)
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version)
       throws BitstampException, IOException;
 
   @POST
   @Path("open_orders/{pair}/")
   BitstampOrder[] getOpenOrders(
-      @FormParam("key") String apiKey,
-      @FormParam("signature") ParamsDigest signer,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version,
       @PathParam("pair") BitstampV2.Pair pair)
       throws BitstampException, IOException;
 
   @POST
   @Path("{side}/market/{pair}/")
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   BitstampOrder placeMarketOrder(
-      @FormParam("key") String apiKey,
-      @FormParam("signature") ParamsDigest signer,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version,
       @PathParam("side") Side side,
       @PathParam("pair") BitstampV2.Pair pair,
       @FormParam("amount") BigDecimal amount)
@@ -56,10 +63,13 @@ public interface BitstampAuthenticatedV2 {
 
   @POST
   @Path("{side}/{pair}/")
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   BitstampOrder placeOrder(
-      @FormParam("key") String apiKey,
-      @FormParam("signature") ParamsDigest signer,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version,
       @PathParam("side") Side side,
       @PathParam("pair") BitstampV2.Pair pair,
       @FormParam("amount") BigDecimal amount,
@@ -69,36 +79,47 @@ public interface BitstampAuthenticatedV2 {
   /** @return true if order has been canceled. */
   @POST
   @Path("cancel_order/")
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   BitstampOrderCancelResponse cancelOrder(
-      @FormParam("key") String apiKey,
-      @FormParam("signature") ParamsDigest signer,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version,
       @FormParam("id") long orderId)
       throws BitstampException, IOException;
 
   @POST
   @Path("order_status/")
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   BitstampOrderStatusResponse getOrderStatus(
-      @FormParam("key") String apiKey,
-      @FormParam("signature") ParamsDigest signer,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version,
       @FormParam("id") long orderId)
       throws BitstampException, IOException;
 
   @POST
   @Path("balance/")
   BitstampBalance getBalance(
-      @FormParam("key") String apiKey,
-      @FormParam("signature") ParamsDigest signer,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce)
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version)
       throws BitstampException, IOException;
 
   @POST
   @Path("user_transactions/")
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   BitstampUserTransaction[] getUserTransactions(
-      @FormParam("key") String apiKey,
-      @FormParam("signature") ParamsDigest signer,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version,
       @FormParam("limit") Long numberOfTransactions,
       @FormParam("offset") Long offset,
       @FormParam("sort") String sort,
@@ -108,10 +129,13 @@ public interface BitstampAuthenticatedV2 {
 
   @POST
   @Path("user_transactions/{pair}/")
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   BitstampUserTransaction[] getUserTransactions(
-      @FormParam("key") String apiKey,
-      @FormParam("signature") ParamsDigest signer,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version,
       @PathParam("pair") BitstampV2.Pair pair,
       @FormParam("limit") Long numberOfTransactions,
       @FormParam("offset") Long offset,
@@ -122,10 +146,13 @@ public interface BitstampAuthenticatedV2 {
 
   @POST
   @Path("xrp_withdrawal/")
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   BitstampWithdrawal xrpWithdrawal(
-      @FormParam("key") String apiKey,
-      @FormParam("signature") ParamsDigest signer,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version,
       @FormParam("amount") BigDecimal amount,
       @FormParam("address") String rippleAddress,
       @FormParam("destination_tag") String destinationTag)
@@ -133,40 +160,52 @@ public interface BitstampAuthenticatedV2 {
 
   @POST
   @Path("ltc_withdrawal/")
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   BitstampWithdrawal withdrawLitecoin(
-      @FormParam("key") String apiKey,
-      @FormParam("signature") ParamsDigest signer,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version,
       @FormParam("amount") BigDecimal amount,
       @FormParam("address") String address)
       throws BitstampException, IOException;
 
   @POST
   @Path("bch_withdrawal/")
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   BitstampWithdrawal bchWithdrawal(
-      @FormParam("key") String apiKey,
-      @FormParam("signature") ParamsDigest signer,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version,
       @FormParam("amount") BigDecimal amount,
       @FormParam("address") String address)
       throws BitstampException, IOException;
 
   @POST
   @Path("eth_withdrawal/")
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   BitstampWithdrawal withdrawEther(
-      @FormParam("key") String apiKey,
-      @FormParam("signature") ParamsDigest signer,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version,
       @FormParam("amount") BigDecimal amount,
       @FormParam("address") String address)
       throws BitstampException, IOException;
 
   @POST
   @Path("transfer-to-main/")
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   BitstampTransferBalanceResponse transferSubAccountBalanceToMain(
-      @FormParam("key") String apiKey,
-      @FormParam("signature") ParamsDigest signer,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version,
       @FormParam("amount") BigDecimal amount,
       @FormParam("currency") String currency,
       @FormParam("subAccount") String subAccount)
@@ -174,19 +213,25 @@ public interface BitstampAuthenticatedV2 {
 
   @POST
   @Path("withdrawal-requests/")
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   WithdrawalRequest[] getWithdrawalRequests(
-      @FormParam("key") String apiKey,
-      @FormParam("signature") ParamsDigest signer,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version,
       @FormParam("timedelta") Long timeDelta)
       throws BitstampException, IOException;
 
   @POST
   @Path("withdrawal/open/")
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   BitstampWithdrawal bankWithdrawal(
-      @FormParam("key") String apiKey,
-      @FormParam("signature") ParamsDigest signer,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version,
       @FormParam("amount") BigDecimal amount,
       @FormParam("account_currency") AccountCurrency accountCurrency,
       @FormParam("name") String name,

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampExchange.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampExchange.java
@@ -2,6 +2,7 @@ package org.knowm.xchange.bitstamp;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.knowm.xchange.BaseExchange;
 import org.knowm.xchange.Exchange;
@@ -20,6 +21,12 @@ public class BitstampExchange extends BaseExchange implements Exchange {
 
   private final SynchronizedValueFactory<Long> nonceFactory =
       new CurrentTimeIncrementalNonceFactory(TimeUnit.NANOSECONDS);
+
+  private final SynchronizedValueFactory<String> uuidNonceFactory =
+          () -> UUID.randomUUID().toString();
+
+  private final SynchronizedValueFactory<String> timestampFactory =
+          () -> String.valueOf(System.currentTimeMillis());
 
   @Override
   protected void initServices() {
@@ -44,8 +51,15 @@ public class BitstampExchange extends BaseExchange implements Exchange {
 
   @Override
   public SynchronizedValueFactory<Long> getNonceFactory() {
-
     return nonceFactory;
+  }
+
+  public SynchronizedValueFactory<String> getUuidNonceFactory() {
+    return uuidNonceFactory;
+  }
+
+  public SynchronizedValueFactory<String> getTimestampFactory() {
+    return timestampFactory;
   }
 
   @Override

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountServiceRaw.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountServiceRaw.java
@@ -10,6 +10,7 @@ import org.knowm.xchange.bitstamp.BitstampAuthenticatedV2;
 import org.knowm.xchange.bitstamp.BitstampAuthenticatedV2.AccountCurrency;
 import org.knowm.xchange.bitstamp.BitstampAuthenticatedV2.BankCurrency;
 import org.knowm.xchange.bitstamp.BitstampAuthenticatedV2.BankWithdrawalType;
+import org.knowm.xchange.bitstamp.BitstampExchange;
 import org.knowm.xchange.bitstamp.BitstampV2;
 import org.knowm.xchange.bitstamp.dto.BitstampException;
 import org.knowm.xchange.bitstamp.dto.BitstampTransferBalanceResponse;
@@ -30,12 +31,19 @@ import si.mazi.rescu.SynchronizedValueFactory;
 /** @author gnandiga */
 public class BitstampAccountServiceRaw extends BitstampBaseService {
 
+  private final String version = "v2";
+
   private final BitstampDigest signatureCreator;
+  private final BitstampDigestV2 signatureCreatorV2;
   private final BitstampAuthenticated bitstampAuthenticated;
 
   private final BitstampAuthenticatedV2 bitstampAuthenticatedV2;
   private final String apiKey;
+  private final String apiKeyForV2Requests;
+
   private final SynchronizedValueFactory<Long> nonceFactory;
+  private final SynchronizedValueFactory<String> uuidNonceFactory;
+  private final SynchronizedValueFactory<String> timestampFactory;
 
   /**
    * Constructor
@@ -56,12 +64,23 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
             .build();
 
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
+    this.apiKeyForV2Requests = "BITSTAMP " + apiKey;
     this.signatureCreator =
         BitstampDigest.createInstance(
             exchange.getExchangeSpecification().getSecretKey(),
             exchange.getExchangeSpecification().getUserName(),
-            apiKey);
+            exchange.getExchangeSpecification().getApiKey());
+
+    this.signatureCreatorV2 =
+            BitstampDigestV2.createInstance(
+                    exchange.getExchangeSpecification().getSecretKey(),
+                    exchange.getExchangeSpecification().getApiKey());
+
+    BitstampExchange bitstampExchange = (BitstampExchange) exchange;
+
     this.nonceFactory = exchange.getNonceFactory();
+    this.uuidNonceFactory = bitstampExchange.getUuidNonceFactory();
+    this.timestampFactory = bitstampExchange.getTimestampFactory();
   }
 
   public BitstampBalance getBitstampBalance() throws IOException {
@@ -69,9 +88,12 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
     try {
       BitstampBalance bitstampBalance =
           bitstampAuthenticatedV2.getBalance(
-              exchange.getExchangeSpecification().getApiKey(),
-              signatureCreator,
-              exchange.getNonceFactory());
+              apiKeyForV2Requests,
+              signatureCreatorV2,
+              uuidNonceFactory,
+              timestampFactory,
+              version
+          );
       if (bitstampBalance.getError() != null) {
         throw new ExchangeException("Error getting balance. " + bitstampBalance.getError());
       }
@@ -122,9 +144,9 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
     try {
       BitstampWithdrawal response =
           bitstampAuthenticated.withdrawBitcoin(
-              exchange.getExchangeSpecification().getApiKey(),
+              apiKey,
               signatureCreator,
-              exchange.getNonceFactory(),
+              nonceFactory,
               amount,
               address);
 
@@ -139,9 +161,11 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
     try {
       BitstampWithdrawal response =
           bitstampAuthenticatedV2.withdrawLitecoin(
-              exchange.getExchangeSpecification().getApiKey(),
-              signatureCreator,
-              exchange.getNonceFactory(),
+              apiKeyForV2Requests,
+              signatureCreatorV2,
+              uuidNonceFactory,
+              timestampFactory,
+              version,
               amount,
               address);
 
@@ -156,9 +180,11 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
     try {
       BitstampWithdrawal response =
           bitstampAuthenticatedV2.withdrawEther(
-              exchange.getExchangeSpecification().getApiKey(),
-              signatureCreator,
-              exchange.getNonceFactory(),
+              apiKeyForV2Requests,
+              signatureCreatorV2,
+              uuidNonceFactory,
+              timestampFactory,
+              version,
               amount,
               address);
 
@@ -174,9 +200,11 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
     try {
       BitstampWithdrawal response =
           bitstampAuthenticatedV2.xrpWithdrawal(
-              exchange.getExchangeSpecification().getApiKey(),
-              signatureCreator,
-              exchange.getNonceFactory(),
+              apiKeyForV2Requests,
+              signatureCreatorV2,
+              uuidNonceFactory,
+              timestampFactory,
+              version,
               amount,
               address,
               destinationTag);
@@ -192,9 +220,11 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
     try {
       BitstampWithdrawal response =
           bitstampAuthenticatedV2.bchWithdrawal(
-              exchange.getExchangeSpecification().getApiKey(),
-              signatureCreator,
-              exchange.getNonceFactory(),
+              apiKeyForV2Requests,
+              signatureCreatorV2,
+              uuidNonceFactory,
+              timestampFactory,
+              version,
               amount,
               address);
       return checkAndReturnWithdrawal(response);
@@ -227,9 +257,9 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
     try {
       final BitstampDepositAddress response =
           bitstampAuthenticated.getBitcoinDepositAddress(
-              exchange.getExchangeSpecification().getApiKey(),
+              apiKey,
               signatureCreator,
-              exchange.getNonceFactory());
+              nonceFactory);
       if (response.getError() != null) {
         throw new ExchangeException(
             "Requesting Bitcoin deposit address failed: " + response.getError());
@@ -245,9 +275,9 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
     try {
       final BitstampDepositAddress response =
           bitstampAuthenticated.getBitcoinCashDepositAddress(
-              exchange.getExchangeSpecification().getApiKey(),
+              apiKey,
               signatureCreator,
-              exchange.getNonceFactory());
+              nonceFactory);
       if (response.getError() != null) {
         throw new ExchangeException(
             "Requesting Bitcoin deposit address failed: " + response.getError());
@@ -263,9 +293,9 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
     try {
       final BitstampDepositAddress response =
           bitstampAuthenticated.getLitecoinDepositAddress(
-              exchange.getExchangeSpecification().getApiKey(),
+              apiKey,
               signatureCreator,
-              exchange.getNonceFactory());
+              nonceFactory);
       if (response.getError() != null) {
         throw new ExchangeException(
             "Requesting Bitcoin deposit address failed: " + response.getError());
@@ -281,9 +311,9 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
     try {
       final BitstampDepositAddress response =
           bitstampAuthenticated.getEthereumDepositAddress(
-              exchange.getExchangeSpecification().getApiKey(),
+              apiKey,
               signatureCreator,
-              exchange.getNonceFactory());
+              nonceFactory);
       if (response.getError() != null) {
         throw new ExchangeException(
             "Requesting Bitcoin deposit address failed: " + response.getError());
@@ -297,9 +327,9 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
   public BitstampRippleDepositAddress getRippleDepositAddress() throws IOException {
 
     return bitstampAuthenticated.getRippleDepositAddress(
-        exchange.getExchangeSpecification().getApiKey(),
+        apiKey,
         signatureCreator,
-        exchange.getNonceFactory());
+        nonceFactory);
   }
 
   /**
@@ -311,9 +341,9 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
 
     try {
       return bitstampAuthenticated.withdrawToRipple(
-          exchange.getExchangeSpecification().getApiKey(),
+          apiKey,
           signatureCreator,
-          exchange.getNonceFactory(),
+          nonceFactory,
           amount,
           currency.getCurrencyCode(),
           rippleAddress);
@@ -328,9 +358,9 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
       final List<DepositTransaction> response =
           Arrays.asList(
               bitstampAuthenticated.getUnconfirmedDeposits(
-                  exchange.getExchangeSpecification().getApiKey(),
+                  apiKey,
                   signatureCreator,
-                  exchange.getNonceFactory()));
+                  nonceFactory));
       return response;
     } catch (BitstampException e) {
       throw handleError(e);
@@ -343,9 +373,11 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
       final List<WithdrawalRequest> response =
           Arrays.asList(
               bitstampAuthenticatedV2.getWithdrawalRequests(
-                  exchange.getExchangeSpecification().getApiKey(),
-                  signatureCreator,
-                  exchange.getNonceFactory(),
+                  apiKeyForV2Requests,
+                  signatureCreatorV2,
+                  uuidNonceFactory,
+                  timestampFactory,
+                  version,
                   timeDelta));
       return response;
     } catch (BitstampException e) {
@@ -364,9 +396,11 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
 
     try {
       return bitstampAuthenticatedV2.getUserTransactions(
-          apiKey,
-          signatureCreator,
-          nonceFactory,
+          apiKeyForV2Requests,
+          signatureCreatorV2,
+          uuidNonceFactory,
+          timestampFactory,
+          version,
           new BitstampV2.Pair(pair),
           numberOfTransactions,
           offset,
@@ -384,9 +418,11 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
 
     try {
       return bitstampAuthenticatedV2.getUserTransactions(
-          apiKey,
-          signatureCreator,
-          nonceFactory,
+          apiKeyForV2Requests,
+          signatureCreatorV2,
+          uuidNonceFactory,
+          timestampFactory,
+          version,
           numberOfTransactions,
           offset,
           sort,
@@ -401,7 +437,14 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
       BigDecimal amount, String currency, String subAccount) throws IOException {
     try {
       return bitstampAuthenticatedV2.transferSubAccountBalanceToMain(
-          apiKey, signatureCreator, nonceFactory, amount, currency, subAccount);
+          apiKeyForV2Requests,
+          signatureCreatorV2,
+          uuidNonceFactory,
+          timestampFactory,
+          version,
+          amount,
+          currency,
+          subAccount);
     } catch (BitstampException e) {
       throw handleError(e);
     }
@@ -436,9 +479,11 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
     try {
       BitstampWithdrawal response =
           bitstampAuthenticatedV2.bankWithdrawal(
-              exchange.getExchangeSpecification().getApiKey(),
-              signatureCreator,
-              exchange.getNonceFactory(),
+              apiKeyForV2Requests,
+              signatureCreatorV2,
+              uuidNonceFactory,
+              timestampFactory,
+              version,
               amount,
               BitstampAuthenticatedV2.AccountCurrency.EUR,
               name,
@@ -519,9 +564,11 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
     try {
       BitstampWithdrawal response =
           bitstampAuthenticatedV2.bankWithdrawal(
-              exchange.getExchangeSpecification().getApiKey(),
-              signatureCreator,
-              exchange.getNonceFactory(),
+              apiKeyForV2Requests,
+              signatureCreatorV2,
+              uuidNonceFactory,
+              timestampFactory,
+              version,
               amount,
               AccountCurrency.EUR,
               name,

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampDigestV2.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampDigestV2.java
@@ -1,0 +1,46 @@
+package org.knowm.xchange.bitstamp.service;
+
+import java.math.BigInteger;
+import javax.crypto.Mac;
+import javax.ws.rs.FormParam;
+import org.knowm.xchange.service.BaseParamsDigest;
+import si.mazi.rescu.RestInvocation;
+
+/** @author Benedikt Bünz */
+public class BitstampDigest extends BaseParamsDigest {
+
+  private final String clientId;
+  private final String apiKey;
+
+  /**
+   * Constructor
+   *
+   * @param secretKeyBase64
+   * @param clientId
+   * @param apiKey @throws IllegalArgumentException if key is invalid (cannot be base-64-decoded or
+   *     the decoded key is invalid).
+   */
+  private BitstampDigest(String secretKeyBase64, String clientId, String apiKey) {
+
+    super(secretKeyBase64, HMAC_SHA_256);
+    this.clientId = clientId;
+    this.apiKey = apiKey;
+  }
+
+  public static BitstampDigest createInstance(
+      String secretKeyBase64, String clientId, String apiKey) {
+
+    return secretKeyBase64 == null ? null : new BitstampDigest(secretKeyBase64, clientId, apiKey);
+  }
+
+  @Override
+  public String digestParams(RestInvocation restInvocation) {
+
+    Mac mac256 = getMac();
+    mac256.update(restInvocation.getParamValue(FormParam.class, "nonce").toString().getBytes());
+    mac256.update(clientId.getBytes());
+    mac256.update(apiKey.getBytes());
+
+    return String.format("%064x", new BigInteger(1, mac256.doFinal())).toUpperCase();
+  }
+}

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampDigestV2.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampDigestV2.java
@@ -36,40 +36,24 @@ public class BitstampDigestV2 extends BaseParamsDigest {
   public String digestParams(RestInvocation restInvocation) {
 
     Mac mac256 = getMac();
-    mac256.update(apiKey.getBytes());
-
-    System.out.println("restInvocation.getHttpMethod() " + restInvocation.getHttpMethod());
-    mac256.update(restInvocation.getHttpMethod().getBytes()); //HTTP VERB
-
-    System.out.println("baseUrlHost " + baseUrlHost);
-    mac256.update(baseUrlHost.getBytes()); //url Host
-
     String okPath = "/" + restInvocation.getPath();
-    System.out.println("restInvocation.getPath() " + okPath);
-    mac256.update(okPath.getBytes()); //url Path
-
-    System.out.println("restInvocation.getQueryString() " + restInvocation.getQueryString());
-    mac256.update(restInvocation.getQueryString().getBytes()); //url Query
-
     String contentType = restInvocation.getReqContentType();
 
+    mac256.update(apiKey.getBytes());
+
+    mac256.update(restInvocation.getHttpMethod().getBytes()); //HTTP VERB
+    mac256.update(baseUrlHost.getBytes()); //url Host
+    mac256.update(okPath.getBytes()); //url Path
+    mac256.update(restInvocation.getQueryString().getBytes()); //url Query
+
     if (contentType != null) {
-      System.out.println("restInvocation.getReqContentType() " + contentType);
       mac256.update(contentType.getBytes()); //content type
     }
 
-    System.out.println("X-Auth-Nonce " + restInvocation.getParamValue(HeaderParam.class, "X-Auth-Nonce").toString());
     mac256.update(restInvocation.getParamValue(HeaderParam.class, "X-Auth-Nonce").toString().getBytes());
-
-    System.out.println("X-Auth-Timestamp " + restInvocation.getParamValue(HeaderParam.class, "X-Auth-Timestamp").toString());
     mac256.update(restInvocation.getParamValue(HeaderParam.class, "X-Auth-Timestamp").toString().getBytes());
-
-    System.out.println("X-Auth-Version " + restInvocation.getParamValue(HeaderParam.class, "X-Auth-Version").toString());
     mac256.update(restInvocation.getParamValue(HeaderParam.class, "X-Auth-Version").toString().getBytes());
-
-    System.out.println("restInvocation.getRequestBody() " + restInvocation.getRequestBody());
     mac256.update(restInvocation.getRequestBody().getBytes());
-
 
     return String.format("%064x", new BigInteger(1, mac256.doFinal())).toUpperCase();
   }

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampDigestV2.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampDigestV2.java
@@ -1,45 +1,75 @@
 package org.knowm.xchange.bitstamp.service;
 
-import java.math.BigInteger;
-import javax.crypto.Mac;
-import javax.ws.rs.FormParam;
 import org.knowm.xchange.service.BaseParamsDigest;
 import si.mazi.rescu.RestInvocation;
 
-/** @author Benedikt Bünz */
-public class BitstampDigest extends BaseParamsDigest {
+import javax.crypto.Mac;
+import javax.ws.rs.HeaderParam;
+import java.math.BigInteger;
 
-  private final String clientId;
+/** @author Benedikt Bünz */
+public class BitstampDigestV2 extends BaseParamsDigest {
+
   private final String apiKey;
+  private final String baseUrlHost = "www.bitstamp.net";
 
   /**
    * Constructor
    *
    * @param secretKeyBase64
-   * @param clientId
    * @param apiKey @throws IllegalArgumentException if key is invalid (cannot be base-64-decoded or
    *     the decoded key is invalid).
    */
-  private BitstampDigest(String secretKeyBase64, String clientId, String apiKey) {
+  private BitstampDigestV2(String secretKeyBase64, String apiKey) {
 
     super(secretKeyBase64, HMAC_SHA_256);
-    this.clientId = clientId;
-    this.apiKey = apiKey;
+    this.apiKey = "BITSTAMP "+ apiKey;
   }
 
-  public static BitstampDigest createInstance(
-      String secretKeyBase64, String clientId, String apiKey) {
+  public static BitstampDigestV2 createInstance(
+      String secretKeyBase64, String apiKey) {
 
-    return secretKeyBase64 == null ? null : new BitstampDigest(secretKeyBase64, clientId, apiKey);
+    return secretKeyBase64 == null ? null : new BitstampDigestV2(secretKeyBase64, apiKey);
   }
 
   @Override
   public String digestParams(RestInvocation restInvocation) {
 
     Mac mac256 = getMac();
-    mac256.update(restInvocation.getParamValue(FormParam.class, "nonce").toString().getBytes());
-    mac256.update(clientId.getBytes());
     mac256.update(apiKey.getBytes());
+
+    System.out.println("restInvocation.getHttpMethod() " + restInvocation.getHttpMethod());
+    mac256.update(restInvocation.getHttpMethod().getBytes()); //HTTP VERB
+
+    System.out.println("baseUrlHost " + baseUrlHost);
+    mac256.update(baseUrlHost.getBytes()); //url Host
+
+    String okPath = "/" + restInvocation.getPath();
+    System.out.println("restInvocation.getPath() " + okPath);
+    mac256.update(okPath.getBytes()); //url Path
+
+    System.out.println("restInvocation.getQueryString() " + restInvocation.getQueryString());
+    mac256.update(restInvocation.getQueryString().getBytes()); //url Query
+
+    String contentType = restInvocation.getReqContentType();
+
+    if (contentType != null) {
+      System.out.println("restInvocation.getReqContentType() " + contentType);
+      mac256.update(contentType.getBytes()); //content type
+    }
+
+    System.out.println("X-Auth-Nonce " + restInvocation.getParamValue(HeaderParam.class, "X-Auth-Nonce").toString());
+    mac256.update(restInvocation.getParamValue(HeaderParam.class, "X-Auth-Nonce").toString().getBytes());
+
+    System.out.println("X-Auth-Timestamp " + restInvocation.getParamValue(HeaderParam.class, "X-Auth-Timestamp").toString());
+    mac256.update(restInvocation.getParamValue(HeaderParam.class, "X-Auth-Timestamp").toString().getBytes());
+
+    System.out.println("X-Auth-Version " + restInvocation.getParamValue(HeaderParam.class, "X-Auth-Version").toString());
+    mac256.update(restInvocation.getParamValue(HeaderParam.class, "X-Auth-Version").toString().getBytes());
+
+    System.out.println("restInvocation.getRequestBody() " + restInvocation.getRequestBody());
+    mac256.update(restInvocation.getRequestBody().getBytes());
+
 
     return String.format("%064x", new BigInteger(1, mac256.doFinal())).toUpperCase();
   }

--- a/xchange-core/src/main/java/org/knowm/xchange/BaseExchange.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/BaseExchange.java
@@ -130,6 +130,7 @@ public abstract class BaseExchange implements Exchange {
     return nonceFactory;
   }
 
+
   protected void loadExchangeMetaData(InputStream is) {
 
     exchangeMetaData = loadMetaData(is, ExchangeMetaData.class);


### PR DESCRIPTION
Hi All,

So this is a fix following the discussions in #3991 

It was a bit more complex than expected, here are some of the subtilities.

- We need both a UUID Nonce Factory and a millisecond time stamp (as string) factory because both are required in the requests.
- I had to write a new `BitstampDigestV2` because it changed completely from V1.
- All the authentication stuff is now in HeaderParams and not FormParams
- The content-type CANNOT be present if there is no body to the requests, hence the move of `@Consumes(MediaType.APPLICATION_FORM_URLENCODED)` from the top to the individual functions (when necessary). It's also taken into account into the `BitstampDigestV2` which includes it or doesn't include it for the signing process.
- Introduction of `apiKeyForV2Requests` as the api key for requests (and signing) must now be `"BITSTAMP " + apiKey`.

I also cleaned/standardized some stuff when different calls where using `this.apiKey` or `exchange.getExchangeSpecification().getApiKey()`

Otherwise it passes all my tests (with a real bitstamp account behind) namely :

- get funding history
- get open orders
- get order books
- get balances
- place and cancel limit order
- get pairs list (and meta)
- get currencies list (and meta)

(Which is all the functionalities I'm using in my app)

All the xchange standard tests are also passing (with some deprecation notices for bitstamp v1 obviously)

Eventually we will have to get rid of all the V1 stuff and this would bring some nice cleaning (I didn't find when exactly the V1 will stop working on bitstamp thou .. I'm not exactly sure what functionality is still missing from V2 in comparison to V1 and if it will be possible to emulate it or just remove it.

You can find documentation about the new authentication method [here](https://www.bitstamp.net/api/#api-authentication
)

Let me know if it's all OK for you ?