### PR TITLE
[core] Rename vars, fix typo

### DIFF
--- a/xchange-stream-bitfinex/src/test/java/info/bitrich/xchangestream/bitfinex/BitfinexManualExample.java
+++ b/xchange-stream-bitfinex/src/test/java/info/bitrich/xchangestream/bitfinex/BitfinexManualExample.java
@@ -46,7 +46,7 @@ public class BitfinexManualExample {
             defaultExchangeSpecification.setExchangeSpecificParametersItem(StreamingExchange.SOCKS_PROXY_PORT, 8889);
 
             defaultExchangeSpecification.setExchangeSpecificParametersItem(StreamingExchange.USE_SANDBOX, true);
-            defaultExchangeSpecification.setExchangeSpecificParametersItem(StreamingExchange.ACCEPT_ALL_CERITICATES, true);
+            defaultExchangeSpecification.setExchangeSpecificParametersItem(StreamingExchange.ACCEPT_ALL_CERTIFICATES, true);
             defaultExchangeSpecification.setExchangeSpecificParametersItem(StreamingExchange.ENABLE_LOGGING_HANDLER, true);
     */
 

--- a/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexAuthenticatedExample.java
+++ b/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexAuthenticatedExample.java
@@ -26,7 +26,7 @@ public class BitmexAuthenticatedExample {
     defaultExchangeSpecification.setExchangeSpecificParametersItem(
         StreamingExchange.USE_SANDBOX, true);
     defaultExchangeSpecification.setExchangeSpecificParametersItem(
-        StreamingExchange.ACCEPT_ALL_CERITICATES, true);
+        StreamingExchange.ACCEPT_ALL_CERTIFICATES, true);
     defaultExchangeSpecification.setExchangeSpecificParametersItem(
         StreamingExchange.ENABLE_LOGGING_HANDLER, true);
 

--- a/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexDeadManSwitchTest.java
+++ b/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexDeadManSwitchTest.java
@@ -2,8 +2,8 @@ package info.bitrich.xchangestream.bitmex;
 
 import static org.knowm.xchange.bitmex.BitmexPrompt.PERPETUAL;
 
+import info.bitrich.xchangestream.core.StreamingExchange;
 import java.math.BigDecimal;
-
 import org.junit.Ignore;
 import org.junit.Test;
 import org.knowm.xchange.Exchange;
@@ -18,8 +18,6 @@ import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.utils.CertHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import info.bitrich.xchangestream.core.StreamingExchange;
 
 /** @author Nikita Belenkiy on 18/05/2018. */
 public class BitmexDeadManSwitchTest {
@@ -51,7 +49,7 @@ public class BitmexDeadManSwitchTest {
     defaultExchangeSpecification.setExchangeSpecificParametersItem(
         StreamingExchange.USE_SANDBOX, true);
     defaultExchangeSpecification.setExchangeSpecificParametersItem(
-        StreamingExchange.ACCEPT_ALL_CERITICATES, true);
+        StreamingExchange.ACCEPT_ALL_CERTIFICATES, true);
     //
     // defaultExchangeSpecification.setExchangeSpecificParametersItem(StreamingExchange.ENABLE_LOGGING_HANDLER, true);
 

--- a/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexOrderReplaceTest.java
+++ b/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexOrderReplaceTest.java
@@ -2,9 +2,9 @@ package info.bitrich.xchangestream.bitmex;
 
 import static org.knowm.xchange.bitmex.BitmexPrompt.PERPETUAL;
 
+import info.bitrich.xchangestream.core.StreamingExchange;
 import java.math.BigDecimal;
 import java.util.List;
-
 import org.junit.Ignore;
 import org.junit.Test;
 import org.knowm.xchange.Exchange;
@@ -21,8 +21,6 @@ import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.utils.CertHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import info.bitrich.xchangestream.core.StreamingExchange;
 
 /** @author Nikita Belenkiy on 18/05/2018. */
 public class BitmexOrderReplaceTest {
@@ -54,7 +52,7 @@ public class BitmexOrderReplaceTest {
     defaultExchangeSpecification.setExchangeSpecificParametersItem(
         StreamingExchange.USE_SANDBOX, true);
     defaultExchangeSpecification.setExchangeSpecificParametersItem(
-        StreamingExchange.ACCEPT_ALL_CERITICATES, true);
+        StreamingExchange.ACCEPT_ALL_CERTIFICATES, true);
     //
     // defaultExchangeSpecification.setExchangeSpecificParametersItem(StreamingExchange.ENABLE_LOGGING_HANDLER, true);
 

--- a/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexTestsCommons.java
+++ b/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexTestsCommons.java
@@ -11,7 +11,7 @@ public class BitmexTestsCommons {
     defaultExchangeSpecification.setExchangeSpecificParametersItem(
         StreamingExchange.USE_SANDBOX, true);
     defaultExchangeSpecification.setExchangeSpecificParametersItem(
-        StreamingExchange.ACCEPT_ALL_CERITICATES, true);
+        StreamingExchange.ACCEPT_ALL_CERTIFICATES, true);
     defaultExchangeSpecification.setExchangeSpecificParametersItem(
         StreamingExchange.ENABLE_LOGGING_HANDLER, true);
 

--- a/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingExchange.java
+++ b/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingExchange.java
@@ -10,7 +10,7 @@ import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 
 public interface StreamingExchange extends Exchange {
-  String ACCEPT_ALL_CERITICATES = "Accept_All_Ceriticates";
+  String ACCEPT_ALL_CERTIFICATES = "Accept_All_Certificates";
   String ENABLE_LOGGING_HANDLER = "Enable_Logging_Handler";
   String SOCKS_PROXY_HOST = "SOCKS_Proxy_Host";
   String SOCKS_PROXY_PORT = "SOCKS_Proxy_Port";
@@ -131,15 +131,15 @@ public interface StreamingExchange extends Exchange {
             exchangeSpec.getExchangeSpecificParametersItem(
                 ConnectableService.BEFORE_CONNECTION_HANDLER));
 
-    Boolean accept_all_ceriticates =
-        (Boolean) exchangeSpec.getExchangeSpecificParametersItem(ACCEPT_ALL_CERITICATES);
-    if (accept_all_ceriticates != null && accept_all_ceriticates) {
+    Boolean acceptAllCertificates =
+        (Boolean) exchangeSpec.getExchangeSpecificParametersItem(ACCEPT_ALL_CERTIFICATES);
+    if (acceptAllCertificates != null && acceptAllCertificates) {
       streamingService.setAcceptAllCertificates(true);
     }
 
-    Boolean enable_logging_handler =
+    Boolean enableLoggingHandler =
         (Boolean) exchangeSpec.getExchangeSpecificParametersItem(ENABLE_LOGGING_HANDLER);
-    if (enable_logging_handler != null && enable_logging_handler) {
+    if (enableLoggingHandler != null && enableLoggingHandler) {
       streamingService.setEnableLoggingHandler(true);
     }
     Boolean autoReconnect =

--- a/xchange-stream-poloniex2/src/test/java/info/bitrich/xchangestream/poloniex2/PoloniexManualExample.java
+++ b/xchange-stream-poloniex2/src/test/java/info/bitrich/xchangestream/poloniex2/PoloniexManualExample.java
@@ -27,7 +27,7 @@ public class PoloniexManualExample {
     defaultExchangeSpecification.setExchangeSpecificParametersItem(
         StreamingExchange.USE_SANDBOX, true);
     defaultExchangeSpecification.setExchangeSpecificParametersItem(
-        StreamingExchange.ACCEPT_ALL_CERITICATES, true);
+        StreamingExchange.ACCEPT_ALL_CERTIFICATES, true);
     defaultExchangeSpecification.setExchangeSpecificParametersItem(
         StreamingExchange.ENABLE_LOGGING_HANDLER, true);
 


### PR DESCRIPTION
Fixed typo:
`ACCEPT_ALL_CERITICATES` -> `ACCEPT_ALL_CERTIFICATES`

Renamed snake_case variable:
`enable_logging_handler` -> `enableLoggingHandler`
