### PR TITLE
Moved getTradeHistoryForSubaccount() to use /fills

### DIFF
--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/FtxAdapters.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/FtxAdapters.java
@@ -234,28 +234,26 @@ public class FtxAdapters {
     return new Trades(trades);
   }
 
-  public static UserTrades adaptUserTrades(List<FtxOrderDto> ftxUserTrades) {
+  public static UserTrades adaptUserTrades(List<FtxFillDto> ftxUserTrades) {
     List<UserTrade> userTrades = new ArrayList<>();
 
     ftxUserTrades.forEach(
-        ftxOrderDto -> {
-          if (ftxOrderDto.getFilledSize().compareTo(BigDecimal.ZERO) != 0) {
+        ftxFillDto -> {
+          if (ftxFillDto.getSize().compareTo(BigDecimal.ZERO) != 0) {
             userTrades.add(
                 new UserTrade.Builder()
                     .instrument(
-                        CurrencyPairDeserializer.getCurrencyPairFromString(ftxOrderDto.getMarket()))
+                        CurrencyPairDeserializer.getCurrencyPairFromString(ftxFillDto.getMarket()))
                     .currencyPair(
-                        CurrencyPairDeserializer.getCurrencyPairFromString(ftxOrderDto.getMarket()))
-                    .timestamp(ftxOrderDto.getCreatedAt())
-                    .id(ftxOrderDto.getId())
-                    .orderId(ftxOrderDto.getId())
-                    .orderUserReference(ftxOrderDto.getClientId())
-                    .originalAmount(ftxOrderDto.getFilledSize())
-                    .type(adaptFtxOrderSideToOrderType(ftxOrderDto.getSide()))
-                    .price(
-                        ftxOrderDto.getAvgFillPrice() == null
-                            ? ftxOrderDto.getPrice()
-                            : ftxOrderDto.getAvgFillPrice())
+                        CurrencyPairDeserializer.getCurrencyPairFromString(ftxFillDto.getMarket()))
+                    .timestamp(ftxFillDto.getTime())
+                    .id(ftxFillDto.getId())
+                    .orderId(ftxFillDto.getOrderId())
+                    .originalAmount(ftxFillDto.getSize())
+                    .type(adaptFtxOrderSideToOrderType(ftxFillDto.getSide()))
+                    .feeAmount(ftxFillDto.getFee())
+                    .feeCurrency(Currency.getInstance(ftxFillDto.getFeeCurrency()))
+                    .price(ftxFillDto.getPrice())
                     .build());
           }
         });

--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/FtxAuthenticated.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/FtxAuthenticated.java
@@ -36,14 +36,7 @@ import org.knowm.xchange.ftx.dto.account.FtxSubAccountTranferDto;
 import org.knowm.xchange.ftx.dto.account.FtxSubAccountTransferPOJO;
 import org.knowm.xchange.ftx.dto.account.FtxSubmitLendingOfferParams;
 import org.knowm.xchange.ftx.dto.account.FtxWalletBalanceDto;
-import org.knowm.xchange.ftx.dto.trade.CancelAllFtxOrdersParams;
-import org.knowm.xchange.ftx.dto.trade.FtxConditionalOrderDto;
-import org.knowm.xchange.ftx.dto.trade.FtxConditionalOrderRequestPayload;
-import org.knowm.xchange.ftx.dto.trade.FtxModifyConditionalOrderRequestPayload;
-import org.knowm.xchange.ftx.dto.trade.FtxModifyOrderRequestPayload;
-import org.knowm.xchange.ftx.dto.trade.FtxOrderDto;
-import org.knowm.xchange.ftx.dto.trade.FtxOrderRequestPayload;
-import org.knowm.xchange.ftx.dto.trade.FtxTriggerDto;
+import org.knowm.xchange.ftx.dto.trade.*;
 import si.mazi.rescu.ParamsDigest;
 
 @Path("/api")
@@ -267,6 +260,18 @@ public interface FtxAuthenticated extends Ftx {
       @HeaderParam("FTX-SIGN") ParamsDigest signature,
       @HeaderParam("FTX-SUBACCOUNT") String subaccount,
       @PathParam("client_order_id") String clientOrderId)
+      throws IOException, FtxException;
+
+  @GET
+  @Path("/fills")
+  FtxResponse<List<FtxFillDto>> fills(
+      @HeaderParam("FTX-KEY") String apiKey,
+      @HeaderParam("FTX-TS") Long nonce,
+      @HeaderParam("FTX-SIGN") ParamsDigest signature,
+      @HeaderParam("FTX-SUBACCOUNT") String subaccount,
+      @QueryParam("market") String market,
+      @QueryParam("start_time") Long startTime,
+      @QueryParam("end_time") Long endTime)
       throws IOException, FtxException;
 
   @POST

--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/dto/trade/FtxFillDto.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/dto/trade/FtxFillDto.java
@@ -1,0 +1,119 @@
+package org.knowm.xchange.ftx.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+public class FtxFillDto {
+
+  private final Date time;
+
+  private final String id;
+
+  private final String market;
+
+  private final BigDecimal price;
+
+  private final FtxOrderSide side;
+
+  private final BigDecimal size;
+
+  private final String orderId;
+
+  private final String tradeId;
+
+  private final BigDecimal fee;
+
+  private final String feeCurrency;
+
+  private final BigDecimal feeRate;
+
+  @JsonCreator
+  public FtxFillDto(
+      @JsonProperty("time") Date time,
+      @JsonProperty("id") String id,
+      @JsonProperty("market") String market,
+      @JsonProperty("price") BigDecimal price,
+      @JsonProperty("side") FtxOrderSide side,
+      @JsonProperty("size") BigDecimal size,
+      @JsonProperty("orderId") String orderId,
+      @JsonProperty("tradeId") String tradeId,
+      @JsonProperty("fee") BigDecimal fee,
+      @JsonProperty("feeCurrency") String feeCurrency,
+      @JsonProperty("feeRate") BigDecimal feeRate) {
+    this.time = time;
+    this.id = id;
+    this.market = market;
+    this.price = price;
+    this.side = side;
+    this.size = size;
+    this.orderId = orderId;
+    this.tradeId = tradeId;
+    this.fee = fee;
+    this.feeCurrency = feeCurrency;
+    this.feeRate = feeRate;
+  }
+
+  public Date getTime() {
+    return time;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getMarket() {
+    return market;
+  }
+
+  public BigDecimal getPrice() {
+    return price;
+  }
+
+  public FtxOrderSide getSide() {
+    return side;
+  }
+
+  public BigDecimal getSize() {
+    return size;
+  }
+
+  public String getOrderId() {
+    return orderId;
+  }
+
+  public String getTradeId() {
+    return tradeId;
+  }
+
+  public BigDecimal getFee() {
+    return fee;
+  }
+
+  public String getFeeCurrency() {
+    return feeCurrency;
+  }
+
+  public BigDecimal getFeeRate() {
+    return feeRate;
+  }
+
+  @Override
+  public String toString() {
+    return "FtxFillDto{" +
+            "time=" + time +
+            ", id='" + id + '\'' +
+            ", market='" + market + '\'' +
+            ", price=" + price +
+            ", side=" + side +
+            ", size=" + size +
+            ", orderId='" + orderId + '\'' +
+            ", tradeId='" + tradeId + '\'' +
+            ", fee=" + fee +
+            ", feeCurrency='" + feeCurrency + '\'' +
+            ", feeRate=" + feeRate +
+            '}';
+  }
+}

--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxTradeServiceRaw.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxTradeServiceRaw.java
@@ -4,11 +4,7 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.account.OpenPositions;
-import org.knowm.xchange.dto.trade.LimitOrder;
-import org.knowm.xchange.dto.trade.MarketOrder;
-import org.knowm.xchange.dto.trade.OpenOrders;
-import org.knowm.xchange.dto.trade.StopOrder;
-import org.knowm.xchange.dto.trade.UserTrades;
+import org.knowm.xchange.dto.trade.*;
 import org.knowm.xchange.ftx.FtxAdapters;
 import org.knowm.xchange.ftx.FtxException;
 import org.knowm.xchange.ftx.dto.FtxResponse;
@@ -30,57 +26,57 @@ public class FtxTradeServiceRaw extends FtxBaseService {
   }
 
   public String placeMarketOrderForSubaccount(String subaccount, MarketOrder marketOrder)
-      throws IOException {
+          throws IOException {
     return placeNewFtxOrder(subaccount, FtxAdapters.adaptMarketOrderToFtxOrderPayload(marketOrder))
-        .getResult()
-        .getId();
+            .getResult()
+            .getId();
   }
 
   public String placeLimitOrderForSubaccount(String subaccount, LimitOrder limitOrder)
-      throws IOException {
+          throws IOException {
     return placeNewFtxOrder(subaccount, FtxAdapters.adaptLimitOrderToFtxOrderPayload(limitOrder))
-        .getResult()
-        .getId();
+            .getResult()
+            .getId();
   }
 
   public FtxResponse<FtxOrderDto> placeNewFtxOrder(
-      String subaccount, FtxOrderRequestPayload payload) throws FtxException, IOException {
+          String subaccount, FtxOrderRequestPayload payload) throws FtxException, IOException {
     try {
       return ftx.placeOrder(
-          exchange.getExchangeSpecification().getApiKey(),
-          exchange.getNonceFactory().createValue(),
-          signatureCreator,
-          subaccount,
-          payload);
+              exchange.getExchangeSpecification().getApiKey(),
+              exchange.getNonceFactory().createValue(),
+              signatureCreator,
+              subaccount,
+              payload);
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }
   }
 
   public FtxResponse<FtxOrderDto> modifyFtxOrder(
-      String subaccount, String orderId, FtxModifyOrderRequestPayload payload)
-      throws FtxException, IOException {
+          String subaccount, String orderId, FtxModifyOrderRequestPayload payload)
+          throws FtxException, IOException {
 
     return ftx.modifyOrder(
-        exchange.getExchangeSpecification().getApiKey(),
-        exchange.getNonceFactory().createValue(),
-        signatureCreator,
-        subaccount,
-        orderId,
-        payload);
+            exchange.getExchangeSpecification().getApiKey(),
+            exchange.getNonceFactory().createValue(),
+            signatureCreator,
+            subaccount,
+            orderId,
+            payload);
   }
 
   public FtxResponse<FtxOrderDto> modifyFtxOrderByClientId(
-      String subaccount, String clientId, FtxModifyOrderRequestPayload payload)
-      throws FtxException, IOException {
+          String subaccount, String clientId, FtxModifyOrderRequestPayload payload)
+          throws FtxException, IOException {
 
     return ftx.modifyOrderByClientId(
-        exchange.getExchangeSpecification().getApiKey(),
-        exchange.getNonceFactory().createValue(),
-        signatureCreator,
-        subaccount,
-        clientId,
-        payload);
+            exchange.getExchangeSpecification().getApiKey(),
+            exchange.getNonceFactory().createValue(),
+            signatureCreator,
+            subaccount,
+            clientId,
+            payload);
   }
 
   public boolean cancelOrderForSubaccount(String subaccount, String orderId) throws IOException {
@@ -88,72 +84,72 @@ public class FtxTradeServiceRaw extends FtxBaseService {
   }
 
   public boolean cancelFtxOrder(String subaccount, String orderId)
-      throws FtxException, IOException {
+          throws FtxException, IOException {
     try {
       return ftx.cancelOrder(
-              exchange.getExchangeSpecification().getApiKey(),
-              exchange.getNonceFactory().createValue(),
-              signatureCreator,
-              subaccount,
-              orderId)
-          .isSuccess();
+                      exchange.getExchangeSpecification().getApiKey(),
+                      exchange.getNonceFactory().createValue(),
+                      signatureCreator,
+                      subaccount,
+                      orderId)
+              .isSuccess();
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }
   }
 
   public boolean cancelFtxByClientId(String subaccount, String clientId)
-      throws FtxException, IOException {
+          throws FtxException, IOException {
     try {
       return ftx.cancelOrderByClientId(
-              exchange.getExchangeSpecification().getApiKey(),
-              exchange.getNonceFactory().createValue(),
-              signatureCreator,
-              subaccount,
-              clientId)
-          .isSuccess();
+                      exchange.getExchangeSpecification().getApiKey(),
+                      exchange.getNonceFactory().createValue(),
+                      signatureCreator,
+                      subaccount,
+                      clientId)
+              .isSuccess();
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }
   }
 
   public boolean cancelOrderForSubaccount(String subaccount, CancelOrderParams orderParams)
-      throws IOException {
+          throws IOException {
     if (orderParams instanceof CancelOrderByCurrencyPair) {
       return cancelAllFtxOrders(
-          subaccount,
-          new CancelAllFtxOrdersParams(
-              FtxAdapters.adaptCurrencyPairToFtxMarket(
-                  ((CancelOrderByCurrencyPair) orderParams).getCurrencyPair())));
+              subaccount,
+              new CancelAllFtxOrdersParams(
+                      FtxAdapters.adaptCurrencyPairToFtxMarket(
+                              ((CancelOrderByCurrencyPair) orderParams).getCurrencyPair())));
     } else if (orderParams instanceof CancelOrderByUserReferenceParams) {
       return cancelFtxByClientId(
-          subaccount, ((CancelOrderByUserReferenceParams) orderParams).getUserReference());
+              subaccount, ((CancelOrderByUserReferenceParams) orderParams).getUserReference());
     } else if (orderParams instanceof CancelConditionalOrderFtxParams) {
       return cancelFtxConditionalOrderForSubAccount(
-          subaccount, ((CancelConditionalOrderFtxParams) orderParams).getOrderId());
+              subaccount, ((CancelConditionalOrderFtxParams) orderParams).getOrderId());
     } else {
       throw new IOException(
-          "CancelOrderParams must implement CancelOrderByCurrencyPair interface.");
+              "CancelOrderParams must implement CancelOrderByCurrencyPair interface.");
     }
   }
 
   public boolean cancelAllFtxOrders(String subaccount, CancelAllFtxOrdersParams payLoad)
-      throws FtxException, IOException {
+          throws FtxException, IOException {
     try {
       return ftx.cancelAllOrders(
-              exchange.getExchangeSpecification().getApiKey(),
-              exchange.getNonceFactory().createValue(),
-              signatureCreator,
-              subaccount,
-              payLoad)
-          .isSuccess();
+                      exchange.getExchangeSpecification().getApiKey(),
+                      exchange.getNonceFactory().createValue(),
+                      signatureCreator,
+                      subaccount,
+                      payLoad)
+              .isSuccess();
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }
   }
 
   public Collection<Order> getOrderFromSubaccount(String subaccount, String... orderIds)
-      throws IOException {
+          throws IOException {
     List<Order> orderList = new ArrayList<>();
     for (String orderId : orderIds) {
       Order order = FtxAdapters.adaptLimitOrder(getFtxOrderStatus(subaccount, orderId).getResult());
@@ -163,65 +159,105 @@ public class FtxTradeServiceRaw extends FtxBaseService {
   }
 
   public FtxResponse<List<FtxOrderDto>> getFtxOpenOrders(String subaccount, String market)
-      throws FtxException, IOException {
+          throws FtxException, IOException {
     try {
       return ftx.openOrders(
-          exchange.getExchangeSpecification().getApiKey(),
-          exchange.getNonceFactory().createValue(),
-          signatureCreator,
-          subaccount,
-          market);
+              exchange.getExchangeSpecification().getApiKey(),
+              exchange.getNonceFactory().createValue(),
+              signatureCreator,
+              subaccount,
+              market);
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }
   }
 
-  public UserTrades getTradeHistoryForSubaccount(String subaccount, TradeHistoryParams params)
-      throws IOException {
-    if (params instanceof TradeHistoryParamsAll) {
-      CurrencyPair currencyPair =
-          new CurrencyPair(((TradeHistoryParamsAll) params).getInstrument().toString());
-      return FtxAdapters.adaptUserTrades(
-          getFtxOrderHistory(
-                  subaccount,
-                  FtxAdapters.adaptCurrencyPairToFtxMarket(currencyPair),
-                  ((TradeHistoryParamsAll) params).getStartTime().getTime(),
-                  ((TradeHistoryParamsAll) params).getEndTime().getTime())
-              .getResult());
-    } else if (params instanceof TradeHistoryParamCurrencyPair) {
-      return FtxAdapters.adaptUserTrades(
-          getFtxOrderHistory(
-                  subaccount,
-                  FtxAdapters.adaptCurrencyPairToFtxMarket(
-                      ((TradeHistoryParamCurrencyPair) params).getCurrencyPair()),
-                  null,
-                  null)
-              .getResult());
+  public OpenOrders getOrderHistoryForSubaccount(String subaccount, TradeHistoryParams params)
+          throws IOException {
+    if (params instanceof TradeHistoryParamCurrencyPair) {
+      return FtxAdapters.adaptOpenOrders(
+              getFtxOrderHistory(
+                      subaccount,
+                      FtxAdapters.adaptCurrencyPairToFtxMarket(
+                              ((TradeHistoryParamCurrencyPair) params).getCurrencyPair()),
+                      ((TradeHistoryParamsAll) params).getStartTime().getTime(),
+                      ((TradeHistoryParamsAll) params).getEndTime().getTime())
+      );
     } else if (params instanceof TradeHistoryParamInstrument) {
       CurrencyPair currencyPair =
-          new CurrencyPair(((TradeHistoryParamInstrument) params).getInstrument().toString());
-      return FtxAdapters.adaptUserTrades(
-          getFtxOrderHistory(
-                  subaccount, FtxAdapters.adaptCurrencyPairToFtxMarket(currencyPair), null, null)
-              .getResult());
+              new CurrencyPair(((TradeHistoryParamInstrument) params).getInstrument().toString());
+      return FtxAdapters.adaptOpenOrders(
+              getFtxOrderHistory(
+                      subaccount,
+                      FtxAdapters.adaptCurrencyPairToFtxMarket(currencyPair),
+                      null,
+                      null));
     } else {
       throw new IOException(
-          "TradeHistoryParams must implement TradeHistoryParamCurrencyPair or TradeHistoryParamInstrument interface.");
+              "TradeHistoryParams must implement TradeHistoryParamCurrencyPair or TradeHistoryParamInstrument interface.");
+    }
+  }
+
+  public UserTrades getTradeHistoryForSubaccount(String subaccount, TradeHistoryParams params)
+          throws IOException {
+    if (params instanceof TradeHistoryParamsAll) {
+      CurrencyPair currencyPair =
+              new CurrencyPair(((TradeHistoryParamsAll) params).getInstrument().toString());
+      return FtxAdapters.adaptUserTrades(
+              getFtxFills(
+                      subaccount,
+                      FtxAdapters.adaptCurrencyPairToFtxMarket(currencyPair),
+                      ((TradeHistoryParamsAll) params).getStartTime().getTime(),
+                      ((TradeHistoryParamsAll) params).getEndTime().getTime())
+                      .getResult());
+    } else if (params instanceof TradeHistoryParamCurrencyPair) {
+      return FtxAdapters.adaptUserTrades(
+              getFtxFills(
+                      subaccount,
+                      FtxAdapters.adaptCurrencyPairToFtxMarket(((TradeHistoryParamCurrencyPair) params).getCurrencyPair()),
+                      null,
+                      null)
+                      .getResult());
+    } else if (params instanceof TradeHistoryParamInstrument) {
+      CurrencyPair currencyPair =
+              new CurrencyPair(((TradeHistoryParamInstrument) params).getInstrument().toString());
+      return FtxAdapters.adaptUserTrades(
+              getFtxFills(subaccount, FtxAdapters.adaptCurrencyPairToFtxMarket(currencyPair), null, null)
+                      .getResult());
+    } else {
+      throw new IOException(
+              "TradeHistoryParams must implement TradeHistoryParamCurrencyPair or TradeHistoryParamInstrument interface.");
     }
   }
 
   public FtxResponse<List<FtxOrderDto>> getFtxOrderHistory(
-      String subaccount, String market, Long startTime, Long endTime)
-      throws FtxException, IOException {
+          String subaccount, String market, Long startTime, Long endTime)
+          throws FtxException, IOException {
     try {
       return ftx.orderHistory(
-          exchange.getExchangeSpecification().getApiKey(),
-          exchange.getNonceFactory().createValue(),
-          signatureCreator,
-          subaccount,
-          market,
-          startTime,
-          endTime);
+              exchange.getExchangeSpecification().getApiKey(),
+              exchange.getNonceFactory().createValue(),
+              signatureCreator,
+              subaccount,
+              market,
+              startTime,
+              endTime);
+    } catch (FtxException e) {
+      throw new FtxException(e.getMessage());
+    }
+  }
+
+  public FtxResponse<List<FtxFillDto>> getFtxFills(String subaccount, String market, Long startTime, Long endTime)
+          throws FtxException, IOException {
+    try {
+      return ftx.fills(
+              exchange.getExchangeSpecification().getApiKey(),
+              exchange.getNonceFactory().createValue(),
+              signatureCreator,
+              subaccount,
+              market,
+              startTime,
+              endTime);
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }
@@ -232,46 +268,46 @@ public class FtxTradeServiceRaw extends FtxBaseService {
   }
 
   public OpenOrders getOpenOrdersForSubaccount(String subaccount, OpenOrdersParams params)
-      throws IOException {
+          throws IOException {
     if (params instanceof FtxTriggerOpenOrdersParams) {
       return FtxAdapters.adaptTriggerOpenOrders(
-          getFtxOpenConditionalOrdersForSubAccount(
-              subaccount,
-              FtxAdapters.adaptCurrencyPairToFtxMarket(
-                  ((OpenOrdersParamCurrencyPair) params).getCurrencyPair())));
+              getFtxOpenConditionalOrdersForSubAccount(
+                      subaccount,
+                      FtxAdapters.adaptCurrencyPairToFtxMarket(
+                              ((OpenOrdersParamCurrencyPair) params).getCurrencyPair())));
     } else if (params instanceof CurrencyPairParam) {
       return FtxAdapters.adaptOpenOrders(
-          getFtxOpenOrders(
-              subaccount,
-              FtxAdapters.adaptCurrencyPairToFtxMarket(
-                  ((CurrencyPairParam) params).getCurrencyPair())));
+              getFtxOpenOrders(
+                      subaccount,
+                      FtxAdapters.adaptCurrencyPairToFtxMarket(
+                              ((CurrencyPairParam) params).getCurrencyPair())));
     } else {
       throw new IOException("OpenOrdersParams must implement CurrencyPairParam interface.");
     }
   }
 
   public FtxResponse<List<FtxOrderDto>> getFtxAllOpenOrdersForSubaccount(String subaccount)
-      throws FtxException, IOException {
+          throws FtxException, IOException {
     try {
       return ftx.openOrdersWithoutMarket(
-          exchange.getExchangeSpecification().getApiKey(),
-          exchange.getNonceFactory().createValue(),
-          signatureCreator,
-          subaccount);
+              exchange.getExchangeSpecification().getApiKey(),
+              exchange.getNonceFactory().createValue(),
+              signatureCreator,
+              subaccount);
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }
   }
 
   public FtxResponse<FtxOrderDto> getFtxOrderStatus(String subaccount, String orderId)
-      throws FtxException, IOException {
+          throws FtxException, IOException {
     try {
       return ftx.getOrderStatus(
-          exchange.getExchangeSpecification().getApiKey(),
-          exchange.getNonceFactory().createValue(),
-          signatureCreator,
-          subaccount,
-          orderId);
+              exchange.getExchangeSpecification().getApiKey(),
+              exchange.getNonceFactory().createValue(),
+              signatureCreator,
+              subaccount,
+              orderId);
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }
@@ -282,30 +318,30 @@ public class FtxTradeServiceRaw extends FtxBaseService {
   }
 
   public FtxResponse<List<FtxPositionDto>> getFtxPositions(String subaccount)
-      throws FtxException, IOException {
+          throws FtxException, IOException {
     try {
       return ftx.getFtxPositions(
-          exchange.getExchangeSpecification().getApiKey(),
-          exchange.getNonceFactory().createValue(),
-          signatureCreator,
-          subaccount,
-          true);
+              exchange.getExchangeSpecification().getApiKey(),
+              exchange.getNonceFactory().createValue(),
+              signatureCreator,
+              subaccount,
+              true);
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }
   }
 
   public String placeStopOrderForSubAccount(String subaccount, StopOrder stopOrder)
-      throws IOException {
+          throws IOException {
     return placeNewFtxConditionalOrderForSubAccount(
             subaccount, FtxAdapters.adaptStopOrderToFtxOrderPayload(stopOrder))
-        .getResult()
-        .getId();
+            .getResult()
+            .getId();
   }
 
   public boolean cancelStopOrder(String orderId) throws IOException {
     return cancelFtxConditionalOrderForSubAccount(
-        exchange.getExchangeSpecification().getUserName(), orderId);
+            exchange.getExchangeSpecification().getUserName(), orderId);
   }
 
   public String changeStopOrder(StopOrder stopOrder) throws IOException {
@@ -313,90 +349,90 @@ public class FtxTradeServiceRaw extends FtxBaseService {
             exchange.getExchangeSpecification().getUserName(),
             stopOrder.getId(),
             FtxAdapters.adaptModifyConditionalOrderToFtxOrderPayload(stopOrder))
-        .getResult()
-        .getId();
+            .getResult()
+            .getId();
   }
 
   public FtxResponse<FtxConditionalOrderDto> placeNewFtxConditionalOrderForSubAccount(
-      String subaccount, FtxConditionalOrderRequestPayload payload)
-      throws FtxException, IOException {
+          String subaccount, FtxConditionalOrderRequestPayload payload)
+          throws FtxException, IOException {
     try {
       return ftx.placeConditionalOrder(
-          exchange.getExchangeSpecification().getApiKey(),
-          exchange.getNonceFactory().createValue(),
-          signatureCreator,
-          subaccount,
-          payload);
+              exchange.getExchangeSpecification().getApiKey(),
+              exchange.getNonceFactory().createValue(),
+              signatureCreator,
+              subaccount,
+              payload);
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }
   }
 
   public FtxResponse<FtxConditionalOrderDto> modifyFtxConditionalOrderForSubAccount(
-      String subaccount, String orderId, FtxModifyConditionalOrderRequestPayload payload)
-      throws FtxException, IOException {
+          String subaccount, String orderId, FtxModifyConditionalOrderRequestPayload payload)
+          throws FtxException, IOException {
 
     return ftx.modifyConditionalOrder(
-        exchange.getExchangeSpecification().getApiKey(),
-        exchange.getNonceFactory().createValue(),
-        signatureCreator,
-        subaccount,
-        orderId,
-        payload);
+            exchange.getExchangeSpecification().getApiKey(),
+            exchange.getNonceFactory().createValue(),
+            signatureCreator,
+            subaccount,
+            orderId,
+            payload);
   }
 
   public boolean cancelFtxConditionalOrderForSubAccount(String subaccount, String orderId)
-      throws FtxException, IOException {
+          throws FtxException, IOException {
     try {
       return ftx.cancelConditionalOrder(
-              exchange.getExchangeSpecification().getApiKey(),
-              exchange.getNonceFactory().createValue(),
-              signatureCreator,
-              subaccount,
-              orderId)
-          .isSuccess();
+                      exchange.getExchangeSpecification().getApiKey(),
+                      exchange.getNonceFactory().createValue(),
+                      signatureCreator,
+                      subaccount,
+                      orderId)
+              .isSuccess();
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }
   }
 
   public FtxResponse<List<FtxConditionalOrderDto>> getFtxOpenConditionalOrdersForSubAccount(
-      String subaccount, String market) throws FtxException, IOException {
+          String subaccount, String market) throws FtxException, IOException {
     try {
       return ftx.openConditionalOrders(
-          exchange.getExchangeSpecification().getApiKey(),
-          exchange.getNonceFactory().createValue(),
-          signatureCreator,
-          subaccount,
-          market);
+              exchange.getExchangeSpecification().getApiKey(),
+              exchange.getNonceFactory().createValue(),
+              signatureCreator,
+              subaccount,
+              market);
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }
   }
 
   public FtxResponse<List<FtxConditionalOrderDto>> getFtxConditionalOrderHistory(
-      String subaccount, String market) throws FtxException, IOException {
+          String subaccount, String market) throws FtxException, IOException {
     try {
       return ftx.conditionalOrderHistory(
-          exchange.getExchangeSpecification().getApiKey(),
-          exchange.getNonceFactory().createValue(),
-          signatureCreator,
-          subaccount,
-          market);
+              exchange.getExchangeSpecification().getApiKey(),
+              exchange.getNonceFactory().createValue(),
+              signatureCreator,
+              subaccount,
+              market);
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }
   }
 
   public FtxResponse<List<FtxTriggerDto>> getFtxTriggersForSubAccount(
-      String subaccount, String orderId) throws FtxException, IOException {
+          String subaccount, String orderId) throws FtxException, IOException {
     try {
       return ftx.getTriggers(
-          exchange.getExchangeSpecification().getApiKey(),
-          exchange.getNonceFactory().createValue(),
-          signatureCreator,
-          subaccount,
-          orderId);
+              exchange.getExchangeSpecification().getApiKey(),
+              exchange.getNonceFactory().createValue(),
+              signatureCreator,
+              subaccount,
+              orderId);
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }
@@ -404,6 +440,6 @@ public class FtxTradeServiceRaw extends FtxBaseService {
 
   public List<FtxTriggerDto> getFtxTriggers(String orderId) throws FtxException, IOException {
     return getFtxTriggersForSubAccount(exchange.getExchangeSpecification().getUserName(), orderId)
-        .getResult();
+            .getResult();
   }
 }


