### PR TITLE
[Binance] Added sandbox support 

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceExchange.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceExchange.java
@@ -78,7 +78,25 @@ public class BinanceExchange extends BaseExchange {
     AuthUtils.setApiAndSecretKey(spec, "binance");
     return spec;
   }
+  
+  @Override
+  public void applySpecification(ExchangeSpecification exchangeSpecification) {
+    concludeHostParams(exchangeSpecification);
+    super.applySpecification(exchangeSpecification);
+  }
 
+  /**
+   * Adjust host parameters depending on exchange specific parameters
+   */
+  private static void concludeHostParams(ExchangeSpecification exchangeSpecification) {
+    if (exchangeSpecification.getExchangeSpecificParameters() != null) {
+      if (Boolean.TRUE.equals(exchangeSpecification.getExchangeSpecificParametersItem("Use_Sandbox"))) {
+        exchangeSpecification.setSslUri("https://testnet.binance.vision");
+        exchangeSpecification.setHost("testnet.binance.vision");
+      }
+    }
+  }
+    
   public BinanceExchangeInfo getExchangeInfo() {
 
     return exchangeInfo;

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingExchange.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingExchange.java
@@ -23,7 +23,8 @@ import org.slf4j.LoggerFactory;
 public class BinanceStreamingExchange extends BinanceExchange implements StreamingExchange {
 
   private static final Logger LOG = LoggerFactory.getLogger(BinanceStreamingExchange.class);
-  private static final String API_BASE_URI = "wss://stream.binance.com:9443/";
+  private static final String WS_API_BASE_URI = "wss://stream.binance.com:9443/";
+  private static final String WS_SANDBOX_API_BASE_URI = "wss://testnet.binance.vision/";
   protected static final String USE_HIGHER_UPDATE_FREQUENCY =
       "Binance_Orderbook_Use_Higher_Frequency";
 
@@ -195,7 +196,9 @@ public class BinanceStreamingExchange extends BinanceExchange implements Streami
   }
 
   private BinanceStreamingService createStreamingService(ProductSubscription subscription) {
-    String path = API_BASE_URI + "stream?streams=" + buildSubscriptionStreams(subscription);
+    String path = Boolean.TRUE.equals(exchangeSpecification.getExchangeSpecificParametersItem(USE_SANDBOX))
+            ? WS_SANDBOX_API_BASE_URI : WS_API_BASE_URI;
+    path += "stream?streams=" + buildSubscriptionStreams(subscription);
     return new BinanceStreamingService(path, subscription);
   }
 


### PR DESCRIPTION
Added sandbox support for Binance exchange/streaming via exchangeSpecification.setExchangeSpecificParametersItem("Use_Sandbox", true)

The Binance spot testnet is located at https://testnet.binance.vision