### PR TITLE
[FTX] Completed *ForSubaccount methods

### DIFF
--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxTradeService.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxTradeService.java
@@ -1,27 +1,19 @@
 package org.knowm.xchange.ftx.service;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import org.knowm.xchange.Exchange;
-import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.account.OpenPositions;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.dto.trade.UserTrades;
-import org.knowm.xchange.ftx.FtxAdapters;
-import org.knowm.xchange.ftx.dto.trade.CancelAllFtxOrdersParams;
 import org.knowm.xchange.service.trade.TradeService;
-import org.knowm.xchange.service.trade.params.CancelOrderByCurrencyPair;
 import org.knowm.xchange.service.trade.params.CancelOrderParams;
-import org.knowm.xchange.service.trade.params.CurrencyPairParam;
-import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
-import org.knowm.xchange.service.trade.params.TradeHistoryParamInstrument;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
+
+import java.io.IOException;
+import java.util.Collection;
 
 public class FtxTradeService extends FtxTradeServiceRaw implements TradeService {
 
@@ -31,100 +23,46 @@ public class FtxTradeService extends FtxTradeServiceRaw implements TradeService 
 
   @Override
   public String placeMarketOrder(MarketOrder marketOrder) throws IOException {
-    return placeMarketOrderForSubaccount(null, marketOrder);
-  }
-
-  public String placeMarketOrderForSubaccount(String subaccount, MarketOrder marketOrder)
-      throws IOException {
-    return placeNewFtxOrder(subaccount, FtxAdapters.adaptMarketOrderToFtxOrderPayload(marketOrder))
-        .getResult()
-        .getId();
+    return placeMarketOrderForSubaccount(exchange.getExchangeSpecification().getUserName(), marketOrder);
   }
 
   @Override
   public String placeLimitOrder(LimitOrder limitOrder) throws IOException {
-    return placeLimitOrderForSubaccount(null, limitOrder);
-  }
-
-  public String placeLimitOrderForSubaccount(String subaccount, LimitOrder limitOrder)
-      throws IOException {
-    return placeNewFtxOrder(subaccount, FtxAdapters.adaptLimitOrderToFtxOrderPayload(limitOrder))
-        .getResult()
-        .getId();
+    return placeLimitOrderForSubaccount(exchange.getExchangeSpecification().getUserName(), limitOrder);
   }
 
   @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
-
-    if (params instanceof TradeHistoryParamCurrencyPair) {
-      return FtxAdapters.adaptUserTrades(
-          getFtxOrderHistory(
-                  FtxAdapters.adaptCurrencyPairToFtxMarket(
-                      ((TradeHistoryParamCurrencyPair) params).getCurrencyPair()))
-              .getResult());
-    } else if (params instanceof TradeHistoryParamInstrument) {
-      CurrencyPair currencyPair =
-          new CurrencyPair(((TradeHistoryParamInstrument) params).getInstrument().toString());
-      return FtxAdapters.adaptUserTrades(
-          getFtxOrderHistory(FtxAdapters.adaptCurrencyPairToFtxMarket(currencyPair)).getResult());
-    } else {
-      throw new IOException(
-          "TradeHistoryParams must implement TradeHistoryParamCurrencyPair or TradeHistoryParamInstrument interface.");
-    }
+    return getTradeHistoryForSubaccount(exchange.getExchangeSpecification().getUserName(), params);
   }
 
   @Override
   public boolean cancelOrder(String orderId) throws IOException {
-    return cancelFtxOrder(orderId);
+    return cancelOrderForSubaccount(exchange.getExchangeSpecification().getUserName(), orderId);
   }
 
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws IOException {
-    if (orderParams instanceof CancelOrderByCurrencyPair) {
-      return cancelAllFtxOrders(
-          new CancelAllFtxOrdersParams(
-              FtxAdapters.adaptCurrencyPairToFtxMarket(
-                  ((CancelOrderByCurrencyPair) orderParams).getCurrencyPair())));
-    } else {
-      throw new IOException(
-          "CancelOrderParams must implement CancelOrderByCurrencyPair interface.");
-    }
+    return cancelOrderForSubaccount(exchange.getExchangeSpecification().getUserName(), orderParams);
   }
 
   @Override
   public Collection<Order> getOrder(String... orderIds) throws IOException {
-    return getOrderFromSubaccount(null, orderIds);
-  }
-
-  public Collection<Order> getOrderFromSubaccount(String subaccount, String... orderIds)
-      throws IOException {
-    List<Order> orderList = new ArrayList<>();
-    for (String orderId : orderIds) {
-      Order order = FtxAdapters.adaptLimitOrder(getFtxOrderStatus(subaccount, orderId).getResult());
-      orderList.add(order);
-    }
-    return orderList;
+    return getOrderFromSubaccount(exchange.getExchangeSpecification().getUserName(), orderIds);
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws IOException {
-    if (params instanceof CurrencyPairParam) {
-      return FtxAdapters.adaptOpenOrders(
-          getFtxOpenOrders(
-              FtxAdapters.adaptCurrencyPairToFtxMarket(
-                  ((CurrencyPairParam) params).getCurrencyPair())));
-    } else {
-      throw new IOException("OpenOrdersParams must implement CurrencyPairParam interface.");
-    }
+    return getOpenOrdersForSubaccount(exchange.getExchangeSpecification().getUserName(), params);
   }
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-    return FtxAdapters.adaptOpenOrders(getFtxAllOpenOrders());
+    return getOpenOrdersForSubaccount(exchange.getExchangeSpecification().getUserName());
   }
 
   @Override
   public OpenPositions getOpenPositions() throws IOException {
-    return FtxAdapters.adaptOpenPositions(getFtxPositions().getResult());
+    return getOpenPositionsForSubaccount(exchange.getExchangeSpecification().getUserName());
   }
 }

