### PR TITLE
Add Kraken timeinforce parameter

### DIFF
--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAuthenticated.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAuthenticated.java
@@ -110,7 +110,7 @@ public interface KrakenAuthenticated extends Kraken {
       @FormParam("expiretm") String expireTime,
       @FormParam("userref") String userRefId,
       @FormParam("close") Map<String, String> closeOrder,
-      @FormParam("timeinforce") String timeInForce,
+      @FormParam("timeInForce") String timeInForce,
       @HeaderParam("API-Key") String apiKey,
       @HeaderParam("API-Sign") ParamsDigest signer,
       @FormParam("nonce") SynchronizedValueFactory<Long> nonce)
@@ -134,7 +134,7 @@ public interface KrakenAuthenticated extends Kraken {
       @FormParam("userref") String userRefId,
       @FormParam("validate") boolean validateOnly,
       @FormParam("close") Map<String, String> closeOrder,
-      @FormParam("timeinforce") String timeInForce,
+      @FormParam("timeInForce") String timeInForce,
       @HeaderParam("API-Key") String apiKey,
       @HeaderParam("API-Sign") ParamsDigest signer,
       @FormParam("nonce") SynchronizedValueFactory<Long> nonce)

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAuthenticated.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAuthenticated.java
@@ -110,6 +110,7 @@ public interface KrakenAuthenticated extends Kraken {
       @FormParam("expiretm") String expireTime,
       @FormParam("userref") String userRefId,
       @FormParam("close") Map<String, String> closeOrder,
+      @FormParam("timeinforce") String timeInForce,
       @HeaderParam("API-Key") String apiKey,
       @HeaderParam("API-Sign") ParamsDigest signer,
       @FormParam("nonce") SynchronizedValueFactory<Long> nonce)
@@ -133,6 +134,7 @@ public interface KrakenAuthenticated extends Kraken {
       @FormParam("userref") String userRefId,
       @FormParam("validate") boolean validateOnly,
       @FormParam("close") Map<String, String> closeOrder,
+      @FormParam("timeinforce") String timeInForce,
       @HeaderParam("API-Key") String apiKey,
       @HeaderParam("API-Sign") ParamsDigest signer,
       @FormParam("nonce") SynchronizedValueFactory<Long> nonce)

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/trade/KrakenStandardOrder.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/trade/KrakenStandardOrder.java
@@ -1,12 +1,9 @@
 package org.knowm.xchange.kraken.dto.trade;
 
