### PR TITLE
[CoinbasePro][Streaming] Implement resubscribeChannels

### DIFF
--- a/xchange-stream-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/CoinbaseProStreamingExchange.java
+++ b/xchange-stream-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/CoinbaseProStreamingExchange.java
@@ -13,6 +13,8 @@ import org.knowm.xchange.coinbasepro.dto.account.CoinbaseProWebsocketAuthData;
 import org.knowm.xchange.coinbasepro.service.CoinbaseProAccountServiceRaw;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 
+import java.io.IOException;
+
 /** CoinbasePro Streaming Exchange. Connects to live WebSocket feed. */
 public class CoinbaseProStreamingExchange extends CoinbaseProExchange implements StreamingExchange {
   private static final String API_URI = "wss://ws-feed.pro.coinbase.com";
@@ -164,6 +166,16 @@ public class CoinbaseProStreamingExchange extends CoinbaseProExchange implements
   @Override
   public void useCompressedMessages(boolean compressedMessages) {
     streamingService.useCompressedMessages(compressedMessages);
+  }
+
+  @Override
+  public void resubscribeChannels() {
+    try {
+      streamingService.sendMessage(streamingService.getUnsubscribeMessage(null));
+    } catch(IOException e) {
+      logger.error("Failed to unsubscribe", e)
+    }
+    streamingService.resubscribeChannels();
   }
 
   public void setOverrideApiUri(String overrideApiUri) {


### PR DESCRIPTION
This PR adds `resubscribeChannels` support. First I unsubscribe from all channels to make sure I get snapshot messages upon resubscribing. This might be useful to resynchronize orderbooks in case we suspect some messages might have been dropped.