### PR TITLE
Replace dependency to resilience4j-all by actually used modules (ratelimiter and retry)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,13 @@
 
       <dependency>
         <groupId>io.github.resilience4j</groupId>
-        <artifactId>resilience4j-all</artifactId>
+        <artifactId>resilience4j-ratelimiter</artifactId>
+        <version>${version.resilience4j}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.github.resilience4j</groupId>
+        <artifactId>resilience4j-retry</artifactId>
         <version>${version.resilience4j}</version>
       </dependency>
 

--- a/xchange-core/pom.xml
+++ b/xchange-core/pom.xml
@@ -42,7 +42,12 @@
 
         <dependency>
             <groupId>io.github.resilience4j</groupId>
-            <artifactId>resilience4j-all</artifactId>
+            <artifactId>resilience4j-ratelimiter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-retry</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Hello, first of all thank you for providing XChange!

We are looking to migrate our project from the javax to the jarkarta namespace and XChange currently brings a transient dependency to javax's cache API because XChange depends on resilience4j cache.
This PR replaces the resisilience4j dependency to the module that actually seem to be used.