### PR TITLE
[CoinbasePro] Fixed synchronization in CoinbaseProDigest

### DIFF
--- a/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/service/CoinbaseProAccountServiceRaw.java
+++ b/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/service/CoinbaseProAccountServiceRaw.java
@@ -22,6 +22,8 @@ import org.knowm.xchange.coinbasepro.dto.trade.CoinbaseProAccountAddress;
 import org.knowm.xchange.coinbasepro.dto.trade.CoinbaseProSendMoneyResponse;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.utils.timestamp.UnixTimestampFactory;
+import si.mazi.rescu.ParamsDigest;
+import si.mazi.rescu.RestInvocation;
 
 public class CoinbaseProAccountServiceRaw extends CoinbaseProBaseService {
 
@@ -201,13 +203,27 @@ public class CoinbaseProAccountServiceRaw extends CoinbaseProBaseService {
   public CoinbaseProWebsocketAuthData getWebsocketAuthData()
       throws CoinbaseProException, IOException {
     long timestamp = UnixTimestampFactory.INSTANCE.createValue();
+    WebhookAuthDataParamsDigestProxy digestProxy = new WebhookAuthDataParamsDigestProxy();
     JsonNode json =
-        decorateApiCall(() -> coinbasePro.getVerifyId(apiKey, digest, timestamp, passphrase))
+        decorateApiCall(() -> coinbasePro.getVerifyId(apiKey, digestProxy, timestamp, passphrase))
             .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
             .call();
     String userId = json.get("id").asText();
-    CoinbaseProDigest coinbaseProDigest = (CoinbaseProDigest) digest;
     return new CoinbaseProWebsocketAuthData(
-        userId, apiKey, passphrase, coinbaseProDigest.getSignature(), timestamp);
+        userId, apiKey, passphrase, digestProxy.getSignature(), timestamp);
+  }
+
+  private class WebhookAuthDataParamsDigestProxy implements ParamsDigest {
+    private String signature;
+
+    @Override
+    public String digestParams(RestInvocation restInvocation) {
+      signature = digest.digestParams(restInvocation);
+      return signature;
+    }
+
+    public String getSignature() {
+      return signature;
+    }
   }
 }

--- a/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/service/CoinbaseProDigest.java
+++ b/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/service/CoinbaseProDigest.java
@@ -10,8 +10,6 @@ import si.mazi.rescu.RestInvocation;
 
 public class CoinbaseProDigest extends BaseParamsDigest {
 
-  private String signature = "";
-
   private CoinbaseProDigest(byte[] secretKey) {
 
     super(secretKey, HMAC_SHA_256);
@@ -41,11 +39,6 @@ public class CoinbaseProDigest extends BaseParamsDigest {
       throw new ExchangeException("Digest encoding exception", e);
     }
 
-    signature = Base64.getEncoder().encodeToString(mac256.doFinal());
-    return signature;
-  }
-
-  public String getSignature() {
-    return signature;
+    return Base64.getEncoder().encodeToString(mac256.doFinal());
   }
 }


### PR DESCRIPTION
Right now when digest is computed it is first stored to `signature` field and then returned. If we run this code in more threads there is a high risk that we return `signature` computed for different request in different thread. That causes "Invalid signature" errors when sent to CoinbasePro API.

This fix removes this unnecessary step of reassignment and return, we just simply return the signature value.

In the only case where we need to store the signature we rather wrap our singleton digest into proxy class that stores our signature for webhook auth in internal field. That way for each call we create a new class instance and avoid any synchronization issues.