### PR TITLE
[Binance] Improve Parsing of Exchange-Specific "recvWindow" Parameter

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceBaseService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceBaseService.java
@@ -35,8 +35,27 @@ public class BinanceBaseService extends BaseResilientExchangeService<BinanceExch
   }
 
   public Long getRecvWindow() {
-    return (Long)
+    Object obj =
         exchange.getExchangeSpecification().getExchangeSpecificParametersItem("recvWindow");
+    if (obj == null) return null;
+    if (obj instanceof Number) {
+      long value = ((Number) obj).longValue();
+      if (value < 0 || value > 60000) {
+        throw new IllegalArgumentException(
+            "Exchange-specific parameter \"recvWindow\" must be in the range [0, 60000].");
+      }
+      return value;
+    }
+    if (obj.getClass().equals(String.class)) {
+      try {
+        return Long.parseLong((String) obj, 10);
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException(
+            "Exchange-specific parameter \"recvWindow\" could not be parsed.", e);
+      }
+    }
+    throw new IllegalArgumentException(
+        "Exchange-specific parameter \"recvWindow\" could not be parsed.");
   }
 
   public SynchronizedValueFactory<Long> getTimestampFactory() {

--- a/xchange-binance/src/test/java/org/knowm/xchange/binance/service/BinanceBaseServiceTest.java
+++ b/xchange-binance/src/test/java/org/knowm/xchange/binance/service/BinanceBaseServiceTest.java
@@ -1,0 +1,68 @@
+package org.knowm.xchange.binance.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.Test;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.binance.BinanceAuthenticated;
+import org.knowm.xchange.binance.BinanceExchange;
+import org.knowm.xchange.binance.BinanceResilience;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
+import org.knowm.xchange.exceptions.ExchangeException;
+
+public class BinanceBaseServiceTest {
+  /**
+   * Tests the functionality of the {@link BinanceBaseService#getRecvWindow()} to safely obtain a
+   * value for the recvWindow for various supplied inputs.
+   */
+  @Test
+  public void testGetRecvWindow() {
+    // Simple helper function that prepares a service with the "recvWindow" param and calls the
+    // getter.
+    Function<Object, Long> serviceBuilder =
+        obj -> {
+          Map<String, Object> params = new HashMap<>();
+          params.put("recvWindow", obj);
+          return getBaseService(params).getRecvWindow();
+        };
+
+    assertThat(serviceBuilder.apply(null)).isNull();
+    assertThat(serviceBuilder.apply(1L)).isEqualTo(1L);
+    assertThat(serviceBuilder.apply(123)).isEqualTo(123L);
+    assertThat(serviceBuilder.apply(0.1)).isEqualTo(0L);
+    assertThat(serviceBuilder.apply(4.9999)).isEqualTo(4L);
+    assertThatThrownBy(() -> serviceBuilder.apply(-1))
+        .isInstanceOf(ExchangeException.class)
+        .hasMessageContaining("must be in the range");
+    assertThatThrownBy(() -> serviceBuilder.apply(60001))
+        .isInstanceOf(ExchangeException.class)
+        .hasMessageContaining("must be in the range");
+    assertThatThrownBy(() -> serviceBuilder.apply("hello world"))
+        .isInstanceOf(ExchangeException.class)
+        .hasMessageContaining("could not be parsed");
+  }
+
+  /**
+   * Constructs a simple instance of the {@link BinanceBaseService} with the exchange-specific
+   * parameters set to the given map.
+   *
+   * @param exchangeSpecificParams The parameters to set on the base service.
+   * @return The instance of the service.
+   */
+  private BinanceBaseService getBaseService(Map<String, Object> exchangeSpecificParams) {
+    ExchangeSpecification spec = new BinanceExchange().getDefaultExchangeSpecification();
+    spec.setExchangeSpecificParameters(exchangeSpecificParams);
+    spec.setApiKey("abc");
+    spec.setSecretKey("123");
+    BinanceExchange exchange = (BinanceExchange) ExchangeFactory.INSTANCE.createExchange(spec);
+    return new BinanceBaseService(
+        exchange,
+        ExchangeRestProxyBuilder.forInterface(BinanceAuthenticated.class, spec).build(),
+        BinanceResilience.createRegistries());
+  }
+}


### PR DESCRIPTION
This change improves the ability of the API to handle a variety of types for the "recvWindow" parameter. This helps improve compatibility with services that load exchange parameters from files using generic deserializers.

I'm not sure what the consensus is regarding throwing exceptions or defaulting to `null` in the case of errors, so I have set it to throw an `IllegalArgumentException` for non-null values which could not be parsed.

I have also added a check to ensure that the obtained value is within the acceptable range [according to the Binance API specification](https://binance-docs.github.io/apidocs/spot/en/#signed-trade-user_data-and-margin-endpoint-security).

> One thing which I'm unsure about, is the creation of the test instances of `BinanceBaseService`, because what I am doing right now is quite slow, so I would appreciate if someone could show me a more efficient way to do this.