### PR TITLE
Fix Huobi NullPointerException bug

### DIFF
--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/HuobiAdapters.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/HuobiAdapters.java
@@ -137,7 +137,7 @@ public class HuobiAdapters {
   private static CurrencyMetaData getCurrencyMetaData(
       HuobiCurrency huobiCurrency, boolean isDelisted) {
     int withdrawPrecision = huobiCurrency.getWithdrawPrecision();
-    BigDecimal transactFeeWithdraw = new BigDecimal(huobiCurrency.getTransactFeeWithdraw());
+    BigDecimal transactFeeWithdraw = huobiCurrency.getTransactFeeWithdraw();
     BigDecimal minWithdrawAmt = new BigDecimal(huobiCurrency.getMinWithdrawAmt());
     WalletHealth walletHealthStatus =
         isDelisted ? WalletHealth.OFFLINE : getWalletHealthStatus(huobiCurrency);

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/dto/marketdata/HuobiCurrency.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/dto/marketdata/HuobiCurrency.java
@@ -2,6 +2,8 @@ package org.knowm.xchange.huobi.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.math.BigDecimal;
+
 public class HuobiCurrency {
 
   private String chain;
@@ -17,7 +19,7 @@ public class HuobiCurrency {
   private String minWithdrawAmt;
   private int numOfConfirmations;
   private int numOfFastConfirmations;
-  private String transactFeeWithdraw;
+  private BigDecimal transactFeeWithdraw;
   private String withdrawFeeType;
   private int withdrawPrecision;
   private String withdrawQuotaPerDay;
@@ -39,7 +41,7 @@ public class HuobiCurrency {
       @JsonProperty("minWithdrawAmt") String minWithdrawAmt,
       @JsonProperty("numOfConfirmations") int numOfConfirmations,
       @JsonProperty("numOfFastConfirmations") int numOfFastConfirmations,
-      @JsonProperty("transactFeeWithdraw") String transactFeeWithdraw,
+      @JsonProperty("transactFeeWithdraw") BigDecimal transactFeeWithdraw,
       @JsonProperty("withdrawFeeType") String withdrawFeeType,
       @JsonProperty("withdrawPrecision") int withdrawPrecision,
       @JsonProperty("withdrawQuotaPerDay") String withdrawQuotaPerDay,
@@ -120,7 +122,7 @@ public class HuobiCurrency {
     return numOfFastConfirmations;
   }
 
-  public String getTransactFeeWithdraw() {
+  public BigDecimal getTransactFeeWithdraw() {
     return transactFeeWithdraw;
   }
 


### PR DESCRIPTION
 - Jackson library is instructed to deserialise `transactFeeWithdraw` into `BigDecimal` directly to avoid `NullPointerException` issue.