### PR TITLE
[Binance] Fixes #4132

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAdapters.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAdapters.java
@@ -2,6 +2,9 @@ package org.knowm.xchange.binance;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.knowm.xchange.binance.dto.account.AssetDetail;
@@ -22,8 +25,19 @@ import org.knowm.xchange.dto.trade.MarketOrder;
 import org.knowm.xchange.dto.trade.StopOrder;
 
 public class BinanceAdapters {
+  private static final DateTimeFormatter DATE_TIME_FMT =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
   private BinanceAdapters() {}
+
+  public static Date toDate(String dateTime) {
+    return java.util.Date.from(
+        toLocalDateTime(dateTime).atZone(ZoneId.systemDefault()).toInstant());
+  }
+
+  public static LocalDateTime toLocalDateTime(String dateTime) {
+    return LocalDateTime.parse(dateTime, DATE_TIME_FMT);
+  }
 
   public static String toSymbol(CurrencyPair pair) {
     if (pair.equals(CurrencyPair.IOTA_BTC)) {

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/account/AssetDribbletLogResponse.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/account/AssetDribbletLogResponse.java
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.knowm.xchange.binance.BinanceAdapters;
 
 public final class AssetDribbletLogResponse
     extends ApiResponse<AssetDribbletLogResponse.AssetDribbletLogResults> {
@@ -64,7 +64,7 @@ public final class AssetDribbletLogResponse
     }
 
     public LocalDateTime getOperateTime() {
-      return LocalDateTime.parse(operate_time, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+      return BinanceAdapters.toLocalDateTime(operate_time);
     }
   }
 
@@ -80,7 +80,7 @@ public final class AssetDribbletLogResponse
     private String fromAsset;
 
     public LocalDateTime getOperateTime() {
-      return LocalDateTime.parse(operateTime, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+      return BinanceAdapters.toLocalDateTime(operateTime);
     }
   }
 }

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/account/BinanceWithdraw.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/account/BinanceWithdraw.java
@@ -14,7 +14,7 @@ public final class BinanceWithdraw {
   private String txId;
   private String id;
   private String coin;
-  private long applyTime;
+  private String applyTime;
   /** (0:Email Sent,1:Cancelled 2:Awaiting Approval 3:Rejected 4:Processing 5:Failure 6Completed) */
   private int status;
 }

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceAccountService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceAccountService.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.knowm.xchange.binance.BinanceAdapters;
 import org.knowm.xchange.binance.BinanceAuthenticated;
 import org.knowm.xchange.binance.BinanceErrorAdapter;
 import org.knowm.xchange.binance.BinanceExchange;
@@ -271,7 +272,7 @@ public class BinanceAccountService extends BinanceAccountServiceRaw implements A
                       new FundingRecord(
                           w.getAddress(),
                           w.getAddressTag(),
-                          new Date(w.getApplyTime()),
+                          BinanceAdapters.toDate(w.getApplyTime()),
                           Currency.getInstance(w.getCoin()),
                           w.getAmount(),
                           w.getId(),


### PR DESCRIPTION
Fixed /sapi/v1/capital/withdraw/history applyTime field parsing. Fixes #4132
Also added toLocalDateTime/toDate parse support and refactor to use BinanceAdapters.toLocalDateTime new parsing methods.