### PR TITLE
Poloniex currency data

### DIFF
--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAdapters.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAdapters.java
@@ -26,6 +26,7 @@ import org.knowm.xchange.dto.marketdata.Trades.TradeSortType;
 import org.knowm.xchange.dto.meta.CurrencyMetaData;
 import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
 import org.knowm.xchange.dto.meta.ExchangeMetaData;
+import org.knowm.xchange.dto.meta.WalletHealth;
 import org.knowm.xchange.dto.trade.FixedRateLoanOrder;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
@@ -252,7 +253,20 @@ public class PoloniexAdapters {
 
       Currency ccy = Currency.getInstance(entry.getKey());
 
-      if (!currencyMetaDataMap.containsKey(ccy)) currencyMetaDataMap.put(ccy, currencyArchetype);
+      if (!currencyMetaDataMap.containsKey(ccy)){
+        currencyMetaDataMap.put(ccy, currencyArchetype);
+      }
+      CurrencyMetaData currencyMetaData = currencyMetaDataMap.get(ccy);
+      WalletHealth walletHealth = WalletHealth.ONLINE;
+      if( entry.getValue().isDelisted() || entry.getValue().isDisabled()){
+        walletHealth = WalletHealth.OFFLINE;
+      }
+      CurrencyMetaData currencyMetaDataUpdated = new CurrencyMetaData(
+              currencyMetaData.getScale(),
+              entry.getValue().getTxFee(),
+              currencyMetaData.getMinWithdrawalAmount(),
+              walletHealth);
+      currencyMetaDataMap.put(ccy, currencyMetaDataUpdated);
     }
 
     Map<CurrencyPair, CurrencyPairMetaData> marketMetaDataMap = exchangeMetaData.getCurrencyPairs();

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexExchange.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexExchange.java
@@ -17,7 +17,7 @@ import si.mazi.rescu.SynchronizedValueFactory;
 /** @author Zach Holmes */
 public class PoloniexExchange extends BaseExchange implements Exchange {
 
-  private SynchronizedValueFactory<Long> nonceFactory = new TimestampIncrementingNonceFactory();
+  private final SynchronizedValueFactory<Long> nonceFactory = new TimestampIncrementingNonceFactory();
 
   @Override
   protected void initServices() {


### PR DESCRIPTION
In generic implementation, Poloniex exchange service does not fills the currency data ( fee and wallet health ) in the remote initialization phase. This fix incorporates these data into currency metadata.