### PR TITLE
[BINANCE] Add "orderId" in myTrades()

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAuthenticated.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAuthenticated.java
@@ -252,16 +252,15 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("api/v3/myTrades")
-  /**
+    /**
    * Get trades for a specific account and symbol.
    *
    * @param symbol
+   * @param orderId optional
    * @param startTime optional
    * @param endTime optional
-   * @param limit optional, default 500; max 1000.
    * @param fromId optional, tradeId to fetch from. Default gets most recent trades.
+   * @param limit optional, default 500; max 1000.
    * @param recvWindow optional
    * @param timestamp
    * @param apiKey
@@ -270,12 +269,15 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("api/v3/myTrades")
   List<BinanceTrade> myTrades(
       @QueryParam("symbol") String symbol,
-      @QueryParam("limit") Integer limit,
+      @QueryParam("orderId") Long orderId,
       @QueryParam("startTime") Long startTime,
       @QueryParam("endTime") Long endTime,
       @QueryParam("fromId") Long fromId,
+      @QueryParam("limit") Integer limit,
       @QueryParam("recvWindow") Long recvWindow,
       @QueryParam("timestamp") SynchronizedValueFactory<Long> timestamp,
       @HeaderParam(X_MBX_APIKEY) String apiKey,

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAuthenticated.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAuthenticated.java
@@ -35,8 +35,6 @@ public interface BinanceAuthenticated extends Binance {
   String SIGNATURE = "signature";
   String X_MBX_APIKEY = "X-MBX-APIKEY";
 
-  @POST
-  @Path("api/v3/order")
   /**
    * Send in a new order
    *
@@ -56,6 +54,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @POST
+  @Path("api/v3/order")
   BinanceNewOrder newOrder(
       @FormParam("symbol") String symbol,
       @FormParam("side") OrderSide side,
@@ -72,8 +72,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @POST
-  @Path("api/v3/order/test")
   /**
    * Test new order creation and signature/recvWindow long. Creates and validates a new order but
    * does not send it into the matching engine.
@@ -94,6 +92,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @POST
+  @Path("api/v3/order/test")
   Object testNewOrder(
       @FormParam("symbol") String symbol,
       @FormParam("side") OrderSide side,
@@ -110,8 +110,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("api/v3/order")
   /**
    * Check an order's status.<br>
    * Either orderId or origClientOrderId must be sent.
@@ -127,6 +125,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("api/v3/order")
   BinanceOrder orderStatus(
       @QueryParam("symbol") String symbol,
       @QueryParam("orderId") long orderId,
@@ -137,8 +137,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @DELETE
-  @Path("api/v3/order")
   /**
    * Cancel an active order.
    *
@@ -155,6 +153,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @DELETE
+  @Path("api/v3/order")
   BinanceCancelledOrder cancelOrder(
       @QueryParam("symbol") String symbol,
       @QueryParam("orderId") long orderId,
@@ -166,8 +166,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @DELETE
-  @Path("api/v3/openOrders")
   /**
    * Cancels all active orders on a symbol. This includes OCO orders.
    *
@@ -178,6 +176,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @DELETE
+  @Path("api/v3/openOrders")
   List<BinanceCancelledOrder> cancelAllOpenOrders(
       @QueryParam("symbol") String symbol,
       @QueryParam("recvWindow") Long recvWindow,
@@ -186,8 +186,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("api/v3/openOrders")
   /**
    * Get open orders on a symbol.
    *
@@ -198,6 +196,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("api/v3/openOrders")
   List<BinanceOrder> openOrders(
       @QueryParam("symbol") String symbol,
       @QueryParam("recvWindow") Long recvWindow,
@@ -206,8 +206,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("api/v3/allOrders")
   /**
    * Get all account orders; active, canceled, or filled. <br>
    * If orderId is set, it will get orders >= that orderId. Otherwise most recent orders are
@@ -224,6 +222,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("api/v3/allOrders")
   List<BinanceOrder> allOrders(
       @QueryParam("symbol") String symbol,
       @QueryParam("orderId") Long orderId,
@@ -234,8 +234,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("api/v3/account")
   /**
    * Get current account information.
    *
@@ -245,6 +243,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("api/v3/account")
   BinanceAccountInformation account(
       @QueryParam("recvWindow") Long recvWindow,
       @QueryParam("timestamp") SynchronizedValueFactory<Long> timestamp,
@@ -252,7 +252,7 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-    /**
+  /**
    * Get trades for a specific account and symbol.
    *
    * @param symbol
@@ -284,8 +284,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @POST
-  @Path("/sapi/v1/capital/withdraw/apply")
   /**
    * Submit a withdraw request.
    *
@@ -302,6 +300,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @POST
+  @Path("/sapi/v1/capital/withdraw/apply")
   WithdrawResponse withdraw(
       @FormParam("coin") String coin,
       @FormParam("address") String address,
@@ -314,8 +314,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("/sapi/v1/capital/deposit/hisrec")
   /**
    * Fetch deposit history.
    *
@@ -330,6 +328,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("/sapi/v1/capital/deposit/hisrec")
   List<BinanceDeposit> depositHistory(
       @QueryParam("coin") String coin,
       @QueryParam("startTime") Long startTime,
@@ -340,8 +340,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("/sapi/v1/capital/withdraw/history")
   /**
    * Fetch withdraw history.
    *
@@ -356,6 +354,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("/sapi/v1/capital/withdraw/history")
   List<BinanceWithdraw> withdrawHistory(
       @QueryParam("coin") String coin,
       @QueryParam("startTime") Long startTime,
@@ -420,8 +420,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("/sapi/v1/capital/deposit/address")
   /**
    * Fetch deposit address.
    *
@@ -434,6 +432,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("/sapi/v1/capital/deposit/address")
   DepositAddress depositAddress(
       @QueryParam("coin") String coin,
       @QueryParam("recvWindow") Long recvWindow,
@@ -442,8 +442,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("/sapi/v1/asset/assetDetail")
   /**
    * Fetch asset details.
    *
@@ -455,6 +453,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("/sapi/v1/asset/assetDetail")
   Map<String, AssetDetail> assetDetail(
       @QueryParam("recvWindow") Long recvWindow,
       @QueryParam("timestamp") SynchronizedValueFactory<Long> timestamp,

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeService.java
@@ -118,7 +118,8 @@ public class BinanceTradeService extends BinanceTradeServiceRaw implements Trade
   public String placeStopOrder(StopOrder order) throws IOException {
     // Time-in-force should not be provided for market orders but is required for
     // limit orders, order we only default it for limit orders. If the caller
-    // specifies one for a market order, we don't remove it, since Binance might allow
+    // specifies one for a market order, we don't remove it, since Binance might
+    // allow
     // it at some point.
     TimeInForce tif =
         timeInForceFromOrder(order).orElse(order.getLimitPrice() != null ? TimeInForce.GTC : null);
@@ -233,22 +234,7 @@ public class BinanceTradeService extends BinanceTradeServiceRaw implements Trade
         throw new ExchangeException(
             "You need to provide the currency pair to get the user trades.");
       }
-
-      Integer limit = null;
-      if (params instanceof TradeHistoryParamLimit) {
-        TradeHistoryParamLimit limitParams = (TradeHistoryParamLimit) params;
-        limit = limitParams.getLimit();
-      }
-      Long fromId = null;
-      if (params instanceof TradeHistoryParamsIdSpan) {
-        TradeHistoryParamsIdSpan idParams = (TradeHistoryParamsIdSpan) params;
-
-        try {
-          fromId = BinanceAdapters.id(idParams.getStartId());
-        } catch (Throwable ignored) {
-        }
-      }
-
+      Long orderId = null;
       Long startTime = null;
       Long endTime = null;
       if (params instanceof TradeHistoryParamsTimeSpan) {
@@ -259,10 +245,27 @@ public class BinanceTradeService extends BinanceTradeServiceRaw implements Trade
           endTime = ((TradeHistoryParamsTimeSpan) params).getEndTime().getTime();
         }
       }
-      if ((fromId != null) && (startTime != null || endTime != null))
+      Long fromId = null;
+      if (params instanceof TradeHistoryParamsIdSpan) {
+        TradeHistoryParamsIdSpan idParams = (TradeHistoryParamsIdSpan) params;
+        try {
+          fromId = BinanceAdapters.id(idParams.getStartId());
+        } catch (Throwable ignored) {
+        }
+      }
+      if ((fromId != null) && (startTime != null || endTime != null)) {
         throw new ExchangeException(
             "You should either specify the id from which you get the user trades from or start and end times. If you specify both, Binance will only honour the fromId parameter.");
-      List<BinanceTrade> binanceTrades = super.myTrades(pair, limit, startTime, endTime, fromId);
+      }
+
+      Integer limit = null;
+      if (params instanceof TradeHistoryParamLimit) {
+        TradeHistoryParamLimit limitParams = (TradeHistoryParamLimit) params;
+        limit = limitParams.getLimit();
+      }
+
+      List<BinanceTrade> binanceTrades =
+          super.myTrades(pair, orderId, startTime, endTime, fromId, limit);
       List<UserTrade> trades =
           binanceTrades.stream()
               .map(

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeServiceRaw.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeServiceRaw.java
@@ -184,16 +184,17 @@ public class BinanceTradeServiceRaw extends BinanceBaseService {
   }
 
   public List<BinanceTrade> myTrades(
-      CurrencyPair pair, Integer limit, Long startTime, Long endTime, Long fromId)
+      CurrencyPair pair, Long orderId, Long startTime, Long endTime, Long fromId, Integer limit)
       throws BinanceException, IOException {
     return decorateApiCall(
             () ->
                 binance.myTrades(
                     BinanceAdapters.toSymbol(pair),
-                    limit,
+                    orderId,
                     startTime,
                     endTime,
                     fromId,
+                    limit,
                     getRecvWindow(),
                     getTimestampFactory(),
                     apiKey,


### PR DESCRIPTION
According to actual Binance API:

```
2021-08-12

    GET api/v3/myTrades has a new optional field orderId
```

This PR adds this field into myTrades().

Solves https://github.com/knowm/XChange/issues/4255