### PR TITLE
[Bittrex] Trade history query support for start and end time.

### DIFF
--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/BittrexAuthenticated.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/BittrexAuthenticated.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bittrex;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.List;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -148,7 +149,9 @@ public interface BittrexAuthenticated extends Bittrex {
       @HeaderParam("Api-Content-Hash") ParamsDigest hash,
       @HeaderParam("Api-Signature") ParamsDigest signature,
       @QueryParam("marketSymbol") String marketSymbol,
-      @QueryParam("pageSize") Integer pageSize)
+      @QueryParam("pageSize") Integer pageSize,
+      @QueryParam("startDate") Date startDate,
+      @QueryParam("endDate") Date endDate)
       throws IOException, BittrexException;
 
   @GET

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexDigest.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexDigest.java
@@ -1,5 +1,7 @@
 package org.knowm.xchange.bittrex.service;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import javax.crypto.Mac;
@@ -40,7 +42,9 @@ public class BittrexDigest extends BaseParamsDigest {
     String content = restInvocation.getRequestBody();
     String contentHash = DigestUtils.bytesToHex(md.digest(content.getBytes()));
 
-    String uri = restInvocation.getInvocationUrl();
+    // In the signature calculation, Bittrex expects the original unencoded URL.
+    // That is not accessible from a RestInvocation, so we have to decode it here.
+    String uri = urlDecode(restInvocation.getInvocationUrl());
     Long timestamp = (Long) restInvocation.getParamValue(HeaderParam.class, "Api-Timestamp");
     String method = restInvocation.getHttpMethod();
 
@@ -50,5 +54,20 @@ public class BittrexDigest extends BaseParamsDigest {
     mac.update(preSign.getBytes());
 
     return DigestUtils.bytesToHex(mac.doFinal());
+  }
+
+  /**
+   * Decodes the URL-encoded string and returns the plain text. The converse of
+   * si.mazi.rescu.Params#urlEncode(java.lang.String, boolean).
+   *
+   * @param data Encoded text.
+   * @return Plain text.
+   */
+  static String urlDecode(String data) {
+    try {
+      return URLDecoder.decode(data, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException("Illegal encoding, fix the code.", e); // should not happen
+    }
   }
 }

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeHistoryParams.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeHistoryParams.java
@@ -1,0 +1,16 @@
+package org.knowm.xchange.bittrex.service;
+
+import java.util.Date;
+import lombok.Data;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
+import org.knowm.xchange.service.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.trade.params.TradeHistoryParamsTimeSpan;
+
+@Data
+public class BittrexTradeHistoryParams
+    implements TradeHistoryParams, TradeHistoryParamCurrencyPair, TradeHistoryParamsTimeSpan {
+  private Date startTime;
+  private Date endTime;
+  private CurrencyPair currencyPair;
+}

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeService.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeService.java
@@ -1,13 +1,16 @@
 package org.knowm.xchange.bittrex.service;
 
 import java.io.IOException;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import org.knowm.xchange.bittrex.*;
 import org.knowm.xchange.bittrex.dto.BittrexException;
 import org.knowm.xchange.bittrex.dto.trade.BittrexOrder;
 import org.knowm.xchange.client.ResilienceRegistries;
+import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.dto.trade.LimitOrder;
@@ -16,9 +19,9 @@ import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.service.trade.TradeService;
 import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
 import org.knowm.xchange.service.trade.params.CancelOrderParams;
-import org.knowm.xchange.service.trade.params.DefaultTradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.trade.params.TradeHistoryParamsTimeSpan;
 import org.knowm.xchange.service.trade.params.orders.DefaultOpenOrdersParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
 
@@ -78,12 +81,28 @@ public class BittrexTradeService extends BittrexTradeServiceRaw implements Trade
 
   @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
+
+    CurrencyPair currencyPair = null;
+    Date startDate = null;
+    Date endDate = null;
+
+    if (params instanceof TradeHistoryParamCurrencyPair) {
+      currencyPair = ((TradeHistoryParamCurrencyPair) params).getCurrencyPair();
+    }
+    if (params instanceof TradeHistoryParamsTimeSpan) {
+      Date start = ((TradeHistoryParamsTimeSpan) params).getStartTime();
+      if (start != null) {
+        startDate = Date.from(start.toInstant().truncatedTo(ChronoUnit.SECONDS));
+      }
+      Date end = ((TradeHistoryParamsTimeSpan) params).getEndTime();
+      if (end != null) {
+        endDate = Date.from(end.toInstant().truncatedTo(ChronoUnit.SECONDS));
+      }
+    }
+
     try {
       List<BittrexOrder> tradeHistory =
-          (params instanceof TradeHistoryParamCurrencyPair)
-              ? getBittrexUserTradeHistory(
-                  ((TradeHistoryParamCurrencyPair) params).getCurrencyPair())
-              : getBittrexUserTradeHistory();
+          getBittrexUserTradeHistory(currencyPair, startDate, endDate);
       return new UserTrades(
           BittrexAdapters.adaptUserTrades(tradeHistory), Trades.TradeSortType.SortByTimestamp);
     } catch (BittrexException e) {
@@ -93,7 +112,7 @@ public class BittrexTradeService extends BittrexTradeServiceRaw implements Trade
 
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
-    return new DefaultTradeHistoryParamCurrencyPair();
+    return new BittrexTradeHistoryParams();
   }
 
   @Override

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeServiceRaw.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeServiceRaw.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.bittrex.service;
 import static org.knowm.xchange.bittrex.BittrexResilience.GET_CLOSED_ORDERS_RATE_LIMITER;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -80,8 +81,8 @@ public class BittrexTradeServiceRaw extends BittrexBaseService {
         openOrders.getSequence(), BittrexAdapters.adaptOpenOrders(openOrders));
   }
 
