### PR TITLE
Implement resubscribeChannels() for KrakenStreamingExchange

### DIFF
--- a/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingExchange.java
+++ b/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingExchange.java
@@ -147,4 +147,12 @@ public class KrakenStreamingExchange extends KrakenExchange implements Streaming
     }
     return null;
   }
+
+    @Override
+    public void resubscribeChannels() {
+        logger.debug("Resubscribing channels");
+        streamingService.resubscribeChannels();
+        if (privateStreamingService != null)
+            privateStreamingService.resubscribeChannels();
+    }
 }


### PR DESCRIPTION
`KrakenStreamingService` inherits a method `resubsribeChannels`(from `JsonNettyStreamingService`), so implementing it `KrakenStreamingExchange` is only a matter of calling the method on `streamingService` and `privateStreamingService` members