### PR TITLE
Fix Poloniex after API changes for returnChartData

### DIFF
--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexUtils.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexUtils.java
@@ -38,13 +38,13 @@ public class PoloniexUtils {
     }
   }
 
-  public static class UnixTimestampDeserializer extends JsonDeserializer<Date> {
+  public static class TimestampDeserializer extends JsonDeserializer<Date> {
     @Override
     public Date deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-      final String dateTimeInUnixFormat = p.getText();
+      final String millis = p.getText();
       try {
         Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        calendar.setTimeInMillis(Long.parseLong(dateTimeInUnixFormat + "000"));
+        calendar.setTimeInMillis(Long.parseLong(millis));
         return calendar.getTime();
       } catch (Exception e) {
         return new Date(0);

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/marketdata/PoloniexChartData.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/marketdata/PoloniexChartData.java
@@ -20,7 +20,7 @@ public class PoloniexChartData {
   @JsonCreator
   public PoloniexChartData(
       @JsonProperty(value = "date", required = true)
-          @JsonDeserialize(using = PoloniexUtils.UnixTimestampDeserializer.class)
+          @JsonDeserialize(using = PoloniexUtils.TimestampDeserializer.class)
           Date date,
       @JsonProperty(value = "high", required = true) BigDecimal high,
       @JsonProperty(value = "low", required = true) BigDecimal low,


### PR DESCRIPTION
Poloniex API for returnChartData now returns only 100 candles + it returns millis instead of seconds for the time of the candle.
We are fixing millis - but anyone using the data needs to improve the fetching inside their project