### PR TITLE
[Bittrex] API v3 add support for "Create a new withdrawal"

### DIFF
--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/BittrexAuthenticated.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/BittrexAuthenticated.java
@@ -20,6 +20,8 @@ import org.knowm.xchange.bittrex.dto.batch.order.BatchOrder;
 import org.knowm.xchange.bittrex.dto.trade.BittrexNewOrder;
 import org.knowm.xchange.bittrex.dto.trade.BittrexOrder;
 import org.knowm.xchange.bittrex.dto.trade.BittrexOrders;
+import org.knowm.xchange.bittrex.dto.withdrawal.BittrexNewWithdrawal;
+import org.knowm.xchange.bittrex.dto.withdrawal.BittrexWithdrawal;
 import si.mazi.rescu.ParamsDigest;
 
 @Path("v3")
@@ -181,5 +183,16 @@ public interface BittrexAuthenticated extends Bittrex {
       @QueryParam("nextPageToken") String nextPageToken,
       @QueryParam("previousPageToken") String previousPageToken,
       @QueryParam("pageSize") Integer pageSize)
+      throws IOException, BittrexException;
+
+  @POST
+  @Path("withdrawals")
+  @Consumes(MediaType.APPLICATION_JSON)
+  BittrexWithdrawal createNewWithdrawal(
+      @HeaderParam("Api-Key") String apiKey,
+      @HeaderParam("Api-Timestamp") Long timestamp,
+      @HeaderParam("Api-Content-Hash") ParamsDigest hash,
+      @HeaderParam("Api-Signature") ParamsDigest signature,
+      BittrexNewWithdrawal newWithdrawal)
       throws IOException, BittrexException;
 }

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/dto/Error.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/dto/Error.java
@@ -1,0 +1,14 @@
+package org.knowm.xchange.bittrex.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Error {
+  private String code;
+  private String detail;
+  private Object data;
+}

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/dto/withdrawal/BittrexNewWithdrawal.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/dto/withdrawal/BittrexNewWithdrawal.java
@@ -1,0 +1,18 @@
+package org.knowm.xchange.bittrex.dto.withdrawal;
+
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BittrexNewWithdrawal {
+  private String currencySymbol;
+  private BigDecimal quantity;
+  private String cryptoAddress;
+  private String cryptoAddressTag;
+  private String fundsTransferMethodId;
+  private String clientWithdrawalId;
+}

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/dto/withdrawal/BittrexWithdrawal.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/dto/withdrawal/BittrexWithdrawal.java
@@ -1,0 +1,28 @@
+package org.knowm.xchange.bittrex.dto.withdrawal;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BittrexWithdrawal {
+  private String id;
+  private String currencySymbol;
+  private BigDecimal quantity;
+  private String cryptoAddress;
+  private String cryptoAddressTag;
+  private String fundsTransferMethodId;
+  private BigDecimal txCost;
+  private String txId;
+  private Status status;
+  private Date createdAt;
+  private Date completedAt;
+  private String clientWithdrawalId;
+  private Target target;
+  private String accountId;
+  private Error error;
+}

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/dto/withdrawal/Status.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/dto/withdrawal/Status.java
@@ -1,0 +1,11 @@
+package org.knowm.xchange.bittrex.dto.withdrawal;
+
+public enum Status {
+  REQUESTED,
+  AUTHORIZED,
+  PENDING,
+  COMPLETED,
+  ERROR_INVALID_ADDRESS,
+  CANCELLED,
+  NEW
+}

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/dto/withdrawal/Target.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/dto/withdrawal/Target.java
@@ -1,0 +1,8 @@
+package org.knowm.xchange.bittrex.dto.withdrawal;
+
+public enum Target {
+  BLOCKCHAIN,
+  WIRE_TRANSFER,
+  CREDIT_CARD,
+  ACH
+}

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexAccountService.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexAccountService.java
@@ -10,7 +10,6 @@ import org.knowm.xchange.bittrex.*;
 import org.knowm.xchange.bittrex.dto.BittrexException;
 import org.knowm.xchange.bittrex.dto.account.BittrexAddress;
 import org.knowm.xchange.bittrex.dto.account.BittrexComissionRatesWithMarket;
-import org.knowm.xchange.bittrex.dto.withdrawal.BittrexWithdrawal;
 import org.knowm.xchange.client.ResilienceRegistries;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -99,8 +98,7 @@ public class BittrexAccountService extends BittrexAccountServiceRaw implements A
   public String withdrawFunds(Currency currency, BigDecimal amount, String address)
       throws IOException {
     try {
-      BittrexWithdrawal createdWithdrawal = createNewWithdrawal(currency, amount, address);
-      return createdWithdrawal.getId();
+      return createNewWithdrawal(currency, amount, address).getId();
     } catch (BittrexException e) {
       throw BittrexErrorAdapter.adapt(e);
     }

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexAccountService.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexAccountService.java
@@ -10,6 +10,7 @@ import org.knowm.xchange.bittrex.*;
 import org.knowm.xchange.bittrex.dto.BittrexException;
 import org.knowm.xchange.bittrex.dto.account.BittrexAddress;
 import org.knowm.xchange.bittrex.dto.account.BittrexComissionRatesWithMarket;
+import org.knowm.xchange.bittrex.dto.withdrawal.BittrexWithdrawal;
 import org.knowm.xchange.client.ResilienceRegistries;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -89,6 +90,17 @@ public class BittrexAccountService extends BittrexAccountServiceRaw implements A
                 BigDecimal.valueOf(tradingFee.getTakerRate())));
       }
       return result;
+    } catch (BittrexException e) {
+      throw BittrexErrorAdapter.adapt(e);
+    }
+  }
+
+  @Override
+  public String withdrawFunds(Currency currency, BigDecimal amount, String address)
+      throws IOException {
+    try {
+      BittrexWithdrawal createdWithdrawal = createNewWithdrawal(currency, amount, address);
+      return createdWithdrawal.getId();
     } catch (BittrexException e) {
       throw BittrexErrorAdapter.adapt(e);
     }

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexAccountServiceRaw.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexAccountServiceRaw.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bittrex.service;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -13,6 +14,8 @@ import org.knowm.xchange.bittrex.BittrexConstants;
 import org.knowm.xchange.bittrex.BittrexExchange;
 import org.knowm.xchange.bittrex.dto.account.*;
 import org.knowm.xchange.bittrex.dto.trade.BittrexOrder;
+import org.knowm.xchange.bittrex.dto.withdrawal.BittrexNewWithdrawal;
+import org.knowm.xchange.bittrex.dto.withdrawal.BittrexWithdrawal;
 import org.knowm.xchange.client.ResilienceRegistries;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.dto.account.Balance;
@@ -127,6 +130,17 @@ public class BittrexAccountServiceRaw extends BittrexBaseService {
         nextPageToken,
         previousPageToken,
         pageSize);
+  }
+
+  public BittrexWithdrawal createNewWithdrawal(Currency currency, BigDecimal amount, String address)
+      throws IOException {
+    BittrexNewWithdrawal newWithdrawal = new BittrexNewWithdrawal();
+    newWithdrawal.setCurrencySymbol(currency.getCurrencyCode());
+    newWithdrawal.setQuantity(amount);
+    newWithdrawal.setCryptoAddress(address);
+
+    return bittrexAuthenticated.createNewWithdrawal(
+        apiKey, System.currentTimeMillis(), contentCreator, signatureCreator, newWithdrawal);
   }
 
   @AllArgsConstructor


### PR DESCRIPTION
Implemented method supporting "Create a new withdrawal" API endpoint - https://bittrex.github.io/api/v3#operation--withdrawals-post