### PR TITLE
Gemini open orders by pair

### DIFF
--- a/xchange-gemini/pom.xml
+++ b/xchange-gemini/pom.xml
@@ -30,6 +30,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/GeminiAdapters.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/GeminiAdapters.java
@@ -341,12 +341,21 @@ public final class GeminiAdapters {
   }
 
   public static OpenOrders adaptOrders(GeminiOrderStatusResponse[] activeOrders) {
+    return adaptOrders(activeOrders, null);
+  }
+
+  public static OpenOrders adaptOrders(GeminiOrderStatusResponse[] activeOrders, CurrencyPair currencyPair) {
 
     List<LimitOrder> limitOrders = new ArrayList<>(activeOrders.length);
 
     for (GeminiOrderStatusResponse order : activeOrders) {
+      CurrencyPair currentCurrencyPair = adaptCurrencyPair(order.getSymbol());
+
+      if(currencyPair != null && !currentCurrencyPair.equals(currencyPair)){
+        continue;
+      }
+
       OrderType orderType = order.getSide().equalsIgnoreCase("buy") ? OrderType.BID : OrderType.ASK;
-      CurrencyPair currencyPair = adaptCurrencyPair(order.getSymbol());
       Date timestamp = convertBigDecimalTimestampToDate(new BigDecimal(order.getTimestamp()));
 
       OrderStatus status = OrderStatus.NEW;
@@ -364,7 +373,7 @@ public final class GeminiAdapters {
           new LimitOrder(
               orderType,
               order.getOriginalAmount(),
-              currencyPair,
+              currentCurrencyPair,
               String.valueOf(order.getId()),
               timestamp,
               order.getPrice(),

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/GeminiTradeService.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/GeminiTradeService.java
@@ -26,6 +26,8 @@ import org.knowm.xchange.service.trade.params.TradeHistoryParamLimit;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamsTimeSpan;
+import org.knowm.xchange.service.trade.params.orders.DefaultOpenOrdersParamCurrencyPair;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
 import org.knowm.xchange.utils.DateUtils;
 
@@ -40,7 +42,7 @@ public class GeminiTradeService extends GeminiTradeServiceRaw implements TradeSe
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-    return getOpenOrders(createOpenOrdersParams());
+    return getOpenOrders(null);
   }
 
   @Override
@@ -50,6 +52,10 @@ public class GeminiTradeService extends GeminiTradeServiceRaw implements TradeSe
     if (activeOrders.length <= 0) {
       return noOpenOrders;
     } else {
+      if (params != null && params instanceof OpenOrdersParamCurrencyPair) {
+        OpenOrdersParamCurrencyPair openOrdersParamCurrencyPair = (OpenOrdersParamCurrencyPair) params;
+        return GeminiAdapters.adaptOrders(activeOrders, openOrdersParamCurrencyPair.getCurrencyPair());
+      }
       return GeminiAdapters.adaptOrders(activeOrders);
     }
   }
@@ -146,7 +152,7 @@ public class GeminiTradeService extends GeminiTradeServiceRaw implements TradeSe
 
   @Override
   public OpenOrdersParams createOpenOrdersParams() {
-    return null;
+    return new DefaultOpenOrdersParamCurrencyPair();
   }
 
   @Override

--- a/xchange-gemini/src/test/java/org/knowm/xchange/gemini/v1/GeminiAdaptersTest.java
+++ b/xchange-gemini/src/test/java/org/knowm/xchange/gemini/v1/GeminiAdaptersTest.java
@@ -11,6 +11,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -104,7 +106,7 @@ public class GeminiAdaptersTest {
   @Test
   public void testAdaptOrdersToOpenOrders() {
 
-    GeminiOrderStatusResponse[] responses = initOrderStatusResponses();
+    GeminiOrderStatusResponse[] responses = initOrderStatusResponses(SYMBOL);
     OpenOrders orders = GeminiAdapters.adaptOrders(responses);
     assertEquals(orders.getOpenOrders().size(), responses.length);
 
@@ -123,10 +125,50 @@ public class GeminiAdaptersTest {
       assertEquals(
           responses[i].getExecutedAmount(),
           order.getOriginalAmount().subtract(order.getRemainingAmount()));
-      assertEquals(GeminiAdapters.adaptCurrencyPair(SYMBOL), order.getCurrencyPair());
+      assertEquals(GeminiAdapters.adaptCurrencyPair(SYMBOL), order.getInstrument());
       assertEquals(expectedOrderType, order.getType());
       assertEquals(expectedTimestampMillis, order.getTimestamp().getTime());
       assertEquals(responses[i].getPrice(), order.getLimitPrice());
+    }
+  }
+
+  @Test
+  public void testAdaptOrdersToOpenOrdersFiltersByCurrencyPair() {
+
+    GeminiOrderStatusResponse[] responsesToRetain =
+            ArrayUtils.addAll(
+                    initOrderStatusResponses(SYMBOL),
+                    initOrderStatusResponses(SYMBOL)
+            );
+
+    GeminiOrderStatusResponse[] responses =
+            ArrayUtils.addAll(
+                    initOrderStatusResponses("ETHBTC"),
+                    responsesToRetain
+                    );
+
+    OpenOrders orders = GeminiAdapters.adaptOrders(responses, CurrencyPair.BTC_USD);
+    assertEquals(orders.getOpenOrders().size(), responsesToRetain.length);
+
+    for (int i = 0; i < responsesToRetain.length; i++) {
+      LimitOrder order = orders.getOpenOrders().get(i);
+      long expectedTimestampMillis =
+          new BigDecimal(responsesToRetain[i].getTimestamp()).multiply(new BigDecimal(1000L)).longValue();
+      Order.OrderType expectedOrderType =
+          responsesToRetain[i].getSide().equalsIgnoreCase("buy")
+              ? Order.OrderType.BID
+              : Order.OrderType.ASK;
+
+      assertEquals(String.valueOf(responsesToRetain[i].getId()), order.getId());
+      assertEquals(responsesToRetain[i].getOriginalAmount(), order.getOriginalAmount());
+      assertEquals(responsesToRetain[i].getRemainingAmount(), order.getRemainingAmount());
+      assertEquals(
+          responsesToRetain[i].getExecutedAmount(),
+          order.getOriginalAmount().subtract(order.getRemainingAmount()));
+      assertEquals(GeminiAdapters.adaptCurrencyPair(SYMBOL), order.getInstrument());
+      assertEquals(expectedOrderType, order.getType());
+      assertEquals(expectedTimestampMillis, order.getTimestamp().getTime());
+      assertEquals(responsesToRetain[i].getPrice(), order.getLimitPrice());
     }
   }
 
@@ -137,7 +179,7 @@ public class GeminiAdaptersTest {
    *
    * @return The generated responses.
    */
-  private GeminiOrderStatusResponse[] initOrderStatusResponses() {
+  private GeminiOrderStatusResponse[] initOrderStatusResponses(String symbol) {
 
     GeminiOrderStatusResponse[] responses = new GeminiOrderStatusResponse[60];
 
@@ -159,7 +201,7 @@ public class GeminiAdaptersTest {
           new GeminiOrderStatusResponse(
               i,
               "Gemini",
-              SYMBOL,
+              symbol,
               price,
               avgExecutionPrice,
               side,

--- a/xchange-gemini/src/test/java/org/knowm/xchange/gemini/v1/service/BaseWiremockTest.java
+++ b/xchange-gemini/src/test/java/org/knowm/xchange/gemini/v1/service/BaseWiremockTest.java
@@ -1,0 +1,26 @@
+package org.knowm.xchange.gemini.v1.service;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Rule;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.gemini.v1.GeminiExchange;
+
+public class BaseWiremockTest {
+
+  @Rule public WireMockRule wireMockRule = new WireMockRule();
+
+
+  public Exchange createExchange() {
+    Exchange exchange =
+        ExchangeFactory.INSTANCE.createExchangeWithoutSpecification(GeminiExchange.class);
+    ExchangeSpecification specification = exchange.getDefaultExchangeSpecification();
+    specification.setHost("localhost");
+    specification.setSslUri("http://localhost:" + wireMockRule.port());
+    specification.setPort(wireMockRule.port());
+    specification.setShouldLoadRemoteMetaData(false);
+    exchange.applySpecification(specification);
+    return exchange;
+  }
+}

--- a/xchange-gemini/src/test/java/org/knowm/xchange/gemini/v1/service/GeminiTradeServiceTest.java
+++ b/xchange-gemini/src/test/java/org/knowm/xchange/gemini/v1/service/GeminiTradeServiceTest.java
@@ -1,0 +1,86 @@
+package org.knowm.xchange.gemini.v1.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.dto.trade.OpenOrders;
+import org.knowm.xchange.service.trade.params.orders.DefaultOpenOrdersParamCurrencyPair;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GeminiTradeServiceTest extends BaseWiremockTest {
+
+    private GeminiTradeService classUnderTest;
+
+    public static final String WIREMOCK_FILES_PATH = "__files";
+    private static final String ORDERS_FILE_NAME = "example-open-orders-data.json";
+
+    @Before
+    public void setup() {
+        classUnderTest = (GeminiTradeService) createExchange().getTradeService();
+    }
+
+    @Test
+    public void ordersTest() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonRoot = mapper.readTree(
+                this.getClass().
+                        getResource("/" + WIREMOCK_FILES_PATH + "/" + ORDERS_FILE_NAME));
+
+        stubFor(
+                post(urlPathEqualTo("/v1/orders"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader("Content-Type", "application/json")
+                                        .withBodyFile(ORDERS_FILE_NAME)
+                        )
+        );
+
+        OpenOrders openOrders = classUnderTest.getOpenOrders();
+
+        assertThat(openOrders).isNotNull();
+        assertThat(openOrders.getOpenOrders()).hasSize(jsonRoot.size());
+        LimitOrder firstOrder = openOrders.getOpenOrders().get(0);
+        assertThat(firstOrder).isNotNull();
+        assertThat(firstOrder.getOriginalAmount()).isNotNull().isPositive();
+        assertThat(firstOrder.getId()).isNotBlank();
+        assertThat(firstOrder.getInstrument()).isEqualTo(CurrencyPair.BTC_USD);
+
+        LimitOrder secondOrder = openOrders.getOpenOrders().get(1);
+        assertThat(secondOrder).isNotNull();
+        assertThat(secondOrder.getOriginalAmount()).isNotNull().isPositive();
+        assertThat(secondOrder.getId()).isNotBlank();
+        assertThat(secondOrder.getInstrument()).isEqualTo(CurrencyPair.LTC_BTC);
+
+    }
+
+    @Test
+    public void openOrdersByCurrencyPairTest() throws Exception {
+        stubFor(
+                post(urlPathEqualTo("/v1/orders"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader("Content-Type", "application/json")
+                                        .withBodyFile(ORDERS_FILE_NAME)
+                        )
+        );
+
+        DefaultOpenOrdersParamCurrencyPair defaultOpenOrdersParamCurrencyPair =
+                new DefaultOpenOrdersParamCurrencyPair(CurrencyPair.BTC_USD);
+
+        OpenOrders openOrders = classUnderTest.getOpenOrders(defaultOpenOrdersParamCurrencyPair);
+        assertThat(openOrders).isNotNull();
+        assertThat(openOrders.getOpenOrders().size()).isEqualTo(1);
+        LimitOrder firstOrder = openOrders.getOpenOrders().get(0);
+        assertThat(firstOrder).isNotNull();
+        assertThat(firstOrder.getOriginalAmount()).isNotNull().isPositive();
+        assertThat(firstOrder.getId()).isNotBlank();
+        assertThat(firstOrder.getInstrument()).isEqualTo(CurrencyPair.BTC_USD);
+    }
+}

--- a/xchange-gemini/src/test/resources/__files/example-open-orders-data.json
+++ b/xchange-gemini/src/test/resources/__files/example-open-orders-data.json
@@ -1,0 +1,32 @@
+[
+{
+  "id": 4003242,
+  "symbol": "btcusd",
+  "price": "900.0",
+  "avg_execution_price": "0.0",
+  "side": "sell",
+  "type": "exchange limit",
+  "timestamp": "1387061342.0",
+  "is_live": true,
+  "is_cancelled": false,
+  "was_forced": false,
+  "original_amount": "0.08",
+  "remaining_amount": "0.06",
+  "executed_amount": "0.02"
+},
+{
+  "id": 4003243,
+  "symbol": "ltcbtc",
+  "price": "0.0002",
+  "avg_execution_price": "0.0",
+  "side": "sell",
+  "type": "exchange limit",
+  "timestamp": "1387061343.0",
+  "is_live": true,
+  "is_cancelled": false,
+  "was_forced": false,
+  "original_amount": "2.08",
+  "remaining_amount": "0.06",
+  "executed_amount": "2.02"
+}
+]


### PR DESCRIPTION
Filter open orders by currency pair.

The Gemini API does not allow for filtering by currency pair. This change filters by desired currency pair after retrieving all open orders from Gemini.