### PR TITLE
[Okx] implement time manage of OrderBookUpdate, through make updateTime…

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/OrderBook.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/OrderBook.java
@@ -2,6 +2,10 @@ package org.knowm.xchange.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.knowm.xchange.dto.Order.OrderType;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.instrument.Instrument;
+
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -10,9 +14,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.knowm.xchange.dto.Order.OrderType;
-import org.knowm.xchange.dto.trade.LimitOrder;
-import org.knowm.xchange.instrument.Instrument;
 
 /** DTO representing the exchange order book */
 public final class OrderBook implements Serializable {
@@ -187,7 +188,7 @@ public final class OrderBook implements Serializable {
 
   // Replace timeStamp if the provided date is non-null and in the future
   // TODO should this raise an exception if the order timestamp is in the past?
-  private void updateDate(Date updateDate) {
+  public void updateDate(Date updateDate) {
 
     if (updateDate != null && (timeStamp == null || updateDate.after(timeStamp))) {
       this.timeStamp = updateDate;

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/OkexAdapters.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/OkexAdapters.java
@@ -19,13 +19,14 @@ import org.knowm.xchange.dto.meta.WalletHealth;
 import org.knowm.xchange.dto.trade.*;
 import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.okex.dto.OkexInstType;
+import org.knowm.xchange.okex.dto.OkexResponse;
 import org.knowm.xchange.okex.dto.account.*;
 import org.knowm.xchange.okex.dto.marketdata.*;
-import org.knowm.xchange.okex.dto.OkexResponse;
 import org.knowm.xchange.okex.dto.trade.*;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -173,7 +174,7 @@ public class OkexAdapters {
     return adaptOrderbookOrder(okexPublicOrder.getVolume(), okexPublicOrder.getPrice(), instrument, orderType);
   }
 
-  public static OrderBook adaptOrderBook(List<OkexOrderbook> okexOrderbooks, Instrument instrument) {
+  public static OrderBook adaptOrderBook(List<OkexOrderbook> okexOrderbooks, Instrument instrument, Date timeStamp) {
     List<LimitOrder> asks = new ArrayList<>();
     List<LimitOrder> bids = new ArrayList<>();
 
@@ -191,17 +192,16 @@ public class OkexAdapters {
             okexBid ->
                 bids.add(adaptLimitOrder(okexBid, instrument, OrderType.BID)));
 
-    return new OrderBook(Date.from(Instant.now()), asks, bids);
+    return new OrderBook(timeStamp, asks, bids);
   }
 
   public static OrderBook adaptOrderBook(
       OkexResponse<List<OkexOrderbook>> okexOrderbook, Instrument instrument) {
-    return adaptOrderBook(okexOrderbook.getData(), instrument);
+    return adaptOrderBook(okexOrderbook.getData(), instrument,new Timestamp(Long.parseLong(okexOrderbook.getData().get(0).getTs())));
   }
 
   public static LimitOrder adaptOrderbookOrder(
       BigDecimal amount, BigDecimal price, Instrument instrument, Order.OrderType orderType) {
-
     return new LimitOrder(orderType, amount, instrument, "", null, price);
   }
 

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/dto/marketdata/OkexOrderbook.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/dto/marketdata/OkexOrderbook.java
@@ -2,6 +2,7 @@ package org.knowm.xchange.okex.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 public class OkexOrderbook {
@@ -9,6 +10,7 @@ public class OkexOrderbook {
   private final List<OkexPublicOrder> asks;
 
   private final List<OkexPublicOrder> bids;
+
   private final String ts;
 
   @JsonCreator
@@ -29,6 +31,8 @@ public class OkexOrderbook {
   public List<OkexPublicOrder> getBids() {
     return bids;
   }
+
+  public String getTs() { return ts; }
 
   @Override
   public String toString() {


### PR DESCRIPTION
Two problems
1. In the initial orderbook, the time is set according to the date of receipt (now.getTime()), and not sent from the server
2. After updating the orderBook for okx, the time for the orderBook does not change, although it would be logical to assign it the time the update was sent from the server.

I saw two options.
1. Edit OkexAdapters.adaptLimitOrder adding timeStamp to each limitOrder
I tried it - it looks crooked, extra operations and CPU waste

2. Make OrderBook.updateDate public
Then everything is beautiful

Made the second option. If there are objections, I'll change it to the first one.