### PR TITLE
Adding Bitfinex deposit/withdraw support for ETC, CLO

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAccountServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAccountServiceRaw.java
@@ -167,6 +167,10 @@ public class BitfinexAccountServiceRaw extends BitfinexBaseService {
       type = "litecoin";
     } else if ("ETH".equalsIgnoreCase(currency)) {
       type = "ethereum";
+    } else if ("ETC".equalsIgnoreCase(currency)) {
+      type = "ethereumc";
+    } else if ("CLO".equalsIgnoreCase(currency)) {
+      type = "clo";
     } else if ("IOT".equalsIgnoreCase(currency)) {
       type = "iota";
     } else if ("BCH".equalsIgnoreCase(currency)) {

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexUtils.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexUtils.java
@@ -87,6 +87,8 @@ public final class BitfinexUtils {
         return "ethereum";
       case "ETC":
         return "ethereumc";
+      case "CLO":
+        return "clo";
       case "ZEC":
         return "zcash";
       case "XMR":


### PR DESCRIPTION
It's next to impossible to overwirte `withdraw type` to get deposit (and withdrawal) Bitfinex address for currencies not supported by XChange.

The `withdraw type` should be obtained through
https://api-pub.bitfinex.com/v2/conf/pub:map:tx:method
and name of the currency lowercased in order to get `withdraw type`

To make deposit/withdraw funcitonal for ETC and CLO, I add support manualy.