### PR DESCRIPTION
Change for #4496 

----------

Moved `getTradeHistoryForSubaccount()` to use that `/fills?market={market}`
DTO was added to process that API response.

Before:
`Pulled Trade: UserTrade[type=BID, originalAmount=0.001, instrument=ETH/USD, price=1752.0, timestamp=Sat Jun 04 02:06:55 HKT 2022, id=151761986698, orderId='151761986698', feeAmount=null, feeCurrency='null', orderUserReference='98d3e174-8d69-4431-89ba-2e9c7755831e']
`

After:
`Pulled Trade: UserTrade[type=BID, originalAmount=0.001, instrument=ETH/USD, price=1752.0, timestamp=Sat Jun 04 02:07:30 HKT 2022, id=8434794907, orderId='151761986698', feeAmount=-5E-9, feeCurrency='ETH', orderUserReference='null']`

 `fee`, `feeCurrency` and `id` now consitent with `getStreamingTradeService().getUserTrades()` callback.

Reference: Callback result by `getStreamingTradeService().getUserTrades()`
`Trade callback: UserTrade[type=BID, originalAmount=0.001, instrument=ETH/USD, price=1751, timestamp=Sat Jun 04 02:37:22 HKT 2022, id=8434996155, orderId='151767264661', feeAmount=-5E-9, feeCurrency='ETH', orderUserReference='0a7bd422-86bb-46cc-b1a2-b5645228f57d']`

----------

Added new method `getOrderHistoryForSubaccount()` to `FtxTradeServiceRaw`, 
using the original `/orders/history` API to retrive order history, 
which including both open and closed orders.

The return should be consitent with `getStreamingTradeService().getOrders()` callback.

----------

Personally I use those two APIs to recover orders/trades missed during websocket disconnection.