### PR TITLE
Make gateio up and running

### DIFF
--- a/xchange-stream-gateio/src/main/java/org/knowm/xchange/gateio/GateioStreamingExchange.java
+++ b/xchange-stream-gateio/src/main/java/org/knowm/xchange/gateio/GateioStreamingExchange.java
@@ -1,3 +1,5 @@
+package org.knowm.xchange.gateio;
+
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.core.StreamingExchange;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;

--- a/xchange-stream-gateio/src/main/java/org/knowm/xchange/gateio/GateioStreamingMarketDataService.java
+++ b/xchange-stream-gateio/src/main/java/org/knowm/xchange/gateio/GateioStreamingMarketDataService.java
@@ -1,5 +1,7 @@
-import dto.response.GateioOrderBookResponse;
-import dto.response.GateioTradesResponse;
+package org.knowm.xchange.gateio;
+
+import org.knowm.xchange.gateio.dto.response.GateioOrderBookResponse;
+import org.knowm.xchange.gateio.dto.response.GateioTradesResponse;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
 import io.reactivex.Observable;
 import org.knowm.xchange.currency.CurrencyPair;

--- a/xchange-stream-gateio/src/main/java/org/knowm/xchange/gateio/GateioStreamingService.java
+++ b/xchange-stream-gateio/src/main/java/org/knowm/xchange/gateio/GateioStreamingService.java
@@ -1,9 +1,11 @@
+package org.knowm.xchange.gateio;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import dto.GateioWebSocketSubscriptionMessage;
-import dto.response.GateioOrderBookResponse;
-import dto.response.GateioTradesResponse;
-import dto.response.GateioWebSocketTransaction;
+import org.knowm.xchange.gateio.dto.GateioWebSocketSubscriptionMessage;
+import org.knowm.xchange.gateio.dto.response.GateioOrderBookResponse;
+import org.knowm.xchange.gateio.dto.response.GateioTradesResponse;
+import org.knowm.xchange.gateio.dto.response.GateioWebSocketTransaction;
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.service.netty.JsonNettyStreamingService;
 import info.bitrich.xchangestream.service.netty.StreamingObjectMapperHelper;

--- a/xchange-stream-gateio/src/main/java/org/knowm/xchange/gateio/dto/GateioWebSocketSubscriptionMessage.java
+++ b/xchange-stream-gateio/src/main/java/org/knowm/xchange/gateio/dto/GateioWebSocketSubscriptionMessage.java
@@ -1,4 +1,4 @@
-package dto;
+package org.knowm.xchange.gateio.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.NoArgsConstructor;
@@ -40,9 +40,11 @@ public class GateioWebSocketSubscriptionMessage {
     this.event = event;
     this.payload =
         Arrays.asList(
-                currencyPair.toString().replace('/', '_'),
-                depth != null ? Integer.toString(depth) : null,
-                interval != null ? interval + "ms" : null)
+                currencyPair.toString().replace('/', '_')
+//                ,
+//                depth != null ? Integer.toString(depth) : null,
+//                interval != null ? interval + "ms" : null
+        )
             .stream()
             .filter(Objects::nonNull)
             .collect(Collectors.toList())

--- a/xchange-stream-gateio/src/main/java/org/knowm/xchange/gateio/dto/response/GateioOrderBookResponse.java
+++ b/xchange-stream-gateio/src/main/java/org/knowm/xchange/gateio/dto/response/GateioOrderBookResponse.java
@@ -1,4 +1,4 @@
-package dto.response;
+package org.knowm.xchange.gateio.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;

--- a/xchange-stream-gateio/src/main/java/org/knowm/xchange/gateio/dto/response/GateioTradesResponse.java
+++ b/xchange-stream-gateio/src/main/java/org/knowm/xchange/gateio/dto/response/GateioTradesResponse.java
@@ -1,4 +1,4 @@
-package dto.response;
+package org.knowm.xchange.gateio.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;

--- a/xchange-stream-gateio/src/main/java/org/knowm/xchange/gateio/dto/response/GateioWebSocketTransaction.java
+++ b/xchange-stream-gateio/src/main/java/org/knowm/xchange/gateio/dto/response/GateioWebSocketTransaction.java
@@ -1,4 +1,4 @@
-package dto.response;
+package org.knowm.xchange.gateio.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;

--- a/xchange-stream-gateio/src/test/java/org/knowm/xchange/gateio/GateioManualExample.java
+++ b/xchange-stream-gateio/src/test/java/org/knowm/xchange/gateio/GateioManualExample.java
@@ -1,3 +1,6 @@
+package org.knowm.xchange.gateio;
+
+import org.knowm.xchange.gateio.GateioStreamingExchange;
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.core.StreamingExchangeFactory;
 import io.reactivex.disposables.Disposable;

--- a/xchange-stream-gateio/src/test/java/org/knowm/xchange/gateio/dto/GateioOrderBookResponseTest.java
+++ b/xchange-stream-gateio/src/test/java/org/knowm/xchange/gateio/dto/GateioOrderBookResponseTest.java
@@ -1,7 +1,7 @@
-package dto;
+package org.knowm.xchange.gateio.dto;
 
 import com.google.common.io.CharStreams;
-import dto.response.GateioOrderBookResponse;
+import org.knowm.xchange.gateio.dto.response.GateioOrderBookResponse;
 import info.bitrich.xchangestream.service.netty.StreamingObjectMapperHelper;
 import org.junit.Assert;
 import org.junit.Test;

--- a/xchange-stream-gateio/src/test/java/org/knowm/xchange/gateio/dto/GateioTradesResponseTest.java
+++ b/xchange-stream-gateio/src/test/java/org/knowm/xchange/gateio/dto/GateioTradesResponseTest.java
@@ -1,7 +1,7 @@
-package dto;
+package org.knowm.xchange.gateio.dto;
 
 import com.google.common.io.CharStreams;
-import dto.response.GateioTradesResponse;
+import org.knowm.xchange.gateio.dto.response.GateioTradesResponse;
 import info.bitrich.xchangestream.service.netty.StreamingObjectMapperHelper;
 import org.junit.Assert;
 import org.junit.Test;


### PR DESCRIPTION
Fix gateio stream service:
- Move gateio files from default package to proper package
- Remove depth and interval from gateio payload (seems not supported by the gateio api)