### PR TITLE
Added OrderType when returning market trades

### DIFF
--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateAdapters.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateAdapters.java
@@ -115,11 +115,24 @@ public class CoinmateAdapters {
   public static Trade adaptTrade(CoinmateTransactionsEntry coinmateEntry) {
     return new Trade.Builder()
         .originalAmount(coinmateEntry.getAmount())
-        .currencyPair(CoinmateUtils.getPair(coinmateEntry.getCurrencyPair()))
+        .instrument(CoinmateUtils.getPair(coinmateEntry.getCurrencyPair()))
         .price(coinmateEntry.getPrice())
         .timestamp(new Date(coinmateEntry.getTimestamp()))
+        .type(typeToOrderTypeOrNull(coinmateEntry.getType()))
         .id(coinmateEntry.getTransactionId())
         .build();
+  }
+
+  public static Order.OrderType typeToOrderTypeOrNull(String type) {
+    switch (type) {
+      case "BUY":
+      case "QUICK_BUY":
+        return Order.OrderType.BID;
+      case "SELL":
+      case "QUICK_SELL":
+        return Order.OrderType.ASK;
+    }
+    return null;
   }
 
   public static Wallet adaptWallet(CoinmateBalance coinmateBalance) {
@@ -145,25 +158,10 @@ public class CoinmateAdapters {
     List<UserTrade> trades = new ArrayList<>(coinmateTradeHistory.getData().size());
 
     for (CoinmateTransactionHistoryEntry entry : coinmateTradeHistory.getData()) {
-      Order.OrderType orderType;
-      String transactionType = entry.getTransactionType();
-      switch (transactionType) {
-        case "BUY":
-        case "QUICK_BUY":
-          orderType = Order.OrderType.BID;
-          break;
-        case "SELL":
-        case "QUICK_SELL":
-          orderType = Order.OrderType.ASK;
-          break;
-        default:
-          // here we ignore the other types, such as withdrawal, voucher etc.
-          continue;
-      }
 
       UserTrade trade =
           new UserTrade.Builder()
-              .type(orderType)
+              .type(typeToOrderTypeOrNull(entry.getTransactionType()))
               .originalAmount(entry.getAmount())
               .currencyPair(
                   CoinmateUtils.getPair(entry.getAmountCurrency() + "_" + entry.getPriceCurrency()))
@@ -184,25 +182,10 @@ public class CoinmateAdapters {
     List<UserTrade> trades = new ArrayList<>(coinmateTradeHistory.getData().size());
 
     for (CoinmateTradeHistoryEntry entry : coinmateTradeHistory.getData()) {
-      Order.OrderType orderType;
-      String transactionType = entry.getType();
-      switch (transactionType) {
-        case "BUY":
-        case "QUICK_BUY":
-          orderType = Order.OrderType.BID;
-          break;
-        case "SELL":
-        case "QUICK_SELL":
-          orderType = Order.OrderType.ASK;
-          break;
-        default:
-          // here we ignore the other types, such as withdrawal, voucher etc.
-          continue;
-      }
 
       UserTrade trade =
           new UserTrade.Builder()
-              .type(orderType)
+              .type(typeToOrderTypeOrNull(entry.getType()))
               .originalAmount(entry.getAmount())
               .currencyPair(CoinmateUtils.getPair(entry.getCurrencyPair()))
               .price(entry.getPrice())

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/marketdata/CoinmateTransactionsEntry.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/marketdata/CoinmateTransactionsEntry.java
@@ -34,19 +34,23 @@ public class CoinmateTransactionsEntry {
   private final BigDecimal price;
   private final BigDecimal amount;
   private final String currencyPair;
+  private final String type;
 
   public CoinmateTransactionsEntry(
       @JsonProperty("timestamp") long timestamp,
       @JsonProperty("transactionId") String transactionId,
       @JsonProperty("price") BigDecimal price,
       @JsonProperty("amount") BigDecimal amount,
-      @JsonProperty("currencyPair") String currencyPair) {
+      @JsonProperty("currencyPair") String currencyPair,
+      @JsonProperty("tradeType") String type
+      ) {
 
     this.timestamp = timestamp;
     this.transactionId = transactionId;
     this.price = price;
     this.amount = amount;
     this.currencyPair = currencyPair;
+      this.type = type;
   }
 
   public long getTimestamp() {
@@ -68,4 +72,6 @@ public class CoinmateTransactionsEntry {
   public String getCurrencyPair() {
     return currencyPair;
   }
+
+  public String getType() { return type; }
 }

--- a/xchange-stream-coinmate/src/main/java/info/bitrich/xchangestream/coinmate/v2/dto/CoinmateWebSocketTrade.java
+++ b/xchange-stream-coinmate/src/main/java/info/bitrich/xchangestream/coinmate/v2/dto/CoinmateWebSocketTrade.java
@@ -28,7 +28,7 @@ public class CoinmateWebSocketTrade {
   }
 
   public CoinmateTransactionsEntry toTransactionEntry(String currencyPair) {
-    return new CoinmateTransactionsEntry(timestamp, null, price, amount, currencyPair);
+    return new CoinmateTransactionsEntry(timestamp, null, price, amount, currencyPair, type);
   }
 
   public long getTimestamp() {


### PR DESCRIPTION
`getMarketDataService.getTrades` is affected, not returning null for `type` property.

 Small cleanup in adapters in same commit to avoid duplicity.