### PR TITLE
Fix for issue #2590

### DIFF
--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAdapters.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAdapters.java
@@ -332,6 +332,8 @@ public final class BitstampAdapters {
 
     if (bitstampOrderStatus.equals(BitstampOrderStatus.Open)) return Order.OrderStatus.NEW;
 
+    if (bitstampOrderStatus.equals(BitstampOrderStatus.Canceled)) return Order.OrderStatus.CANCELED;
+
     throw new NotYetImplementedForExchangeException();
   }
 
@@ -353,40 +355,54 @@ public final class BitstampAdapters {
     // Use only the first transaction, because we assume that for a single order id all transactions
     // will
     // be of the same currency pair
-    CurrencyPair currencyPair = adaptCurrencyPair(bitstampTransactions[0], exchangeSymbols);
-    Date date = bitstampTransactions[0].getDatetime();
-
-    BigDecimal averagePrice =
-        Arrays.stream(bitstampTransactions)
-            .map(t -> t.getPrice())
-            .reduce((x, y) -> x.add(y))
-            .get()
-            .divide(BigDecimal.valueOf(bitstampTransactions.length), 2);
-
-    BigDecimal cumulativeAmount =
-        Arrays.stream(bitstampTransactions)
-            .map(t -> getBaseCurrencyAmountFromBitstampTransaction(t, currencyPair))
-            .reduce((x, y) -> x.add(y))
-            .get();
-
-    BigDecimal totalFee =
-        Arrays.stream(bitstampTransactions).map(t -> t.getFee()).reduce((x, y) -> x.add(y)).get();
 
     Order.OrderStatus orderStatus = adaptOrderStatus(bitstampOrderStatusResponse.getStatus());
 
-    BitstampGenericOrder bitstampGenericOrder =
-        new BitstampGenericOrder(
-            null, // not discernable from response data
-            null, // not discernable from the data
-            currencyPair,
-            orderId,
-            date,
-            averagePrice,
-            cumulativeAmount,
-            totalFee,
-            orderStatus);
+    if (bitstampTransactions.length > 0) {
+      CurrencyPair currencyPair = adaptCurrencyPair(bitstampTransactions[0], exchangeSymbols);
+      Date date = bitstampTransactions[0].getDatetime();
+      BigDecimal averagePrice =
+              Arrays.stream(bitstampTransactions)
+                      .map(t -> t.getPrice())
+                      .reduce((x, y) -> x.add(y))
+                      .get()
+                      .divide(BigDecimal.valueOf(bitstampTransactions.length), 2);
 
-    return bitstampGenericOrder;
+      BigDecimal cumulativeAmount =
+              Arrays.stream(bitstampTransactions)
+                      .map(t -> getBaseCurrencyAmountFromBitstampTransaction(t, currencyPair))
+                      .reduce((x, y) -> x.add(y))
+                      .get();
+
+      BigDecimal totalFee =
+              Arrays.stream(bitstampTransactions).map(t -> t.getFee()).reduce((x, y) -> x.add(y)).get();
+
+      return new BitstampGenericOrder(
+                      null, // not discernable from response data
+                      null, // not discernable from the data
+                      currencyPair,
+                      orderId,
+                      date,
+                      averagePrice,
+                      cumulativeAmount,
+                      totalFee,
+                      orderStatus);
+
+    } else {
+      return new BitstampGenericOrder(
+                      null, // not discernable from response data
+                      null, // not discernable from the data
+                      null, // not discernable from the data
+                      orderId,
+                      null, // not discernable from the data
+                      new BigDecimal("0.0"), // not discernable from the data
+                      new BigDecimal("0.0"), // not discernable from the data
+                      new BigDecimal("0.0"), // not discernable from the data
+                      orderStatus);
+
+    }
+
+
   }
 
   public static Map<CurrencyPair, CurrencyPairMetaData> adaptCurrencyPairs(

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/trade/BitstampOrderStatus.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/trade/BitstampOrderStatus.java
@@ -13,6 +13,7 @@ import java.util.Map;
 public enum BitstampOrderStatus {
   Queue,
   Open,
+  Canceled,
   Finished;
 
   private static final Map<String, BitstampOrderStatus> fromString =


### PR DESCRIPTION
This is a fix for issue #2590

Basically if the order was not filled, there are no transactions in the response from Bitstamp, example  : 

`{"status": "Canceled", "id": 1372542846992384, "amount_remaining": "0.00943030", "transactions": []}`

It is then impossible to compute or fill some informations in the Order, i have handled this case AND I have added the "Cancelled" Status which was not handled at the moment .. 

Let me know if this can be merged ..