### PR TITLE
Include askSize and bidSize in Kraken Ticker

### DIFF
--- a/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingAdapters.java
+++ b/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingAdapters.java
@@ -159,8 +159,8 @@ public class KrakenStreamingAdapters {
         .filter(JsonNode::isObject)
         .map(
             tickerNode -> {
-              ArrayNode askList = (ArrayNode) tickerNode.get("a");
-              ArrayNode bidList = (ArrayNode) tickerNode.get("b");
+              ArrayNode askArray = (ArrayNode) tickerNode.get("a");
+              ArrayNode bidArray = (ArrayNode) tickerNode.get("b");
               Iterator<JsonNode> closeIterator = tickerNode.get("c").iterator();
               Iterator<JsonNode> volumeIterator = tickerNode.get("v").iterator();
               Iterator<JsonNode> vwapIterator = tickerNode.get("p").iterator();
@@ -175,10 +175,10 @@ public class KrakenStreamingAdapters {
 
               return new Ticker.Builder()
                   .open(nextNodeAsDecimal(openPriceIterator))
-                  .ask(arrayNodeItemAsDecimal(askList, 0))
-                  .bid(arrayNodeItemAsDecimal(bidList, 0))
-                  .askSize(arrayNodeItemAsDecimal(askList, 2))
-                  .bidSize(arrayNodeItemAsDecimal(bidList, 2))
+                  .ask(arrayNodeItemAsDecimal(askArray, 0))
+                  .bid(arrayNodeItemAsDecimal(bidArray, 0))
+                  .askSize(arrayNodeItemAsDecimal(askArray, 2))
+                  .bidSize(arrayNodeItemAsDecimal(bidArray, 2))
                   .last(nextNodeAsDecimal(closeIterator))
                   .high(nextNodeAsDecimal(highPriceIterator))
                   .low(nextNodeAsDecimal(lowPriceIterator))

--- a/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingAdapters.java
+++ b/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingAdapters.java
@@ -1,32 +1,24 @@
 package info.bitrich.xchangestream.kraken;
 
-import static info.bitrich.xchangestream.kraken.KrakenStreamingChecksum.createCrcChecksum;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.node.*;
 import com.google.common.collect.Streams;
-import java.math.BigDecimal;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.TreeSet;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.knowm.xchange.dto.Order;
-import org.knowm.xchange.dto.marketdata.OrderBook;
-import org.knowm.xchange.dto.marketdata.Ticker;
-import org.knowm.xchange.dto.marketdata.Trade;
-import org.knowm.xchange.dto.trade.LimitOrder;
-import org.knowm.xchange.instrument.Instrument;
-import org.knowm.xchange.kraken.KrakenAdapters;
-import org.knowm.xchange.kraken.dto.trade.KrakenType;
-import org.knowm.xchange.utils.DateUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.google.common.collect.*;
+import org.knowm.xchange.dto.*;
+import org.knowm.xchange.dto.marketdata.*;
+import org.knowm.xchange.dto.trade.*;
+import org.knowm.xchange.instrument.*;
+import org.knowm.xchange.kraken.*;
+import org.knowm.xchange.kraken.dto.trade.*;
+import org.knowm.xchange.utils.*;
+import org.slf4j.*;
+
+import java.math.*;
+import java.util.*;
+import java.util.concurrent.atomic.*;
+import java.util.stream.*;
+
+import static info.bitrich.xchangestream.kraken.KrakenStreamingChecksum.*;
 
 /** Kraken streaming adapters */
 public class KrakenStreamingAdapters {
@@ -225,7 +217,11 @@ public class KrakenStreamingAdapters {
     if (arrayNode == null || index > arrayNode.size()) {
       return null;
     }
-    return new BigDecimal(arrayNode.get(index).asText());
+    JsonNode itemNode = arrayNode.get(index);
+    if (itemNode == null) {
+      return null;
+    }
+    return new BigDecimal(itemNode.asText());
   }
 
   /**

--- a/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingAdapters.java
+++ b/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingAdapters.java
@@ -159,8 +159,8 @@ public class KrakenStreamingAdapters {
         .filter(JsonNode::isObject)
         .map(
             tickerNode -> {
-              Iterator<JsonNode> askIterator = tickerNode.get("a").iterator();
-              Iterator<JsonNode> bidIterator = tickerNode.get("b").iterator();
+              ArrayNode askList = (ArrayNode) tickerNode.get("a");
+              ArrayNode bidList = (ArrayNode) tickerNode.get("b");
               Iterator<JsonNode> closeIterator = tickerNode.get("c").iterator();
               Iterator<JsonNode> volumeIterator = tickerNode.get("v").iterator();
               Iterator<JsonNode> vwapIterator = tickerNode.get("p").iterator();
@@ -175,8 +175,10 @@ public class KrakenStreamingAdapters {
 
               return new Ticker.Builder()
                   .open(nextNodeAsDecimal(openPriceIterator))
-                  .ask(nextNodeAsDecimal(askIterator))
-                  .bid(nextNodeAsDecimal(bidIterator))
+                  .ask(arrayNodeItemAsDecimal(askList, 0))
+                  .bid(arrayNodeItemAsDecimal(bidList, 0))
+                  .askSize(arrayNodeItemAsDecimal(askList, 2))
+                  .bidSize(arrayNodeItemAsDecimal(bidList, 2))
                   .last(nextNodeAsDecimal(closeIterator))
                   .high(nextNodeAsDecimal(highPriceIterator))
                   .low(nextNodeAsDecimal(lowPriceIterator))
@@ -213,6 +215,17 @@ public class KrakenStreamingAdapters {
         .type(nextNodeAsOrderType(iterator))
         .instrument(instrument)
         .build();
+  }
+
+  /**
+   * Returns the element at index in arrayNode as a BigDecimal. Retuns null if the arrayNode is null
+   * or index does not exist.
+   */
+  private static BigDecimal arrayNodeItemAsDecimal(ArrayNode arrayNode, int index) {
+    if (arrayNode == null || index > arrayNode.size()) {
+      return null;
+    }
+    return new BigDecimal(arrayNode.get(index).asText());
   }
 
   /**

--- a/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingAdapters.java
+++ b/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingAdapters.java
@@ -214,7 +214,7 @@ public class KrakenStreamingAdapters {
    * or index does not exist.
    */
   private static BigDecimal arrayNodeItemAsDecimal(ArrayNode arrayNode, int index) {
-    if (arrayNode == null || index > arrayNode.size()) {
+    if (arrayNode == null) {
       return null;
     }
     JsonNode itemNode = arrayNode.get(index);

--- a/xchange-stream-kraken/src/test/java/info/bitrich/xchangestream/kraken/KrakenStreamingAdaptersTest.java
+++ b/xchange-stream-kraken/src/test/java/info/bitrich/xchangestream/kraken/KrakenStreamingAdaptersTest.java
@@ -113,6 +113,8 @@ public class KrakenStreamingAdaptersTest {
     assertThat(ticker.getOpen()).isEqualByComparingTo("9668.90000");
     assertThat(ticker.getAsk()).isEqualByComparingTo("9971.00000");
     assertThat(ticker.getBid()).isEqualByComparingTo("9970.90000");
+    assertThat(ticker.getAskSize()).isEqualByComparingTo("2.83251755");
+    assertThat(ticker.getBidSize()).isEqualByComparingTo("10.57957134");
     assertThat(ticker.getHigh()).isEqualByComparingTo("9990.00000");
     assertThat(ticker.getLow()).isEqualByComparingTo("9653.20000");
     assertThat(ticker.getVwap()).isEqualByComparingTo("9732.48471");


### PR DESCRIPTION
askSize and bidSize are returned by the Kraken API (see https://docs.kraken.com/rest/#operation/getTickerInformation) , but not yet mapped into Ticker.