### PR TITLE
Corrected fee currency in adaptKrakenUserTrade()

### DIFF
--- a/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingTradeService.java
+++ b/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingTradeService.java
@@ -198,7 +198,7 @@ public class KrakenStreamingTradeService implements StreamingTradeService {
                 .type(KrakenAdapters.adaptOrderType(KrakenType.fromString(dto.type)))
                 .price(dto.price)
                 .feeAmount(dto.fee)
-                .feeCurrency(currencyPair.base)
+                .feeCurrency(currencyPair.counter)
                 .originalAmount(dto.vol)
                 .build());
       }


### PR DESCRIPTION
Corected fee currency from **base** to **counter** currency in adaptKrakenUserTrade(), because the documentation of KrakenOwnTrade states that the fee relates to the "**quote** currency".