### PR TITLE
closes knowm/XChange#3647  Added support for tinyproxy acting as reverse proxy.

### DIFF
--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingExchange.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingExchange.java
@@ -75,7 +75,7 @@ public class BinanceStreamingExchange extends BinanceExchange implements Streami
 
     ProductSubscription subscriptions = args[0];
     streamingService = createStreamingService(subscriptions);
-
+    applyStreamingSpecification(getExchangeSpecification(), streamingService);
     List<Completable> completables = new ArrayList<>();
 
     if (subscriptions.hasUnauthenticated()) {

--- a/xchange-stream-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexStreamingExchange.java
+++ b/xchange-stream-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexStreamingExchange.java
@@ -28,6 +28,8 @@ public class BitmexStreamingExchange extends BitmexExchange implements Streaming
 
   @Override
   public Completable connect(ProductSubscription... args) {
+    // ensure we setup any proxy related settings before connecting
+    applyStreamingSpecification(getExchangeSpecification(), streamingService);
     return streamingService.connect();
   }
 

--- a/xchange-stream-bitstamp/src/main/java/info/bitrich/xchangestream/bitstamp/v2/BitstampStreamingExchange.java
+++ b/xchange-stream-bitstamp/src/main/java/info/bitrich/xchangestream/bitstamp/v2/BitstampStreamingExchange.java
@@ -31,6 +31,7 @@ public class BitstampStreamingExchange extends BitstampExchange implements Strea
 
   @Override
   public Completable connect(ProductSubscription... args) {
+    applyStreamingSpecification(getExchangeSpecification(), streamingService);
     return streamingService.connect();
   }
 

--- a/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingExchange.java
+++ b/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingExchange.java
@@ -128,11 +128,12 @@ public interface StreamingExchange extends Exchange {
         (String) exchangeSpec.getExchangeSpecificParametersItem(SOCKS_PROXY_HOST));
     streamingService.setSocksProxyPort(
         (Integer) exchangeSpec.getExchangeSpecificParametersItem(SOCKS_PROXY_PORT));
+    streamingService.setHttpProxyHost(exchangeSpec.getProxyHost());
+    streamingService.setHttpProxyPort(exchangeSpec.getProxyPort());
     streamingService.setBeforeConnectionHandler(
         (Runnable)
             exchangeSpec.getExchangeSpecificParametersItem(
                 ConnectableService.BEFORE_CONNECTION_HANDLER));
-
     Boolean accept_all_ceriticates =
         (Boolean) exchangeSpec.getExchangeSpecificParametersItem(ACCEPT_ALL_CERITICATES);
     if (accept_all_ceriticates != null && accept_all_ceriticates) {

--- a/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingExchange.java
+++ b/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingExchange.java
@@ -60,6 +60,7 @@ public class KrakenStreamingExchange extends KrakenExchange implements Streaming
 
   @Override
   public Completable connect(ProductSubscription... args) {
+    applyStreamingSpecification(getExchangeSpecification(), streamingService);
     if (privateStreamingService != null)
       return privateStreamingService.connect().mergeWith(streamingService.connect());
     return streamingService.connect();

--- a/xchange-stream-poloniex2/src/main/java/info/bitrich/xchangestream/poloniex2/PoloniexStreamingExchange.java
+++ b/xchange-stream-poloniex2/src/main/java/info/bitrich/xchangestream/poloniex2/PoloniexStreamingExchange.java
@@ -65,6 +65,7 @@ public class PoloniexStreamingExchange extends PoloniexExchange implements Strea
 
   @Override
   public Completable connect(ProductSubscription... args) {
+    applyStreamingSpecification(getExchangeSpecification(), streamingService);
     return streamingService.connect();
   }
 

--- a/xchange-stream-service-netty/src/main/java/info/bitrich/xchangestream/service/netty/ProxyFriendlyWebSocketClientHandshaker.java
+++ b/xchange-stream-service-netty/src/main/java/info/bitrich/xchangestream/service/netty/ProxyFriendlyWebSocketClientHandshaker.java
@@ -1,0 +1,270 @@
+package info.bitrich.xchangestream.service.netty;
+
+import io.netty.channel.*;
+import io.netty.handler.codec.http.*;
+import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
+import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker13;
+import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
+import io.netty.handler.codec.http.websocketx.WebSocketVersion;
+import java.lang.reflect.Field;
+import java.net.URI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProxyFriendlyWebSocketClientHandshaker extends WebSocketClientHandshaker13 {
+    private static final Logger LOG =
+            LoggerFactory.getLogger(ProxyFriendlyWebSocketClientHandshaker.class);
+
+    public static final String HANDLER_HTTP_CLIENT_CODEC = "http.client.codec";
+    private String expectedSubprotocol;
+
+    public ProxyFriendlyWebSocketClientHandshaker(
+            URI webSocketURL,
+            WebSocketVersion version,
+            String subprotocol,
+            boolean allowExtensions,
+            HttpHeaders customHeaders,
+            int maxFramePayloadLength) {
+        super(
+                webSocketURL, version, subprotocol, allowExtensions, customHeaders, maxFramePayloadLength);
+        this.expectedSubprotocol = subprotocol;
+    }
+
+    public ProxyFriendlyWebSocketClientHandshaker(
+            URI webSocketURL,
+            WebSocketVersion version,
+            String subprotocol,
+            boolean allowExtensions,
+            HttpHeaders customHeaders,
+            int maxFramePayloadLength,
+            boolean performMasking,
+            boolean allowMaskMismatch) {
+        super(
+                webSocketURL,
+                version,
+                subprotocol,
+                allowExtensions,
+                customHeaders,
+                maxFramePayloadLength,
+                performMasking,
+                allowMaskMismatch);
+        this.expectedSubprotocol = subprotocol;
+    }
+
+    public ProxyFriendlyWebSocketClientHandshaker(
+            URI webSocketURL,
+            WebSocketVersion version,
+            String subprotocol,
+            boolean allowExtensions,
+            HttpHeaders customHeaders,
+            int maxFramePayloadLength,
+            boolean performMasking,
+            boolean allowMaskMismatch,
+            long forceCloseTimeoutMillis) {
+        super(
+                webSocketURL,
+                version,
+                subprotocol,
+                allowExtensions,
+                customHeaders,
+                maxFramePayloadLength,
+                performMasking,
+                allowMaskMismatch,
+                forceCloseTimeoutMillis);
+        this.expectedSubprotocol = subprotocol;
+    }
+
+    @Override
+    public ChannelFuture handshake(Channel channel) {
+        if (channel == null) {
+            throw new NullPointerException("channel");
+        }
+        return fixedHandshake(channel, channel.newPromise());
+    }
+
+    // fix the ws-encoder placement
+    // ref to
+    // io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker.handshake(io.netty.channel.Channel, io.netty.channel.ChannelPromise)
+    public ChannelFuture fixedHandshake(Channel channel, final ChannelPromise promise) {
+        ChannelPipeline pipeline = channel.pipeline();
+        HttpResponseDecoder decoder = pipeline.get(HttpResponseDecoder.class);
+        if (decoder == null) {
+            HttpClientCodec codec = pipeline.get(HttpClientCodec.class);
+            if (codec == null) {
+                promise.setFailure(
+                        new IllegalStateException(
+                                "ChannelPipeline does not contain " + "a HttpResponseDecoder or HttpClientCodec"));
+                return promise;
+            }
+        }
+
+        FullHttpRequest request = newHandshakeRequest();
+
+        channel
+                .writeAndFlush(request)
+                .addListener(
+                        new ChannelFutureListener() {
+                            @Override
+                            public void operationComplete(ChannelFuture future) {
+                                if (future.isSuccess()) {
+                                    ChannelPipeline p = future.channel().pipeline();
+                                    // quick fix here
+                                    if (p.get(HANDLER_HTTP_CLIENT_CODEC) != null) {
+                                        p.addAfter(HANDLER_HTTP_CLIENT_CODEC, "ws-encoder", newWebSocketEncoder());
+                                    } else {
+                                        ChannelHandlerContext ctx = p.context(HttpRequestEncoder.class);
+                                        if (ctx == null) {
+                                            ctx = p.context(HttpClientCodec.class);
+                                        }
+                                        if (ctx == null) {
+                                            promise.setFailure(
+                                                    new IllegalStateException(
+                                                            "ChannelPipeline does not contain "
+                                                                    + "a HttpRequestEncoder or HttpClientCodec"));
+                                            return;
+                                        }
+                                        p.addAfter(ctx.name(), "ws-encoder", newWebSocketEncoder());
+                                    }
+
+                                    promise.setSuccess();
+                                } else {
+                                    promise.setFailure(future.cause());
+                                }
+                            }
+                        });
+        return promise;
+    }
+
+    // ref to io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker.finishHandshake
+    public void fixedFinishHandshake(Channel channel, FullHttpResponse response) {
+        verify(response);
+
+        // Verify the subprotocol that we received from the server.
+        // This must be one of our expected subprotocols - or null/empty if we didn't want to speak a
+        // subprotocol
+        String receivedProtocol = response.headers().get(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL);
+        receivedProtocol = receivedProtocol != null ? receivedProtocol.trim() : null;
+        String expectedProtocol = expectedSubprotocol != null ? expectedSubprotocol : "";
+        boolean protocolValid = false;
+
+        if (expectedProtocol.isEmpty() && receivedProtocol == null) {
+            // No subprotocol required and none received
+            protocolValid = true;
+            setActualSubprotocol(expectedSubprotocol); // null or "" - we echo what the user requested
+        } else if (!expectedProtocol.isEmpty()
+                && receivedProtocol != null
+                && !receivedProtocol.isEmpty()) {
+            // We require a subprotocol and received one -> verify it
+            for (String protocol : expectedProtocol.split(",")) {
+                if (protocol.trim().equals(receivedProtocol)) {
+                    protocolValid = true;
+                    setActualSubprotocol(receivedProtocol);
+                    break;
+                }
+            }
+        } // else mixed cases - which are all errors
+
+        if (!protocolValid) {
+            throw new WebSocketHandshakeException(
+                    String.format(
+                            "Invalid subprotocol. Actual: %s. Expected one of: %s",
+                            receivedProtocol, expectedSubprotocol));
+        }
+
+        setHandshakeComplete();
+
+        final ChannelPipeline p = channel.pipeline();
+        // Remove decompressor from pipeline if its in use
+        HttpContentDecompressor decompressor = p.get(HttpContentDecompressor.class);
+        if (decompressor != null) {
+            p.remove(decompressor);
+        }
+
+        // Remove aggregator if present before
+        HttpObjectAggregator aggregator = p.get(HttpObjectAggregator.class);
+        if (aggregator != null) {
+            p.remove(aggregator);
+        }
+
+        ChannelHandlerContext ctx = p.context(HttpResponseDecoder.class);
+        if (ctx == null) {
+            final HttpClientCodec codec;
+            String codecName;
+            if (p.get(HANDLER_HTTP_CLIENT_CODEC) != null) {
+                codec = (HttpClientCodec) p.get(HANDLER_HTTP_CLIENT_CODEC);
+                codecName = HANDLER_HTTP_CLIENT_CODEC;
+            } else {
+                ctx = p.context(HttpClientCodec.class);
+                if (ctx == null) {
+                    throw new IllegalStateException(
+                            "ChannelPipeline does not contain " + "a HttpRequestEncoder or HttpClientCodec");
+                }
+                codec = (HttpClientCodec) ctx.handler();
+                codecName = ctx.name();
+            }
+
+            // Remove the encoder part of the codec as the user may start writing frames after this method
+            // returns.
+            codec.removeOutboundHandler();
+            p.addAfter(codecName, "ws-decoder", newWebsocketDecoder());
+
+            // Delay the removal of the decoder so the user can setup the pipeline if needed to handle
+            // WebSocketFrame messages.
+            // See https://github.com/netty/netty/issues/4533
+            channel
+                    .eventLoop()
+                    .execute(
+                            new Runnable() {
+                                @Override
+                                public void run() {
+                                    p.remove(codec);
+                                }
+                            });
+        } else {
+            if (p.get(HttpRequestEncoder.class) != null) {
+                // Remove the encoder part of the codec as the user may start writing frames after this
+                // method returns.
+                p.remove(HttpRequestEncoder.class);
+            }
+            final ChannelHandlerContext context = ctx;
+            p.addAfter(context.name(), "ws-decoder", newWebsocketDecoder());
+
+            // Delay the removal of the decoder so the user can setup the pipeline if needed to handle
+            // WebSocketFrame messages.
+            // See https://github.com/netty/netty/issues/4533
+            channel
+                    .eventLoop()
+                    .execute(
+                            new Runnable() {
+                                @Override
+                                public void run() {
+                                    p.remove(context.handler());
+                                }
+                            });
+        }
+    }
+
+    private void setActualSubprotocol(String actualSubprotocol) {
+        //        this.actualSubprotocol = actualSubprotocol;
+        // hack to access the parent private field
+        try {
+            Field privateField = WebSocketClientHandshaker.class.getDeclaredField("actualSubprotocol");
+            privateField.setAccessible(true);
+            privateField.set(this, actualSubprotocol);
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            LOG.error("Cannot access field[actualSubprotocol]", e);
+        }
+    }
+
+    private void setHandshakeComplete() {
+        //        handshakeComplete = true;
+        // hack to access the parent private field
+        try {
+            Field privateField = WebSocketClientHandshaker.class.getDeclaredField("handshakeComplete");
+            privateField.setAccessible(true);
+            privateField.setBoolean(this, true);
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            LOG.error("Cannot access field[handshakeComplete]", e);
+        }
+    }
+}

--- a/xchange-stream-service-netty/src/main/java/info/bitrich/xchangestream/service/netty/WebSocketClientHandler.java
+++ b/xchange-stream-service-netty/src/main/java/info/bitrich/xchangestream/service/netty/WebSocketClientHandler.java
@@ -60,7 +60,11 @@ public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> 
     Channel ch = ctx.channel();
     if (!handshaker.isHandshakeComplete()) {
       try {
-        handshaker.finishHandshake(ch, (FullHttpResponse) msg);
+          if (handshaker instanceof ProxyFriendlyWebSocketClientHandshaker) {
+            ((ProxyFriendlyWebSocketClientHandshaker)handshaker).fixedFinishHandshake(ch, (FullHttpResponse) msg);
+          } else {
+            handshaker.finishHandshake(ch, (FullHttpResponse) msg);
+          }
         LOG.info("WebSocket Client connected! {}", ctx.channel());
         handshakeFuture.setSuccess();
       } catch (WebSocketHandshakeException e) {


### PR DESCRIPTION
This will support a reverse proxy setup such as tinyproxy 
when connecting to any of the supported exchanges
used 
by a spring java app like this
<img width="980" alt="image" src="https://user-images.githubusercontent.com/6606061/132508385-f89a4e56-b2b5-4310-b3d9-2f7b42facdc2.png">
use case 
is going thr a lightweight firewall like tinyproxy
