### PR TITLE
[Kraken] Set marketOrderEnabled to true in InstrumentMetaData

### DIFF
--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java
@@ -470,6 +470,7 @@ public class KrakenAdapters {
             .volumeScale(krakenPair.getVolumeLotScale())
             .feeTiers(adaptFeeTiers(krakenPair.getFees_maker(), krakenPair.getFees()))
             .tradingFeeCurrency(KrakenUtils.translateKrakenCurrencyCode(krakenPair.getFeeVolumeCurrency()))
+            .marketOrderEnabled(true)
             .build();
   }
 


### PR DESCRIPTION
After migration to `InstrumentMetaData` `marketOrderEnabled` is by default `false`. Previously the `CurrencyPairMetaData` constructor was used instead of a builder and that one used to set it correctly to `true`.

Added `marketOrderEnabled(true)` to the builder to revert this unintended change.