### PR TITLE
Threads are leaking if disconnecting service that was closed by the server

### DIFF
--- a/xchange-stream-service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
+++ b/xchange-stream-service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
@@ -322,6 +322,15 @@ public abstract class NettyStreamingService<T> extends ConnectableService {
                                 completable.onComplete();
                               });
                     });
+          } else if (webSocketChannel != null) {
+            channels.clear();
+            eventLoopGroup
+                .shutdownGracefully(2, idleTimeoutSeconds, TimeUnit.SECONDS)
+                .addListener(
+                    f -> {
+                      connectionStateModel.setState(State.CLOSED);
+                      completable.onComplete();
+                    });
           } else {
             LOG.warn("Disconnect called but already disconnected");
             connectionStateModel.setState(State.CLOSED);

--- a/xchange-stream-service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
+++ b/xchange-stream-service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
@@ -322,7 +322,7 @@ public abstract class NettyStreamingService<T> extends ConnectableService {
                                 completable.onComplete();
                               });
                     });
-          } else if (webSocketChannel != null) {
+          } else if (webSocketChannel != null) { // web socket is closed already
             channels.clear();
             eventLoopGroup
                 .shutdownGracefully(2, idleTimeoutSeconds, TimeUnit.SECONDS)


### PR DESCRIPTION
If reconnection is handled by the client code every call of disconnect() and connecting again creates a new thread while the old one still lives