### PR TITLE
Adapt cumulativeAmount of ftx limit orders

### DIFF
--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/FtxAdapters.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/FtxAdapters.java
@@ -281,6 +281,7 @@ public class FtxAdapters {
                         (ftxOrderDto.isIoc() ? FtxOrderFlags.IOC : null),
                         (ftxOrderDto.isPostOnly() ? FtxOrderFlags.POST_ONLY : null),
                         (ftxOrderDto.isReduceOnly() ? FtxOrderFlags.REDUCE_ONLY : null)))))
+        .cumulativeAmount(ftxOrderDto.getFilledSize())
         .remainingAmount(ftxOrderDto.getRemainingSize())
         .orderStatus(ftxOrderDto.getStatus())
         .id(ftxOrderDto.getId())


### PR DESCRIPTION
If I cancel the FTX order, the remainingAmount becomes 0 even though none of the orders are filled, and the cumulativeAmount is not specified, so the cumulativeAmount becomes the originalAmount.

It fixes one issue of #4440 and #4269