### PR TITLE
[core] Add support for junit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <version.fasterxml>2.14.1</version.fasterxml>
     <version.github.mmazi>2.1.0</version.github.mmazi>
     <version.resilience4j>1.7.0</version.resilience4j>
-    <version.junit>4.13.2</version.junit>
+    <version.junit>5.9.3</version.junit>
     <version.lombok>1.18.22</version.lombok>
     <version.knowm.xchart>3.8.2</version.knowm.xchart>
     <version.qos.logback>1.4.5</version.qos.logback>
@@ -387,11 +387,12 @@
 
     <!-- JUnit for testing -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>


### PR DESCRIPTION
Added dependency to `junit-vintage-engine` to enable junit 5 runner, but leaving existing junit 4 tests available and untouched