### PR TITLE
Add additional fields for CoinMarketCap v1 API

### DIFF
--- a/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/pro/v1/CmcAuthenticated.java
+++ b/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/pro/v1/CmcAuthenticated.java
@@ -25,7 +25,8 @@ public interface CmcAuthenticated {
       @HeaderParam(API_KEY_HEADER) String apiKey,
       @QueryParam("listing_status") String listingStatus,
       @QueryParam("start") int start,
-      @QueryParam("limit") int limit)
+      @QueryParam("limit") int limit,
+      @QueryParam("sort") String sort)
       throws IOException;
 
   @GET

--- a/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/pro/v1/dto/marketdata/CmcCurrency.java
+++ b/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/pro/v1/dto/marketdata/CmcCurrency.java
@@ -10,6 +10,7 @@ public final class CmcCurrency {
   private final String name;
   private final String symbol;
   private final String slug;
+  private final int rank;
   private final boolean isActive;
   private final Date firstHistoricalData;
   private final Date lastHistoricalData;
@@ -20,6 +21,7 @@ public final class CmcCurrency {
       @JsonProperty("name") String name,
       @JsonProperty("symbol") String symbol,
       @JsonProperty("slug") String slug,
+      @JsonProperty("rank") int rank,
       @JsonProperty("is_active") int isActive,
       @JsonProperty("first_historical_data") @JsonDeserialize(using = ISO8601DateDeserializer.class)
           Date firstHistoricalData,
@@ -31,6 +33,7 @@ public final class CmcCurrency {
     this.name = name;
     this.symbol = symbol;
     this.slug = slug;
+    this.rank = rank;
     this.isActive = (1 == isActive);
     this.firstHistoricalData = firstHistoricalData;
     this.lastHistoricalData = lastHistoricalData;
@@ -51,6 +54,10 @@ public final class CmcCurrency {
 
   public String getSlug() {
     return slug;
+  }
+
+  public int getRank() {
+    return rank;
   }
 
   public boolean isActive() {
@@ -82,6 +89,8 @@ public final class CmcCurrency {
         + '\''
         + ", slug='"
         + slug
+        + ", rank='"
+        + rank
         + '\''
         + ", isActive="
         + isActive

--- a/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/pro/v1/dto/marketdata/CmcQuote.java
+++ b/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/pro/v1/dto/marketdata/CmcQuote.java
@@ -13,7 +13,12 @@ public final class CmcQuote {
   private BigDecimal percentChange1h;
   private BigDecimal percentChange7d;
   private BigDecimal percentChange24h;
+  private BigDecimal percentChange30d;
+  private BigDecimal percentChange60d;
+  private BigDecimal percentChange90d;
   private BigDecimal marketCap;
+  private BigDecimal marketCapDominance;
+  private BigDecimal fullyDilutedMarketCap;
   private Date lastUpdated;
 
   public CmcQuote(
@@ -22,7 +27,12 @@ public final class CmcQuote {
       @JsonProperty("percent_change_1h") BigDecimal percentChange1h,
       @JsonProperty("percent_change_7d") BigDecimal percentChange7d,
       @JsonProperty("percent_change_24h") BigDecimal percentChange24h,
+      @JsonProperty("percent_change_30d") BigDecimal percentChange30d,
+      @JsonProperty("percent_change_60d") BigDecimal percentChange60d,
+      @JsonProperty("percent_change_90d") BigDecimal percentChange90d,
       @JsonProperty("market_cap") BigDecimal marketCap,
+      @JsonProperty("market_cap_dominance") BigDecimal marketCapDominance,
+      @JsonProperty("fully_diluted_market_cap") BigDecimal fullyDilutedMarketCap,
       @JsonProperty("last_updated") @JsonDeserialize(using = ISO8601DateDeserializer.class)
           Date lastUpdated) {
 
@@ -31,7 +41,12 @@ public final class CmcQuote {
     this.percentChange1h = percentChange1h;
     this.percentChange7d = percentChange7d;
     this.percentChange24h = percentChange24h;
+    this.percentChange30d = percentChange30d;
+    this.percentChange60d = percentChange60d;
+    this.percentChange90d = percentChange90d;
     this.marketCap = marketCap;
+    this.marketCapDominance = marketCapDominance;
+    this.fullyDilutedMarketCap = fullyDilutedMarketCap;
     this.lastUpdated = lastUpdated;
   }
 
@@ -55,8 +70,28 @@ public final class CmcQuote {
     return percentChange24h;
   }
 
+  public BigDecimal getPercentChange30d() {
+    return percentChange30d;
+  }
+
+  public BigDecimal getPercentChange60d() {
+    return percentChange60d;
+  }
+
+  public BigDecimal getPercentChange90d() {
+    return percentChange90d;
+  }
+
   public BigDecimal getMarketCap() {
     return marketCap;
+  }
+
+  public BigDecimal getMarketCapDominance() {
+    return marketCapDominance;
+  }
+
+  public BigDecimal getFullyDilutedMarketCap() {
+    return fullyDilutedMarketCap;
   }
 
   public Date getLastUpdated() {
@@ -76,8 +111,18 @@ public final class CmcQuote {
         + percentChange7d
         + ", percentChange24h="
         + percentChange24h
+        + ", percentChange30d="
+        + percentChange30d
+        + ", percentChange60d="
+        + percentChange60d
+        + ", percentChange90d="
+        + percentChange90d
         + ", marketCap="
         + marketCap
+        + ", marketCapDominance="
+        + marketCapDominance
+        + ", fullyDilutedMarketCap="
+        + fullyDilutedMarketCap
         + ", lastUpdated='"
         + lastUpdated
         + '\''
@@ -105,9 +150,24 @@ public final class CmcQuote {
     if (getPercentChange24h() != null
         ? !getPercentChange24h().equals(that.getPercentChange24h())
         : that.getPercentChange24h() != null) return false;
+    if (getPercentChange30d() != null
+            ? !getPercentChange30d().equals(that.getPercentChange30d())
+            : that.getPercentChange30d() != null) return false;
+    if (getPercentChange60d() != null
+            ? !getPercentChange60d().equals(that.getPercentChange60d())
+            : that.getPercentChange60d() != null) return false;
+    if (getPercentChange90d() != null
+            ? !getPercentChange90d().equals(that.getPercentChange90d())
+            : that.getPercentChange90d() != null) return false;
     if (getMarketCap() != null
         ? !getMarketCap().equals(that.getMarketCap())
         : that.getMarketCap() != null) return false;
+    if (getMarketCapDominance() != null
+            ? !getMarketCapDominance().equals(that.getMarketCapDominance())
+            : that.getMarketCapDominance() != null) return false;
+    if (getFullyDilutedMarketCap() != null
+            ? !getFullyDilutedMarketCap().equals(that.getFullyDilutedMarketCap())
+            : that.getFullyDilutedMarketCap() != null) return false;
     return getLastUpdated() != null
         ? getLastUpdated().equals(that.getLastUpdated())
         : that.getLastUpdated() == null;
@@ -120,7 +180,12 @@ public final class CmcQuote {
     result = 31 * result + (getPercentChange1h() != null ? getPercentChange1h().hashCode() : 0);
     result = 31 * result + (getPercentChange7d() != null ? getPercentChange7d().hashCode() : 0);
     result = 31 * result + (getPercentChange24h() != null ? getPercentChange24h().hashCode() : 0);
+    result = 31 * result + (getPercentChange30d() != null ? getPercentChange30d().hashCode() : 0);
+    result = 31 * result + (getPercentChange60d() != null ? getPercentChange60d().hashCode() : 0);
+    result = 31 * result + (getPercentChange90d() != null ? getPercentChange90d().hashCode() : 0);
     result = 31 * result + (getMarketCap() != null ? getMarketCap().hashCode() : 0);
+    result = 31 * result + (getMarketCapDominance() != null ? getMarketCapDominance().hashCode() : 0);
+    result = 31 * result + (getFullyDilutedMarketCap() != null ? getFullyDilutedMarketCap().hashCode() : 0);
     result = 31 * result + (getLastUpdated() != null ? getLastUpdated().hashCode() : 0);
     return result;
   }

--- a/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/pro/v1/dto/marketdata/CmcQuote.java
+++ b/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/pro/v1/dto/marketdata/CmcQuote.java
@@ -151,23 +151,23 @@ public final class CmcQuote {
         ? !getPercentChange24h().equals(that.getPercentChange24h())
         : that.getPercentChange24h() != null) return false;
     if (getPercentChange30d() != null
-            ? !getPercentChange30d().equals(that.getPercentChange30d())
-            : that.getPercentChange30d() != null) return false;
+        ? !getPercentChange30d().equals(that.getPercentChange30d())
+        : that.getPercentChange30d() != null) return false;
     if (getPercentChange60d() != null
-            ? !getPercentChange60d().equals(that.getPercentChange60d())
-            : that.getPercentChange60d() != null) return false;
+        ? !getPercentChange60d().equals(that.getPercentChange60d())
+        : that.getPercentChange60d() != null) return false;
     if (getPercentChange90d() != null
-            ? !getPercentChange90d().equals(that.getPercentChange90d())
-            : that.getPercentChange90d() != null) return false;
+        ? !getPercentChange90d().equals(that.getPercentChange90d())
+        : that.getPercentChange90d() != null) return false;
     if (getMarketCap() != null
         ? !getMarketCap().equals(that.getMarketCap())
         : that.getMarketCap() != null) return false;
     if (getMarketCapDominance() != null
-            ? !getMarketCapDominance().equals(that.getMarketCapDominance())
-            : that.getMarketCapDominance() != null) return false;
+        ? !getMarketCapDominance().equals(that.getMarketCapDominance())
+        : that.getMarketCapDominance() != null) return false;
     if (getFullyDilutedMarketCap() != null
-            ? !getFullyDilutedMarketCap().equals(that.getFullyDilutedMarketCap())
-            : that.getFullyDilutedMarketCap() != null) return false;
+        ? !getFullyDilutedMarketCap().equals(that.getFullyDilutedMarketCap())
+        : that.getFullyDilutedMarketCap() != null) return false;
     return getLastUpdated() != null
         ? getLastUpdated().equals(that.getLastUpdated())
         : that.getLastUpdated() == null;

--- a/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/pro/v1/service/CmcMarketDataServiceRaw.java
+++ b/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/pro/v1/service/CmcMarketDataServiceRaw.java
@@ -60,7 +60,7 @@ class CmcMarketDataServiceRaw extends CmcBaseService {
 
     CmcCurrencyMapResponse response = null;
     try {
-      response = cmcAuthenticated.getCurrencyMap(apiKey, "active", 1, 5000);
+      response = cmcAuthenticated.getCurrencyMap(apiKey, "active", 1, 5000, "id");
     } catch (HttpStatusIOException ex) {
       CmcErrorAdapter.adapt(ex);
     }

--- a/xchange-coinmarketcap/src/test/java/org/knowm/xchange/coinmarketcap/pro/v1/dto/marketdata/CmcCurrencyTest.java
+++ b/xchange-coinmarketcap/src/test/java/org/knowm/xchange/coinmarketcap/pro/v1/dto/marketdata/CmcCurrencyTest.java
@@ -30,12 +30,13 @@ public class CmcCurrencyTest {
     assertThat(currencyMap.getName()).isEqualTo(Currency.BTC.getDisplayName());
     assertThat(currencyMap.getSymbol()).isEqualTo(Currency.BTC.getSymbol());
     assertThat(currencyMap.getSlug()).isEqualTo("bitcoin");
+    assertThat(currencyMap.getRank()).isEqualTo(1);
     assertThat(currencyMap.isActive()).isTrue();
 
     SimpleDateFormat iso8601Format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
     iso8601Format.setTimeZone(TimeZone.getTimeZone("UTC"));
     Date firstHistoricalData = iso8601Format.parse("2013-04-28T18:47:21.000Z");
-    Date lastHistoricalData = iso8601Format.parse("2019-02-15T20:39:01.000Z");
+    Date lastHistoricalData = iso8601Format.parse("2021-08-28T16:49:13.000Z");
 
     assertThat(currencyMap.getFirstHistoricalData()).isEqualTo(firstHistoricalData);
     assertThat(currencyMap.getLastHistoricalData()).isEqualTo(lastHistoricalData);

--- a/xchange-coinmarketcap/src/test/java/org/knowm/xchange/coinmarketcap/pro/v1/dto/marketdata/CmcTickerTest.java
+++ b/xchange-coinmarketcap/src/test/java/org/knowm/xchange/coinmarketcap/pro/v1/dto/marketdata/CmcTickerTest.java
@@ -31,8 +31,8 @@ public class CmcTickerTest {
     assertThat(ticker.getName()).isEqualTo(Currency.BTC.getDisplayName());
     assertThat(ticker.getSymbol()).isEqualTo(Currency.BTC.getSymbol());
     assertThat(ticker.getSlug()).isEqualTo("bitcoin");
-    assertThat(ticker.getCirculatingSupply()).isEqualTo(new BigDecimal("17519062"));
-    assertThat(ticker.getTotalSupply()).isEqualTo(new BigDecimal("17519062"));
+    assertThat(ticker.getCirculatingSupply()).isEqualTo(new BigDecimal("18799950"));
+    assertThat(ticker.getTotalSupply()).isEqualTo(new BigDecimal("18799950"));
     assertThat(ticker.getMaxSupply()).isEqualTo(new BigDecimal("21000000"));
 
     SimpleDateFormat iso8601Format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
@@ -40,20 +40,25 @@ public class CmcTickerTest {
     Date dateAdded = iso8601Format.parse("2013-04-28T00:00:00.000Z");
 
     assertThat(ticker.getDateAdded()).isEqualTo(dateAdded);
-    assertThat(ticker.getNumMarketPairs()).isEqualTo(new BigDecimal("6513"));
+    assertThat(ticker.getNumMarketPairs()).isEqualTo(new BigDecimal("8901"));
     assertThat(ticker.getTags().get(0)).isEqualTo("mineable");
     assertThat(ticker.getCmcRank()).isEqualTo(1);
 
-    Date lastUpdated = iso8601Format.parse("2019-02-04T16:34:24.000Z");
+    Date lastUpdated = iso8601Format.parse("2021-08-28T16:13:19.000Z");
     assertThat(ticker.getLastUpdated()).isEqualTo(lastUpdated);
 
     CmcQuote quote = ticker.getQuote().get("USD");
-    assertThat(quote.getPrice()).isEqualTo(new BigDecimal("3463.69103385"));
-    assertThat(quote.getVolume24h()).isEqualTo(new BigDecimal("5327785294.41072"));
-    assertThat(quote.getPercentChange1h()).isEqualTo(new BigDecimal("0.25934"));
-    assertThat(quote.getPercentChange24h()).isEqualTo(new BigDecimal("-0.342853"));
-    assertThat(quote.getPercentChange7d()).isEqualTo(new BigDecimal("0.070337"));
-    assertThat(quote.getMarketCap()).isEqualTo(new BigDecimal("60680617970.86225"));
+    assertThat(quote.getPrice()).isEqualTo(new BigDecimal("48827.989730634145"));
+    assertThat(quote.getVolume24h()).isEqualTo(new BigDecimal("29502617632.520878"));
+    assertThat(quote.getPercentChange1h()).isEqualTo(new BigDecimal("0.53605754"));
+    assertThat(quote.getPercentChange24h()).isEqualTo(new BigDecimal("1.25693894"));
+    assertThat(quote.getPercentChange7d()).isEqualTo(new BigDecimal("-0.98822569"));
+    assertThat(quote.getPercentChange30d()).isEqualTo(new BigDecimal("22.4523943"));
+    assertThat(quote.getPercentChange60d()).isEqualTo(new BigDecimal("35.00831003"));
+    assertThat(quote.getPercentChange90d()).isEqualTo(new BigDecimal("37.52836154"));
+    assertThat(quote.getMarketCap()).isEqualTo(new BigDecimal("917963765536.4354"));
+    assertThat(quote.getMarketCapDominance()).isEqualTo(new BigDecimal("43.7315"));
+    assertThat(quote.getFullyDilutedMarketCap()).isEqualTo(new BigDecimal("1025387784343.32"));
     assertThat(quote.getLastUpdated()).isEqualTo(lastUpdated);
   }
 }

--- a/xchange-coinmarketcap/src/test/resources/org/knowm/xchange/coinmarketcap/pro/v1/dto/marketdata/example-currency.json
+++ b/xchange-coinmarketcap/src/test/resources/org/knowm/xchange/coinmarketcap/pro/v1/dto/marketdata/example-currency.json
@@ -3,8 +3,9 @@
   "name": "Bitcoin",
   "symbol": "BTC",
   "slug": "bitcoin",
+  "rank": 1,
   "is_active": 1,
   "first_historical_data": "2013-04-28T18:47:21.000Z",
-  "last_historical_data": "2019-02-15T20:39:01.000Z",
+  "last_historical_data": "2021-08-28T16:49:13.000Z",
   "platform": null
 }

--- a/xchange-coinmarketcap/src/test/resources/org/knowm/xchange/coinmarketcap/pro/v1/dto/marketdata/example-ticker.json
+++ b/xchange-coinmarketcap/src/test/resources/org/knowm/xchange/coinmarketcap/pro/v1/dto/marketdata/example-ticker.json
@@ -3,26 +3,31 @@
   "name": "Bitcoin",
   "symbol": "BTC",
   "slug": "bitcoin",
-  "circulating_supply": 17519062,
-  "total_supply": 17519062,
-  "max_supply": 21000000,
+  "num_market_pairs": 8901,
   "date_added": "2013-04-28T00:00:00.000Z",
-  "num_market_pairs": 6513,
   "tags": [
     "mineable"
   ],
+  "max_supply": 21000000,
+  "circulating_supply": 18799950,
+  "total_supply": 18799950,
   "platform": null,
   "cmc_rank": 1,
-  "last_updated": "2019-02-04T16:34:24.000Z",
+  "last_updated": "2021-08-28T16:13:19.000Z",
   "quote": {
     "USD": {
-      "price": 3463.69103385,
-      "volume_24h": 5327785294.41072,
-      "percent_change_1h": 0.25934,
-      "percent_change_24h": -0.342853,
-      "percent_change_7d": 0.070337,
-      "market_cap": 60680617970.86225,
-      "last_updated": "2019-02-04T16:34:24.000Z"
+      "price": 48827.989730634145,
+      "volume_24h": 29502617632.520878,
+      "percent_change_1h": 0.53605754,
+      "percent_change_24h": 1.25693894,
+      "percent_change_7d": -0.98822569,
+      "percent_change_30d": 22.4523943,
+      "percent_change_60d": 35.00831003,
+      "percent_change_90d": 37.52836154,
+      "market_cap": 917963765536.4354,
+      "market_cap_dominance": 43.7315,
+      "fully_diluted_market_cap": 1025387784343.32,
+      "last_updated": "2021-08-28T16:13:19.000Z"
     }
   }
 }


### PR DESCRIPTION
* Added rank in `CmcCurrency`
* Added 5 new fields related to percent change and market cap in `CmcQuote`
* Added additional sort param for `cryptocurrency/map` endpoint
* Updated json payloads for tests

Reference can be found here: https://coinmarketcap.com/api/documentation/v1/#