### PR TITLE
[binance] Updated BinanceResilience timeout duration to one minute.

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceResilience.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceResilience.java
@@ -21,6 +21,7 @@ public final class BinanceResilience {
         .rateLimiter(
             REQUEST_WEIGHT_RATE_LIMITER,
             RateLimiterConfig.from(registries.rateLimiters().getDefaultConfig())
+                .timeoutDuration(Duration.ofMinutes(1))
                 .limitRefreshPeriod(Duration.ofMinutes(1))
                 .limitForPeriod(1200)
                 .build());


### PR DESCRIPTION
Motivated with the fact, that the Binance exchange refreshes permits per minute. Default xchange configuration (30s) looked for me as a bit too short. Waiting requests didn't wait enough for the permits to regenerate (if I understand everything correctly). Btw, this change was a successful remedy for my issues.