### PR TITLE
moving stream-gateio to a package

### DIFF
--- a/xchange-stream-gateio/src/main/java/info/bitrich/xchangestream/gateio/GateioStreamingExchange.java
+++ b/xchange-stream-gateio/src/main/java/info/bitrich/xchangestream/gateio/GateioStreamingExchange.java
@@ -1,3 +1,5 @@
+package info.bitrich.xchangestream.gateio;
+
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.core.StreamingExchange;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;

--- a/xchange-stream-gateio/src/main/java/info/bitrich/xchangestream/gateio/GateioStreamingMarketDataService.java
+++ b/xchange-stream-gateio/src/main/java/info/bitrich/xchangestream/gateio/GateioStreamingMarketDataService.java
@@ -1,5 +1,7 @@
-import dto.response.GateioOrderBookResponse;
-import dto.response.GateioTradesResponse;
+package info.bitrich.xchangestream.gateio;
+
+import info.bitrich.xchangestream.gateio.dto.response.GateioOrderBookResponse;
+import info.bitrich.xchangestream.gateio.dto.response.GateioTradesResponse;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
 import io.reactivex.Observable;
 import java.util.List;

--- a/xchange-stream-gateio/src/main/java/info/bitrich/xchangestream/gateio/GateioStreamingService.java
+++ b/xchange-stream-gateio/src/main/java/info/bitrich/xchangestream/gateio/GateioStreamingService.java
@@ -1,9 +1,11 @@
+package info.bitrich.xchangestream.gateio;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import dto.GateioWebSocketSubscriptionMessage;
-import dto.response.GateioOrderBookResponse;
-import dto.response.GateioTradesResponse;
-import dto.response.GateioWebSocketTransaction;
+import info.bitrich.xchangestream.gateio.dto.GateioWebSocketSubscriptionMessage;
+import info.bitrich.xchangestream.gateio.dto.response.GateioOrderBookResponse;
+import info.bitrich.xchangestream.gateio.dto.response.GateioTradesResponse;
+import info.bitrich.xchangestream.gateio.dto.response.GateioWebSocketTransaction;
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.service.netty.JsonNettyStreamingService;
 import info.bitrich.xchangestream.service.netty.StreamingObjectMapperHelper;

--- a/xchange-stream-gateio/src/main/java/info/bitrich/xchangestream/gateio/dto/GateioWebSocketSubscriptionMessage.java
+++ b/xchange-stream-gateio/src/main/java/info/bitrich/xchangestream/gateio/dto/GateioWebSocketSubscriptionMessage.java
@@ -1,4 +1,4 @@
-package dto;
+package info.bitrich.xchangestream.gateio.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;

--- a/xchange-stream-gateio/src/main/java/info/bitrich/xchangestream/gateio/dto/response/GateioOrderBookResponse.java
+++ b/xchange-stream-gateio/src/main/java/info/bitrich/xchangestream/gateio/dto/response/GateioOrderBookResponse.java
@@ -1,4 +1,4 @@
-package dto.response;
+package info.bitrich.xchangestream.gateio.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;

--- a/xchange-stream-gateio/src/main/java/info/bitrich/xchangestream/gateio/dto/response/GateioTradesResponse.java
+++ b/xchange-stream-gateio/src/main/java/info/bitrich/xchangestream/gateio/dto/response/GateioTradesResponse.java
@@ -1,4 +1,4 @@
-package dto.response;
+package info.bitrich.xchangestream.gateio.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;

--- a/xchange-stream-gateio/src/main/java/info/bitrich/xchangestream/gateio/dto/response/GateioWebSocketTransaction.java
+++ b/xchange-stream-gateio/src/main/java/info/bitrich/xchangestream/gateio/dto/response/GateioWebSocketTransaction.java
@@ -1,4 +1,4 @@
-package dto.response;
+package info.bitrich.xchangestream.gateio.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;

--- a/xchange-stream-gateio/src/test/java/info/bitrich/xchangestream/gateio/GateioManualExample.java
+++ b/xchange-stream-gateio/src/test/java/info/bitrich/xchangestream/gateio/GateioManualExample.java
@@ -1,3 +1,5 @@
+package info.bitrich.xchangestream.gateio;
+
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.core.StreamingExchangeFactory;
 import io.reactivex.disposables.Disposable;

--- a/xchange-stream-gateio/src/test/java/info/bitrich/xchangestream/gateio/dto/GateioOrderBookResponseTest.java
+++ b/xchange-stream-gateio/src/test/java/info/bitrich/xchangestream/gateio/dto/GateioOrderBookResponseTest.java
@@ -1,7 +1,7 @@
-package dto;
+package info.bitrich.xchangestream.gateio.dto;
 
 import com.google.common.io.CharStreams;
-import dto.response.GateioOrderBookResponse;
+import info.bitrich.xchangestream.gateio.dto.response.GateioOrderBookResponse;
 import info.bitrich.xchangestream.service.netty.StreamingObjectMapperHelper;
 import java.io.IOException;
 import java.io.InputStream;

--- a/xchange-stream-gateio/src/test/java/info/bitrich/xchangestream/gateio/dto/GateioTradesResponseTest.java
+++ b/xchange-stream-gateio/src/test/java/info/bitrich/xchangestream/gateio/dto/GateioTradesResponseTest.java
@@ -1,7 +1,7 @@
-package dto;
+package info.bitrich.xchangestream.gateio.dto;
 
 import com.google.common.io.CharStreams;
-import dto.response.GateioTradesResponse;
+import info.bitrich.xchangestream.gateio.dto.response.GateioTradesResponse;
 import info.bitrich.xchangestream.service.netty.StreamingObjectMapperHelper;
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
`stream-gateio` is for some reason without `info.bitrich.xchangestream` package as the others. The reason for fixing this is because in Scala/SBT, root namespace classes from an imported library are missing in classpath as it is some kind of violation of best practices.