### PR TITLE
[kucoin] Add missing general api methods

### DIFF
--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinMarketDataServiceRaw.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinMarketDataServiceRaw.java
@@ -70,7 +70,7 @@ public class KucoinMarketDataServiceRaw extends KucoinBaseService {
     return classifyingExceptions(
         () ->
             decorateApiCall(
-                    () -> tradingFeeAPI.getBaseFee(apiKey, digest, nonceFactory, passphrase))
+                () -> tradingFeeAPI.getBaseFee(apiKey, digest, nonceFactory, passphrase))
                 .withRetry(retry("baseFee"))
                 .withRateLimiter(rateLimiter(PUBLIC_REST_ENDPOINT_RATE_LIMITER))
                 .call());
@@ -81,18 +81,31 @@ public class KucoinMarketDataServiceRaw extends KucoinBaseService {
     return classifyingExceptions(
         () ->
             decorateApiCall(
-                    () ->
-                        tradingFeeAPI.getTradeFee(
-                            apiKey, digest, nonceFactory, passphrase, symbols))
+                () ->
+                    tradingFeeAPI.getTradeFee(
+                        apiKey, digest, nonceFactory, passphrase, symbols))
                 .withRetry(retry("tradeFee"))
                 .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
                 .call());
   }
 
+  /**
+   * @deprecated use {@link #getKucoinSymbolsV2()}
+   */
+  @Deprecated
   public List<SymbolResponse> getKucoinSymbols() throws IOException {
     return classifyingExceptions(
         () ->
             decorateApiCall(symbolApi::getSymbols)
+                .withRetry(retry("symbols"))
+                .withRateLimiter(rateLimiter(PUBLIC_REST_ENDPOINT_RATE_LIMITER))
+                .call());
+  }
+
+  public List<SymbolResponse> getKucoinSymbolsV2() throws IOException {
+    return classifyingExceptions(
+        () ->
+            decorateApiCall(symbolApi::getSymbolsV2)
                 .withRetry(retry("symbols"))
                 .withRateLimiter(rateLimiter(PUBLIC_REST_ENDPOINT_RATE_LIMITER))
                 .call());
@@ -111,9 +124,9 @@ public class KucoinMarketDataServiceRaw extends KucoinBaseService {
     return classifyingExceptions(
         () ->
             decorateApiCall(
-                    () ->
-                        orderBookApi.getPartOrderBookAggregated(
-                            KucoinAdapters.adaptCurrencyPair(pair)))
+                () ->
+                    orderBookApi.getPartOrderBookAggregated(
+                        KucoinAdapters.adaptCurrencyPair(pair)))
                 .withRetry(retry("partialOrderBook"))
                 .withRateLimiter(rateLimiter(PUBLIC_REST_ENDPOINT_RATE_LIMITER))
                 .call());
@@ -123,9 +136,9 @@ public class KucoinMarketDataServiceRaw extends KucoinBaseService {
     return classifyingExceptions(
         () ->
             decorateApiCall(
-                    () ->
-                        orderBookApi.getPartOrderBookShallowAggregated(
-                            KucoinAdapters.adaptCurrencyPair(pair)))
+                () ->
+                    orderBookApi.getPartOrderBookShallowAggregated(
+                        KucoinAdapters.adaptCurrencyPair(pair)))
                 .withRetry(retry("partialShallowOrderBook"))
                 .withRateLimiter(rateLimiter(PUBLIC_REST_ENDPOINT_RATE_LIMITER))
                 .call());
@@ -135,13 +148,13 @@ public class KucoinMarketDataServiceRaw extends KucoinBaseService {
     return classifyingExceptions(
         () ->
             decorateApiCall(
-                    () ->
-                        orderBookApi.getFullOrderBookAggregated(
-                            KucoinAdapters.adaptCurrencyPair(pair),
-                            apiKey,
-                            digest,
-                            nonceFactory,
-                            passphrase))
+                () ->
+                    orderBookApi.getFullOrderBookAggregated(
+                        KucoinAdapters.adaptCurrencyPair(pair),
+                        apiKey,
+                        digest,
+                        nonceFactory,
+                        passphrase))
                 .withRetry(retry("fullOrderBook"))
                 .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
                 .call());
@@ -151,7 +164,7 @@ public class KucoinMarketDataServiceRaw extends KucoinBaseService {
     return classifyingExceptions(
         () ->
             decorateApiCall(
-                    () -> historyApi.getTradeHistories(KucoinAdapters.adaptCurrencyPair(pair)))
+                () -> historyApi.getTradeHistories(KucoinAdapters.adaptCurrencyPair(pair)))
                 .withRetry(retry("tradeHistories"))
                 .withRateLimiter(rateLimiter(PUBLIC_REST_ENDPOINT_RATE_LIMITER))
                 .call());
@@ -163,12 +176,12 @@ public class KucoinMarketDataServiceRaw extends KucoinBaseService {
         classifyingExceptions(
             () ->
                 decorateApiCall(
-                        () ->
-                            historyApi.getKlines(
-                                KucoinAdapters.adaptCurrencyPair(pair),
-                                startTime,
-                                endTime,
-                                type.code()))
+                    () ->
+                        historyApi.getKlines(
+                            KucoinAdapters.adaptCurrencyPair(pair),
+                            startTime,
+                            endTime,
+                            type.code()))
                     .withRetry(retry("klines"))
                     .withRateLimiter(rateLimiter(PUBLIC_REST_ENDPOINT_RATE_LIMITER))
                     .call());

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinMarketDataServiceRaw.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinMarketDataServiceRaw.java
@@ -10,10 +10,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.knowm.xchange.client.ResilienceRegistries;
+import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.kucoin.dto.KlineIntervalType;
 import org.knowm.xchange.kucoin.dto.response.AllTickersResponse;
 import org.knowm.xchange.kucoin.dto.response.CurrenciesResponse;
+import org.knowm.xchange.kucoin.dto.response.CurrencyResponseV2;
 import org.knowm.xchange.kucoin.dto.response.KucoinKline;
 import org.knowm.xchange.kucoin.dto.response.OrderBookResponse;
 import org.knowm.xchange.kucoin.dto.response.SymbolResponse;
@@ -115,6 +117,15 @@ public class KucoinMarketDataServiceRaw extends KucoinBaseService {
     return classifyingExceptions(
         () ->
             decorateApiCall(symbolApi::getCurrencies)
+                .withRetry(retry("currencies"))
+                .withRateLimiter(rateLimiter(PUBLIC_REST_ENDPOINT_RATE_LIMITER))
+                .call());
+  }
+
+  public CurrencyResponseV2 getKucoinCurrencies(Currency currency) throws IOException {
+    return classifyingExceptions(
+        () ->
+            decorateApiCall(() -> symbolApi.getCurrencies(currency.getCurrencyCode()))
                 .withRetry(retry("currencies"))
                 .withRateLimiter(rateLimiter(PUBLIC_REST_ENDPOINT_RATE_LIMITER))
                 .call());

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/CurrencyResponseV2.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/CurrencyResponseV2.java
@@ -1,0 +1,70 @@
+package org.knowm.xchange.kucoin.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.Data;
+import lombok.extern.jackson.Jacksonized;
+
+@Data
+@Jacksonized
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CurrencyResponseV2 {
+
+  @JsonProperty("currency")
+  private String currency;
+
+  @JsonProperty("name")
+  private String name;
+
+  @JsonProperty("fullName")
+  private String fullName;
+
+  @JsonProperty("precision")
+  private BigDecimal precision;
+
+  @JsonProperty("chains")
+  private List<Chain> chains;
+
+  @JsonProperty("withdrawalMinSize")
+  private String withdrawalMinSize;
+
+  @JsonProperty("withdrawalMinFee")
+  private String withdrawalMinFee;
+
+  @JsonProperty("isMarginEnabled")
+  private Boolean isMarginEnabled;
+
+  @JsonProperty("isDebitEnabled")
+  private Boolean isDebitEnabled;
+
+  @Data
+  public static class Chain {
+
+    @JsonProperty("chainName")
+    private String chainName;
+
+    @JsonProperty("chain")
+    private String chain;
+
+    @JsonProperty("withdrawalMinSize")
+    private BigDecimal withdrawalMinSize;
+
+    @JsonProperty("withdrawalMinFee")
+    private BigDecimal withdrawalMinFee;
+
+    @JsonProperty("isWithdrawEnabled")
+    private Boolean isWithdrawEnabled;
+
+    @JsonProperty("isDepositEnabled")
+    private Boolean isDepositEnabled;
+
+    @JsonProperty("confirms")
+    private Long confirms;
+
+    @JsonProperty("contractAddress")
+    private String contractAddress;
+
+  }
+}

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/SymbolAPI.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/SymbolAPI.java
@@ -7,11 +7,13 @@ import java.util.List;
 import java.util.Map;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import org.knowm.xchange.kucoin.dto.response.AllTickersResponse;
 import org.knowm.xchange.kucoin.dto.response.CurrenciesResponse;
+import org.knowm.xchange.kucoin.dto.response.CurrencyResponseV2;
 import org.knowm.xchange.kucoin.dto.response.KucoinResponse;
 import org.knowm.xchange.kucoin.dto.response.SymbolResponse;
 import org.knowm.xchange.kucoin.dto.response.SymbolTickResponse;
@@ -50,6 +52,15 @@ public interface SymbolAPI {
   @GET
   @Path("/v1/currencies")
   KucoinResponse<List<CurrenciesResponse>> getCurrencies() throws IOException;
+
+  /**
+   * Get currency detail.
+   *
+   * @return The available currencies.
+   */
+  @GET
+  @Path("/v2/currencies/{currency}")
+  KucoinResponse<CurrencyResponseV2> getCurrencies(@PathParam("currency") String currency) throws IOException;
 
   /**
    * Get the fiat price of the currencies for the available trading pairs.

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/SymbolAPI.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/SymbolAPI.java
@@ -18,7 +18,7 @@ import org.knowm.xchange.kucoin.dto.response.SymbolTickResponse;
 import org.knowm.xchange.kucoin.dto.response.TickerResponse;
 
 /** Based on code by chenshiwei on 2019/1/11. */
-@Path("api/v1")
+@Path("api")
 @Produces(MediaType.APPLICATION_JSON)
 public interface SymbolAPI {
 
@@ -26,10 +26,21 @@ public interface SymbolAPI {
    * Get a list of available currency pairs for trading.
    *
    * @return The available symbols.
+   * @deprecated use {@link #getSymbolsV2()}
    */
   @GET
-  @Path("/symbols")
+  @Path("/v1/symbols")
+  @Deprecated
   KucoinResponse<List<SymbolResponse>> getSymbols() throws IOException;
+
+  /**
+   * Get a list of available currency pairs for trading.
+   *
+   * @return The available symbols.
+   */
+  @GET
+  @Path("/v2/symbols")
+  KucoinResponse<List<SymbolResponse>> getSymbolsV2() throws IOException;
 
   /**
    * Get a list of available currencies for trading.
@@ -37,7 +48,7 @@ public interface SymbolAPI {
    * @return The available currencies.
    */
   @GET
-  @Path("/currencies")
+  @Path("/v1/currencies")
   KucoinResponse<List<CurrenciesResponse>> getCurrencies() throws IOException;
 
   /**
@@ -46,7 +57,7 @@ public interface SymbolAPI {
    * @return USD fiat price of the currencies.
    */
   @GET
-  @Path("/prices")
+  @Path("/v1/prices")
   KucoinResponse<Map<String, BigDecimal>> getPrices() throws IOException;
 
   /**
@@ -56,7 +67,7 @@ public interface SymbolAPI {
    * @return The ticker.
    */
   @GET
-  @Path("/market/orderbook/level1")
+  @Path("/v1/market/orderbook/level1")
   KucoinResponse<TickerResponse> getTicker(@QueryParam("symbol") String symbol) throws IOException;
 
   /**
@@ -65,7 +76,7 @@ public interface SymbolAPI {
    * @return The allTickersTickerResponse.
    */
   @GET
-  @Path("/market/allTickers")
+  @Path("/v1/market/allTickers")
   KucoinResponse<AllTickersResponse> getTickers() throws IOException;
 
   /**
@@ -76,7 +87,7 @@ public interface SymbolAPI {
    * @return The 24hr stats for the symbol.
    */
   @GET
-  @Path("/market/stats")
+  @Path("/v1/market/stats")
   KucoinResponse<SymbolTickResponse> getMarketStats(@QueryParam("symbol") String symbol)
       throws IOException;
 }


### PR DESCRIPTION
- Added v2 get-symbols, marked v1 method as deprecated, see https://docs.kucoin.com/#get-symbols-list-deprecated
- Added getting of curerncy detail from api v2