### PR TITLE
[CoinbasePro] Implement get open orders by currency pair

### DIFF
--- a/xchange-coinbasepro/pom.xml
+++ b/xchange-coinbasepro/pom.xml
@@ -25,15 +25,19 @@
     <dependencies>
 
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.knowm.xchange</groupId>
             <artifactId>xchange-core</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
         </dependency>
 
     </dependencies>

--- a/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/CoinbasePro.java
+++ b/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/CoinbasePro.java
@@ -140,6 +140,17 @@ public interface CoinbasePro {
       @QueryParam("after") String after)
       throws CoinbaseProException, IOException;
 
+  @GET
+  @Path("orders")
+  CoinbaseProOrder[] getListOrders(
+      @HeaderParam("CB-ACCESS-KEY") String apiKey,
+      @HeaderParam("CB-ACCESS-SIGN") ParamsDigest signer,
+      @HeaderParam("CB-ACCESS-TIMESTAMP") long timestamp,
+      @HeaderParam("CB-ACCESS-PASSPHRASE") String passphrase,
+      @QueryParam("status") String status,
+      @QueryParam("product_id") String productId)
+      throws CoinbaseProException, IOException;
+
   @POST
   @Path("orders")
   @Consumes(MediaType.APPLICATION_JSON)

--- a/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/CoinbaseProAdapters.java
+++ b/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/CoinbaseProAdapters.java
@@ -406,7 +406,7 @@ public class CoinbaseProAdapters {
   }
 
   public static String adaptProductID(CurrencyPair currencyPair) {
-    return currencyPair.base.getCurrencyCode() + "-" + currencyPair.counter.getCurrencyCode();
+    return currencyPair == null ? null : currencyPair.base.getCurrencyCode() + "-" + currencyPair.counter.getCurrencyCode();
   }
 
   public static CoinbaseProPlaceOrder.Side adaptSide(OrderType orderType) {

--- a/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/service/CoinbaseProTradeService.java
+++ b/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/service/CoinbaseProTradeService.java
@@ -20,6 +20,7 @@ import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
 import org.knowm.xchange.service.trade.params.CancelOrderParams;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.orders.DefaultOpenOrdersParamCurrencyPair;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
 import org.knowm.xchange.service.trade.params.orders.OrderQueryParams;
 
@@ -32,7 +33,7 @@ public class CoinbaseProTradeService extends CoinbaseProTradeServiceRaw implemen
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-    return getOpenOrders(createOpenOrdersParams());
+    return CoinbaseProAdapters.adaptOpenOrders(getCoinbaseProOpenOrders());
   }
 
   @Override
@@ -42,6 +43,11 @@ public class CoinbaseProTradeService extends CoinbaseProTradeServiceRaw implemen
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws IOException {
+    if (params instanceof OpenOrdersParamCurrencyPair) {
+      OpenOrdersParamCurrencyPair pairParams = (OpenOrdersParamCurrencyPair) params;
+      String productId = CoinbaseProAdapters.adaptProductID(pairParams.getCurrencyPair());
+      return CoinbaseProAdapters.adaptOpenOrders(getCoinbaseProOpenOrders(productId));
+    }
     return CoinbaseProAdapters.adaptOpenOrders(getCoinbaseProOpenOrders());
   }
 

--- a/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/service/CoinbaseProTradeServiceRaw.java
+++ b/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/service/CoinbaseProTradeServiceRaw.java
@@ -37,6 +37,25 @@ public class CoinbaseProTradeServiceRaw extends CoinbaseProBaseService {
     }
   }
 
