### PR TITLE
Make CurrencyPair equals use instanceof instead of class. Allows use …

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/currency/CurrencyPair.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/CurrencyPair.java
@@ -483,7 +483,7 @@ public class CurrencyPair extends Instrument implements Comparable<CurrencyPair>
     if (obj == null) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (!(obj instanceof CurrencyPair)) {
       return false;
     }
     CurrencyPair other = (CurrencyPair) obj;


### PR DESCRIPTION
CurrencyPair::equals() uses a conditional check of "getClass() != obj.getClass()". If this conditional is true, equals() returns false.

If a user wants to supply a CurrencyPair-derived class, Binance (and maybe others) will fail to deliver data. They fail because they are comparing their own copies of CurrencyPair objects with CurrencyPair-derived objects and CurrencyPair.getClass() != UserDerivedCurrencyPair.getClass() will fail.

By changing the conditional check _**getClass() != obj.getClass()**_ to **_!(obj instanceof CurrencyPair)_**, the CurrencyPair::equals method can handle equality against user derived classes of CurrencyPair.
