### PR TITLE
[Binance] Fixed mapping of binance trade "isBuyerMaker" to ASK/BID order types (reversed it...)

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAdapters.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAdapters.java
@@ -121,8 +121,18 @@ public class BinanceAdapters {
     }
   }
 
-  public static OrderType convertType(boolean isBuyer) {
-    return isBuyer ? OrderType.BID : OrderType.ASK;
+  /**
+   * If "is buyer maker" is true for the trade, it means that the order of whoever was on the buy
+   * side, was sitting as a bid in the orderbook for some time (so that it was making the market)
+   * and then someone came in and matched it immediately (market taker). So, that specific trade
+   * will now qualify as SELL (=ASK) and in UI highlight as reddish. On the opposite isBuyerMaker=false
+   * trade will qualify as BUY (=BID) and highlight greenish (source:
+   * https://money.stackexchange.com/a/102005).
+   *
+   * <p>Many other exchanges label trades directly as buy or sell.
+   */
+  public static OrderType convertType(boolean isBuyerMaker) {
+    return isBuyerMaker ? OrderType.ASK : OrderType.BID;
   }
 
   public static CurrencyPair adaptSymbol(String symbol) {


### PR DESCRIPTION
This PR reverses the trade type mapping for Binance market...

I have cross checked a few other markets, how they map trade side reported by exchange to XChange OrderType.BID/ASK.

The mapping seems to be: 
- BUY from exchange → OrderType.BID
- SELL from exchange → OrderType.ASK

However Binance doesn’t report BUY/SELL information, just the boolean flag if the buyer was the market maker.

I had good feeling that the trade type should be from the taker perspective. It is the taker, who initiates the trade. My understanding has been confirmed at last here:
https://money.stackexchange.com/a/102005

But I really wonder, why nobody detected this issue earlier. It is quite major, to reverse the trade side… I hope I misunderstood something, and this PR is not necessary;)