### PR TITLE
Could org.knowm.xchange:xchange-dydx:5.0.10-SNAPSHOT drop off redundant dependencies to loose weight?

### DIFF
--- a/xchange-dydx/pom.xml
+++ b/xchange-dydx/pom.xml
@@ -21,6 +21,23 @@
             <groupId>org.knowm.xchange</groupId>
             <artifactId>xchange-core</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion> 
+                    <groupId>com.google.j2objc</groupId>  
+                    <artifactId>j2objc-annotations</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>jakarta.ws.rs</groupId>  
+                    <artifactId>jakarta.ws.rs-api</artifactId> 
+                </exclusion>
+                <exclusion> 
+                    <groupId>io.vavr</groupId>  
+                    <artifactId>vavr-match</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>javax.cache</groupId>  
+                    <artifactId>cache-api</artifactId> 
+                </exclusion>
         </dependency>
     </dependencies>
 

--- a/xchange-dydx/pom.xml
+++ b/xchange-dydx/pom.xml
@@ -38,6 +38,7 @@
                     <groupId>javax.cache</groupId>  
                     <artifactId>cache-api</artifactId> 
                 </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Hi, I am a user of project **_org.knowm.xchange:xchange-dydx:5.0.10-SNAPSHOT_**. I found that its pom file introduced **_35_** dependencies. However, among them, **_4_** libraries (**_11%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for this project. 
This PR helps **_org.knowm.xchange:xchange-dydx:5.0.10-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards