### PR TITLE
Make `KucoinStreamingMarketDataService` available outside package

### DIFF
--- a/xchange-stream-kucoin/src/main/java/info/bitrich/xchangestream/kucoin/KucoinStreamingMarketDataService.java
+++ b/xchange-stream-kucoin/src/main/java/info/bitrich/xchangestream/kucoin/KucoinStreamingMarketDataService.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-class KucoinStreamingMarketDataService implements StreamingMarketDataService {
+public class KucoinStreamingMarketDataService implements StreamingMarketDataService {
 
   private static final Logger logger =
       LoggerFactory.getLogger(KucoinStreamingMarketDataService.class);


### PR DESCRIPTION
Similar to `BinanceStreamingMarketDataService` which is also public this was needed to be able to use this class in my code which uses the XChange library.
Sample code that works for Binance, but not (yet) for KuCoin:
```
 kucoinStreamingExchange
            .getStreamingMarketDataService()
            .getOrderBook(currencyPair)
            .subscribe(orderBook -> log.debug("Received orderbook: {}", orderBook) );
```

`getStreamingMarketDataService()` returns a type which is not usable outside the package itself.