-  public List<BittrexOrder> getBittrexUserTradeHistory(CurrencyPair currencyPair)
-      throws IOException {
+  public List<BittrexOrder> getBittrexUserTradeHistory(
+      CurrencyPair currencyPair, Date start, Date end) throws IOException {
     return decorateApiCall(
             () ->
                 bittrexAuthenticated.getClosedOrders(
@@ -90,10 +91,17 @@ public class BittrexTradeServiceRaw extends BittrexBaseService {
                     contentCreator,
                     signatureCreator,
                     BittrexUtils.toPairString(currencyPair),
-                    200))
+                    200,
+                    start,
+                    end))
         .withRetry(retry("getClosedOrders"))
         .withRateLimiter(rateLimiter(GET_CLOSED_ORDERS_RATE_LIMITER))
         .call();
+  }
+
+  public List<BittrexOrder> getBittrexUserTradeHistory(CurrencyPair currencyPair)
+      throws IOException {
+    return getBittrexUserTradeHistory(currencyPair, null, null);
   }
 
   public List<BittrexOrder> getBittrexUserTradeHistory() throws IOException {

--- a/xchange-bittrex/src/test/java/org/knowm/xchange/bittrex/service/BittrexDigestTest.java
+++ b/xchange-bittrex/src/test/java/org/knowm/xchange/bittrex/service/BittrexDigestTest.java
@@ -1,6 +1,6 @@
 package org.knowm.xchange.bittrex.service;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
@@ -14,6 +14,6 @@ public class BittrexDigestTest {
     String encoded =
         "https://api.bittrex.com/v3/orders/closed?marketSymbol=BTC-USD&pageSize=100&startDate=2020-11-04T09%3A09%3A21Z";
 
-    assertEquals(unencoded, BittrexDigest.urlDecode(encoded));
+    assertThat(BittrexDigest.urlDecode(encoded)).isEqualTo(unencoded);
   }
 }

--- a/xchange-bittrex/src/test/java/org/knowm/xchange/bittrex/service/BittrexDigestTest.java
+++ b/xchange-bittrex/src/test/java/org/knowm/xchange/bittrex/service/BittrexDigestTest.java
@@ -1,0 +1,19 @@
+package org.knowm.xchange.bittrex.service;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class BittrexDigestTest {
+
+  @Test
+  public void urlDecodeEncodedQueryParam() {
+
+    String unencoded =
+        "https://api.bittrex.com/v3/orders/closed?marketSymbol=BTC-USD&pageSize=100&startDate=2020-11-04T09:09:21Z";
+    String encoded =
+        "https://api.bittrex.com/v3/orders/closed?marketSymbol=BTC-USD&pageSize=100&startDate=2020-11-04T09%3A09%3A21Z";
+
+    assertEquals(unencoded, BittrexDigest.urlDecode(encoded));
+  }
+}


### PR DESCRIPTION
This adds support for querying Bittrex trade history with a start and end time passed as a `TradeHistoryParamsTimeSpan`.

I had to tweak `BittrexDigest`, which provides the `Api-Signature` header value in authenticated requests, because Bittrex appears to use the unencoded URL when calculating this. When a date is specified in the query the `:` characters are URL-encoded.

Fixes #4050 