### PR TITLE
[Binance][Streaming] access to the raw OrderBookUpdate stream (i.e. binance depthUpdate)

### DIFF
--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingMarketDataService.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingMarketDataService.java
@@ -113,6 +113,17 @@ public class BinanceStreamingMarketDataService implements StreamingMarketDataSer
         currencyPair, s -> triggerObservableBody(rawTradeStream(currencyPair)).share());
   }
 
+  public Observable<BinanceRawOrderBookUpdate> getRawOrderBookUpdates(CurrencyPair currencyPair, Object... args) {
+    if (!service.isLiveSubscriptionEnabled()
+            && !service.getProductSubscription().getOrderBook().contains(currencyPair)) {
+      throw new UpFrontSubscriptionRequiredException();
+    }
+    return orderBookRawUpdatesSubscriptions.computeIfAbsent(
+            currencyPair, s -> triggerObservableBody(rawOrderBookUpdates(currencyPair)))
+            .map(transaction -> transaction.getRawDepthUpdate()).share();
+  }
+
+
   /**
    * Api to get binance incremental order book updates. As binance websocket provides only api to
    * get incremental updates {@link #getOrderBook(CurrencyPair, Object...)} have to build book from

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/dto/BinanceRawOrderBookUpdate.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/dto/BinanceRawOrderBookUpdate.java
@@ -1,0 +1,59 @@
+package info.bitrich.xchangestream.binance.dto;
+
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.function.BiConsumer;
+
+public class BinanceRawOrderBookUpdate {
+    private final String eventType;
+    private final String eventTime;
+    private final String symbol;
+    private final SortedMap<BigDecimal, BigDecimal> bids;
+    private final SortedMap<BigDecimal, BigDecimal> asks;
+    private final long firstUpdateId;
+    private final long lastUpdateId;
+
+    public BinanceRawOrderBookUpdate(String eventType,
+                                     String eventTime,
+                                     String symbol,
+                                     long firstUpdateId,
+                                     long lastUpdateId,
+                                     List<Object[]> _bids,
+                                     List<Object[]> _asks) {
+        this.eventType = eventType;
+        this.eventTime = eventTime;
+        this.symbol = symbol;
+        this.firstUpdateId = firstUpdateId;
+        this.lastUpdateId = lastUpdateId;
+
+        BiConsumer<Object[], Map<BigDecimal, BigDecimal>> entryProcessor =
+        (obj, col) -> {
+          BigDecimal price = new BigDecimal(obj[0].toString());
+          BigDecimal qty = new BigDecimal(obj[1].toString());
+          col.put(price, qty);
+        };
+
+        TreeMap<BigDecimal, BigDecimal> bids = new TreeMap<>((k1, k2) -> -k1.compareTo(k2));
+        TreeMap<BigDecimal, BigDecimal> asks = new TreeMap<>();
+
+        _bids.forEach(e -> entryProcessor.accept(e, bids));
+        _asks.forEach(e -> entryProcessor.accept(e, asks));
+
+        this.bids = Collections.unmodifiableSortedMap(bids);
+        this.asks = Collections.unmodifiableSortedMap(asks);
+    }
+
+    public String getEventType() { return eventType; }
+
+    public String getEventTime() { return eventTime; }
+
+    public String getSymbol() { return symbol; }
+
+    public long getFirstUpdateId() { return firstUpdateId; }
+
+    public long getLastUpdateId() { return lastUpdateId; }
+
+    public SortedMap<BigDecimal, BigDecimal> getBids() { return bids; }
+
+    public SortedMap<BigDecimal, BigDecimal> getAsks() { return asks; }
+}

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/dto/DepthBinanceWebSocketTransaction.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/dto/DepthBinanceWebSocketTransaction.java
@@ -7,6 +7,7 @@ import org.knowm.xchange.binance.dto.marketdata.BinanceOrderbook;
 public class DepthBinanceWebSocketTransaction extends ProductBinanceWebSocketTransaction {
 
   private final BinanceOrderbook orderBook;
+  private final BinanceRawOrderBookUpdate rawDepthUpdate;
   private final long lastUpdateId;
   private final long firstUpdateId;
 
@@ -22,6 +23,8 @@ public class DepthBinanceWebSocketTransaction extends ProductBinanceWebSocketTra
     this.firstUpdateId = firstUpdateId;
     this.lastUpdateId = lastUpdateId;
     orderBook = new BinanceOrderbook(lastUpdateId, _bids, _asks);
+    rawDepthUpdate = new BinanceRawOrderBookUpdate(eventType, eventTime, symbol,
+            firstUpdateId, lastUpdateId, _bids, _asks);
   }
 
   public BinanceOrderbook getOrderBook() {
@@ -35,4 +38,6 @@ public class DepthBinanceWebSocketTransaction extends ProductBinanceWebSocketTra
   public long getLastUpdateId() {
     return lastUpdateId;
   }
+
+  public BinanceRawOrderBookUpdate getRawDepthUpdate() { return rawDepthUpdate; }
 }


### PR DESCRIPTION
Hi,
I would like to store locally to a file some raw stream data from binance like `depthUpdate` and `aggTrade`. While the `BinanceStreamingMarketDataService` provides a `getRawTrades()` there is no `getRawOrderBookUpdates()`.

I have prepared a patch, but as I'm new to the project, I hope someone can take a look.