### PR TITLE
Feature/okex legacy getorderbook

### DIFF
--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/v5/service/OkexMarketDataService.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/v5/service/OkexMarketDataService.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.okex.v5.service;
 import java.io.IOException;
 
 import org.knowm.xchange.client.ResilienceRegistries;
+import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.instrument.Instrument;
@@ -25,6 +26,11 @@ public class OkexMarketDataService extends OkexMarketDataServiceRaw implements M
   public OrderBook getOrderBook(Instrument instrument, Object... args) throws IOException {
     return OkexAdapters.adaptOrderBook(
         getOkexOrderbook(OkexAdapters.adaptCurrencyPairId(instrument)), instrument);
+  }
+
+  @Override
+  public OrderBook getOrderBook(CurrencyPair currencyPair, Object... args) throws IOException {
+    return this.getOrderBook((Instrument) currencyPair, args);
   }
 
   @Override


### PR DESCRIPTION
I tried to use the new APIs instead of deprecated. Unfortunately, most of the exchange implementations support legacy API. So I think that deprecated API should be implemented in the master branch till it is completely removed from the API.