### PR TITLE
[core] Order book synchonized

### DIFF
--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java
@@ -470,6 +470,7 @@ public class KrakenAdapters {
             .volumeScale(krakenPair.getVolumeLotScale())
             .feeTiers(adaptFeeTiers(krakenPair.getFees_maker(), krakenPair.getFees()))
             .tradingFeeCurrency(KrakenUtils.translateKrakenCurrencyCode(krakenPair.getFeeVolumeCurrency()))
+            .marketOrderEnabled(true)
             .build();
   }
 


### PR DESCRIPTION
to be able to work with the orderbook, for example, to make a full(deepcopy) copy, synchronization is needed ...
choose stampedlock so it's faster and provides more flexibility than synchonized method