### PR TITLE
[FTX]changeLeverage

### DIFF
--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxAccountServiceRaw.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxAccountServiceRaw.java
@@ -128,7 +128,7 @@ public class FtxAccountServiceRaw extends FtxBaseService {
           exchange.getExchangeSpecification().getApiKey(),
           exchange.getNonceFactory().createValue(),
           signatureCreator,
-          URLEncoder.encode(subaccount, "UTF-8"),
+          null,
           new FtxLeverageDto(leverage));
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());


### PR DESCRIPTION
Does not have a subaccount parameter in the FTX API, passing one causes NPE
this call changes MaxLeverage for whole account