### PR TITLE
[Binance][Accounts] updating the name of properties to correctly bind to the API

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/account/DepositAddress.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/account/DepositAddress.java
@@ -5,17 +5,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public final class DepositAddress {
 
   public String address;
-  public boolean success;
+  public String url;
   public String addressTag;
   public String asset;
 
   public DepositAddress(
       @JsonProperty("address") String address,
-      @JsonProperty("success") boolean success,
-      @JsonProperty("addressTag") String addressTag,
-      @JsonProperty("asset") String asset) {
+      @JsonProperty("url") String url,
+      @JsonProperty("tag") String addressTag,
+      @JsonProperty("coin") String asset) {
     this.address = address;
-    this.success = success;
+    this.url = url;
     this.addressTag = addressTag;
     this.asset = asset;
   }


### PR DESCRIPTION
According to the binance API documentation, the fields informed in the response are slightly different from the properties of the DepositAddress class, notably the "addressTag" which made it impossible to use this information for deposits such as EOS, XRP, BNB, etc.