### PR TITLE
Ftx hotfix: Server time format did not match local time format

### DIFF
--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/FtxAdapters.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/FtxAdapters.java
@@ -11,10 +11,13 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.derivative.FuturesContract;
+import org.knowm.xchange.derivative.OptionsContract;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.account.AccountInfo;
 import org.knowm.xchange.dto.account.Balance;
@@ -49,6 +52,7 @@ import org.knowm.xchange.ftx.dto.trade.FtxOrderFlags;
 import org.knowm.xchange.ftx.dto.trade.FtxOrderRequestPayload;
 import org.knowm.xchange.ftx.dto.trade.FtxOrderSide;
 import org.knowm.xchange.ftx.dto.trade.FtxOrderType;
+import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.utils.jackson.CurrencyPairDeserializer;
 
 public class FtxAdapters {
@@ -326,6 +330,22 @@ public class FtxAdapters {
     } else {
       return currencyPair.toString();
     }
+  }
+
+  public static String adaptInstrumentToFtxMarket(Instrument instrument) {
+    return adaptCurrencyPairToFtxMarket(
+        Objects.requireNonNull(getCurrencyPairFromInstrument(instrument)));
+  }
+
+  public static CurrencyPair getCurrencyPairFromInstrument(Instrument instrument) {
+    if(instrument instanceof FuturesContract){
+      return ((FuturesContract)instrument).getCurrencyPair();
+    } else if(instrument instanceof OptionsContract){
+      return ((OptionsContract)instrument).getCurrencyPair();
+    } else if(instrument instanceof CurrencyPair){
+      return (CurrencyPair)instrument;
+    }
+    return null;
   }
 
   public static OpenPositions adaptOpenPositions(List<FtxPositionDto> ftxPositionDtos) {

--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxMarketDataService.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxMarketDataService.java
@@ -7,6 +7,7 @@ import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.ftx.FtxAdapters;
+import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 
 public class FtxMarketDataService extends FtxMarketDataServiceRaw implements MarketDataService {
@@ -30,15 +31,44 @@ public class FtxMarketDataService extends FtxMarketDataServiceRaw implements Mar
 
   @Override
   public Ticker getTicker(CurrencyPair currencyPair, Object... args) throws IOException {
-
+    String startTime = null;
+    String endTime = null;
+    Integer limit = 200;
+    String resolution = "60";
+    if (args.length > 0) {
+      if (args[0] instanceof String) {
+        startTime = args[0].toString();
+      }
+      if (args.length > 1) {
+        if (args[1] instanceof String) {
+          endTime = args[1].toString();
+        }
+      }
+      if (args.length > 2) {
+        if (args[2] instanceof Integer) {
+          limit = (int) args[2];
+        }
+      }
+      if (args.length > 3) {
+        if (args[2] instanceof String) {
+          resolution = args[3].toString();
+        }
+      }
+    }
     return FtxAdapters.adaptTicker(
         getFtxMarket(FtxAdapters.adaptCurrencyPairToFtxMarket(currencyPair)),
         getFtxCandles(
             FtxAdapters.adaptCurrencyPairToFtxMarket(currencyPair),
             "60",
-            null,
-            null,
-            null), // 60 seconds
+            startTime,
+            endTime,
+            limit), // 60 seconds
         currencyPair);
+  }
+
+  @Override
+  public Ticker getTicker(Instrument instrument, Object... args) throws IOException {
+    CurrencyPair currencyPair = FtxAdapters.getCurrencyPairFromInstrument(instrument);
+    return getTicker(currencyPair, args);
   }
 }


### PR DESCRIPTION
The FTX Exchange sends e.g. "40000**.**0" as the bitcoin price in the orderbook.
But my local time format is "40000**,**0", so the orderbook checksum was wrong and I could not receive the orderbook.
This hotfix solve the problem :-)