### PR TITLE
[BINANCE] put annotations below javadoc

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/Binance.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/Binance.java
@@ -21,47 +21,45 @@ import org.knowm.xchange.binance.dto.meta.exchangeinfo.BinanceExchangeInfo;
 @Produces(MediaType.APPLICATION_JSON)
 public interface Binance {
 
-  @GET
-  @Path("sapi/v1/system/status")
   /**
    * Fetch system status which is normal or system maintenance.
    *
    * @throws IOException
    */
+  @GET
+  @Path("sapi/v1/system/status")
   BinanceSystemStatus systemStatus() throws IOException;
 
-  @GET
-  @Path("api/v3/ping")
   /**
    * Test connectivity to the Rest API.
    *
    * @return
    * @throws IOException
    */
+  @GET
+  @Path("api/v3/ping")
   Object ping() throws IOException;
 
-  @GET
-  @Path("api/v3/time")
   /**
    * Test connectivity to the Rest API and get the current server time.
    *
    * @return
    * @throws IOException
    */
+  @GET
+  @Path("api/v3/time")
   BinanceTime time() throws IOException;
 
-  @GET
-  @Path("api/v3/exchangeInfo")
   /**
    * Current exchange trading rules and symbol information.
    *
    * @return
    * @throws IOException
    */
+  @GET
+  @Path("api/v3/exchangeInfo")
   BinanceExchangeInfo exchangeInfo() throws IOException;
 
-  @GET
-  @Path("api/v3/depth")
   /**
    * @param symbol
    * @param limit optional, default 100 max 5000. Valid limits: [5, 10, 20, 50, 100, 500, 1000,
@@ -70,11 +68,11 @@ public interface Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("api/v3/depth")
   BinanceOrderbook depth(@QueryParam("symbol") String symbol, @QueryParam("limit") Integer limit)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("api/v3/aggTrades")
   /**
    * Get compressed, aggregate trades. Trades that fill at the time, from the same order, with the
    * same price will have the quantity aggregated.<br>
@@ -92,6 +90,8 @@ public interface Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("api/v3/aggTrades")
   List<BinanceAggTrades> aggTrades(
       @QueryParam("symbol") String symbol,
       @QueryParam("fromId") Long fromId,
@@ -100,8 +100,6 @@ public interface Binance {
       @QueryParam("limit") Integer limit)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("api/v3/klines")
   /**
    * Kline/candlestick bars for a symbol. Klines are uniquely identified by their open time.<br>
    * If startTime and endTime are not sent, the most recent klines are returned.
@@ -115,6 +113,8 @@ public interface Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("api/v3/klines")
   List<Object[]> klines(
       @QueryParam("symbol") String symbol,
       @QueryParam("interval") String interval,
@@ -123,8 +123,6 @@ public interface Binance {
       @QueryParam("endTime") Long endTime)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("api/v3/ticker/24hr")
   /**
    * 24 hour price change statistics for all symbols. - bee carreful this api call have a big
    * weight, only about 4 call per minut can be without ban.
@@ -133,10 +131,10 @@ public interface Binance {
    * @throws IOException
    * @throws BinanceException
    */
-  List<BinanceTicker24h> ticker24h() throws IOException, BinanceException;
-
   @GET
   @Path("api/v3/ticker/24hr")
+  List<BinanceTicker24h> ticker24h() throws IOException, BinanceException;
+
   /**
    * 24 hour price change statistics.
    *
@@ -145,11 +143,11 @@ public interface Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("api/v3/ticker/24hr")
   BinanceTicker24h ticker24h(@QueryParam("symbol") String symbol)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("api/v3/ticker/price")
   /**
    * Latest price for a symbol.
    *
@@ -157,11 +155,11 @@ public interface Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("api/v3/ticker/price")
   BinancePrice tickerPrice(@QueryParam("symbol") String symbol)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("api/v3/ticker/price")
   /**
    * Latest price for all symbols.
    *
@@ -169,10 +167,10 @@ public interface Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("api/v3/ticker/price")
   List<BinancePrice> tickerAllPrices() throws IOException, BinanceException;
 
-  @GET
-  @Path("api/v3/ticker/bookTicker")
   /**
    * Best price/qty on the order book for all symbols.
    *
@@ -180,5 +178,7 @@ public interface Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("api/v3/ticker/bookTicker")
   List<BinancePriceQuantity> tickerAllBookTickers() throws IOException, BinanceException;
 }

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAuthenticated.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAuthenticated.java
@@ -35,8 +35,6 @@ public interface BinanceAuthenticated extends Binance {
   String SIGNATURE = "signature";
   String X_MBX_APIKEY = "X-MBX-APIKEY";
 
-  @POST
-  @Path("api/v3/order")
   /**
    * Send in a new order
    *
@@ -56,6 +54,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @POST
+  @Path("api/v3/order")
   BinanceNewOrder newOrder(
       @FormParam("symbol") String symbol,
       @FormParam("side") OrderSide side,
@@ -72,8 +72,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @POST
-  @Path("api/v3/order/test")
   /**
    * Test new order creation and signature/recvWindow long. Creates and validates a new order but
    * does not send it into the matching engine.
@@ -94,6 +92,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @POST
+  @Path("api/v3/order/test")
   Object testNewOrder(
       @FormParam("symbol") String symbol,
       @FormParam("side") OrderSide side,
@@ -110,8 +110,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("api/v3/order")
   /**
    * Check an order's status.<br>
    * Either orderId or origClientOrderId must be sent.
@@ -127,6 +125,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("api/v3/order")
   BinanceOrder orderStatus(
       @QueryParam("symbol") String symbol,
       @QueryParam("orderId") long orderId,
@@ -137,8 +137,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @DELETE
-  @Path("api/v3/order")
   /**
    * Cancel an active order.
    *
@@ -155,6 +153,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @DELETE
+  @Path("api/v3/order")
   BinanceCancelledOrder cancelOrder(
       @QueryParam("symbol") String symbol,
       @QueryParam("orderId") long orderId,
@@ -166,8 +166,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @DELETE
-  @Path("api/v3/openOrders")
   /**
    * Cancels all active orders on a symbol. This includes OCO orders.
    *
@@ -178,6 +176,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @DELETE
+  @Path("api/v3/openOrders")
   List<BinanceCancelledOrder> cancelAllOpenOrders(
       @QueryParam("symbol") String symbol,
       @QueryParam("recvWindow") Long recvWindow,
@@ -186,8 +186,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("api/v3/openOrders")
   /**
    * Get open orders on a symbol.
    *
@@ -198,6 +196,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("api/v3/openOrders")
   List<BinanceOrder> openOrders(
       @QueryParam("symbol") String symbol,
       @QueryParam("recvWindow") Long recvWindow,
@@ -206,8 +206,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("api/v3/allOrders")
   /**
    * Get all account orders; active, canceled, or filled. <br>
    * If orderId is set, it will get orders >= that orderId. Otherwise most recent orders are
@@ -224,6 +222,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("api/v3/allOrders")
   List<BinanceOrder> allOrders(
       @QueryParam("symbol") String symbol,
       @QueryParam("orderId") Long orderId,
@@ -234,8 +234,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("api/v3/account")
   /**
    * Get current account information.
    *
@@ -245,6 +243,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("api/v3/account")
   BinanceAccountInformation account(
       @QueryParam("recvWindow") Long recvWindow,
       @QueryParam("timestamp") SynchronizedValueFactory<Long> timestamp,
@@ -252,8 +252,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("api/v3/myTrades")
   /**
    * Get trades for a specific account and symbol.
    *
@@ -270,6 +268,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("api/v3/myTrades")
   List<BinanceTrade> myTrades(
       @QueryParam("symbol") String symbol,
       @QueryParam("limit") Integer limit,
@@ -282,8 +282,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @POST
-  @Path("/sapi/v1/capital/withdraw/apply")
   /**
    * Submit a withdraw request.
    *
@@ -300,6 +298,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @POST
+  @Path("/sapi/v1/capital/withdraw/apply")
   WithdrawResponse withdraw(
       @FormParam("coin") String coin,
       @FormParam("address") String address,
@@ -312,8 +312,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("/sapi/v1/capital/deposit/hisrec")
   /**
    * Fetch deposit history.
    *
@@ -328,6 +326,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("/sapi/v1/capital/deposit/hisrec")
   List<BinanceDeposit> depositHistory(
       @QueryParam("coin") String coin,
       @QueryParam("startTime") Long startTime,
@@ -338,8 +338,6 @@ public interface BinanceAuthenticated extends Binance {
       @QueryParam(SIGNATURE) ParamsDigest signature)
       throws IOException, BinanceException;
 
-  @GET
-  @Path("/sapi/v1/capital/withdraw/history")
   /**
    * Fetch withdraw history.
    *
@@ -354,6 +352,8 @@ public interface BinanceAuthenticated extends Binance {
    * @throws IOException
    * @throws BinanceException
    */
+  @GET
+  @Path("/sapi/v1/capital/withdraw/history")
   List<BinanceWithdraw> withdrawHistory(
       @QueryParam("coin") String coin,
       @QueryParam("startTime") Long startTime,


### PR DESCRIPTION
If annotations are put above the javadoc, no javadoc can be consumed by calling methods. Hence, put annotations always below javadoc.