### PR TITLE
[Coinmate] handle null amounts in order response

### DIFF
--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateAdapters.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateAdapters.java
@@ -370,16 +370,21 @@ public class CoinmateAdapters {
       orderStatus = Order.OrderStatus.UNKNOWN;
     }
 
+    BigDecimal originalAmount = entry.getOriginalAmount();
+    BigDecimal remainingAmount = entry.getRemainingAmount();
+    BigDecimal cumulativeAmount = (originalAmount != null && remainingAmount != null) ?
+        originalAmount.subtract(remainingAmount) : null;
+
     // TODO: we can probably use `orderTradeType` to distinguish between Market and Limit order
     Order order =
         new MarketOrder(
             orderType,
-            entry.getOriginalAmount(),
+            originalAmount,
             null,
             Long.toString(entry.getId()),
             new Date(entry.getTimestamp()),
             entry.getAvgPrice(),
-            entry.getOriginalAmount().subtract(entry.getRemainingAmount()),
+            cumulativeAmount,
             null,
             orderStatus,
             null);

--- a/xchange-coinmate/src/test/java/org/knowm/xchange/coinmate/CoinmateAdapterTest.java
+++ b/xchange-coinmate/src/test/java/org/knowm/xchange/coinmate/CoinmateAdapterTest.java
@@ -24,16 +24,22 @@
 package org.knowm.xchange.coinmate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
+import java.util.List;
 import java.util.TimeZone;
 import org.junit.Test;
 import org.knowm.xchange.coinmate.dto.marketdata.CoinmateTicker;
+import org.knowm.xchange.coinmate.dto.trade.CoinmateOrders;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.marketdata.Ticker;
 
 /** @author Martin Stachon */
@@ -47,11 +53,13 @@ public class CoinmateAdapterTest {
         CoinmateAdapterTest.class.getResourceAsStream(
             "/org/knowm/xchange/coinmate/dto/marketdata/example-ticker.json");
 
+    assertNotNull(is);
+
     // Use Jackson to parse it
     ObjectMapper mapper = new ObjectMapper();
-    CoinmateTicker bitstampTicker = mapper.readValue(is, CoinmateTicker.class);
+    CoinmateTicker coinmateTicker = mapper.readValue(is, CoinmateTicker.class);
 
-    Ticker ticker = CoinmateAdapters.adaptTicker(bitstampTicker, CurrencyPair.BTC_EUR);
+    Ticker ticker = CoinmateAdapters.adaptTicker(coinmateTicker, CurrencyPair.BTC_EUR);
 
     assertThat(ticker.getLast().toString()).isEqualTo("254.08");
     assertThat(ticker.getBid().toString()).isEqualTo("252.93");
@@ -61,5 +69,60 @@ public class CoinmateAdapterTest {
     f.setTimeZone(TimeZone.getTimeZone("UTC"));
     String dateString = f.format(ticker.getTimestamp());
     assertThat(dateString).isEqualTo("2017-01-26 20:12:57");
+  }
+
+  @Test
+  public void testOrderAdapter_nullPrice() throws IOException {
+
+    // Read in the JSON from the example resources
+    InputStream is =
+        CoinmateAdapterTest.class.getResourceAsStream(
+            "/org/knowm/xchange/coinmate/dto/trade/example-order1.json");
+
+    assertNotNull(is);
+
+    // Use Jackson to parse it
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    CoinmateOrders coinmateOrders = mapper.readValue(is, CoinmateOrders.class);
+
+    List<Order> orders = CoinmateAdapters.adaptOrders(coinmateOrders);
+
+    Order order1 = orders.get(0);
+    assertThat(order1.getType() == Order.OrderType.ASK);
+    assertThat(order1.getId().equals("1"));
+    assertThat(order1.getAveragePrice().equals(new BigDecimal("996740")));
+    assertThat(order1.getTimestamp().equals(1631188240000L));
+    assertNull(order1.getOriginalAmount());
+    assertNull(order1.getCumulativeAmount());
+    assertThat(order1.getStatus() == Order.OrderStatus.FILLED);
+  }
+
+  @Test
+  public void testOrderAdapter_notNullPrice() throws IOException {
+
+    // Read in the JSON from the example resources
+    InputStream is =
+        CoinmateAdapterTest.class.getResourceAsStream(
+            "/org/knowm/xchange/coinmate/dto/trade/example-order2.json");
+
+    assertNotNull(is);
+
+    // Use Jackson to parse it
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    CoinmateOrders coinmateOrders = mapper.readValue(is, CoinmateOrders.class);
+
+    List<Order> orders = CoinmateAdapters.adaptOrders(coinmateOrders);
+
+    Order order2 = orders.get(0);
+    assertThat(order2.getType() == Order.OrderType.ASK);
+    assertThat(order2.getId().equals("2"));
+    assertThat(order2.getAveragePrice().equals(new BigDecimal("997850")));
+    assertThat(order2.getTimestamp().equals(16311882400001L));
+    assertThat(order2.getOriginalAmount().compareTo(new BigDecimal("0.0002")) == 0);
+    assertThat(order2.getCumulativeAmount().compareTo(new BigDecimal("0.0002")) == 0);
+    assertThat(order2.getRemainingAmount().compareTo(BigDecimal.ZERO) == 0);
+    assertThat(order2.getStatus() == Order.OrderStatus.FILLED);
   }
 }

--- a/xchange-coinmate/src/test/resources/org/knowm/xchange/coinmate/dto/trade/example-order1.json
+++ b/xchange-coinmate/src/test/resources/org/knowm/xchange/coinmate/dto/trade/example-order1.json
@@ -1,0 +1,22 @@
+{
+  "error": false,
+  "errorMessage": null,
+  "data": {
+    "id": 1,
+    "timestamp": 1631188240000,
+    "trailingUpdatedTimestamp": null,
+    "type": "BUY",
+    "price": null,
+    "remainingAmount": null,
+    "originalAmount": null,
+    "stopPrice": null,
+    "originalStopPrice": null,
+    "marketPriceAtLastUpdate": null,
+    "marketPriceAtOrderCreation": null,
+    "status": "FILLED",
+    "orderTradeType": "INSTANT",
+    "hidden": false,
+    "avgPrice": 996740,
+    "trailing": false
+  }
+}

--- a/xchange-coinmate/src/test/resources/org/knowm/xchange/coinmate/dto/trade/example-order2.json
+++ b/xchange-coinmate/src/test/resources/org/knowm/xchange/coinmate/dto/trade/example-order2.json
@@ -1,0 +1,22 @@
+{
+  "error": false,
+  "errorMessage": null,
+  "data": {
+    "id": 2,
+    "timestamp": 16311882400001,
+    "trailingUpdatedTimestamp": null,
+    "type": "BUY",
+    "price": 998808,
+    "remainingAmount": 0,
+    "originalAmount": 0.0002,
+    "stopPrice": null,
+    "originalStopPrice": null,
+    "marketPriceAtLastUpdate": null,
+    "marketPriceAtOrderCreation": null,
+    "status": "FILLED",
+    "orderTradeType": "LIMIT",
+    "hidden": false,
+    "avgPrice": 997850,
+    "trailing": false
+  }
+}


### PR DESCRIPTION
Avoid NPE when API sometimes sends null amounts in Order response