### PR TITLE
Update BinanceTrade.java

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/trade/BinanceTrade.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/trade/BinanceTrade.java
@@ -5,8 +5,9 @@ import java.math.BigDecimal;
 import java.util.Date;
 
 public final class BinanceTrade {
-
+  
   public final long id;
+  public final long tradeId;
   public final long orderId;
   public final BigDecimal price;
   public final BigDecimal qty;
@@ -19,6 +20,7 @@ public final class BinanceTrade {
 
   public BinanceTrade(
       @JsonProperty("id") long id,
+      @JsonProperty("tradeId") long tradeId,
       @JsonProperty("orderId") long orderId,
       @JsonProperty("price") BigDecimal price,
       @JsonProperty("qty") BigDecimal qty,
@@ -29,6 +31,7 @@ public final class BinanceTrade {
       @JsonProperty("isMaker") boolean isMaker,
       @JsonProperty("isBestMatch") boolean isBestMatch) {
     this.id = id;
+    this.tradeId = tradeId;
     this.orderId = orderId;
     this.price = price;
     this.qty = qty;


### PR DESCRIPTION
Add optional response property "tradeId" which is needed to correctly map `BinanceNewOrder#fills`.

```
{
..
  "orderId": 3621851162,
..
"fills": [
    {
      "price": "384.50000000",
      "qty": "0.10000000",
      "commission": "0.00007501",
      "commissionAsset": "BNB",
       // the response defines "tradeId"
      "tradeId": 510209803
    }
]
}
```

See more https://dev.binance.vision/t/add-tradeid-and-time-to-order-fills/8881/13.