### PR TITLE
[Binance][Streaming] Preserving balance timestamp when converting from Binance balance DTO to core Balance

### DIFF
--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingAccountService.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingAccountService.java
@@ -3,7 +3,6 @@ package info.bitrich.xchangestream.binance;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import info.bitrich.xchangestream.binance.dto.BaseBinanceWebSocketTransaction;
-import info.bitrich.xchangestream.binance.dto.BinanceWebsocketBalance;
 import info.bitrich.xchangestream.binance.dto.OutboundAccountInfoBinanceWebsocketTransaction;
 import info.bitrich.xchangestream.core.StreamingAccountService;
 import info.bitrich.xchangestream.service.netty.StreamingObjectMapperHelper;
@@ -11,7 +10,6 @@ import io.reactivex.Observable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.Subject;
-import java.util.List;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.dto.account.Balance;
 import org.knowm.xchange.exceptions.ExchangeException;
@@ -42,9 +40,8 @@ public class BinanceStreamingAccountService implements StreamingAccountService {
   public Observable<Balance> getBalanceChanges() {
     checkConnected();
     return getRawAccountInfo()
-        .map(OutboundAccountInfoBinanceWebsocketTransaction::getBalances)
-        .flatMap((List<BinanceWebsocketBalance> balances) -> Observable.fromIterable(balances))
-        .map(BinanceWebsocketBalance::toBalance);
+        .map(OutboundAccountInfoBinanceWebsocketTransaction::toBalanceList)
+        .flatMap(Observable::fromIterable);
   }
 
   private void checkConnected() {

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/dto/BinanceWebsocketBalance.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/dto/BinanceWebsocketBalance.java
@@ -3,7 +3,6 @@ package info.bitrich.xchangestream.binance.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
 import org.knowm.xchange.currency.Currency;
-import org.knowm.xchange.dto.account.Balance;
 
 public final class BinanceWebsocketBalance {
 
@@ -34,10 +33,6 @@ public final class BinanceWebsocketBalance {
 
   public BigDecimal getLocked() {
     return locked;
-  }
-
-  public Balance toBalance() {
-    return new Balance(currency, getTotal(), getAvailable(), getLocked());
   }
 
   @Override

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/dto/OutboundAccountInfoBinanceWebsocketTransaction.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/dto/OutboundAccountInfoBinanceWebsocketTransaction.java
@@ -2,7 +2,10 @@ package info.bitrich.xchangestream.binance.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
+import org.knowm.xchange.dto.account.Balance;
 
 public class OutboundAccountInfoBinanceWebsocketTransaction
     extends BaseBinanceWebSocketTransaction {
@@ -82,6 +85,23 @@ public class OutboundAccountInfoBinanceWebsocketTransaction
 
   public List<String> getPermissions() {
     return permissions;
+  }
+
+  public List<Balance> toBalanceList() {
+    return balances.stream()
+        .map(
+            b ->
+                new Balance(
+                    b.getCurrency(),
+                    b.getTotal(),
+                    b.getAvailable(),
+                    b.getLocked(),
+                    BigDecimal.ZERO,
+                    BigDecimal.ZERO,
+                    BigDecimal.ZERO,
+                    BigDecimal.ZERO,
+                    new Date(lastUpdateTimestamp)))
+        .collect(Collectors.toList());
   }
 
   @Override


### PR DESCRIPTION
Hi,
For some reason BinanceStreamingAccountService emits balance changes without timestamp, although it is present in server response. I'd like to include it with this PR.

I'm new to this project, hope someone can have a look. Thank you in advance. 