### PR TITLE
Binance.us support

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceExchange.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceExchange.java
@@ -25,18 +25,18 @@ import si.mazi.rescu.SynchronizedValueFactory;
 public class BinanceExchange extends BaseExchange {
   public static final String SPECIFIC_PARAM_USE_SANDBOX = "Use_Sandbox";
 
-  private static ResilienceRegistries RESILIENCE_REGISTRIES;
+  protected static ResilienceRegistries RESILIENCE_REGISTRIES;
 
-  private BinanceExchangeInfo exchangeInfo;
-  private BinanceAuthenticated binance;
-  private SynchronizedValueFactory<Long> timestampFactory;
+  protected BinanceExchangeInfo exchangeInfo;
+  protected BinanceAuthenticated binance;
+  protected SynchronizedValueFactory<Long> timestampFactory;
 
   @Override
   protected void initServices() {
     this.binance =
         ExchangeRestProxyBuilder.forInterface(
-            BinanceAuthenticated.class, getExchangeSpecification())
-                                .build();
+                BinanceAuthenticated.class, getExchangeSpecification())
+            .build();
     this.timestampFactory =
         new BinanceTimestampFactory(
             binance, getExchangeSpecification().getResilience(), getResilienceRegistries());
@@ -98,90 +98,98 @@ public class BinanceExchange extends BaseExchange {
   public void remoteInit() {
 
     try {
-      // populate currency pair keys only, exchange does not provide any other metadata for download
-      Map<CurrencyPair, CurrencyPairMetaData> currencyPairs = exchangeMetaData.getCurrencyPairs();
-      Map<Currency, CurrencyMetaData> currencies = exchangeMetaData.getCurrencies();
-
       BinanceMarketDataService marketDataService =
           (BinanceMarketDataService) this.marketDataService;
       exchangeInfo = marketDataService.getExchangeInfo();
-      Symbol[] symbols = exchangeInfo.getSymbols();
 
       BinanceAccountService accountService = (BinanceAccountService) getAccountService();
       Map<String, AssetDetail> assetDetailMap = null;
       if (!usingSandbox() && isAuthenticated()) {
         assetDetailMap = accountService.getAssetDetails(); // not available in sndbox
       }
-      // Clear all hardcoded currencies when loading dynamically from exchange.
-      if (assetDetailMap != null) {
-        currencies.clear();
-      }
-      for (Symbol symbol : symbols) {
-        if (symbol.getStatus().equals("TRADING")) { // Symbols which are trading
-          int basePrecision = Integer.parseInt(symbol.getBaseAssetPrecision());
-          int counterPrecision = Integer.parseInt(symbol.getQuotePrecision());
-          int pairPrecision = 8;
-          int amountPrecision = 8;
 
-          BigDecimal minQty = null;
-          BigDecimal maxQty = null;
-          BigDecimal stepSize = null;
+      postInit(assetDetailMap);
 
-          BigDecimal counterMinQty = null;
-          BigDecimal counterMaxQty = null;
-
-          Filter[] filters = symbol.getFilters();
-
-          CurrencyPair currentCurrencyPair =
-              new CurrencyPair(symbol.getBaseAsset(), symbol.getQuoteAsset());
-
-          for (Filter filter : filters) {
-            if (filter.getFilterType().equals("PRICE_FILTER")) {
-              pairPrecision = Math.min(pairPrecision, numberOfDecimals(filter.getTickSize()));
-              counterMaxQty = new BigDecimal(filter.getMaxPrice()).stripTrailingZeros();
-            } else if (filter.getFilterType().equals("LOT_SIZE")) {
-              amountPrecision = Math.min(amountPrecision, numberOfDecimals(filter.getStepSize()));
-              minQty = new BigDecimal(filter.getMinQty()).stripTrailingZeros();
-              maxQty = new BigDecimal(filter.getMaxQty()).stripTrailingZeros();
-              stepSize = new BigDecimal(filter.getStepSize()).stripTrailingZeros();
-            } else if (filter.getFilterType().equals("MIN_NOTIONAL")) {
-              counterMinQty = new BigDecimal(filter.getMinNotional()).stripTrailingZeros();
-            }
-          }
-
-          boolean marketOrderAllowed = Arrays.asList(symbol.getOrderTypes()).contains("MARKET");
-          currencyPairs.put(
-              currentCurrencyPair,
-              new CurrencyPairMetaData(
-                  new BigDecimal("0.1"), // Trading fee at Binance is 0.1 %
-                  minQty, // Min amount
-                  maxQty, // Max amount
-                  counterMinQty,
-                  counterMaxQty,
-                  amountPrecision, // base precision
-                  pairPrecision, // counter precision
-                  null,
-                  null, /* TODO get fee tiers, although this is not necessary now
-                        because their API returns current fee directly */
-                  stepSize,
-                  null,
-                  marketOrderAllowed));
-
-          Currency baseCurrency = currentCurrencyPair.base;
-          CurrencyMetaData baseCurrencyMetaData =
-              BinanceAdapters.adaptCurrencyMetaData(
-                  currencies, baseCurrency, assetDetailMap, basePrecision);
-          currencies.put(baseCurrency, baseCurrencyMetaData);
-
-          Currency counterCurrency = currentCurrencyPair.counter;
-          CurrencyMetaData counterCurrencyMetaData =
-              BinanceAdapters.adaptCurrencyMetaData(
-                  currencies, counterCurrency, assetDetailMap, counterPrecision);
-          currencies.put(counterCurrency, counterCurrencyMetaData);
-        }
-      }
     } catch (Exception e) {
       throw new ExchangeException("Failed to initialize: " + e.getMessage(), e);
+    }
+  }
+
+  protected void postInit(Map<String, AssetDetail> assetDetailMap) {
+    // populate currency pair keys only, exchange does not provide any other metadata for download
+    Map<CurrencyPair, CurrencyPairMetaData> currencyPairs = exchangeMetaData.getCurrencyPairs();
+    Map<Currency, CurrencyMetaData> currencies = exchangeMetaData.getCurrencies();
+
+    // Clear all hardcoded currencies when loading dynamically from exchange.
+    if (assetDetailMap != null) {
+      currencies.clear();
+    }
+
+    Symbol[] symbols = exchangeInfo.getSymbols();
+
+    for (Symbol symbol : symbols) {
+      if (symbol.getStatus().equals("TRADING")) { // Symbols which are trading
+        int basePrecision = Integer.parseInt(symbol.getBaseAssetPrecision());
+        int counterPrecision = Integer.parseInt(symbol.getQuotePrecision());
+        int pairPrecision = 8;
+        int amountPrecision = 8;
+
+        BigDecimal minQty = null;
+        BigDecimal maxQty = null;
+        BigDecimal stepSize = null;
+
+        BigDecimal counterMinQty = null;
+        BigDecimal counterMaxQty = null;
+
+        Filter[] filters = symbol.getFilters();
+
+        CurrencyPair currentCurrencyPair =
+            new CurrencyPair(symbol.getBaseAsset(), symbol.getQuoteAsset());
+
+        for (Filter filter : filters) {
+          if (filter.getFilterType().equals("PRICE_FILTER")) {
+            pairPrecision = Math.min(pairPrecision, numberOfDecimals(filter.getTickSize()));
+            counterMaxQty = new BigDecimal(filter.getMaxPrice()).stripTrailingZeros();
+          } else if (filter.getFilterType().equals("LOT_SIZE")) {
+            amountPrecision = Math.min(amountPrecision, numberOfDecimals(filter.getStepSize()));
+            minQty = new BigDecimal(filter.getMinQty()).stripTrailingZeros();
+            maxQty = new BigDecimal(filter.getMaxQty()).stripTrailingZeros();
+            stepSize = new BigDecimal(filter.getStepSize()).stripTrailingZeros();
+          } else if (filter.getFilterType().equals("MIN_NOTIONAL")) {
+            counterMinQty = new BigDecimal(filter.getMinNotional()).stripTrailingZeros();
+          }
+        }
+
+        boolean marketOrderAllowed = Arrays.asList(symbol.getOrderTypes()).contains("MARKET");
+        currencyPairs.put(
+            currentCurrencyPair,
+            new CurrencyPairMetaData(
+                new BigDecimal("0.1"), // Trading fee at Binance is 0.1 %
+                minQty, // Min amount
+                maxQty, // Max amount
+                counterMinQty,
+                counterMaxQty,
+                amountPrecision, // base precision
+                pairPrecision, // counter precision
+                null,
+                null, /* TODO get fee tiers, although this is not necessary now
+                      because their API returns current fee directly */
+                stepSize,
+                null,
+                marketOrderAllowed));
+
+        Currency baseCurrency = currentCurrencyPair.base;
+        CurrencyMetaData baseCurrencyMetaData =
+            BinanceAdapters.adaptCurrencyMetaData(
+                currencies, baseCurrency, assetDetailMap, basePrecision);
+        currencies.put(baseCurrency, baseCurrencyMetaData);
+
+        Currency counterCurrency = currentCurrencyPair.counter;
+        CurrencyMetaData counterCurrencyMetaData =
+            BinanceAdapters.adaptCurrencyMetaData(
+                currencies, counterCurrency, assetDetailMap, counterPrecision);
+        currencies.put(counterCurrency, counterCurrencyMetaData);
+      }
     }
   }
 

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceUsExchange.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceUsExchange.java
@@ -1,0 +1,57 @@
+package org.knowm.xchange.binance;
+
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.binance.dto.account.AssetDetail;
+import org.knowm.xchange.binance.service.BinanceAccountService;
+import org.knowm.xchange.binance.service.BinanceMarketDataService;
+import org.knowm.xchange.binance.service.BinanceTradeService;
+import org.knowm.xchange.binance.service.BinanceUsAccountService;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
+import org.knowm.xchange.utils.AuthUtils;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class BinanceUsExchange extends BinanceExchange {
+
+  @Override
+  public ExchangeSpecification getDefaultExchangeSpecification() {
+
+    ExchangeSpecification spec = new ExchangeSpecification(this.getClass());
+    spec.setSslUri("https://api.binance.us");
+    spec.setHost("www.binance.us");
+    spec.setPort(80);
+    spec.setExchangeName("Binance US");
+    spec.setExchangeDescription("Binance US Exchange.");
+    AuthUtils.setApiAndSecretKey(spec, "binanceus");
+    return spec;
+  }
+
+  @Override
+  protected void initServices() {
+    this.binance =
+        ExchangeRestProxyBuilder.forInterface(
+                BinanceAuthenticated.class, getExchangeSpecification())
+            .build();
+    this.timestampFactory =
+        new BinanceTimestampFactory(
+            binance, getExchangeSpecification().getResilience(), getResilienceRegistries());
+    this.marketDataService = new BinanceMarketDataService(this, binance, getResilienceRegistries());
+    this.tradeService = new BinanceTradeService(this, binance, getResilienceRegistries());
+    this.accountService = new BinanceUsAccountService(this, binance, getResilienceRegistries());
+  }
+
+  @Override
+  public void remoteInit() {
+    BinanceMarketDataService marketDataService = (BinanceMarketDataService) this.marketDataService;
+    try {
+      exchangeInfo = marketDataService.getExchangeInfo();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    Map<String, AssetDetail> assetDetailMap = null;
+
+    postInit(assetDetailMap);
+  }
+}

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceUsAccountService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceUsAccountService.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.binance.service;
 import org.knowm.xchange.binance.BinanceAuthenticated;
 import org.knowm.xchange.binance.BinanceExchange;
 import org.knowm.xchange.binance.dto.account.AssetDetail;
+import org.knowm.xchange.binance.dto.meta.BinanceSystemStatus;
 import org.knowm.xchange.client.ResilienceRegistries;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -87,5 +88,11 @@ public class BinanceUsAccountService extends BinanceAccountService {
   public List<FundingRecord> getFundingHistory(TradeHistoryParams params) throws IOException {
     LOG.warn("getFundingHistory: {}", NOT_SUPPORTED);
     return new ArrayList<>();
+  }
+
+  @Override
+  public BinanceSystemStatus getSystemStatus() throws IOException {
+    LOG.warn("getSystemStatus: {}", NOT_SUPPORTED);
+    return new BinanceSystemStatus();
   }
 }

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceUsAccountService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceUsAccountService.java
@@ -1,0 +1,91 @@
+package org.knowm.xchange.binance.service;
+
+import org.knowm.xchange.binance.BinanceAuthenticated;
+import org.knowm.xchange.binance.BinanceExchange;
+import org.knowm.xchange.binance.dto.account.AssetDetail;
+import org.knowm.xchange.client.ResilienceRegistries;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.account.AccountInfo;
+import org.knowm.xchange.dto.account.AddressWithTag;
+import org.knowm.xchange.dto.account.Fee;
+import org.knowm.xchange.dto.account.FundingRecord;
+import org.knowm.xchange.service.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.trade.params.WithdrawFundsParams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BinanceUsAccountService extends BinanceAccountService {
+
+  private final String NOT_SUPPORTED = "Not Supported by Binance.US";
+  protected final Logger LOG = LoggerFactory.getLogger(getClass());
+
+  public BinanceUsAccountService(
+      BinanceExchange exchange,
+      BinanceAuthenticated binance,
+      ResilienceRegistries resilienceRegistries) {
+    super(exchange, binance, resilienceRegistries);
+  }
+
+  @Override
+  public AccountInfo getAccountInfo() throws IOException {
+    return super.getAccountInfo();
+  }
+
+  @Override
+  public Map<CurrencyPair, Fee> getDynamicTradingFees() throws IOException {
+    return super.getDynamicTradingFees();
+  }
+
+  @Override
+  public String withdrawFunds(Currency currency, BigDecimal amount, String address)
+      throws IOException {
+    return NOT_SUPPORTED;
+  }
+
+  @Override
+  public String withdrawFunds(Currency currency, BigDecimal amount, AddressWithTag address)
+      throws IOException {
+    return NOT_SUPPORTED;
+  }
+
+  @Override
+  public String withdrawFunds(WithdrawFundsParams params) throws IOException {
+    return NOT_SUPPORTED;
+  }
+
+  @Override
+  public String requestDepositAddress(Currency currency, String... args) throws IOException {
+    return NOT_SUPPORTED;
+  }
+
+  @Override
+  public AddressWithTag requestDepositAddressData(Currency currency, String... args)
+      throws IOException {
+    return new AddressWithTag(NOT_SUPPORTED, NOT_SUPPORTED);
+  }
+
+  @Override
+  public Map<String, AssetDetail> getAssetDetails() throws IOException {
+    LOG.warn("getAssetDetails: {}", NOT_SUPPORTED);
+    return new HashMap<>();
+  }
+
+  @Override
+  public TradeHistoryParams createFundingHistoryParams() {
+    return super.createFundingHistoryParams();
+  }
+
+  @Override
+  public List<FundingRecord> getFundingHistory(TradeHistoryParams params) throws IOException {
+    LOG.warn("getFundingHistory: {}", NOT_SUPPORTED);
+    return new ArrayList<>();
+  }
+}

--- a/xchange-binance/src/main/resources/binanceus.json
+++ b/xchange-binance/src/main/resources/binanceus.json
@@ -1,0 +1,4 @@
+{
+  "currency_pairs": {},
+  "currencies": {}
+}

--- a/xchange-binance/src/test/java/org/knowm/xchange/binance/us/BinanceUsExchangeIntegration.java
+++ b/xchange-binance/src/test/java/org/knowm/xchange/binance/us/BinanceUsExchangeIntegration.java
@@ -1,0 +1,62 @@
+package org.knowm.xchange.binance.us;
+
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.binance.BinanceExchange;
+import org.knowm.xchange.binance.BinanceUsExchange;
+import org.knowm.xchange.binance.dto.meta.BinanceSystemStatus;
+import org.knowm.xchange.binance.service.BinanceAccountService;
+import org.knowm.xchange.binance.service.BinanceUsAccountService;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BinanceUsExchangeIntegration {
+  protected static BinanceUsExchange exchange;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    createExchange();
+  }
+
+  @Test
+  public void testSetupIsCorrect() {
+    ExchangeSpecification specification = exchange.getDefaultExchangeSpecification();
+    assertThat(specification.getExchangeName().equalsIgnoreCase("Binance US")).isTrue();
+    assertThat(specification.getSslUri().equalsIgnoreCase("https://api.binance.us")).isTrue();
+    assertThat(specification.getHost().equalsIgnoreCase("www.binance.us")).isTrue();
+    assertThat(specification.getExchangeDescription().equalsIgnoreCase("Binance US Exchange."))
+        .isTrue();
+    assertThat(specification.getExchangeClass().equals(BinanceUsExchange.class)).isTrue();
+    assertThat(specification.getResilience()).isNotNull();
+  }
+
+  @Test
+  public void testSystemStatus() throws IOException {
+    assumeProduction();
+    BinanceSystemStatus systemStatus =
+        ((BinanceUsAccountService) exchange.getAccountService()).getSystemStatus();
+    assertThat(systemStatus).isNotNull();
+    // Not yet supported by binance.us
+    assertThat(systemStatus.getStatus()).isNull();
+  }
+
+  protected static void createExchange() throws Exception {
+    exchange = ExchangeFactory.INSTANCE.createExchangeWithoutSpecification(BinanceUsExchange.class);
+    ExchangeSpecification spec = exchange.getDefaultExchangeSpecification();
+    boolean useSandbox =
+        Boolean.parseBoolean(
+            System.getProperty(
+                BinanceExchange.SPECIFIC_PARAM_USE_SANDBOX, Boolean.FALSE.toString()));
+    spec.setExchangeSpecificParametersItem(BinanceExchange.SPECIFIC_PARAM_USE_SANDBOX, useSandbox);
+    exchange.applySpecification(spec);
+  }
+
+  protected void assumeProduction() {
+    Assume.assumeFalse("Using sandbox", exchange.usingSandbox());
+  }
+}

--- a/xchange-binance/src/test/java/org/knowm/xchange/binance/us/ExchangeMetaDataIntegration.java
+++ b/xchange-binance/src/test/java/org/knowm/xchange/binance/us/ExchangeMetaDataIntegration.java
@@ -1,6 +1,4 @@
-package org.knowm.xchange.binance;
-
-import static org.assertj.core.api.Assertions.assertThat;
+package org.knowm.xchange.binance.us;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -8,7 +6,9 @@ import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
 import org.knowm.xchange.dto.meta.ExchangeMetaData;
 
-public class ExchangeMetaDataIntegration extends BinanceExchangeIntegration {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExchangeMetaDataIntegration extends BinanceUsExchangeIntegration {
 
   static ExchangeMetaData metaData;
 

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingExchange.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingExchange.java
@@ -195,7 +195,7 @@ public class BinanceStreamingExchange extends BinanceExchange implements Streami
     return streamingTradeService;
   }
 
-  private BinanceStreamingService createStreamingService(ProductSubscription subscription) {
+  protected BinanceStreamingService createStreamingService(ProductSubscription subscription) {
     String path =
         Boolean.TRUE.equals(exchangeSpecification.getExchangeSpecificParametersItem(USE_SANDBOX))
             ? WS_SANDBOX_API_BASE_URI

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceUsStreamingExchange.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceUsStreamingExchange.java
@@ -1,0 +1,33 @@
+package info.bitrich.xchangestream.binance;
+
+import info.bitrich.xchangestream.core.ProductSubscription;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.utils.AuthUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BinanceUsStreamingExchange extends BinanceStreamingExchange {
+  private static final Logger LOG = LoggerFactory.getLogger(BinanceStreamingExchange.class);
+  private static final String API_BASE_URI = "wss://stream.binance.us:9443/";
+
+  @Override
+  protected BinanceStreamingService createStreamingService(ProductSubscription subscription) {
+    String path = API_BASE_URI + "stream?streams=" + buildSubscriptionStreams(subscription);
+    return new BinanceStreamingService(path, subscription);
+  }
+
+  // This is needed since BinanceStreamingExchange extends BinanceExchange which has the spec
+  // configured for binance.com
+  @Override
+  public ExchangeSpecification getDefaultExchangeSpecification() {
+
+    ExchangeSpecification spec = new ExchangeSpecification(this.getClass());
+    spec.setSslUri("https://api.binance.us");
+    spec.setHost("www.binance.us");
+    spec.setPort(80);
+    spec.setExchangeName("Binance US");
+    spec.setExchangeDescription("Binance US Exchange.");
+    AuthUtils.setApiAndSecretKey(spec, "binanceus");
+    return spec;
+  }
+}

--- a/xchange-stream-binance/src/test/java/info/bitrich/xchangestream/binance/BinanceUsIntegration.java
+++ b/xchange-stream-binance/src/test/java/info/bitrich/xchangestream/binance/BinanceUsIntegration.java
@@ -1,0 +1,71 @@
+package info.bitrich.xchangestream.binance;
+
+import info.bitrich.xchangestream.core.ProductSubscription;
+import info.bitrich.xchangestream.core.StreamingExchangeFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.currency.CurrencyPair;
+
+import static info.bitrich.xchangestream.binance.BinanceStreamingExchange.USE_HIGHER_UPDATE_FREQUENCY;
+import static info.bitrich.xchangestream.binance.BinanceStreamingExchange.USE_REALTIME_BOOK_TICKER;
+
+public class BinanceUsIntegration {
+
+    @Test
+    public void channelCreateUrlTest() {
+        BinanceUsStreamingExchange exchange =
+                (BinanceUsStreamingExchange)
+                        StreamingExchangeFactory.INSTANCE.createExchange(BinanceUsStreamingExchange.class);
+        ProductSubscription.ProductSubscriptionBuilder builder = ProductSubscription.create();
+        builder.addTicker(CurrencyPair.BTC_USD).addTicker(CurrencyPair.DASH_BTC);
+        String buildSubscriptionStreams = exchange.buildSubscriptionStreams(builder.build());
+        Assert.assertEquals("btcusd@ticker/dashbtc@ticker", buildSubscriptionStreams);
+
+        ProductSubscription.ProductSubscriptionBuilder builder2 = ProductSubscription.create();
+        builder2
+                .addTicker(CurrencyPair.BTC_USD)
+                .addTicker(CurrencyPair.DASH_BTC)
+                .addOrderbook(CurrencyPair.ETH_BTC);
+        String buildSubscriptionStreams2 = exchange.buildSubscriptionStreams(builder2.build());
+        Assert.assertEquals("btcusd@ticker/dashbtc@ticker/ethbtc@depth", buildSubscriptionStreams2);
+    }
+
+    @Test
+    public void channelCreateUrlWithUpdateFrequencyTest() {
+        ProductSubscription.ProductSubscriptionBuilder builder = ProductSubscription.create();
+        builder
+                .addTicker(CurrencyPair.BTC_USD)
+                .addTicker(CurrencyPair.DASH_BTC)
+                .addOrderbook(CurrencyPair.ETH_BTC);
+        ExchangeSpecification spec =
+                StreamingExchangeFactory.INSTANCE
+                        .createExchange(BinanceUsStreamingExchange.class)
+                        .getDefaultExchangeSpecification();
+        spec.setExchangeSpecificParametersItem(USE_HIGHER_UPDATE_FREQUENCY, true);
+        BinanceUsStreamingExchange exchange =
+                (BinanceUsStreamingExchange) StreamingExchangeFactory.INSTANCE.createExchange(spec);
+        String buildSubscriptionStreams = exchange.buildSubscriptionStreams(builder.build());
+        Assert.assertEquals(
+                "btcusd@ticker/dashbtc@ticker/ethbtc@depth@100ms", buildSubscriptionStreams);
+    }
+
+    @Test
+    public void channelCreateUrlWithRealtimeBookTickerTest() {
+        ProductSubscription.ProductSubscriptionBuilder builder = ProductSubscription.create();
+        builder
+                .addTicker(CurrencyPair.BTC_USD)
+                .addTicker(CurrencyPair.DASH_BTC)
+                .addOrderbook(CurrencyPair.ETH_BTC);
+        ExchangeSpecification spec =
+                StreamingExchangeFactory.INSTANCE
+                        .createExchange(BinanceUsStreamingExchange.class)
+                        .getDefaultExchangeSpecification();
+        spec.setExchangeSpecificParametersItem(USE_REALTIME_BOOK_TICKER, true);
+        BinanceUsStreamingExchange exchange =
+                (BinanceUsStreamingExchange) StreamingExchangeFactory.INSTANCE.createExchange(spec);
+        String buildSubscriptionStreams = exchange.buildSubscriptionStreams(builder.build());
+        Assert.assertEquals(
+                "btcusd@bookTicker/dashbtc@bookTicker/ethbtc@depth", buildSubscriptionStreams);
+    }
+}


### PR DESCRIPTION
Adds support for Binance.US rest and streaming api. This does *not* guarantee 1:1 rest api support as .us and .com have diverged quite a bit. However, fetching candles, getting account info, and a few other things should work as expected.

For the streaming api, Trades, OrderBook, Tickers should all work (those I have in production already).

This addition is meant to get the ball rolling and will need to be further updated to support more rest features and probably streaming endpoints. The Binance.com api is quite different now so it's possible in the future that the .US code will need to be broken off into its own package(s).