### PR TITLE
[BINANCE] use "Long" instead of "long" for "orderId" 

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeServiceRaw.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeServiceRaw.java
@@ -115,7 +115,7 @@ public class BinanceTradeServiceRaw extends BinanceBaseService {
         .call();
   }
 
-  public BinanceOrder orderStatus(CurrencyPair pair, long orderId, String origClientOrderId)
+  public BinanceOrder orderStatus(CurrencyPair pair, Long orderId, String origClientOrderId)
       throws IOException, BinanceException {
     return decorateApiCall(
             () ->
@@ -133,7 +133,7 @@ public class BinanceTradeServiceRaw extends BinanceBaseService {
   }
 
   public BinanceCancelledOrder cancelOrder(
-      CurrencyPair pair, long orderId, String origClientOrderId, String newClientOrderId)
+      CurrencyPair pair, Long orderId, String origClientOrderId, String newClientOrderId)
       throws IOException, BinanceException {
     return decorateApiCall(
             () ->


### PR DESCRIPTION
- use type "Long" instead of "long" for parameter "orderId" in orderStatus() and cancelOrder()

The `BinanceTradeService` should use `Long orderId` instead of `long orderId` as parameter, because `orderId` is optional (see official Binance API documentation). If a user wants to set `clientOrderId`, then `orderId` must be set to null (which is actually not possible in BinanceTradeService).

Solves https://github.com/knowm/XChange/issues/4193