-import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import org.knowm.xchange.currency.CurrencyPair;
-import org.knowm.xchange.dto.Order.IOrderFlags;
+import java.math.*;
+import java.util.*;
+import org.knowm.xchange.currency.*;
+import org.knowm.xchange.dto.Order.*;
 
 public class KrakenStandardOrder {
 
@@ -24,6 +21,7 @@ public class KrakenStandardOrder {
   private final String userRefId;
   private final boolean validateOnly;
   private final Map<String, String> closeOrder;
+  private final TimeInForce timeInForce;
 
   private KrakenStandardOrder(
       CurrencyPair currencyPair,
@@ -39,7 +37,8 @@ public class KrakenStandardOrder {
       String expireTime,
       String userRefId,
       boolean validateOnly,
-      Map<String, String> closeOrder) {
+      Map<String, String> closeOrder,
+      TimeInForce timeInForce) {
 
     this.currencyPair = currencyPair;
     this.type = type;
@@ -55,6 +54,7 @@ public class KrakenStandardOrder {
     this.userRefId = userRefId;
     this.validateOnly = validateOnly;
     this.closeOrder = closeOrder;
+    this.timeInForce = timeInForce;
   }
 
   public static KrakenOrderBuilder getMarketOrderBuilder(
@@ -242,6 +242,11 @@ public class KrakenStandardOrder {
     return closeOrder;
   }
 
+  public TimeInForce getTimeInForce() {
+
+    return timeInForce;
+  }
+
   @Override
   public String toString() {
 
@@ -273,6 +278,8 @@ public class KrakenStandardOrder {
         + validateOnly
         + ", closeOrder="
         + closeOrder
+        + ", timeInForce="
+        + timeInForce
         + "]";
   }
 
@@ -292,6 +299,7 @@ public class KrakenStandardOrder {
     private String userRefId;
     private boolean validateOnly;
     private Map<String, String> closeOrder;
+    private TimeInForce timeInForce;
 
     private KrakenOrderBuilder(
         CurrencyPair currencyPair, KrakenType type, KrakenOrderType orderType, BigDecimal volume) {
@@ -374,6 +382,11 @@ public class KrakenStandardOrder {
       return this;
     }
 
+    public KrakenOrderBuilder withTimeInForce(TimeInForce timeInForce) {
+      this.timeInForce = timeInForce;
+      return this;
+    }
+
     public KrakenStandardOrder buildOrder() {
 
       return new KrakenStandardOrder(
@@ -390,7 +403,8 @@ public class KrakenStandardOrder {
           expireTime,
           userRefId,
           validateOnly,
-          closeOrder == null ? new HashMap<>() : closeOrder);
+          closeOrder == null ? new HashMap<>() : closeOrder,
+          timeInForce);
     }
 
     @Override
@@ -424,6 +438,8 @@ public class KrakenStandardOrder {
           + validateOnly
           + ", closeOrder="
           + closeOrder
+          + ", timeInForce="
+          + timeInForce
           + "]";
     }
 
@@ -495,6 +511,11 @@ public class KrakenStandardOrder {
     public Map<String, String> getCloseOrder() {
 
       return closeOrder;
+    }
+
+    public TimeInForce getTimeInForce() {
+
+      return timeInForce;
     }
   }
 }

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/trade/TimeInForce.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/trade/TimeInForce.java
@@ -1,0 +1,9 @@
+package org.knowm.xchange.kraken.dto.trade;
+
+import org.knowm.xchange.dto.*;
+
+public enum TimeInForce implements Order.IOrderFlags {
+  GTC,
+  IOC,
+  GTD
+}

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenTradeServiceRaw.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenTradeServiceRaw.java
@@ -2,7 +2,6 @@ package org.knowm.xchange.kraken.service;
 
 import java.io.IOException;
 import java.util.*;
-
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.*;

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenTradeServiceRaw.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenTradeServiceRaw.java
@@ -246,7 +246,7 @@ public class KrakenTradeServiceRaw extends KrakenBaseService {
               krakenStandardOrder.getExpireTime(),
               krakenStandardOrder.getUserRefId(),
               krakenStandardOrder.getCloseOrder(),
-              nullSafeToString(krakenStandardOrder),
+              nullSafeToString(krakenStandardOrder.getTimeInForce()),
               exchange.getExchangeSpecification().getApiKey(),
               signatureCreator,
               exchange.getNonceFactory());
@@ -267,7 +267,7 @@ public class KrakenTradeServiceRaw extends KrakenBaseService {
               krakenStandardOrder.getUserRefId(),
               true,
               krakenStandardOrder.getCloseOrder(),
-              nullSafeToString(krakenStandardOrder),
+              nullSafeToString(krakenStandardOrder.getTimeInForce()),
               exchange.getExchangeSpecification().getApiKey(),
               signatureCreator,
               exchange.getNonceFactory());
@@ -316,9 +316,7 @@ public class KrakenTradeServiceRaw extends KrakenBaseService {
     return checkResult(krakenOrderResult);
   }
 
-  private String nullSafeToString(KrakenStandardOrder krakenStandardOrder) {
-    return krakenStandardOrder.getTimeInForce() == null
-        ? null
-        : krakenStandardOrder.getTimeInForce().toString();
+  private String nullSafeToString(Object value) {
+    return value == null ? null : value.toString();
   }
 }

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenTradeServiceRaw.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenTradeServiceRaw.java
@@ -1,21 +1,18 @@
 package org.knowm.xchange.kraken.service;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.*;
+
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.*;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
 import org.knowm.xchange.kraken.KrakenUtils;
 import org.knowm.xchange.kraken.dto.account.KrakenTradeVolume;
 import org.knowm.xchange.kraken.dto.account.results.KrakenTradeVolumeResult;
-import org.knowm.xchange.kraken.dto.trade.KrakenOpenPosition;
-import org.knowm.xchange.kraken.dto.trade.KrakenOrder;
-import org.knowm.xchange.kraken.dto.trade.KrakenOrderResponse;
-import org.knowm.xchange.kraken.dto.trade.KrakenStandardOrder;
+import org.knowm.xchange.kraken.dto.trade.*;
 import org.knowm.xchange.kraken.dto.trade.KrakenStandardOrder.KrakenOrderBuilder;
-import org.knowm.xchange.kraken.dto.trade.KrakenTrade;
-import org.knowm.xchange.kraken.dto.trade.KrakenType;
 import org.knowm.xchange.kraken.dto.trade.results.KrakenCancelOrderResult;
 import org.knowm.xchange.kraken.dto.trade.results.KrakenCancelOrderResult.KrakenCancelOrderResponse;
 import org.knowm.xchange.kraken.dto.trade.results.KrakenClosedOrdersResult;
@@ -217,9 +214,17 @@ public class KrakenTradeServiceRaw extends KrakenBaseService {
                 limitOrder.getOriginalAmount())
             .withUserRefId(limitOrder.getUserReference())
             .withOrderFlags(limitOrder.getOrderFlags())
-            .withLeverage(limitOrder.getLeverage());
+            .withLeverage(limitOrder.getLeverage())
+            .withTimeInForce(timeInForceFromOrder(limitOrder).orElse(null));
 
     return placeKrakenOrder(krakenOrderBuilder.buildOrder());
+  }
+
+  private Optional<TimeInForce> timeInForceFromOrder(Order order) {
+    return order.getOrderFlags().stream()
+        .filter(flag -> flag instanceof TimeInForce)
+        .map(flag -> (TimeInForce) flag)
+        .findFirst();
   }
 
   public KrakenOrderResponse placeKrakenOrder(KrakenStandardOrder krakenStandardOrder)
@@ -242,6 +247,7 @@ public class KrakenTradeServiceRaw extends KrakenBaseService {
               krakenStandardOrder.getExpireTime(),
               krakenStandardOrder.getUserRefId(),
               krakenStandardOrder.getCloseOrder(),
+              nullSafeToString(krakenStandardOrder),
               exchange.getExchangeSpecification().getApiKey(),
               signatureCreator,
               exchange.getNonceFactory());
@@ -262,6 +268,7 @@ public class KrakenTradeServiceRaw extends KrakenBaseService {
               krakenStandardOrder.getUserRefId(),
               true,
               krakenStandardOrder.getCloseOrder(),
+              nullSafeToString(krakenStandardOrder),
               exchange.getExchangeSpecification().getApiKey(),
               signatureCreator,
               exchange.getNonceFactory());
@@ -308,5 +315,11 @@ public class KrakenTradeServiceRaw extends KrakenBaseService {
             exchange.getNonceFactory());
 
     return checkResult(krakenOrderResult);
+  }
+
+  private String nullSafeToString(KrakenStandardOrder krakenStandardOrder) {
+    return krakenStandardOrder.getTimeInForce() == null
+        ? null
+        : krakenStandardOrder.getTimeInForce().toString();
   }
 }

--- a/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/BaseWiremockTest.java
+++ b/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/BaseWiremockTest.java
@@ -1,17 +1,21 @@
 package org.knowm.xchange.kraken.service;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.common.collect.*;
 import org.junit.Rule;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeFactory;
 import org.knowm.xchange.ExchangeSpecification;
-import org.knowm.xchange.kraken.KrakenExchange;
+import org.knowm.xchange.kraken.*;
+import org.knowm.xchange.kraken.dto.marketdata.*;
 
 public class BaseWiremockTest {
 
   @Rule public WireMockRule wireMockRule = new WireMockRule();
 
   public Exchange createExchange() {
+    KrakenUtils.setKrakenAssets(ASSETS);
+    KrakenUtils.setKrakenAssetPairs(ASSET_PAIRS);
     Exchange exchange =
         ExchangeFactory.INSTANCE.createExchangeWithoutSpecification(KrakenExchange.class);
     ExchangeSpecification specification = exchange.getDefaultExchangeSpecification();
@@ -22,4 +26,12 @@ public class BaseWiremockTest {
     exchange.applySpecification(specification);
     return exchange;
   }
+
+  public static final ImmutableMap<String, KrakenAsset> ASSETS =
+      ImmutableMap.of(
+          "XXBT", new KrakenAsset("XBT", "currency", 8, 6),
+          "ZUSD", new KrakenAsset("USD", "currency", 4, 2));
+
+  public static final ImmutableMap<String, KrakenAssetPair> ASSET_PAIRS =
+      ImmutableMap.of("XXBTZUSD", KrakenAssetPair.builder().base("XXBT").quote("ZUSD").build());
 }

--- a/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/KrakenTradeServiceTest.java
+++ b/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/KrakenTradeServiceTest.java
@@ -2,21 +2,30 @@ package org.knowm.xchange.kraken.service;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.verification.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.*;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.dto.trade.UserTrade;
 import org.knowm.xchange.dto.trade.UserTrades;
+import org.knowm.xchange.kraken.dto.trade.*;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.orders.DefaultOpenOrdersParamCurrencyPair;
+
+import java.math.*;
+import java.util.*;
+import java.util.stream.*;
 
 public class KrakenTradeServiceTest extends BaseWiremockTest {
 
@@ -117,6 +126,57 @@ public class KrakenTradeServiceTest extends BaseWiremockTest {
     assertThat(secondUserTrade.getOriginalAmount()).isNotNull().isPositive();
     assertThat(secondUserTrade.getId()).isNotBlank();
     assertThat(secondUserTrade.getInstrument()).isEqualTo(CurrencyPair.LTC_USD);
+  }
+
+  @Test
+  public void placeOrderTest() throws Exception {
+    stubAddOrderApi();
+
+    String orderId = classUnderTest.placeLimitOrder(LIMIT_ORDER);
+    assertThat(orderId).isEqualTo("OUF4EM-FRGI2-MQMWZD");
+
+    List<LoggedRequest> requests =
+        wireMockRule.findAll(postRequestedFor(urlEqualTo("/0/private/AddOrder")));
+    assertThat(requests).hasSize(1);
+
+    Map<String, String> requestParams = parseAddOrderRequestBody(requests);
+    assertThat(requestParams.get("type")).isEqualTo("buy");
+    assertThat(requestParams.get("volume")).isEqualTo("2.12340000");
+    assertThat(requestParams.get("pair")).isEqualTo("XXBTZUSD");
+    assertThat(requestParams.get("price")).isEqualTo("45000.1");
+  }
+
+  @Test
+  public void placeOrderWithTimeInForceTest() throws Exception {
+    stubAddOrderApi();
+
+    LimitOrder order = LIMIT_ORDER;
+    order.addOrderFlag(TimeInForce.IOC);
+
+    classUnderTest.placeLimitOrder(order);
+
+    List<LoggedRequest> requests =
+        wireMockRule.findAll(postRequestedFor(urlEqualTo("/0/private/AddOrder")));
+    assertThat(requests).hasSize(1);
+
+    Map<String, String> requestParams = parseAddOrderRequestBody(requests);
+    assertThat(requestParams.get("timeinforce")).isEqualTo("IOC");
+  }
+
+  private void stubAddOrderApi() {
+    stubFor(
+        post(urlPathEqualTo("/0/private/AddOrder"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(PLACE_ORDER_RESPONSE_BODY)));
+  }
+
+  private Map<String, String> parseAddOrderRequestBody(List<LoggedRequest> requests) {
+    return Arrays.stream(requests.get(0).getBodyAsString().split("&"))
+        .map(keyValueString -> keyValueString.split("=", 2))
+        .collect(Collectors.toMap(a -> a[0], b -> b[1]));
   }
 
   private static String OPEN_ORDERS_BODY =
@@ -973,6 +1033,29 @@ public class KrakenTradeServiceTest extends BaseWiremockTest {
           + "      }\n"
           + "    },\n"
           + "    \"count\": 2346\n"
+          + "  }\n"
+          + "}";
+
+  public static final LimitOrder LIMIT_ORDER =
+      new LimitOrder(
+          Order.OrderType.BID,
+          new BigDecimal("2.12340000"),
+          CurrencyPair.XBT_USD,
+          null,
+          null,
+          new BigDecimal("45000.1"));
+
+  private static String PLACE_ORDER_RESPONSE_BODY =
+      "{\n"
+          + "  \"error\": [],\n"
+          + "  \"result\": {\n"
+          + "    \"descr\": {\n"
+          + "      \"order\": \"buy 2.12340000 XBTUSD @ limit 45000.1 with 2:1 leverage\",\n"
+          + "      \"close\": \"close position @ stop loss 38000.0 -> limit 36000.0\"\n"
+          + "    },\n"
+          + "    \"txid\": [\n"
+          + "      \"OUF4EM-FRGI2-MQMWZD\"\n"
+          + "    ]\n"
           + "  }\n"
           + "}";
 }

--- a/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/KrakenTradeServiceTest.java
+++ b/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/KrakenTradeServiceTest.java
@@ -11,6 +11,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.verification.*;
+import java.math.*;
+import java.util.*;
+import java.util.stream.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -22,10 +25,6 @@ import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.kraken.dto.trade.*;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.orders.DefaultOpenOrdersParamCurrencyPair;
-
-import java.math.*;
-import java.util.*;
-import java.util.stream.*;
 
 public class KrakenTradeServiceTest extends BaseWiremockTest {
 

--- a/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/KrakenTradeServiceTest.java
+++ b/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/KrakenTradeServiceTest.java
@@ -159,7 +159,7 @@ public class KrakenTradeServiceTest extends BaseWiremockTest {
     assertThat(requests).hasSize(1);
 
     Map<String, String> requestParams = parseAddOrderRequestBody(requests.get(0));
-    assertThat(requestParams.get("timeinforce")).isEqualTo("IOC");
+    assertThat(requestParams.get("timeInForce")).isEqualTo("IOC");
   }
 
   private void stubAddOrderApi() {

--- a/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/KrakenTradeServiceTest.java
+++ b/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/KrakenTradeServiceTest.java
@@ -138,7 +138,7 @@ public class KrakenTradeServiceTest extends BaseWiremockTest {
         wireMockRule.findAll(postRequestedFor(urlEqualTo("/0/private/AddOrder")));
     assertThat(requests).hasSize(1);
 
-    Map<String, String> requestParams = parseAddOrderRequestBody(requests);
+    Map<String, String> requestParams = parseAddOrderRequestBody(requests.get(0));
     assertThat(requestParams.get("type")).isEqualTo("buy");
     assertThat(requestParams.get("volume")).isEqualTo("2.12340000");
     assertThat(requestParams.get("pair")).isEqualTo("XXBTZUSD");
@@ -158,7 +158,7 @@ public class KrakenTradeServiceTest extends BaseWiremockTest {
         wireMockRule.findAll(postRequestedFor(urlEqualTo("/0/private/AddOrder")));
     assertThat(requests).hasSize(1);
 
-    Map<String, String> requestParams = parseAddOrderRequestBody(requests);
+    Map<String, String> requestParams = parseAddOrderRequestBody(requests.get(0));
     assertThat(requestParams.get("timeinforce")).isEqualTo("IOC");
   }
 
@@ -172,8 +172,8 @@ public class KrakenTradeServiceTest extends BaseWiremockTest {
                     .withBody(PLACE_ORDER_RESPONSE_BODY)));
   }
 
-  private Map<String, String> parseAddOrderRequestBody(List<LoggedRequest> requests) {
-    return Arrays.stream(requests.get(0).getBodyAsString().split("&"))
+  private Map<String, String> parseAddOrderRequestBody(LoggedRequest request) {
+    return Arrays.stream(request.getBodyAsString().split("&"))
         .map(keyValueString -> keyValueString.split("=", 2))
         .collect(Collectors.toMap(a -> a[0], b -> b[1]));
   }


### PR DESCRIPTION
Add support for Kraken "timeInForce" parameter - see https://docs.kraken.com/rest/#operation/addOrder

The case of the API field name appears to be wrong in the docs (`timeinforce`) or Kraken has a bug as only `timeInForce` is accepted by the API.