### PR TITLE
[Coinbasepro-Stream] Add support for overriding websocket uri

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/ExchangeSpecification.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/ExchangeSpecification.java
@@ -24,6 +24,7 @@ public class ExchangeSpecification {
   private String apiKey;
   private String sslUri;
   private String plainTextUri;
+  private String overrideWebsocketApiUri;
   private String host;
   private int port = 80;
   private String proxyHost;
@@ -473,6 +474,26 @@ public class ExchangeSpecification {
   public void setShouldLoadRemoteMetaData(boolean shouldLoadRemoteMetaData) {
 
     this.shouldLoadRemoteMetaData = shouldLoadRemoteMetaData;
+  }
+
+  /**
+   * Get uri to override websocket uri
+   *
+   * @return The uri that will be used instead of standard exchange websocket uri
+   */
+  public String getOverrideWebsocketApiUri() {
+
+    return overrideWebsocketApiUri;
+  }
+
+  /**
+   * Set uri to override websocket uri
+   *
+   * @param overrideWebsocketApiUri The uri that will be used instead of standard exchange websocket uris
+   */
+  public void setOverrideWebsocketApiUri(String overrideWebsocketApiUri) {
+
+    this.overrideWebsocketApiUri = overrideWebsocketApiUri;
   }
 
   public static class ResilienceSpecification {

--- a/xchange-stream-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/CoinbaseProStreamingExchange.java
+++ b/xchange-stream-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/CoinbaseProStreamingExchange.java
@@ -19,7 +19,7 @@ public class CoinbaseProStreamingExchange extends CoinbaseProExchange implements
   private static final String SANDBOX_API_URI = "wss://ws-feed-public.sandbox.pro.coinbase.com";
   private static final String PRIME_API_URI = "wss://ws-feed.exchange.coinbase.com";
   private static final String PRIME_SANDBOX_API_URI =
-      "wss://ws-feed-public.sandbox.exchange.coinbase.com";
+          "wss://ws-feed-public.sandbox.exchange.coinbase.com";
 
   private CoinbaseProStreamingService streamingService;
   private CoinbaseProStreamingMarketDataService streamingMarketDataService;
@@ -37,26 +37,17 @@ public class CoinbaseProStreamingExchange extends CoinbaseProExchange implements
     if (args == null || args.length == 0)
       throw new UnsupportedOperationException("The ProductSubscription must be defined!");
     ExchangeSpecification exchangeSpec = getExchangeSpecification();
-    boolean useSandbox =
-        Boolean.TRUE.equals(exchangeSpecification.getExchangeSpecificParametersItem("Use_Sandbox"));
-    boolean usePrime =
-        Boolean.TRUE.equals(exchangeSpecification.getExchangeSpecificParametersItem("Use_Prime"));
 
-    String apiUri;
-    if (useSandbox) {
-      apiUri = usePrime ? PRIME_SANDBOX_API_URI : SANDBOX_API_URI;
-    } else {
-      apiUri = usePrime ? PRIME_API_URI : API_URI;
-    }
+    String apiUri = getApiUri();
 
     boolean subscribeToL3Orderbook =
-        Boolean.TRUE.equals(
-            exchangeSpecification.getExchangeSpecificParametersItem(
-                StreamingExchange.L3_ORDERBOOK));
+            Boolean.TRUE.equals(
+                    exchangeSpecification.getExchangeSpecificParametersItem(
+                            StreamingExchange.L3_ORDERBOOK));
 
     this.streamingService =
-        new CoinbaseProStreamingService(
-            apiUri, () -> authData(exchangeSpec), subscribeToL3Orderbook);
+            new CoinbaseProStreamingService(
+                    apiUri, () -> authData(exchangeSpec), subscribeToL3Orderbook);
     applyStreamingSpecification(exchangeSpecification, this.streamingService);
 
     this.streamingMarketDataService = new CoinbaseProStreamingMarketDataService(streamingService);
@@ -65,18 +56,40 @@ public class CoinbaseProStreamingExchange extends CoinbaseProExchange implements
     return streamingService.connect();
   }
 
+  public String getApiUri() {
+      String apiUri;
+      ExchangeSpecification exchangeSpec = getExchangeSpecification();
+
+      boolean useSandbox =
+              Boolean.TRUE.equals(
+                      exchangeSpecification.getExchangeSpecificParametersItem(Parameters.PARAM_USE_SANDBOX));
+      boolean usePrime =
+              Boolean.TRUE.equals(
+                      exchangeSpecification.getExchangeSpecificParametersItem(Parameters.PARAM_USE_PRIME));
+
+      if (useSandbox) {
+          apiUri = usePrime ? PRIME_SANDBOX_API_URI : SANDBOX_API_URI;
+      } else {
+          apiUri = usePrime ? PRIME_API_URI : API_URI;
+      }
+
+      return exchangeSpec.getOverrideWebsocketApiUri() == null
+              ? apiUri
+              : exchangeSpec.getOverrideWebsocketApiUri();
+  }
+
   private CoinbaseProWebsocketAuthData authData(ExchangeSpecification exchangeSpec) {
     CoinbaseProWebsocketAuthData authData = null;
     if (exchangeSpec.getApiKey() != null) {
       try {
         CoinbaseProAccountServiceRaw rawAccountService =
-            (CoinbaseProAccountServiceRaw) getAccountService();
+                (CoinbaseProAccountServiceRaw) getAccountService();
         authData = rawAccountService.getWebsocketAuthData();
       } catch (Exception e) {
         logger.warn(
-            "Failed attempting to acquire Websocket AuthData needed for private data on"
-                + " websocket.  Will only receive public information via API",
-            e);
+                "Failed attempting to acquire Websocket AuthData needed for private data on"
+                        + " websocket.  Will only receive public information via API",
+                e);
       }
     }
     return authData;
@@ -139,7 +152,7 @@ public class CoinbaseProStreamingExchange extends CoinbaseProExchange implements
    * @param channelInactiveHandler a WebSocketMessageHandler instance.
    */
   public void setChannelInactiveHandler(
-      WebSocketClientHandler.WebSocketMessageHandler channelInactiveHandler) {
+          WebSocketClientHandler.WebSocketMessageHandler channelInactiveHandler) {
     streamingService.setChannelInactiveHandler(channelInactiveHandler);
   }
 
@@ -151,5 +164,13 @@ public class CoinbaseProStreamingExchange extends CoinbaseProExchange implements
   @Override
   public void useCompressedMessages(boolean compressedMessages) {
     streamingService.useCompressedMessages(compressedMessages);
+  }
+
+  public void setOverrideApiUri(String overrideApiUri) {
+    getExchangeSpecification().setOverrideWebsocketApiUri(overrideApiUri);
+  }
+
+  public String getOverrideApiUri() {
+    return this.getExchangeSpecification().getOverrideWebsocketApiUri();
   }
 }

--- a/xchange-stream-coinbasepro/src/test/java/info/bitrich/xchangestream/coinbasepro/CoinbaseProStreamingExchangeTest.java
+++ b/xchange-stream-coinbasepro/src/test/java/info/bitrich/xchangestream/coinbasepro/CoinbaseProStreamingExchangeTest.java
@@ -1,0 +1,191 @@
+package info.bitrich.xchangestream.coinbasepro;
+
+import info.bitrich.xchangestream.core.StreamingExchangeFactory;
+import org.junit.Test;
+import org.knowm.xchange.ExchangeSpecification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CoinbaseProStreamingExchangeTest {
+
+  @Test
+  public void testOverrideWebsocketApiUriWhenUsingSandBoxAndPrime() {
+    final String overrideWebsocketApiUri = "wss://demo.websocket.com";
+    final CoinbaseProStreamingExchange coinbaseProStreamingExchange =
+        new CoinbaseProStreamingExchange();
+    final ExchangeSpecification sandboxExchangeSpecification =
+        coinbaseProStreamingExchange.getDefaultExchangeSpecification();
+    sandboxExchangeSpecification.setExchangeSpecificParametersItem(
+        Parameters.PARAM_USE_SANDBOX, true);
+    sandboxExchangeSpecification.setExchangeSpecificParametersItem(
+        Parameters.PARAM_USE_PRIME, true);
+    sandboxExchangeSpecification.setOverrideWebsocketApiUri(overrideWebsocketApiUri);
+    sandboxExchangeSpecification.setShouldLoadRemoteMetaData(false);
+
+    final CoinbaseProStreamingExchange exchange =
+        (CoinbaseProStreamingExchange)
+            StreamingExchangeFactory.INSTANCE.createExchange(sandboxExchangeSpecification);
+
+    assertThat(exchange.getApiUri()).isEqualTo(overrideWebsocketApiUri);
+    assertThat(exchange.getExchangeSpecification().getOverrideWebsocketApiUri())
+        .isEqualTo(overrideWebsocketApiUri);
+  }
+
+  @Test
+  public void testOverrideWebsocketApiUriWhenUsingSandBox() {
+    final String overrideWebsocketApiUri = "wss://demo.websocket.com";
+    final CoinbaseProStreamingExchange coinbaseProStreamingExchange =
+        new CoinbaseProStreamingExchange();
+    final ExchangeSpecification sandboxExchangeSpecification =
+        coinbaseProStreamingExchange.getDefaultExchangeSpecification();
+    sandboxExchangeSpecification.setExchangeSpecificParametersItem(
+        Parameters.PARAM_USE_SANDBOX, true);
+    sandboxExchangeSpecification.setExchangeSpecificParametersItem(
+        Parameters.PARAM_USE_PRIME, false);
+    sandboxExchangeSpecification.setOverrideWebsocketApiUri(overrideWebsocketApiUri);
+    sandboxExchangeSpecification.setShouldLoadRemoteMetaData(false);
+
+    final CoinbaseProStreamingExchange exchange =
+        (CoinbaseProStreamingExchange)
+            StreamingExchangeFactory.INSTANCE.createExchange(sandboxExchangeSpecification);
+
+    assertThat(exchange.getApiUri()).isEqualTo(overrideWebsocketApiUri);
+    assertThat(exchange.getExchangeSpecification().getOverrideWebsocketApiUri())
+        .isEqualTo(overrideWebsocketApiUri);
+  }
+
+  @Test
+  public void testOverrideWebsocketApiUriWhenUsingPrime() {
+    final String overrideWebsocketApiUri = "wss://demo.websocket.com";
+    final CoinbaseProStreamingExchange coinbaseProStreamingExchange =
+        new CoinbaseProStreamingExchange();
+    final ExchangeSpecification sandboxExchangeSpecification =
+        coinbaseProStreamingExchange.getDefaultExchangeSpecification();
+    sandboxExchangeSpecification.setExchangeSpecificParametersItem(
+        Parameters.PARAM_USE_SANDBOX, false);
+    sandboxExchangeSpecification.setExchangeSpecificParametersItem(
+        Parameters.PARAM_USE_PRIME, true);
+    sandboxExchangeSpecification.setOverrideWebsocketApiUri(overrideWebsocketApiUri);
+    sandboxExchangeSpecification.setShouldLoadRemoteMetaData(false);
+
+    final CoinbaseProStreamingExchange exchange =
+        (CoinbaseProStreamingExchange)
+            StreamingExchangeFactory.INSTANCE.createExchange(sandboxExchangeSpecification);
+
+    assertThat(exchange.getApiUri()).isEqualTo(overrideWebsocketApiUri);
+    assertThat(exchange.getExchangeSpecification().getOverrideWebsocketApiUri())
+        .isEqualTo(overrideWebsocketApiUri);
+  }
+
+  @Test
+  public void testOverrideWebsocketApiUri() {
+    final String overrideWebsocketApiUri = "wss://demo.websocket.com";
+    final CoinbaseProStreamingExchange coinbaseProStreamingExchange =
+        new CoinbaseProStreamingExchange();
+    final ExchangeSpecification sandboxExchangeSpecification =
+        coinbaseProStreamingExchange.getDefaultExchangeSpecification();
+    sandboxExchangeSpecification.setExchangeSpecificParametersItem(
+        Parameters.PARAM_USE_SANDBOX, false);
+    sandboxExchangeSpecification.setExchangeSpecificParametersItem(
+        Parameters.PARAM_USE_PRIME, false);
+    sandboxExchangeSpecification.setOverrideWebsocketApiUri(overrideWebsocketApiUri);
+    sandboxExchangeSpecification.setShouldLoadRemoteMetaData(false);
+
+    final CoinbaseProStreamingExchange exchange =
+        (CoinbaseProStreamingExchange)
+            StreamingExchangeFactory.INSTANCE.createExchange(sandboxExchangeSpecification);
+
+    assertThat(exchange.getApiUri()).isEqualTo(overrideWebsocketApiUri);
+    assertThat(exchange.getExchangeSpecification().getOverrideWebsocketApiUri())
+        .isEqualTo(overrideWebsocketApiUri);
+  }
+
+  @Test
+  public void testWhenUsingSandbox() {
+    final String sandboxApiUri = "wss://ws-feed-public.sandbox.pro.coinbase.com";
+    final CoinbaseProStreamingExchange coinbaseProStreamingExchange =
+        new CoinbaseProStreamingExchange();
+    final ExchangeSpecification sandboxExchangeSpecification =
+        coinbaseProStreamingExchange.getDefaultExchangeSpecification();
+    sandboxExchangeSpecification.setExchangeSpecificParametersItem(
+        Parameters.PARAM_USE_SANDBOX, true);
+    sandboxExchangeSpecification.setExchangeSpecificParametersItem(
+        Parameters.PARAM_USE_PRIME, false);
+    sandboxExchangeSpecification.setShouldLoadRemoteMetaData(false);
+
+    final CoinbaseProStreamingExchange exchange =
+        (CoinbaseProStreamingExchange)
+            StreamingExchangeFactory.INSTANCE.createExchange(sandboxExchangeSpecification);
+
+    assertThat(exchange.getApiUri()).isEqualTo(sandboxApiUri);
+    assertThat(exchange.getExchangeSpecification().getOverrideWebsocketApiUri()).isEqualTo(null);
+  }
+
+  @Test
+  public void testWhenUsingSandboxWithPrime() {
+    final String primeSandboxApiUri = "wss://ws-feed-public.sandbox.exchange.coinbase.com";
+    final CoinbaseProStreamingExchange coinbaseProStreamingExchange =
+        new CoinbaseProStreamingExchange();
+    final ExchangeSpecification sandboxExchangeSpecification =
+        coinbaseProStreamingExchange.getDefaultExchangeSpecification();
+    sandboxExchangeSpecification.setExchangeSpecificParametersItem(
+        Parameters.PARAM_USE_SANDBOX, true);
+    sandboxExchangeSpecification.setExchangeSpecificParametersItem(
+        Parameters.PARAM_USE_PRIME, true);
+    sandboxExchangeSpecification.setShouldLoadRemoteMetaData(false);
+
+    final CoinbaseProStreamingExchange exchange =
+        (CoinbaseProStreamingExchange)
+            StreamingExchangeFactory.INSTANCE.createExchange(sandboxExchangeSpecification);
+
+    assertThat(exchange.getApiUri()).isEqualTo(primeSandboxApiUri);
+    assertThat(exchange.getExchangeSpecification().getOverrideWebsocketApiUri()).isEqualTo(null);
+  }
+
+  @Test
+  public void testWhenUsingPrime() {
+    final String primeApiUri = "wss://ws-feed.exchange.coinbase.com";
+    final CoinbaseProStreamingExchange coinbaseProStreamingExchange =
+        new CoinbaseProStreamingExchange();
+    final ExchangeSpecification sandboxExchangeSpecification =
+        coinbaseProStreamingExchange.getDefaultExchangeSpecification();
+    sandboxExchangeSpecification.setExchangeSpecificParametersItem(
+        Parameters.PARAM_USE_SANDBOX, false);
+    sandboxExchangeSpecification.setExchangeSpecificParametersItem(
+        Parameters.PARAM_USE_PRIME, true);
+    sandboxExchangeSpecification.setShouldLoadRemoteMetaData(false);
+
+    final CoinbaseProStreamingExchange exchange =
+        (CoinbaseProStreamingExchange)
+            StreamingExchangeFactory.INSTANCE.createExchange(sandboxExchangeSpecification);
+
+    assertThat(exchange.getApiUri()).isEqualTo(primeApiUri);
+    assertThat(exchange.getExchangeSpecification().getOverrideWebsocketApiUri()).isEqualTo(null);
+  }
+
+  @Test
+  public void testWhenUsingOnlyApiUri() {
+    final String apiUri = "wss://ws-feed.pro.coinbase.com";
+    final CoinbaseProStreamingExchange coinbaseProStreamingExchange =
+        new CoinbaseProStreamingExchange();
+    final ExchangeSpecification sandboxExchangeSpecification =
+        coinbaseProStreamingExchange.getDefaultExchangeSpecification();
+    sandboxExchangeSpecification.setExchangeSpecificParametersItem(
+        Parameters.PARAM_USE_SANDBOX, false);
+    sandboxExchangeSpecification.setExchangeSpecificParametersItem(
+        Parameters.PARAM_USE_PRIME, false);
+    sandboxExchangeSpecification.setShouldLoadRemoteMetaData(false);
+
+    final CoinbaseProStreamingExchange exchange =
+        (CoinbaseProStreamingExchange)
+            StreamingExchangeFactory.INSTANCE.createExchange(sandboxExchangeSpecification);
+
+    assertThat(exchange.getApiUri()).isEqualTo(apiUri);
+    assertThat(exchange.getExchangeSpecification().getOverrideWebsocketApiUri()).isEqualTo(null);
+  }
+
+  public static final class Parameters {
+    public static final String PARAM_USE_SANDBOX = "Use_Sandbox";
+    public static final String PARAM_USE_PRIME = "Use_Prime";
+  }
+}


### PR DESCRIPTION
# Problem
Currently we are unable to override our websocket uris in our streaming projects. They are essentially hardcoded. There are situations that exist when one would want to change them like demos or due to internal servers structures.

# Solution
This update would allow for any `xchange-stream` project to expose an override for their websocket uri via their respective `StreamingExchange`. In this pr, I have done this in `xchange-stream-coinbasepro` in the `CoinbaseProStreamingExchange`.

# Considerations
I could have implemented this via `ExchangeSpecification.getExchangeSpecificParametersItem` however I thought this functionality was something all streaming exchanges could benefit from. If there are strong objects, I can rework this pr to override the websocket uri only for `xchange-stream-coinbasepro` via `ExchangeSpecification.getExchangeSpecificParametersItem` 