--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxTradeServiceRaw.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxTradeServiceRaw.java
@@ -1,14 +1,27 @@
 package org.knowm.xchange.ftx.service;
 
-import java.io.IOException;
-import java.util.List;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.account.OpenPositions;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.dto.trade.MarketOrder;
+import org.knowm.xchange.dto.trade.OpenOrders;
+import org.knowm.xchange.dto.trade.UserTrades;
+import org.knowm.xchange.ftx.FtxAdapters;
 import org.knowm.xchange.ftx.FtxException;
 import org.knowm.xchange.ftx.dto.FtxResponse;
 import org.knowm.xchange.ftx.dto.trade.CancelAllFtxOrdersParams;
 import org.knowm.xchange.ftx.dto.trade.FtxOrderDto;
 import org.knowm.xchange.ftx.dto.trade.FtxOrderRequestPayload;
 import org.knowm.xchange.ftx.dto.trade.FtxPositionDto;
+import org.knowm.xchange.service.trade.params.*;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 public class FtxTradeServiceRaw extends FtxBaseService {
 
@@ -16,27 +29,45 @@ public class FtxTradeServiceRaw extends FtxBaseService {
     super(exchange);
   }
 
+  public String placeMarketOrderForSubaccount(String subaccount, MarketOrder marketOrder)
+          throws IOException {
+    return placeNewFtxOrder(subaccount, FtxAdapters.adaptMarketOrderToFtxOrderPayload(marketOrder))
+            .getResult()
+            .getId();
+  }
+
+  public String placeLimitOrderForSubaccount(String subaccount, LimitOrder limitOrder)
+          throws IOException {
+    return placeNewFtxOrder(subaccount, FtxAdapters.adaptLimitOrderToFtxOrderPayload(limitOrder))
+            .getResult()
+            .getId();
+  }
+
   public FtxResponse<FtxOrderDto> placeNewFtxOrder(
-      String subAccount, FtxOrderRequestPayload payload) throws FtxException, IOException {
+      String subaccount, FtxOrderRequestPayload payload) throws FtxException, IOException {
     try {
       return ftx.placeOrder(
           exchange.getExchangeSpecification().getApiKey(),
           exchange.getNonceFactory().createValue(),
           signatureCreator,
-          subAccount,
+          subaccount,
           payload);
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }
   }
 
-  public boolean cancelFtxOrder(String orderId) throws FtxException, IOException {
+  public boolean cancelOrderForSubaccount(String subaccount, String orderId) throws IOException {
+    return cancelFtxOrder(subaccount, orderId);
+  }
+
+  public boolean cancelFtxOrder(String subaccount, String orderId) throws FtxException, IOException {
     try {
       return ftx.cancelOrder(
               exchange.getExchangeSpecification().getApiKey(),
               exchange.getNonceFactory().createValue(),
               signatureCreator,
-              null,
+              subaccount,
               orderId)
           .isSuccess();
     } catch (FtxException e) {
@@ -44,14 +75,26 @@ public class FtxTradeServiceRaw extends FtxBaseService {
     }
   }
 
-  public boolean cancelAllFtxOrders(CancelAllFtxOrdersParams payLoad)
+  public boolean cancelOrderForSubaccount(String subaccount, CancelOrderParams orderParams) throws IOException {
+    if (orderParams instanceof CancelOrderByCurrencyPair) {
+      return cancelAllFtxOrders(subaccount,
+              new CancelAllFtxOrdersParams(
+                      FtxAdapters.adaptCurrencyPairToFtxMarket(
+                              ((CancelOrderByCurrencyPair) orderParams).getCurrencyPair())));
+    } else {
+      throw new IOException(
+              "CancelOrderParams must implement CancelOrderByCurrencyPair interface.");
+    }
+  }
+
+  public boolean cancelAllFtxOrders(String subaccount, CancelAllFtxOrdersParams payLoad)
       throws FtxException, IOException {
     try {
       return ftx.cancelAllOrders(
               exchange.getExchangeSpecification().getApiKey(),
               exchange.getNonceFactory().createValue(),
               signatureCreator,
-              null,
+              subaccount,
               payLoad)
           .isSuccess();
     } catch (FtxException e) {
@@ -59,41 +102,85 @@ public class FtxTradeServiceRaw extends FtxBaseService {
     }
   }
 
-  public FtxResponse<List<FtxOrderDto>> getFtxOpenOrders(String market)
+  public Collection<Order> getOrderFromSubaccount(String subaccount, String... orderIds)
+          throws IOException {
+    List<Order> orderList = new ArrayList<>();
+    for (String orderId : orderIds) {
+      Order order = FtxAdapters.adaptLimitOrder(getFtxOrderStatus(subaccount, orderId).getResult());
+      orderList.add(order);
+    }
+    return orderList;
+  }
+
+  public FtxResponse<List<FtxOrderDto>> getFtxOpenOrders(String subaccount, String market)
       throws FtxException, IOException {
     try {
       return ftx.openOrders(
           exchange.getExchangeSpecification().getApiKey(),
           exchange.getNonceFactory().createValue(),
           signatureCreator,
-          null,
+              subaccount,
           market);
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }
   }
 
-  public FtxResponse<List<FtxOrderDto>> getFtxOrderHistory(String market)
-      throws FtxException, IOException {
+  public UserTrades getTradeHistoryForSubaccount(String subaccount, TradeHistoryParams params) throws IOException {
+    if (params instanceof TradeHistoryParamCurrencyPair) {
+      return FtxAdapters.adaptUserTrades(
+              getFtxOrderHistory(
+                      subaccount,
+                      FtxAdapters.adaptCurrencyPairToFtxMarket(
+                              ((TradeHistoryParamCurrencyPair) params).getCurrencyPair()))
+                      .getResult());
+    } else if (params instanceof TradeHistoryParamInstrument) {
+      CurrencyPair currencyPair =
+              new CurrencyPair(((TradeHistoryParamInstrument) params).getInstrument().toString());
+      return FtxAdapters.adaptUserTrades(
+              getFtxOrderHistory(subaccount, FtxAdapters.adaptCurrencyPairToFtxMarket(currencyPair)).getResult());
+    } else {
+      throw new IOException(
+              "TradeHistoryParams must implement TradeHistoryParamCurrencyPair or TradeHistoryParamInstrument interface.");
+    }
+  }
+
+  public FtxResponse<List<FtxOrderDto>> getFtxOrderHistory(String subaccount, String market)
+          throws FtxException, IOException {
     try {
       return ftx.orderHistory(
-          exchange.getExchangeSpecification().getApiKey(),
-          exchange.getNonceFactory().createValue(),
-          signatureCreator,
-          null,
-          market);
+              exchange.getExchangeSpecification().getApiKey(),
+              exchange.getNonceFactory().createValue(),
+              signatureCreator,
+              subaccount,
+              market);
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }
   }
 
-  public FtxResponse<List<FtxOrderDto>> getFtxAllOpenOrders() throws FtxException, IOException {
+  public OpenOrders getOpenOrdersForSubaccount(String subaccount) throws IOException {
+    return FtxAdapters.adaptOpenOrders(getFtxAllOpenOrdersForSubaccount(subaccount));
+  }
+
+  public OpenOrders getOpenOrdersForSubaccount(String subaccount, OpenOrdersParams params) throws IOException {
+    if (params instanceof CurrencyPairParam) {
+      return FtxAdapters.adaptOpenOrders(
+              getFtxOpenOrders(subaccount,
+                      FtxAdapters.adaptCurrencyPairToFtxMarket(
+                              ((CurrencyPairParam) params).getCurrencyPair())));
+    } else {
+      throw new IOException("OpenOrdersParams must implement CurrencyPairParam interface.");
+    }
+  }
+
+  public FtxResponse<List<FtxOrderDto>> getFtxAllOpenOrdersForSubaccount(String subaccount) throws FtxException, IOException {
     try {
       return ftx.openOrdersWithoutMarket(
           exchange.getExchangeSpecification().getApiKey(),
           exchange.getNonceFactory().createValue(),
           signatureCreator,
-          null);
+              subaccount);
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }
@@ -113,13 +200,17 @@ public class FtxTradeServiceRaw extends FtxBaseService {
     }
   }
 
-  public FtxResponse<List<FtxPositionDto>> getFtxPositions() throws FtxException, IOException {
+  public OpenPositions getOpenPositionsForSubaccount(String subaccount) throws IOException {
+    return FtxAdapters.adaptOpenPositions(getFtxPositions(subaccount).getResult());
+  }
+
+  public FtxResponse<List<FtxPositionDto>> getFtxPositions(String subaccount) throws FtxException, IOException {
     try {
       return ftx.getFtxPositions(
           exchange.getExchangeSpecification().getApiKey(),
           exchange.getNonceFactory().createValue(),
           signatureCreator,
-          null);
+          subaccount);
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }


### PR DESCRIPTION
In response to issue #4095

- All methods already exists now have their corresponding *ForSubaccount method
- All methods without *ForSubaccount now call to *ForSubaccount with `exspec.username` instead of null
- All non-`@Override` method were moved from `FtxTradeService` to `FtxTradeServiceRaw` for best practice
- Minor refactor for consistency

