### PR TITLE
added LNX as lightning network ticker

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
@@ -149,6 +149,7 @@ public class Currency implements Comparable<Currency>, Serializable {
   public static final Currency LAK = createCurrency("LAK", "Laotian Kip", null);
   public static final Currency LBP = createCurrency("LBP", "Lebanese Pound", null);
   public static final Currency LSK = createCurrency("LSK", "Lisk", null);
+  public static final Currency LNX = createCurrency("LNX", "Bitcoin (Lightning Network)", null);
   public static final Currency LKR = createCurrency("LKR", "Sri Lankan Rupee", null);
   public static final Currency LRD = createCurrency("LRD", "Liberian Dollar", null);
   public static final Currency LSL = createCurrency("LSL", "Lesotho Loti", null);


### PR DESCRIPTION
I'd like to use this library with bitfinex and their bitcoin lightning. Their supported ticker is `LNX` 
https://api-pub.bitfinex.com//v2/conf/pub:map:tx:method
