### PR TITLE
Coinmate Metadata Fix

### DIFF
--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/Coinmate.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/Coinmate.java
@@ -31,7 +31,7 @@ import org.knowm.xchange.coinmate.dto.marketdata.CoinmateOrderBook;
 import org.knowm.xchange.coinmate.dto.marketdata.CoinmateQuickRate;
 import org.knowm.xchange.coinmate.dto.marketdata.CoinmateTicker;
 import org.knowm.xchange.coinmate.dto.marketdata.CoinmateTransactions;
-import org.knowm.xchange.dto.meta.ExchangeMetaData;
+import org.knowm.xchange.coinmate.dto.metadata.CoinmateExchangeMetaData;
 
 /** @author Martin Stachon */
 @Path("api")
@@ -58,7 +58,7 @@ public interface Coinmate {
 
   @GET
   @Path("xchange")
-  ExchangeMetaData getMetadata() throws IOException;
+  CoinmateExchangeMetaData getMetadata() throws IOException;
 
   @GET
   @Path("buyQuickRate")

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateAdapters.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateAdapters.java
@@ -39,6 +39,7 @@ import org.knowm.xchange.coinmate.dto.marketdata.CoinmateTickerData;
 import org.knowm.xchange.coinmate.dto.marketdata.CoinmateTradeStatistics;
 import org.knowm.xchange.coinmate.dto.marketdata.CoinmateTransactions;
 import org.knowm.xchange.coinmate.dto.marketdata.CoinmateTransactionsEntry;
+import org.knowm.xchange.coinmate.dto.metadata.CoinmateInstrumentMetaData;
 import org.knowm.xchange.coinmate.dto.trade.*;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -50,11 +51,13 @@ import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trade;
 import org.knowm.xchange.dto.marketdata.Trades;
+import org.knowm.xchange.dto.meta.InstrumentMetaData;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
 import org.knowm.xchange.dto.trade.StopOrder;
 import org.knowm.xchange.dto.trade.UserTrade;
 import org.knowm.xchange.dto.trade.UserTrades;
+import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamsSorted;
 
 /** @author Martin Stachon */
@@ -452,5 +455,32 @@ public class CoinmateAdapters {
         .open(tradeStatistics.getTodaysOpen())
         .percentageChange(tradeStatistics.getDailyChange())
         .build();
+  }
+
+  public static Map<Instrument, InstrumentMetaData> adaptInstrumentMetadataMap(Map<Instrument, CoinmateInstrumentMetaData> instrumentMetaDataMap) {
+    if (instrumentMetaDataMap == null) {
+      return null;
+    }
+    return instrumentMetaDataMap.entrySet()
+        .stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> adaptInstrumentMetaData(e.getValue())));
+  }
+
+  private static InstrumentMetaData adaptInstrumentMetaData(CoinmateInstrumentMetaData coinmateInstrumentMetaData) {
+    return new InstrumentMetaData(
+        coinmateInstrumentMetaData.getTradingFee(),
+        coinmateInstrumentMetaData.getFeeTiers(),
+        coinmateInstrumentMetaData.getMinimumAmount(),
+        coinmateInstrumentMetaData.getMaximumAmount(),
+        coinmateInstrumentMetaData.getCounterMinimumAmount(),
+        coinmateInstrumentMetaData.getCounterMaximumAmount(),
+        coinmateInstrumentMetaData.getPriceScale(),
+        coinmateInstrumentMetaData.getVolumeScale(),
+        coinmateInstrumentMetaData.getAmountStepSize(),
+        coinmateInstrumentMetaData.getPriceStepSize(),
+        coinmateInstrumentMetaData.getTradingFeeCurrency(),
+        coinmateInstrumentMetaData.isMarketOrderEnabled(),
+        coinmateInstrumentMetaData.getContractValue()
+    );
   }
 }

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateExchange.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateExchange.java
@@ -26,6 +26,7 @@ package org.knowm.xchange.coinmate;
 import org.knowm.xchange.BaseExchange;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.coinmate.dto.metadata.CoinmateExchangeMetaData;
 import org.knowm.xchange.coinmate.service.CoinmateAccountService;
 import org.knowm.xchange.coinmate.service.CoinmateMarketDataService;
 import org.knowm.xchange.coinmate.service.CoinmateMetadataServiceRaw;
