### PR TITLE
fix use gateio without apiKey

### DIFF
--- a/xchange-gateio/src/main/java/org/knowm/xchange/gateio/GateioAdapters.java
+++ b/xchange-gateio/src/main/java/org/knowm/xchange/gateio/GateioAdapters.java
@@ -242,13 +242,15 @@ public final class GateioAdapters {
       currencyPairs.put(currencyPair, currencyPairMetaData);
     }
 
-    Map<String, GateioFeeInfo> gateioFees = marketDataService.getGateioFees();
-    Map<String, GateioCoin> coins = marketDataService.getGateioCoinInfo().getCoins();
-    for (String coin : coins.keySet()) {
-      GateioCoin gateioCoin = coins.get(coin);
-      GateioFeeInfo gateioFeeInfo = gateioFees.get(coin);
-      if (gateioCoin != null && gateioFeeInfo != null) {
-        currencies.put(new Currency(coin), adaptCurrencyMetaData(gateioCoin, gateioFeeInfo));
+    if(marketDataService.getApiKey() != null) {
+      Map<String, GateioFeeInfo> gateioFees = marketDataService.getGateioFees();
+      Map<String, GateioCoin> coins = marketDataService.getGateioCoinInfo().getCoins();
+      for (String coin : coins.keySet()) {
+        GateioCoin gateioCoin = coins.get(coin);
+        GateioFeeInfo gateioFeeInfo = gateioFees.get(coin);
+        if (gateioCoin != null && gateioFeeInfo != null) {
+          currencies.put(new Currency(coin), adaptCurrencyMetaData(gateioCoin, gateioFeeInfo));
+        }
       }
     }
 

--- a/xchange-gateio/src/main/java/org/knowm/xchange/gateio/service/GateioBaseService.java
+++ b/xchange-gateio/src/main/java/org/knowm/xchange/gateio/service/GateioBaseService.java
@@ -41,4 +41,8 @@ public class GateioBaseService extends BaseExchangeService implements BaseServic
 
     return response;
   }
+
+  public String getApiKey() {
+    return apiKey;
+  }
 }


### PR DESCRIPTION
Fix Error:
`
{
    "result":"false",
    "code":5,
    "message":"Error: empty key or sign"
}`
when try createExchange() without apiKey