### PR TITLE
kucoin_currencies not implemented

### DIFF
--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinExchange.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinExchange.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.kucoin;
 import static org.knowm.xchange.kucoin.KucoinExceptionClassifier.classifyingExceptions;
 
 import java.io.IOException;
+
 import org.knowm.xchange.BaseExchange;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeSpecification;
@@ -65,7 +66,7 @@ public class KucoinExchange extends BaseExchange implements Exchange {
   public void remoteInit() throws IOException, ExchangeException {
     this.exchangeMetaData =
         KucoinAdapters.adaptMetadata(
-            this.exchangeMetaData, getMarketDataService().getKucoinSymbols());
+            this.exchangeMetaData, getMarketDataService().getKucoinSymbols(), getMarketDataService().getKucoinCurrencies());
   }
 
   @Override

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinMarketDataServiceRaw.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinMarketDataServiceRaw.java
@@ -7,12 +7,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import org.knowm.xchange.currency.CurrencyPair;
-import org.knowm.xchange.kucoin.dto.response.AllTickersResponse;
-import org.knowm.xchange.kucoin.dto.response.OrderBookResponse;
-import org.knowm.xchange.kucoin.dto.response.SymbolResponse;
-import org.knowm.xchange.kucoin.dto.response.SymbolTickResponse;
-import org.knowm.xchange.kucoin.dto.response.TickerResponse;
-import org.knowm.xchange.kucoin.dto.response.TradeHistoryResponse;
+import org.knowm.xchange.kucoin.dto.response.*;
 
 public class KucoinMarketDataServiceRaw extends KucoinBaseService {
 
@@ -39,6 +34,10 @@ public class KucoinMarketDataServiceRaw extends KucoinBaseService {
 
   public List<SymbolResponse> getKucoinSymbols() throws IOException {
     return classifyingExceptions(symbolApi::getSymbols);
+  }
+
+  public List<CurrenciesResponse> getKucoinCurrencies() throws IOException {
+    return classifyingExceptions(symbolApi::getCurrencies);
   }
 
   public OrderBookResponse getKucoinOrderBookPartial(CurrencyPair pair) throws IOException {

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/CurrenciesResponse.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/CurrenciesResponse.java
@@ -1,0 +1,32 @@
+package org.knowm.xchange.kucoin.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CurrenciesResponse {
+
+    private String currency;
+
+    private String name;
+
+    private String fullName;
+
+    private BigDecimal precision;
+
+    private String withdrawalMinSize;
+
+    private String withdrawalMinFee;
+
+    private boolean isWithdrawEnabled;
+
+    private boolean isDepositEnabled;
+
+    private boolean isMarginEnabled;
+
+    private boolean isDebitEnabled;
+
+}

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/SymbolAPI.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/SymbolAPI.java
@@ -10,11 +10,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-import org.knowm.xchange.kucoin.dto.response.AllTickersResponse;
-import org.knowm.xchange.kucoin.dto.response.KucoinResponse;
-import org.knowm.xchange.kucoin.dto.response.SymbolResponse;
-import org.knowm.xchange.kucoin.dto.response.SymbolTickResponse;
-import org.knowm.xchange.kucoin.dto.response.TickerResponse;
+
+import org.knowm.xchange.kucoin.dto.response.*;
 
 /** Based on code by chenshiwei on 2019/1/11. */
 @Path("api/v1")
@@ -29,6 +26,15 @@ public interface SymbolAPI {
   @GET
   @Path("/symbols")
   KucoinResponse<List<SymbolResponse>> getSymbols() throws IOException;
+
+  /**
+   * Get a list of available currencies for trading.
+   *
+   * @return The available currencies.
+   */
+  @GET
+  @Path("/currencies")
+  KucoinResponse<List<CurrenciesResponse>> getCurrencies() throws IOException;
 
   /**
    * Get the fiat price of the currencies for the available trading pairs.


### PR DESCRIPTION
Kucoin had no getCurrencies() implementation and because of that ExchangeMetaData was not properly created in KucoinAdapters.