### PR TITLE
[kraken] Change deprecated Ethereum (Hex) method for Ethereum (ERC20)

### DIFF
--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenAccountService.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenAccountService.java
@@ -100,7 +100,7 @@ public class KrakenAccountService extends KrakenAccountServiceRaw implements Acc
     } else if (Currency.LTC.equals(currency)) {
       depositAddresses = getDepositAddresses(currency.toString(), "Litecoin", false);
     } else if (Currency.ETH.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "Ether (Hex)", false);
+      depositAddresses = getDepositAddresses(currency.toString(), "Ethereum (ERC20)", false);
     } else if (Currency.ZEC.equals(currency)) {
       depositAddresses = getDepositAddresses(currency.toString(), "Zcash (Transparent)", false);
     } else if (Currency.ADA.equals(currency)) {


### PR DESCRIPTION
Hi, I suggest changing the default method of getting ETH deposit address from Kraken.
Kraken last year introduced a unified ERC20 deposit address for Ethereum deposits together with ERC20 tokens.
Where `Ether (Hex)` method in some time will be dropped.

You can find more details in the link below:
https://support.kraken.com/hc/en-us/articles/4410585641108-Important-change-to-ETH-and-ERC-20-deposits

```
kraken_request('/0/private/DepositMethods', {
    "asset": "ETH"
})
```
```
{'error': [], 'result': [
{'method': 'Ether (Hex)', 'limit': False, 'gen-address': True}, 
{'method': 'Ethereum (ERC20)', 'limit': False, 'gen-address': True}
]}
```