@@ -33,6 +34,7 @@ import org.knowm.xchange.coinmate.service.CoinmateTradeService;
 import org.knowm.xchange.exceptions.ExchangeException;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 /** @author Martin Stachon */
 public class CoinmateExchange extends BaseExchange implements Exchange {
@@ -61,5 +63,10 @@ public class CoinmateExchange extends BaseExchange implements Exchange {
   public void remoteInit() throws IOException, ExchangeException {
     CoinmateMetadataServiceRaw metadataService = new CoinmateMetadataServiceRaw(this);
     exchangeMetaData = metadataService.getMetadata();
+  }
+
+  @Override
+  protected void loadExchangeMetaData(InputStream is) {
+    exchangeMetaData = loadMetaData(is, CoinmateExchangeMetaData.class);
   }
 }

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/metadata/CoinmateExchangeMetaData.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/metadata/CoinmateExchangeMetaData.java
@@ -1,0 +1,24 @@
+package org.knowm.xchange.coinmate.dto.metadata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.knowm.xchange.coinmate.CoinmateAdapters;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.dto.meta.CurrencyMetaData;
+import org.knowm.xchange.dto.meta.ExchangeMetaData;
+import org.knowm.xchange.dto.meta.RateLimit;
+import org.knowm.xchange.instrument.Instrument;
+
+import java.util.Map;
+
+public class CoinmateExchangeMetaData extends ExchangeMetaData {
+
+  public CoinmateExchangeMetaData(
+      @JsonProperty("currency_pairs") Map<Instrument, CoinmateInstrumentMetaData> instruments,
+      @JsonProperty("currencies") Map<Currency, CurrencyMetaData> currency,
+      @JsonProperty("public_rate_limits") RateLimit[] publicRateLimits,
+      @JsonProperty("private_rate_limits") RateLimit[] privateRateLimits,
+      @JsonProperty("share_rate_limits") Boolean shareRateLimits) {
+
+    super(CoinmateAdapters.adaptInstrumentMetadataMap(instruments), currency, publicRateLimits, privateRateLimits, shareRateLimits);
+  }
+}

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/metadata/CoinmateInstrumentMetaData.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/metadata/CoinmateInstrumentMetaData.java
@@ -1,0 +1,41 @@
+package org.knowm.xchange.coinmate.dto.metadata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.dto.meta.FeeTier;
+import org.knowm.xchange.dto.meta.InstrumentMetaData;
+
+import java.math.BigDecimal;
+
+public class CoinmateInstrumentMetaData extends InstrumentMetaData {
+
+  public CoinmateInstrumentMetaData(
+      @JsonProperty("trading_fee") BigDecimal tradingFee,
+      @JsonProperty("fee_tiers") FeeTier[] feeTiers,
+      @JsonProperty("min_amount") BigDecimal minimumAmount,
+      @JsonProperty("max_amount") BigDecimal maximumAmount,
+      @JsonProperty("counter_min_amount") BigDecimal counterMinimumAmount,
+      @JsonProperty("counter_max_amount") BigDecimal counterMaximumAmount,
+      @JsonProperty("price_scale") Integer priceScale,
+      @JsonProperty("base_scale") Integer volumeScale,
+      @JsonProperty("amount_step_size") BigDecimal amountStepSize,
+      @JsonProperty("price_step_size") BigDecimal priceStepSize,
+      @JsonProperty("trading_fee_currency") Currency tradingFeeCurrency,
+      @JsonProperty("market_order_enabled") boolean marketOrderEnabled,
+      @JsonProperty("contract_value") BigDecimal contractValue) {
+    super(
+        tradingFee,
+        feeTiers,
+        minimumAmount,
+        maximumAmount,
+        counterMinimumAmount,
+        counterMaximumAmount,
+        priceScale,
+        volumeScale,
+        amountStepSize,
+        priceStepSize,
+        tradingFeeCurrency,
+        marketOrderEnabled,
+        contractValue);
+  }
+}

--- a/xchange-coinmate/src/main/resources/coinmate.json
+++ b/xchange-coinmate/src/main/resources/coinmate.json
@@ -10,20 +10,20 @@
       "min_amount" : 0.001,
       "base_scale" : 8
     },
-    "ETH/DAI" : {
-      "price_scale" : 2,
-      "min_amount" : 0.001,
-      "base_scale" : 8
-    },
     "XRP/EUR" : {
       "price_scale" : 5,
       "min_amount" : 1,
       "base_scale" : 8
     },
-    "BCH/EUR" : {
-      "price_scale" : 2,
-      "min_amount" : 0.001,
+    "BTC/USDT" : {
+      "price_scale" : 1,
+      "min_amount" : 0.0001,
       "base_scale" : 8
+    },
+    "USDT/EUR" : {
+      "price_scale" : 4,
+      "min_amount" : 1,
+      "base_scale" : 2
     },
     "ETH/BTC" : {
       "price_scale" : 5,
@@ -55,34 +55,14 @@
       "min_amount" : 0.0001,
       "base_scale" : 8
     },
-    "BCH/CZK" : {
-      "price_scale" : 1,
-      "min_amount" : 0.001,
-      "base_scale" : 8
-    },
     "DASH/EUR" : {
       "price_scale" : 2,
       "min_amount" : 0.001,
       "base_scale" : 8
     },
-    "DAI/EUR" : {
-      "price_scale" : 4,
-      "min_amount" : 1,
-      "base_scale" : 2
-    },
     "XRP/CZK" : {
       "price_scale" : 4,
       "min_amount" : 1,
-      "base_scale" : 8
-    },
-    "BCH/BTC" : {
-      "price_scale" : 5,
-      "min_amount" : 0.001,
-      "base_scale" : 8
-    },
-    "BTC/DAI" : {
-      "price_scale" : 2,
-      "min_amount" : 0.0001,
       "base_scale" : 8
     },
     "LTC/CZK" : {
@@ -110,6 +90,11 @@
       "min_amount" : 0.01,
       "base_scale" : 8
     },
+    "USDT/CZK" : {
+      "price_scale" : 3,
+      "min_amount" : 1,
+      "base_scale" : 2
+    },
     "BTC/EUR" : {
       "price_scale" : 1,
       "min_amount" : 0.0001,
@@ -134,6 +119,21 @@
     "CZK" : {
       "scale" : 2
     },
+    "GBP" : {
+      "scale" : 2
+    },
+    "HUF" : {
+      "scale" : 2
+    },
+    "PLN" : {
+      "scale" : 2
+    },
+    "USD" : {
+      "scale" : 2
+    },
+    "USDT" : {
+      "scale" : 2
+    },
     "BCH" : {
       "scale" : 8
     },
@@ -154,6 +154,12 @@
     },
     "ADA" : {
       "scale" : 6
+    },
+    "TRX" : {
+      "scale" : 8
+    },
+    "LUNA" : {
+      "scale" : 8
     }
   },
   "private_rate_limits" : [ {


### PR DESCRIPTION
New core InstrumentMetaData uses volume_scale instead of base_scale, however Coinmate still returns base_scale from API, so a custom DTO needs to be used.