### PR TITLE
FtxStreamingAdapters 3 bugfix

### DIFF
--- a/xchange-stream-ftx/src/main/java/info/bitrich/xchangestream/ftx/FtxStreamingAdapters.java
+++ b/xchange-stream-ftx/src/main/java/info/bitrich/xchangestream/ftx/FtxStreamingAdapters.java
@@ -11,11 +11,12 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.time.Instant;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.zip.CRC32;
 import org.knowm.xchange.currency.Currency;
@@ -36,16 +37,17 @@ import org.knowm.xchange.instrument.Instrument;
 public class FtxStreamingAdapters {
 
   private static final ObjectMapper mapper = StreamingObjectMapperHelper.getObjectMapper();
-  /**
-   * Incoming values always has 1 trailing 0 after the decimal, and start with 1 zero
-   */
+  /** Incoming values always has 1 trailing 0 after the decimal, and start with 1 zero */
   private static final ThreadLocal<DecimalFormat> dfp =
-      ThreadLocal.withInitial(() -> new DecimalFormat("0.0#######"));
+      ThreadLocal.withInitial(
+          () -> new DecimalFormat("0.0#######", new DecimalFormatSymbols(Locale.US)));
 
   private static final ThreadLocal<DecimalFormat> dfs =
-      ThreadLocal.withInitial(() -> new DecimalFormat("0.####E00"));
+      ThreadLocal.withInitial(
+          () -> new DecimalFormat("0.####E00", new DecimalFormatSymbols(Locale.US)));
   private static final ThreadLocal<DecimalFormat> dfq =
-      ThreadLocal.withInitial(() -> new DecimalFormat("0.0#######"));
+      ThreadLocal.withInitial(
+          () -> new DecimalFormat("0.0#######", new DecimalFormatSymbols(Locale.US)));
 
   static Ticker NULL_TICKER =
       new Ticker.Builder().build(); // not need to create a new one each time
@@ -115,7 +117,17 @@ public class FtxStreamingAdapters {
                     getOrderbookChecksum(orderBook.getAsks(), orderBook.getBids());
 
                 if (!calculatedChecksum.equals(message.getChecksum())) {
-                  throw new IllegalStateException("Checksum is not correct!");
+                  final OrderBook sortedOrderBook =
+                      new OrderBook(
+                          Date.from(Instant.now()),
+                          new ArrayList<>(orderBook.getAsks()),
+                          new ArrayList<>(orderBook.getBids()),
+                          true);
+                  calculatedChecksum =
+                      getOrderbookChecksum(sortedOrderBook.getAsks(), sortedOrderBook.getBids());
+                  if (!calculatedChecksum.equals(message.getChecksum())) {
+                    throw new IllegalStateException("Checksum is not correct!");
+                  }
                 }
               }
             });
@@ -155,11 +167,11 @@ public class FtxStreamingAdapters {
       }
     }
 
-    String s = data.toString().replace("E", "e"); // strip last :
+    String s = data.toString().replace("E", "e");
 
     CRC32 crc32 = new CRC32();
     byte[] toBytes = s.getBytes(StandardCharsets.UTF_8);
-    crc32.update(toBytes, 0, toBytes.length - 1);
+    crc32.update(toBytes, 0, toBytes.length - 1); // strip last :
 
     return crc32.getValue();
   }
@@ -216,7 +228,7 @@ public class FtxStreamingAdapters {
             .instrument(new CurrencyPair(data.get("market").asText()))
             .originalAmount(data.get("size").decimalValue())
             .price(data.get("price").decimalValue())
-            .timestamp(Date.from(OffsetDateTime.parse(data.get("time").asText()).toInstant()))
+            .timestamp(Date.from(Instant.ofEpochMilli(data.get("time").asLong())))
             .id(data.get("id").asText())
             .orderId(data.get("orderId").asText())
             .feeAmount(data.get("fee").decimalValue())
@@ -240,8 +252,8 @@ public class FtxStreamingAdapters {
 
     LimitOrder.Builder order =
         new LimitOrder.Builder(
-            "buy".equals(data.get("side").asText()) ? Order.OrderType.BID : Order.OrderType.ASK,
-            new CurrencyPair(data.get("market").asText()))
+                "buy".equals(data.get("side").asText()) ? Order.OrderType.BID : Order.OrderType.ASK,
+                new CurrencyPair(data.get("market").asText()))
             .id(data.get("id").asText())
             .timestamp(Date.from(Instant.now()))
             .limitPrice(data.get("price").decimalValue())


### PR DESCRIPTION
`new DecimalFormat("0.0#######", new DecimalFormatSymbols(Locale.US)))`

The default DecimalFormat is created with the default locale. Which in some cases leads to incorrect formatting, the point is changed to a comma (0,0##)

```
                if (!calculatedChecksum.equals(message.getChecksum())) {
                  final OrderBook sortedOrderBook =
                      new OrderBook(
                          Date.from(Instant.now()),
                          new ArrayList<>(orderBook.getAsks()),
                          new ArrayList<>(orderBook.getBids()),
                          true);
                  calculatedChecksum =
                      getOrderbookChecksum(sortedOrderBook.getAsks(), sortedOrderBook.getBids());
                  if (!calculatedChecksum.equals(message.getChecksum())) {
                    throw new IllegalStateException("Checksum is not correct!");
                  }
```
				  
According to the specification of the FTX exchange API, the checksum is considered in the sorted list:

> <best_bid_price>:<best_bid_size>:<best_ask_price>:<best_ask_size>:<second_best_bid_price>:<second_best_bid_size>:...

Occasionally, with some trading pairs, a situation arises that the list of orders after the update is not sorted, specifically, I encountered this on the exchange with only one coin.
Because of the rarity of this situation, put the variable inside the check so that it only takes memory to create it if the checksum fails.
I'm not completely sure about the correctness of this decision ...


```
	String s = data.toString().replace("E", "e"); 
    CRC32 crc32 = new CRC32();
    byte[] toBytes = s.getBytes(StandardCharsets.UTF_8);
    crc32.update(toBytes, 0, toBytes.length - 1); // strip last :
```
Here simply places comments in right place.