+  /** https://docs.pro.coinbase.com/#list-orders */
+  public CoinbaseProOrder[] getCoinbaseProOpenOrders(String productId) throws IOException {
+    try {
+      return decorateApiCall(
+              () ->
+                      coinbasePro.getListOrders(
+                              apiKey,
+                              digest,
+                              UnixTimestampFactory.INSTANCE.createValue(),
+                              passphrase,
+                              "open",
+                              productId))
+              .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+              .call();
+    } catch (CoinbaseProException e) {
+      throw handleError(e);
+    }
+  }
+
   /** https://docs.pro.coinbase.com/#fills */
   public CoinbasePagedResponse<CoinbaseProFill> getCoinbaseProFills(
       TradeHistoryParams tradeHistoryParams) throws IOException {

--- a/xchange-coinbasepro/src/test/java/org/knowm/xchange/coinbasepro/CoinbaseProAdaptersTest.java
+++ b/xchange-coinbasepro/src/test/java/org/knowm/xchange/coinbasepro/CoinbaseProAdaptersTest.java
@@ -22,6 +22,7 @@ import org.knowm.xchange.coinbasepro.dto.marketdata.CoinbaseProProductStats;
 import org.knowm.xchange.coinbasepro.dto.marketdata.CoinbaseProProductTicker;
 import org.knowm.xchange.coinbasepro.dto.trade.CoinbaseProFill;
 import org.knowm.xchange.coinbasepro.dto.trade.CoinbaseProOrder;
+import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.OrderType;
@@ -369,6 +370,20 @@ public class CoinbaseProAdaptersTest {
     assertThat(openOrders.getHiddenOrders()).hasSize(1);
     assertStopOrderFilled(openOrders.getHiddenOrders().get(0));
     assertLimitOrderPending(openOrders.getOpenOrders().get(0));
+  }
+
+  @Test
+  public void testAdaptProductID() {
+    String productID = CoinbaseProAdapters.adaptProductID(CurrencyPair.ETH_BTC);
+
+    assertThat(productID).isEqualTo(Currency.ETH + "-" + Currency.BTC);
+  }
+
+  @Test
+  public void testAdaptProductIDHandlesNull() {
+    String productID = CoinbaseProAdapters.adaptProductID(null);
+
+    assertThat(productID).isEqualTo(null);
   }
 
   private void assertStopOrderFilled(final Order order) {

--- a/xchange-coinbasepro/src/test/java/org/knowm/xchange/coinbasepro/CoinbaseProExchangeIntegration.java
+++ b/xchange-coinbasepro/src/test/java/org/knowm/xchange/coinbasepro/CoinbaseProExchangeIntegration.java
@@ -62,7 +62,7 @@ public class CoinbaseProExchangeIntegration {
     CoinbaseProTrades trades1 =
         marketDataServiceRaw.getCoinbaseProTradesExtended(
             currencyPair, new Long(Integer.MAX_VALUE), null);
-    assertEquals("Unexpected trades list length (100)", 100, trades1.size());
+    assertEquals("Unexpected trades list length (1000)", 1000, trades1.size());
 
     // get latest 10 trades
     CoinbaseProTrades trades2 =

--- a/xchange-coinbasepro/src/test/java/org/knowm/xchange/coinbasepro/service/BaseWiremockTest.java
+++ b/xchange-coinbasepro/src/test/java/org/knowm/xchange/coinbasepro/service/BaseWiremockTest.java
@@ -1,0 +1,27 @@
+package org.knowm.xchange.coinbasepro.service;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Rule;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.coinbasepro.CoinbaseProExchange;
+
+public class BaseWiremockTest {
+
+  @Rule public WireMockRule wireMockRule = new WireMockRule();
+  public static final String WIREMOCK_FILES_PATH = "__files";
+
+
+  public Exchange createExchange() {
+    Exchange exchange =
+        ExchangeFactory.INSTANCE.createExchangeWithoutSpecification(CoinbaseProExchange.class);
+    ExchangeSpecification specification = exchange.getDefaultExchangeSpecification();
+    specification.setHost("localhost");
+    specification.setSslUri("http://localhost:" + wireMockRule.port());
+    specification.setPort(wireMockRule.port());
+    specification.setShouldLoadRemoteMetaData(false);
+    exchange.applySpecification(specification);
+    return exchange;
+  }
+}

--- a/xchange-coinbasepro/src/test/java/org/knowm/xchange/coinbasepro/service/CoinbaseProTradeServiceTest.java
+++ b/xchange-coinbasepro/src/test/java/org/knowm/xchange/coinbasepro/service/CoinbaseProTradeServiceTest.java
@@ -1,0 +1,90 @@
+package org.knowm.xchange.coinbasepro.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.knowm.xchange.coinbasepro.CoinbaseProExchange;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.dto.trade.OpenOrders;
+import org.knowm.xchange.service.trade.params.orders.DefaultOpenOrdersParamCurrencyPair;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CoinbaseProTradeServiceTest extends BaseWiremockTest {
+
+    private CoinbaseProTradeService classUnderTest;
+
+    public static final String WIREMOCK_FILES_PATH = "__files";
+    private static final String ORDERS_FILE_NAME = "orders.json";
+    private static final String OPENORDERS_FILE_NAME = "openOrders.json";
+
+    @Before
+    public void setup(){
+        classUnderTest = (CoinbaseProTradeService) createExchange().getTradeService();
+    }
+
+    @Test
+    public void ordersTest() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonRoot =
+                mapper.readTree(
+                        this.getClass().getResource("/" + WIREMOCK_FILES_PATH + "/" + ORDERS_FILE_NAME));
+
+        stubFor(
+                get(urlPathEqualTo("/orders"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader("Content-Type", "application/json")
+                                        .withBodyFile("orders.json")));
+
+        OpenOrders openOrders = classUnderTest.getOpenOrders();
+
+        assertThat(openOrders).isNotNull();
+        assertThat(openOrders.getOpenOrders()).hasSize(jsonRoot.size());
+        LimitOrder firstOrder = openOrders.getOpenOrders().get(0);
+        assertThat(firstOrder).isNotNull();
+        assertThat(firstOrder.getOriginalAmount()).isNotNull().isPositive();
+        assertThat(firstOrder.getId()).isNotBlank();
+        assertThat(firstOrder.getInstrument()).isEqualTo(CurrencyPair.ETH_BTC);
+
+        LimitOrder secondOrder = openOrders.getOpenOrders().get(1);
+        assertThat(secondOrder).isNotNull();
+        assertThat(secondOrder.getOriginalAmount()).isNotNull().isPositive();
+        assertThat(secondOrder.getId()).isNotBlank();
+        assertThat(secondOrder.getInstrument()).isEqualTo(CurrencyPair.LTC_BTC);
+
+    }
+
+    @Test
+    public void openOrdersByProductTest() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonRoot =
+                mapper.readTree(
+                        this.getClass().getResource("/" + WIREMOCK_FILES_PATH + "/" + OPENORDERS_FILE_NAME));
+        stubFor(
+                get(urlPathEqualTo("/orders"))
+                        .withQueryParam("status", equalTo("open"))
+                        .withQueryParam("product_id", equalTo("BTC-USD"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader("Content-Type", "application/json")
+                                        .withBodyFile("openOrders.json")));
+
+        DefaultOpenOrdersParamCurrencyPair defaultOpenOrdersParamCurrencyPair =
+                new DefaultOpenOrdersParamCurrencyPair(CurrencyPair.BTC_USD);
+
+        OpenOrders openOrders = classUnderTest.getOpenOrders(defaultOpenOrdersParamCurrencyPair);
+        assertThat(openOrders).isNotNull();
+        assertThat(openOrders.getOpenOrders()).hasSize(jsonRoot.size());
+        LimitOrder firstOrder = openOrders.getOpenOrders().get(0);
+        assertThat(firstOrder).isNotNull();
+        assertThat(firstOrder.getOriginalAmount()).isNotNull().isPositive();
+        assertThat(firstOrder.getId()).isNotBlank();
+        assertThat(firstOrder.getInstrument()).isEqualTo(CurrencyPair.BTC_USD);
+    }
+}

--- a/xchange-coinbasepro/src/test/resources/__files/openOrders.json
+++ b/xchange-coinbasepro/src/test/resources/__files/openOrders.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "d0c5340b-6d6c-49d9-b567-48c4bfca13d2",
+    "price": "0.10000000",
+    "size": "0.01000000",
+    "product_id": "BTC-USD",
+    "side": "buy",
+    "stp": "dc",
+    "type": "limit",
+    "time_in_force": "GTC",
+    "post_only": false,
+    "created_at": "2016-12-08T20:02:28.53864Z",
+    "fill_fees": "0.0000000000000000",
+    "filled_size": "0.00000000",
+    "executed_value": "0.0000000000000000",
+    "status": "open",
+    "settled": false
+  },
+  {
+    "id": "8b99b139-58f2-4ab2-8e7a-c11c846e3022",
+    "price": "1.00000000",
+    "size": "1.00000000",
+    "product_id": "BTC-USD",
+    "side": "buy",
+    "stp": "dc",
+    "type": "limit",
+    "time_in_force": "GTC",
+    "post_only": false,
+    "created_at": "2016-12-08T20:01:19.038644Z",
+    "fill_fees": "0.0000000000000000",
+    "filled_size": "0.00000000",
+    "executed_value": "0.0000000000000000",
+    "status": "open",
+    "settled": false
+  }
+]

--- a/xchange-coinbasepro/src/test/resources/__files/orders.json
+++ b/xchange-coinbasepro/src/test/resources/__files/orders.json
@@ -1,0 +1,53 @@
+[
+  {
+    "id": "d0c5340b-6d6c-49d9-b567-48c4bfca13d2",
+    "price": "0.10000000",
+    "size": "0.01000000",
+    "product_id": "ETH-BTC",
+    "side": "buy",
+    "stp": "dc",
+    "type": "limit",
+    "time_in_force": "GTC",
+    "post_only": false,
+    "created_at": "2016-12-08T20:02:28.53864Z",
+    "fill_fees": "0.0000000000000000",
+    "filled_size": "0.00000000",
+    "executed_value": "0.0000000000000000",
+    "status": "open",
+    "settled": false
+  },
+  {
+    "id": "8b99b139-58f2-4ab2-8e7a-c11c846e3022",
+    "price": "1.00000000",
+    "size": "1.00000000",
+    "product_id": "LTC-BTC",
+    "side": "buy",
+    "stp": "dc",
+    "type": "limit",
+    "time_in_force": "GTC",
+    "post_only": false,
+    "created_at": "2016-12-08T20:01:19.038644Z",
+    "fill_fees": "0.0000000000000000",
+    "filled_size": "0.00000000",
+    "executed_value": "0.0000000000000000",
+    "status": "open",
+    "settled": false
+  },
+  {
+    "id": "8b99b139-58f2-4ab2-8e7a-c11c846e3023",
+    "price": "1.00000000",
+    "size": "1.00000000",
+    "product_id": "LTC-BTC",
+    "side": "buy",
+    "stp": "dc",
+    "type": "limit",
+    "time_in_force": "GTC",
+    "post_only": false,
+    "created_at": "2016-12-08T20:01:20.038644Z",
+    "fill_fees": "0.0000000000000000",
+    "filled_size": "0.00000000",
+    "executed_value": "0.0000000000000000",
+    "status": "open",
+    "settled": false
+  }
+]


### PR DESCRIPTION
This pull request will give users the ability to get open orders by currency pair. 

The implementation of get open orders prior to this pull request ignores the currency pair specification and returns all open orders.