### PR TITLE
[minor-refactoring] Replace explicit constructor calls with builder() method

### DIFF
--- a/xchange-ascendex/src/main/java/org/knowm/xchange/ascendex/AscendexAdapters.java
+++ b/xchange-ascendex/src/main/java/org/knowm/xchange/ascendex/AscendexAdapters.java
@@ -118,7 +118,7 @@ public class AscendexAdapters {
     ascendexOrderHistoryResponse.forEach(
         order ->
             userTrades.add(
-                new UserTrade.Builder()
+                UserTrade.builder()
                     .feeAmount(order.getCumFee())
                     .orderId(order.getOrderId())
                     .price(order.getPrice())

--- a/xchange-bankera/src/main/java/org/knowm/xchange/bankera/BankeraAdapters.java
+++ b/xchange-bankera/src/main/java/org/knowm/xchange/bankera/BankeraAdapters.java
@@ -188,7 +188,7 @@ public final class BankeraAdapters {
               CurrencyPair pair = new CurrencyPair(currencies[0], currencies[1]);
               Currency feeCurrency = new Currency(currencies[1]);
               tradeList.add(
-                  new UserTrade.Builder()
+                  UserTrade.builder()
                       .type(trade.getSide().equalsIgnoreCase("buy") ? OrderType.BID : OrderType.ASK)
                       .originalAmount(new BigDecimal(trade.getAmount()))
                       .currencyPair(pair)

--- a/xchange-bibox/src/main/java/org/knowm/xchange/bibox/dto/BiboxAdapters.java
+++ b/xchange-bibox/src/main/java/org/knowm/xchange/bibox/dto/BiboxAdapters.java
@@ -144,7 +144,7 @@ public class BiboxAdapters {
   }
 
   private static UserTrade adaptUserTrade(BiboxOrder order) {
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .orderId(order.getId())
         .id(order.getId())
         .currencyPair(new CurrencyPair(order.getCoinSymbol(), order.getCurrencySymbol()))

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAdapters.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAdapters.java
@@ -351,7 +351,7 @@ public class BinanceAdapters {
             binanceTrades.stream()
                     .map(
                             t ->
-                                    new UserTrade.Builder()
+                                    UserTrade.builder()
                                             .type(BinanceAdapters.convertType(t.isBuyer))
                                             .originalAmount(t.qty)
                                             .instrument(adaptSymbol(t.symbol, isFuture))

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/BitbayAdapters.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/BitbayAdapters.java
@@ -206,7 +206,7 @@ public class BitbayAdapters {
       throw new IllegalArgumentException(e);
     }
 
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(type)
         .originalAmount(bitbayOrder.getAmount())
         .currencyPair(currencyPair)
@@ -244,7 +244,7 @@ public class BitbayAdapters {
         String id = (type + "_" + date + "_" + market).replaceAll("\\s+", "");
 
         trades.add(
-            new UserTrade.Builder()
+            UserTrade.builder()
                 .type(orderType)
                 .originalAmount(amount)
                 .currencyPair(pair)

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/BitbayAdapters.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/v3/BitbayAdapters.java
@@ -36,7 +36,7 @@ public class BitbayAdapters {
           new CurrencyPair(Currency.getInstance(parts[0]), Currency.getInstance(parts[1]));
       Date timestamp = new Date(trade.getTime());
       trades.add(
-          new UserTrade.Builder()
+          UserTrade.builder()
               .id(trade.getId().toString())
               .type(orderType)
               .originalAmount(trade.getAmount())

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeAdapters.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/v4/BitcoindeAdapters.java
@@ -394,7 +394,7 @@ public final class BitcoindeAdapters {
               : trade.getCreatedAt();
 
       result.add(
-          new UserTrade.Builder()
+          UserTrade.builder()
               .id(trade.getTradeId())
               .timestamp(timestamp)
               .currencyPair(trade.getTradingPair())

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
@@ -582,7 +582,7 @@ public final class BitfinexAdapters {
       Date timestamp = convertBigDecimalTimestampToDate(trade.getTimestamp());
       final BigDecimal fee = trade.getFeeAmount() == null ? null : trade.getFeeAmount().negate();
       pastTrades.add(
-          new UserTrade.Builder()
+          UserTrade.builder()
               .type(orderType)
               .originalAmount(trade.getAmount())
               .currencyPair(currencyPair)
@@ -611,7 +611,7 @@ public final class BitfinexAdapters {
               : trade.getExecAmount();
       final BigDecimal fee = trade.getFee() != null ? trade.getFee().negate() : null;
       pastTrades.add(
-          new UserTrade.Builder()
+          UserTrade.builder()
               .type(orderType)
               .originalAmount(amount)
               .currencyPair(adaptCurrencyPair(trade.getSymbol()))

--- a/xchange-bithumb/src/main/java/org/knowm/xchange/bithumb/BithumbAdapters.java
+++ b/xchange-bithumb/src/main/java/org/knowm/xchange/bithumb/BithumbAdapters.java
@@ -179,7 +179,7 @@ public final class BithumbAdapters {
   private static UserTrade adaptUserTrade(
       BithumbUserTransaction bithumbTransaction, CurrencyPair currencyPair) {
 
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .currencyPair(currencyPair)
         .originalAmount(bithumbTransaction.getUnits())
         .type(adaptTransactionSearch(bithumbTransaction.getSearch()))

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexAdapters.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexAdapters.java
@@ -354,7 +354,7 @@ public class BitmexAdapters {
     OrderType orderType = convertType(exec.side);
     return orderType == null
         ? null
-        : new UserTrade.Builder()
+        : UserTrade.builder()
             .id(exec.execID)
             .orderId(exec.orderID)
             .currencyPair(pair)

--- a/xchange-bitso/src/main/java/org/knowm/xchange/bitso/BitsoAdapters.java
+++ b/xchange-bitso/src/main/java/org/knowm/xchange/bitso/BitsoAdapters.java
@@ -171,7 +171,7 @@ public final class BitsoAdapters {
         String feeCurrency =
             sell ? currencyPair.counter.getCurrencyCode() : currencyPair.base.getCurrencyCode();
         UserTrade trade =
-            new UserTrade.Builder()
+            UserTrade.builder()
                 .type(orderType)
                 .originalAmount(originalAmount)
                 .currencyPair(currencyPair)

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAdapters.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAdapters.java
@@ -234,7 +234,7 @@ public final class BitstampAdapters {
       final CurrencyPair pair =
           new CurrencyPair(t.getBaseCurrency().toUpperCase(), t.getCounterCurrency().toUpperCase());
       UserTrade trade =
-          new UserTrade.Builder()
+          UserTrade.builder()
               .type(orderType)
               .originalAmount(t.getBaseAmount().abs())
               .currencyPair(pair)

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/BittrexAdapters.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/BittrexAdapters.java
@@ -146,7 +146,7 @@ public final class BittrexAdapters {
     return bittrexUserTrades.stream()
         .map(
             bittrexOrder ->
-                new UserTrade.Builder()
+                UserTrade.builder()
                     .type(
                         BittrexConstants.BUY.equalsIgnoreCase(bittrexOrder.getDirection())
                             ? OrderType.BID

--- a/xchange-bity/src/main/java/org/knowm/xchange/bity/BityAdapters.java
+++ b/xchange-bity/src/main/java/org/knowm/xchange/bity/BityAdapters.java
@@ -56,7 +56,7 @@ public final class BityAdapters {
     Date date = order.getTimestampCreated();
     String orderId = order.getResourceUri();
 
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(orderType)
         .originalAmount(amount)
         .currencyPair(currencyPair)

--- a/xchange-bl3p/src/main/java/org/knowm/xchange/bl3p/Bl3pAdapters.java
+++ b/xchange-bl3p/src/main/java/org/knowm/xchange/bl3p/Bl3pAdapters.java
@@ -86,7 +86,7 @@ public class Bl3pAdapters {
 
     for (Bl3pUserTransactions.Bl3pUserTransaction t : transactions) {
       UserTrade ut =
-          new UserTrade.Builder()
+          UserTrade.builder()
               .currencyPair(CurrencyPair.BTC_EUR)
               .id(Integer.toString(t.id))
               .orderId(Integer.toString(t.orderId))

--- a/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/BleutradeAdapters.java
+++ b/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/BleutradeAdapters.java
@@ -184,7 +184,7 @@ public class BleutradeAdapters {
   public static UserTrade adaptUserTrade(BluetradeExecutedTrade trade) {
     OrderType orderType = trade.type.equalsIgnoreCase("sell") ? OrderType.ASK : OrderType.BID;
     CurrencyPair currencyPair = BleutradeUtils.toCurrencyPair(trade.exchange);
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(orderType)
         .originalAmount(trade.quantity)
         .currencyPair(currencyPair)

--- a/xchange-blockchain/src/main/java/org/knowm/xchange/blockchain/BlockchainAdapters.java
+++ b/xchange-blockchain/src/main/java/org/knowm/xchange/blockchain/BlockchainAdapters.java
@@ -212,7 +212,7 @@ public class BlockchainAdapters {
 
     public static UserTrades toUserTrades(List<BlockchainOrder> blockchainTrades) {
         List<UserTrade> trades = blockchainTrades.stream()
-                .map(blockchainTrade -> new UserTrade.Builder()
+                .map(blockchainTrade -> UserTrade.builder()
                                 .type(blockchainTrade.getOrderType())
                                 .originalAmount(blockchainTrade.getCumQty())
                                 .currencyPair(blockchainTrade.getSymbol())

--- a/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/BTCMarketsAdapters.java
+++ b/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/BTCMarketsAdapters.java
@@ -152,7 +152,7 @@ public final class BTCMarketsAdapters {
     final String tradeId = Long.toString(trade.getId());
     final Long orderId = trade.getOrderId();
     final String feeCurrency = currencyPair.counter.getCurrencyCode();
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(type)
         .originalAmount(trade.getVolume())
         .currencyPair(currencyPair)
@@ -172,7 +172,7 @@ public final class BTCMarketsAdapters {
     final String orderId = trade.orderId;
     final String feeCurrency = currencyPair.counter.getCurrencyCode();
     try {
-      return new UserTrade.Builder()
+      return UserTrade.builder()
           .type(type)
           .originalAmount(trade.amount)
           .currencyPair(currencyPair)

--- a/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/service/BTCMarketsTestSupport.java
+++ b/xchange-btcmarkets/src/test/java/org/knowm/xchange/btcmarkets/service/BTCMarketsTestSupport.java
@@ -157,7 +157,7 @@ public class BTCMarketsTestSupport extends BTCMarketsDtoTestSupport {
 
   protected static UserTrade[] expectedUserTrades() {
     return new UserTrade[] {
-      new UserTrade.Builder()
+      UserTrade.builder()
           .type(Order.OrderType.ASK)
           .originalAmount(new BigDecimal("20.00000000"))
           .currencyPair(CurrencyPair.BTC_AUD)
@@ -167,7 +167,7 @@ public class BTCMarketsTestSupport extends BTCMarketsDtoTestSupport {
           .feeAmount(BigDecimal.ONE)
           .feeCurrency(Currency.AUD)
           .build(),
-      new UserTrade.Builder()
+      UserTrade.builder()
           .type(Order.OrderType.ASK)
           .originalAmount(new BigDecimal("40.00000000"))
           .currencyPair(CurrencyPair.BTC_AUD)
@@ -177,7 +177,7 @@ public class BTCMarketsTestSupport extends BTCMarketsDtoTestSupport {
           .feeAmount(BigDecimal.valueOf(2))
           .feeCurrency(Currency.AUD)
           .build(),
-      new UserTrade.Builder()
+      UserTrade.builder()
           .type(Order.OrderType.BID)
           .originalAmount(new BigDecimal("60.00000000"))
           .currencyPair(CurrencyPair.BTC_AUD)
@@ -187,7 +187,7 @@ public class BTCMarketsTestSupport extends BTCMarketsDtoTestSupport {
           .feeAmount(BigDecimal.valueOf(3))
           .feeCurrency(Currency.AUD)
           .build(),
-      new UserTrade.Builder()
+      UserTrade.builder()
           .type(Order.OrderType.BID)
           .originalAmount(new BigDecimal("80.00000000"))
           .currencyPair(CurrencyPair.BTC_AUD)
@@ -197,7 +197,7 @@ public class BTCMarketsTestSupport extends BTCMarketsDtoTestSupport {
           .feeAmount(BigDecimal.valueOf(4))
           .feeCurrency(Currency.AUD)
           .build(),
-      new UserTrade.Builder()
+      UserTrade.builder()
           .type(Order.OrderType.BID)
           .originalAmount(BigDecimal.ZERO)
           .currencyPair(CurrencyPair.BTC_AUD)

--- a/xchange-btcturk/src/main/java/org/knowm/xchange/btcturk/service/BTCTurkTradeService.java
+++ b/xchange-btcturk/src/main/java/org/knowm/xchange/btcturk/service/BTCTurkTradeService.java
@@ -93,7 +93,7 @@ public class BTCTurkTradeService extends BTCTurkTradeServiceRaw implements Trade
     for (BTCTurkUserTransactions transaction : transactions) {
       if (transaction.getOperation().equals(BTCTurkOperations.trade))
         trades.add(
-            new UserTrade.Builder()
+            UserTrade.builder()
                 .type(
                     ((transaction.getAmount().compareTo(BigDecimal.ZERO) > 0)
                         ? OrderType.ASK

--- a/xchange-ccex/src/main/java/org/knowm/xchange/ccex/CCEXAdapters.java
+++ b/xchange-ccex/src/main/java/org/knowm/xchange/ccex/CCEXAdapters.java
@@ -228,7 +228,7 @@ public class CCEXAdapters {
       price = trade.getLimit();
     }
 
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(orderType)
         .originalAmount(amount)
         .currencyPair(currencyPair)

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/CexIOAdapters.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/CexIOAdapters.java
@@ -238,7 +238,7 @@ public class CexIOAdapters {
               : Currency.getInstance(cexIOArchivedOrder.feeCcy);
       BigDecimal fee = cexIOArchivedOrder.feeValue;
 
-      return new UserTrade.Builder()
+      return UserTrade.builder()
           .type(orderType)
           .originalAmount(originalAmount)
           .currencyPair(currencyPair)

--- a/xchange-coinbase/src/main/java/org/knowm/xchange/coinbase/CoinbaseAdapters.java
+++ b/xchange-coinbase/src/main/java/org/knowm/xchange/coinbase/CoinbaseAdapters.java
@@ -57,7 +57,7 @@ public final class CoinbaseAdapters {
   }
 
   private static UserTrade adaptTrade(CoinbaseBuySell transaction, OrderType orderType) {
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(orderType)
         .originalAmount(transaction.getAmount().getAmount())
         .currencyPair(
@@ -101,7 +101,7 @@ public final class CoinbaseAdapters {
     final BigDecimal feeAmount = transfer.getCoinbaseFee().getAmount();
     final String feeCurrency = transfer.getCoinbaseFee().getCurrency();
 
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(orderType)
         .originalAmount(originalAmount)
         .currencyPair(new CurrencyPair(tradableIdentifier, transactionCurrency))

--- a/xchange-coinbase/src/test/java/org/knowm/xchange/coinbase/CoinbaseAdapterTest.java
+++ b/xchange-coinbase/src/test/java/org/knowm/xchange/coinbase/CoinbaseAdapterTest.java
@@ -66,7 +66,7 @@ public class CoinbaseAdapterTest {
     BigDecimal price = new BigDecimal("905.10").divide(originalAmount, RoundingMode.HALF_EVEN);
 
     UserTrade expectedTrade =
-        new UserTrade.Builder()
+        UserTrade.builder()
             .type(OrderType.BID)
             .originalAmount(originalAmount)
             .currencyPair(CurrencyPair.BTC_USD)

--- a/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/CoinbaseProAdapters.java
+++ b/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/CoinbaseProAdapters.java
@@ -309,7 +309,7 @@ public class CoinbaseProAdapters {
       CurrencyPair currencyPair = new CurrencyPair(fill.getProductId().replace('-', '/'));
 
       trades.add(
-          new UserTrade.Builder()
+          UserTrade.builder()
               .type("buy".equals(fill.getSide()) ? OrderType.BID : OrderType.ASK)
               .originalAmount(fill.getSize())
               .currencyPair(currencyPair)

--- a/xchange-coindeal/src/main/java/org/knowm/xchange/coindeal/CoindealAdapters.java
+++ b/xchange-coindeal/src/main/java/org/knowm/xchange/coindeal/CoindealAdapters.java
@@ -32,7 +32,7 @@ public final class CoindealAdapters {
       CurrencyPair currencyPair =
           CurrencyPairDeserializer.getCurrencyPairFromString(coindealTradeHistory.getSymbol());
       userTrades.add(
-          new UserTrade.Builder()
+          UserTrade.builder()
               .type(
                   (coindealTradeHistory.getSide().equals("BUY"))
                       ? Order.OrderType.BID

--- a/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectTradeService.java
+++ b/xchange-coindirect/src/main/java/org/knowm/xchange/coindirect/service/CoindirectTradeService.java
@@ -97,7 +97,7 @@ public class CoindirectTradeService extends CoindirectTradeServiceRaw implements
                   if (t.executedAmount == null || t.executedAmount.signum() == 0) {
                     return null;
                   }
-                  return new UserTrade.Builder()
+                  return UserTrade.builder()
                       .type(CoindirectAdapters.convert(t.side))
                       .originalAmount(t.executedAmount)
                       .currencyPair(CoindirectAdapters.toCurrencyPair(t.symbol))

--- a/xchange-coinegg/src/main/java/org/knowm/xchange/coinegg/CoinEggAdapters.java
+++ b/xchange-coinegg/src/main/java/org/knowm/xchange/coinegg/CoinEggAdapters.java
@@ -140,7 +140,7 @@ public class CoinEggAdapters {
             .timestamp(coinEggTradeView.getDateTime())
             .build();
 
-    trades.add((UserTrade) UserTrade.Builder.from(trade).build());
+    trades.add((UserTrade) UserTrade.builder().from(trade).build());
 
     return new UserTrades(trades, null);
   }

--- a/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/CoinfloorAdapters.java
+++ b/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/CoinfloorAdapters.java
@@ -129,7 +129,7 @@ public class CoinfloorAdapters {
       final BigDecimal feeAmount = transaction.getFee();
 
       UserTrade trade =
-          new UserTrade.Builder()
+          UserTrade.builder()
               .type(transaction.getSide())
               .originalAmount(transaction.getAmount().abs())
               .currencyPair(transaction.getCurrencyPair())

--- a/xchange-coingi/src/main/java/org/knowm/xchange/coingi/CoingiAdapters.java
+++ b/xchange-coingi/src/main/java/org/knowm/xchange/coingi/CoingiAdapters.java
@@ -209,7 +209,7 @@ public final class CoingiAdapters {
               o.getCurrencyPair().get("counter").toUpperCase());
 
       UserTrade trade =
-          new UserTrade.Builder()
+          UserTrade.builder()
               .type(orderType)
               .originalAmount(o.getOriginalBaseAmount())
               .currencyPair(pair)

--- a/xchange-coinjar/src/main/java/org/knowm/xchange/coinjar/CoinjarAdapters.java
+++ b/xchange-coinjar/src/main/java/org/knowm/xchange/coinjar/CoinjarAdapters.java
@@ -130,7 +130,7 @@ public class CoinjarAdapters {
   }
 
   public static UserTrade adaptOrderToUserTrade(CoinjarOrder order) {
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .id(order.oid.toString())
         .orderId(order.oid.toString())
         .currencyPair(productToCurrencyPair(order.productId))
@@ -165,7 +165,7 @@ public class CoinjarAdapters {
   }
 
   public static UserTrade adaptFillToUserTrade(CoinjarFill coinjarFill) {
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .id(coinjarFill.tid.toString())
         .orderId(coinjarFill.oid.toString())
         .currencyPair(productToCurrencyPair(coinjarFill.productId))

--- a/xchange-coinjar/src/test/java/org/knowm/xchange/coinjar/CoinjarAdaptersTest.java
+++ b/xchange-coinjar/src/test/java/org/knowm/xchange/coinjar/CoinjarAdaptersTest.java
@@ -62,7 +62,7 @@ public class CoinjarAdaptersTest {
             "2017-10-12T15:39:27.000+11:00");
 
     final UserTrade expected =
-        new UserTrade.Builder()
+        UserTrade.builder()
             .id("3267")
             .orderId("3267")
             .currencyPair(CurrencyPair.BTC_AUD)

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateAdapters.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateAdapters.java
@@ -191,7 +191,7 @@ public class CoinmateAdapters {
   public static UserTrades adaptTransactionHistory(
       CoinmateTransactionHistory coinmateTradeHistory) {
     List<UserTrade> trades = coinmateTradeHistory.getData().stream().map(
-          entry -> new UserTrade.Builder()
+          entry -> UserTrade.builder()
             .type(typeToOrderTypeOrNull(entry.getTransactionType()))
             .originalAmount(entry.getAmount())
             .currencyPair(
@@ -210,7 +210,7 @@ public class CoinmateAdapters {
   }
 
   public static UserTrades adaptTradeHistory(CoinmateTradeHistory coinmateTradeHistory) {
-    List<UserTrade> trades = coinmateTradeHistory.getData().stream().map(entry -> new UserTrade.Builder()
+    List<UserTrade> trades = coinmateTradeHistory.getData().stream().map(entry -> UserTrade.builder()
           .type(typeToOrderTypeOrNull(entry.getType()))
           .originalAmount(entry.getAmount())
           .currencyPair(CoinmateUtils.getPair(entry.getCurrencyPair()))

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/UserTrade.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/UserTrade.java
@@ -67,7 +67,7 @@ public class UserTrade extends Trade {
   }
 
   public static UserTrade.Builder builder() {
-    return new UserTrade.Builder();
+    return UserTrade.builder();
   }
 
   public String getOrderId() {

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/UserTrade.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/UserTrade.java
@@ -67,7 +67,7 @@ public class UserTrade extends Trade {
   }
 
   public static UserTrade.Builder builder() {
-    return UserTrade.builder();
+    return new UserTrade.Builder();
   }
 
   public String getOrderId() {

--- a/xchange-core/src/test/java/org/knowm/xchange/dto/trade/UserTradeTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/dto/trade/UserTradeTest.java
@@ -29,7 +29,7 @@ public class UserTradeTest {
     final String orderUserReference = "orderUserReference";
 
     final UserTrade copy =
-        new UserTrade.Builder()
+        UserTrade.builder()
             .type(type)
             .originalAmount(originalAmount)
             .currencyPair(currencyPair)
@@ -67,7 +67,7 @@ public class UserTradeTest {
     final Currency feeCurrency = Currency.BTC;
 
     final UserTrade original =
-        new UserTrade.Builder()
+        UserTrade.builder()
             .type(type)
             .originalAmount(originalAmount)
             .currencyPair(currencyPair)
@@ -104,7 +104,7 @@ public class UserTradeTest {
     final BigDecimal feeAmount = new BigDecimal("0");
     final Currency feeCurrency = Currency.BTC;
     final UserTrade original =
-        new UserTrade.Builder()
+        UserTrade.builder()
             .type(type)
             .originalAmount(originalAmount)
             .currencyPair(currencyPair)
@@ -136,7 +136,7 @@ public class UserTradeTest {
     final Currency feeCurrency = Currency.BTC;
 
     final UserTrade original =
-        new UserTrade.Builder()
+        UserTrade.builder()
             .type(type)
             .originalAmount(originalAmount)
             .currencyPair(currencyPair)
@@ -148,7 +148,7 @@ public class UserTradeTest {
             .feeCurrency(feeCurrency)
             .build();
     final UserTrade copy =
-        new UserTrade.Builder()
+        UserTrade.builder()
             .type(type)
             .originalAmount(originalAmount)
             .currencyPair(currencyPair)
@@ -173,7 +173,7 @@ public class UserTradeTest {
     final String id = "id";
 
     final UserTrade original =
-        new UserTrade.Builder()
+        UserTrade.builder()
             .type(type)
             .originalAmount(originalAmount)
             .currencyPair(currencyPair)
@@ -186,7 +186,7 @@ public class UserTradeTest {
             .build();
 
     final UserTrade copy =
-        new UserTrade.Builder()
+        UserTrade.builder()
             .type(type)
             .originalAmount(originalAmount)
             .currencyPair(currencyPair)
@@ -210,7 +210,7 @@ public class UserTradeTest {
     final Date timestamp = new Date();
 
     final UserTrade original =
-        new UserTrade.Builder()
+        UserTrade.builder()
             .type(type)
             .originalAmount(originalAmount)
             .currencyPair(currencyPair)
@@ -223,7 +223,7 @@ public class UserTradeTest {
             .build();
 
     final UserTrade copy =
-        new UserTrade.Builder()
+        UserTrade.builder()
             .type(type)
             .originalAmount(originalAmount)
             .currencyPair(currencyPair)

--- a/xchange-core/src/test/java/org/knowm/xchange/dto/trade/UserTradeTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/dto/trade/UserTradeTest.java
@@ -79,7 +79,7 @@ public class UserTradeTest {
             .feeCurrency(feeCurrency)
             .build();
 
-    final UserTrade copy = UserTrade.Builder.from(original).build();
+    final UserTrade copy = UserTrade.builder().from(original).build();
 
     assertThat(copy.getType()).isEqualTo(original.getType());
     assertThat(copy.getOriginalAmount()).isEqualTo(original.getOriginalAmount());

--- a/xchange-core/src/test/java/org/knowm/xchange/dto/trade/UserTradesTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/dto/trade/UserTradesTest.java
@@ -19,14 +19,14 @@ public class UserTradesTest {
 
     List<UserTrade> userTradeList = new ArrayList<>();
     userTradeList.add(
-        new UserTrade.Builder()
+        UserTrade.builder()
             .timestamp(Date.from(Instant.now()))
             .currencyPair(CurrencyPair.BTC_USD)
             .price(BigDecimal.ONE)
             .originalAmount(BigDecimal.ONE)
             .build());
     userTradeList.add(
-        new UserTrade.Builder()
+        UserTrade.builder()
             .timestamp(Date.from(Instant.now()))
             .currencyPair(CurrencyPair.BTC_USD)
             .id("id")
@@ -34,7 +34,7 @@ public class UserTradesTest {
             .originalAmount(BigDecimal.ONE)
             .build());
     userTradeList.add(
-        new UserTrade.Builder()
+        UserTrade.builder()
             .timestamp(Date.from(Instant.now()))
             .currencyPair(CurrencyPair.BTC_USD)
             .id("id")

--- a/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/DeribitAdapters.java
+++ b/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/DeribitAdapters.java
@@ -351,7 +351,7 @@ public class DeribitAdapters {
   }
 
   private static UserTrade adaptUserTrade(org.knowm.xchange.deribit.v2.dto.trade.Trade trade) {
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(adapt(trade.getDirection()))
         .originalAmount(trade.getAmount())
         .instrument(adaptInstrument(trade.getInstrumentName()))

--- a/xchange-dvchain/src/main/java/org/knowm/xchange/dvchain/DVChainAdapters.java
+++ b/xchange-dvchain/src/main/java/org/knowm/xchange/dvchain/DVChainAdapters.java
@@ -58,7 +58,7 @@ public class DVChainAdapters {
       CurrencyPair currencyPair = new CurrencyPair(trade.getAsset(), "USD");
       final BigDecimal fee = null;
       pastTrades.add(
-          new UserTrade.Builder()
+          UserTrade.builder()
               .type(orderType)
               .originalAmount(trade.getQuantity())
               .currencyPair(currencyPair)

--- a/xchange-exmo/src/main/java/org/knowm/xchange/exmo/service/ExmoAdapters.java
+++ b/xchange-exmo/src/main/java/org/knowm/xchange/exmo/service/ExmoAdapters.java
@@ -24,7 +24,7 @@ public class ExmoAdapters {
     String tradeId = tradeDatum.get("trade_id");
     String orderId = tradeDatum.get("order_id");
 
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(type)
         .originalAmount(amount)
         .currencyPair(currencyPair)

--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/FtxAdapters.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/FtxAdapters.java
@@ -241,7 +241,7 @@ public class FtxAdapters {
         ftxFillDto -> {
           if (ftxFillDto.getSize().compareTo(BigDecimal.ZERO) != 0) {
             userTrades.add(
-                new UserTrade.Builder()
+                UserTrade.builder()
                     .instrument(
                         CurrencyPairDeserializer.getCurrencyPairFromString(ftxFillDto.getMarket()))
                     .currencyPair(

--- a/xchange-gateio/src/main/java/org/knowm/xchange/gateio/GateioAdapters.java
+++ b/xchange-gateio/src/main/java/org/knowm/xchange/gateio/GateioAdapters.java
@@ -215,7 +215,7 @@ public final class GateioAdapters {
     Date timestamp = DateUtils.fromMillisUtc(gateioTrade.getTimeUnix() * 1000);
     CurrencyPair currencyPair = adaptCurrencyPair(gateioTrade.getPair());
 
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(orderType)
         .originalAmount(gateioTrade.getAmount())
         .currencyPair(currencyPair)

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/GeminiAdapters.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/GeminiAdapters.java
@@ -417,7 +417,7 @@ public final class GeminiAdapters {
       Date timestamp = convertBigDecimalTimestampToDate(trade.getTimestamp());
       final BigDecimal fee = trade.getFeeAmount();
       pastTrades.add(
-          new UserTrade.Builder()
+          UserTrade.builder()
               .type(orderType)
               .originalAmount(trade.getAmount())
               .currencyPair(currencyPair)

--- a/xchange-globitex/src/main/java/org/knowm/xchange/globitex/GlobitexAdapters.java
+++ b/xchange-globitex/src/main/java/org/knowm/xchange/globitex/GlobitexAdapters.java
@@ -205,7 +205,7 @@ public class GlobitexAdapters {
   }
 
   private static UserTrade adaptToUserTrade(GlobitexUserTrade globitexUserTrade) {
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(
             (globitexUserTrade.getSide().equals("sell")
                 ? Order.OrderType.ASK

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/HuobiAdapters.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/HuobiAdapters.java
@@ -304,7 +304,7 @@ public class HuobiAdapters {
             .multiply(order.getLimitPrice())
             .multiply(fee)
             .setScale(8, RoundingMode.DOWN);
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(order.getType())
         .originalAmount(order.getCumulativeAmount())
         .currencyPair(order.getCurrencyPair())
@@ -365,7 +365,7 @@ public class HuobiAdapters {
 
   public static List<UserTrade> adaptUserTradeList(HuobiOrder[] tradeHistory){
     return Arrays.stream(tradeHistory).sequential()
-            .map(huobiOrder -> new UserTrade.Builder()
+            .map(huobiOrder -> UserTrade.builder()
                     .id(Long.toString(huobiOrder.getId()))
                     .instrument(adaptCurrencyPair(huobiOrder.getSymbol()))
                     .orderUserReference(huobiOrder.getClOrdId())

--- a/xchange-idex/src/main/java/org/knowm/xchange/idex/IdexTradeService.java
+++ b/xchange-idex/src/main/java/org/knowm/xchange/idex/IdexTradeService.java
@@ -161,7 +161,7 @@ public class IdexTradeService extends BaseExchangeService implements TradeServic
           returnTradeHistoryApi.tradeHistory((TradeHistoryReq) tradeHistoryParams).stream()
               .map(
                   tradeHistoryItem ->
-                      new UserTrade.Builder()
+                      UserTrade.builder()
                           .originalAmount(
                               IdexExchange.Companion.safeParse(tradeHistoryItem.getAmount()))
                           .price(IdexExchange.Companion.safeParse(tradeHistoryItem.getPrice()))

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/IndependentReserveAdapters.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/IndependentReserveAdapters.java
@@ -197,7 +197,7 @@ public class IndependentReserveAdapters {
       CurrencyPair currencyPair = new CurrencyPair(primary, secondary);
 
       UserTrade ut =
-          new UserTrade.Builder()
+          UserTrade.builder()
               .type(adapeOrderType(trade.getOrderType()))
               .originalAmount(trade.getVolumeTraded())
               .currencyPair(currencyPair)

--- a/xchange-itbit/src/main/java/org/knowm/xchange/itbit/ItBitAdapters.java
+++ b/xchange-itbit/src/main/java/org/knowm/xchange/itbit/ItBitAdapters.java
@@ -258,7 +258,7 @@ public final class ItBitAdapters {
       Currency feeCcy = adaptCcy(ccy == null ? itBitTrade.getRebateCurrency() : ccy);
 
       UserTrade userTrade =
-          new UserTrade.Builder()
+          UserTrade.builder()
               .type(orderType)
               .originalAmount(totalQuantity)
               .currencyPair(currencyPair)

--- a/xchange-krakenfutures/src/main/java/org/knowm/xchange/krakenfutures/KrakenFuturesAdapters.java
+++ b/xchange-krakenfutures/src/main/java/org/knowm/xchange/krakenfutures/KrakenFuturesAdapters.java
@@ -139,7 +139,7 @@ public class KrakenFuturesAdapters {
   }
 
   public static UserTrade adaptFill(KrakenFuturesFill fill) {
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(adaptOrderType(fill.getSide()))
         .originalAmount(fill.getSize())
         .instrument(adaptInstrument(fill.getSymbol()))

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinAdapters.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinAdapters.java
@@ -325,7 +325,7 @@ public class KucoinAdapters {
   }
 
   public static UserTrade adaptUserTrade(TradeResponse trade) {
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .currencyPair(adaptCurrencyPair(trade.getSymbol()))
         .feeAmount(trade.getFee())
         .feeCurrency(Currency.getInstance(trade.getFeeCurrency()))
@@ -340,7 +340,7 @@ public class KucoinAdapters {
 
   public static UserTrade adaptHistOrder(HistOrdersResponse histOrder) {
     CurrencyPair currencyPair = adaptCurrencyPair(histOrder.getSymbol());
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .currencyPair(currencyPair)
         .feeAmount(histOrder.getFee())
         .feeCurrency(currencyPair.base)

--- a/xchange-latoken/src/main/java/org/knowm/xchange/latoken/LatokenAdapters.java
+++ b/xchange-latoken/src/main/java/org/knowm/xchange/latoken/LatokenAdapters.java
@@ -204,7 +204,7 @@ public class LatokenAdapters {
   }
 
   public static UserTrade adaptUserTrade(LatokenUserTrade latokenUserTrade, CurrencyPair pair) {
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(adaptOrderType(latokenUserTrade.getSide()))
         .originalAmount(latokenUserTrade.getAmount())
         .currencyPair(pair)

--- a/xchange-lgo/src/main/java/org/knowm/xchange/lgo/LgoAdapters.java
+++ b/xchange-lgo/src/main/java/org/knowm/xchange/lgo/LgoAdapters.java
@@ -160,7 +160,7 @@ public final class LgoAdapters {
     OrderType type = adaptUserTradeType(lgoUserTrade);
     CurrencyPair currencyPair = adaptProductId(lgoUserTrade.getProductId());
     Date creationDate = lgoUserTrade.getCreationDate();
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(type)
         .originalAmount(lgoUserTrade.getQuantity())
         .currencyPair(currencyPair)

--- a/xchange-lgo/src/test/java/org/knowm/xchange/lgo/LgoAdaptersTest.java
+++ b/xchange-lgo/src/test/java/org/knowm/xchange/lgo/LgoAdaptersTest.java
@@ -218,7 +218,7 @@ public class LgoAdaptersTest {
     assertThat(userTrades.getUserTrades()).hasSize(2);
     assertThat(userTrades.getUserTrades().get(0))
         .isEqualToComparingFieldByField(
-            new UserTrade.Builder()
+            UserTrade.builder()
                 .type(OrderType.ASK)
                 .originalAmount(new BigDecimal("0.00500000"))
                 .currencyPair(CurrencyPair.BTC_USD)
@@ -231,7 +231,7 @@ public class LgoAdaptersTest {
                 .build());
     assertThat(userTrades.getUserTrades().get(1))
         .isEqualToComparingFieldByField(
-            new UserTrade.Builder()
+            UserTrade.builder()
                 .type(OrderType.BID)
                 .originalAmount(new BigDecimal("0.00829566"))
                 .currencyPair(CurrencyPair.BTC_USD)

--- a/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/LivecoinAdapters.java
+++ b/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/LivecoinAdapters.java
@@ -231,7 +231,7 @@ public class LivecoinAdapters {
 
     String id = map.get("id").toString();
 
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(type)
         .originalAmount(amountA)
         .currencyPair(new CurrencyPair(ccyA, ccyB))

--- a/xchange-luno/src/main/java/org/knowm/xchange/luno/service/LunoTradeService.java
+++ b/xchange-luno/src/main/java/org/knowm/xchange/luno/service/LunoTradeService.java
@@ -173,7 +173,7 @@ public class LunoTradeService extends LunoBaseService implements TradeService {
         feeCurrency = pair.counter;
       }
       trades.add(
-          new UserTrade.Builder()
+          UserTrade.builder()
               .type(t.buy ? OrderType.BID : OrderType.ASK)
               .originalAmount(t.volume)
               .currencyPair(pair)

--- a/xchange-lykke/src/main/java/org/knowm/xchange/lykke/LykkeAdapter.java
+++ b/xchange-lykke/src/main/java/org/knowm/xchange/lykke/LykkeAdapter.java
@@ -120,7 +120,7 @@ public class LykkeAdapter {
   private static UserTrade adaptUserTrade(
       List<Instrument> currencyPairList, LykkeOrder tradeHistory) throws IOException {
 
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(getOrderTypeFromVolumeSign(tradeHistory.getVolume()))
         .originalAmount(
             BigDecimal.valueOf(Math.abs(tradeHistory.getVolume()))

--- a/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/MercadoBitcoinAdapters.java
+++ b/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/MercadoBitcoinAdapters.java
@@ -216,7 +216,7 @@ public final class MercadoBitcoinAdapters {
         String txId = f.getKey();
         OperationEntry op = f.getValue();
         result.add(
-            new UserTrade.Builder()
+            UserTrade.builder()
                 .currencyPair(pair)
                 .id(txId)
                 .orderId(orderId)

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinAdapters.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinAdapters.java
@@ -322,7 +322,7 @@ public final class OkCoinAdapters {
     // instead.
     String tradeId, orderId;
     tradeId = orderId = String.valueOf(order.getOrderId());
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(adaptOrderType(order.getType()))
         .originalAmount(order.getDealAmount())
         .currencyPair(adaptSymbol(order.getSymbol()))
@@ -335,7 +335,7 @@ public final class OkCoinAdapters {
 
   private static UserTrade adaptTradeFutures(OkCoinFuturesOrder order) {
 
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(adaptOrderType(order.getType()))
         .originalAmount(order.getDealAmount())
         .currencyPair(adaptSymbol(order.getSymbol()))
@@ -368,7 +368,7 @@ public final class OkCoinAdapters {
 
       BigDecimal feeAmount = BigDecimal.ZERO;
       UserTrade trade =
-          new UserTrade.Builder()
+          UserTrade.builder()
               .type(orderType)
               .originalAmount(originalAmount)
               .currencyPair(currencyPair)

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/v3/service/OkexTradeService.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/v3/service/OkexTradeService.java
@@ -215,7 +215,7 @@ public class OkexTradeService extends OkexTradeServiceRaw implements TradeServic
                       }
 
                       UserTrade ut =
-                          new UserTrade.Builder()
+                          UserTrade.builder()
                               .currencyPair(p)
                               .id(t.getLedgerId())
                               .orderId(o.getOrderId())
@@ -295,7 +295,7 @@ public class OkexTradeService extends OkexTradeServiceRaw implements TradeServic
                       }
 
                       UserTrade ut =
-                          new UserTrade.Builder()
+                          UserTrade.builder()
                               .currencyPair(p)
                               .id(t.getLedgerId())
                               .orderId(o.getOrderId())

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/OkexAdapters.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/OkexAdapters.java
@@ -48,7 +48,7 @@ public class OkexAdapters {
         okexOrderDetails -> {
           Instrument instrument = adaptOkexInstrumentId(okexOrderDetails.getInstrumentId());
           userTradeList.add(
-                  new UserTrade.Builder()
+                  UserTrade.builder()
                           .originalAmount(convertContractSizeToVolume(okexOrderDetails.getAmount(), instrument, exchangeMetaData.getInstruments().get(instrument).getContractValue()))
                           .instrument(instrument)
                           .price(new BigDecimal(okexOrderDetails.getAverageFilledPrice()))

--- a/xchange-paymium/src/main/java/org/knowm/xchange/paymium/service/PaymiumTradeService.java
+++ b/xchange-paymium/src/main/java/org/knowm/xchange/paymium/service/PaymiumTradeService.java
@@ -71,7 +71,7 @@ public class PaymiumTradeService extends PaymiumTradeServiceRaw implements Trade
       }
 
       UserTrade userTrade =
-          new UserTrade.Builder()
+          UserTrade.builder()
               .type(orderType)
               .originalAmount(order.getTradedCurrency())
               .currencyPair(CurrencyPair.BTC_EUR)

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAdapters.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAdapters.java
@@ -224,7 +224,7 @@ public class PoloniexAdapters {
       feeCurrencyCode = currencyPair.base.getCurrencyCode();
     }
 
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(orderType)
         .originalAmount(amount)
         .currencyPair(currencyPair)

--- a/xchange-quoine/src/main/java/org/knowm/xchange/quoine/QuoineAdapters.java
+++ b/xchange-quoine/src/main/java/org/knowm/xchange/quoine/QuoineAdapters.java
@@ -193,7 +193,7 @@ public class QuoineAdapters {
     List<UserTrade> res = new ArrayList<>();
     for (QuoineExecution execution : executions) {
       res.add(
-          new UserTrade.Builder()
+          UserTrade.builder()
               .type(execution.mySide.equals("sell") ? OrderType.ASK : OrderType.BID)
               .originalAmount(execution.quantity)
               .currencyPair(currencyPair)

--- a/xchange-simulated/src/main/java/org/knowm/xchange/simulated/MatchingEngine.java
+++ b/xchange-simulated/src/main/java/org/knowm/xchange/simulated/MatchingEngine.java
@@ -270,7 +270,7 @@ final class MatchingEngine {
     Date timestamp = new Date();
 
     UserTrade takerTrade =
-        new UserTrade.Builder()
+        UserTrade.builder()
             .currencyPair(currencyPair)
             .id(randomUUID().toString())
             .originalAmount(tradeAmount)
@@ -291,7 +291,7 @@ final class MatchingEngine {
 
     OrderType makerType = takerOrder.getType() == OrderType.ASK ? OrderType.BID : OrderType.ASK;
     UserTrade makerTrade =
-        new UserTrade.Builder()
+        UserTrade.builder()
             .currencyPair(currencyPair)
             .id(randomUUID().toString())
             .originalAmount(tradeAmount)

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/dto/ExecutionReportBinanceUserTransaction.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/dto/ExecutionReportBinanceUserTransaction.java
@@ -102,7 +102,7 @@ public class ExecutionReportBinanceUserTransaction extends ProductBinanceWebSock
 
   public UserTrade toUserTrade(boolean isFuture) {
     if (executionType != ExecutionType.TRADE) throw new IllegalStateException("Not a trade");
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(BinanceAdapters.convert(side))
         .originalAmount(lastExecutedQuantity)
         .instrument(BinanceAdapters.adaptSymbol(symbol, isFuture))

--- a/xchange-stream-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/BitfinexStreamingAdapters.java
+++ b/xchange-stream-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/BitfinexStreamingAdapters.java
@@ -261,7 +261,7 @@ class BitfinexStreamingAdapters {
   }
 
   static UserTrade adaptUserTrade(BitfinexWebSocketAuthTrade authTrade) {
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .currencyPair(BitfinexAdapters.adaptCurrencyPair(adaptV2SymbolToV1(authTrade.getPair())))
         .feeAmount(authTrade.getFee().abs())
         .feeCurrency(Currency.getInstance(authTrade.getFeeCurrency()))

--- a/xchange-stream-coinjar/src/main/java/info/bitrich/xchangestream/coinjar/CoinjarStreamingAdapters.java
+++ b/xchange-stream-coinjar/src/main/java/info/bitrich/xchangestream/coinjar/CoinjarStreamingAdapters.java
@@ -52,7 +52,7 @@ class CoinjarStreamingAdapters {
   }
 
   public static UserTrade adaptUserTrade(CoinjarWebSocketUserTradeEvent event) {
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .timestamp(Date.from(ZonedDateTime.parse(event.payload.fill.timestamp).toInstant()))
         .id(Long.toString(event.payload.fill.tid))
         .originalAmount(new BigDecimal(event.payload.fill.size))

--- a/xchange-stream-coinjar/src/test/java/info/bitrich/xchangestream/coinjar/CoinjarStreamingAdaptersTest.java
+++ b/xchange-stream-coinjar/src/test/java/info/bitrich/xchangestream/coinjar/CoinjarStreamingAdaptersTest.java
@@ -48,7 +48,7 @@ public class CoinjarStreamingAdaptersTest {
     UserTrade userTrade = CoinjarStreamingAdapters.adaptUserTrade(event);
 
     UserTrade expected =
-        new UserTrade.Builder()
+        UserTrade.builder()
             .id("9130900")
             .orderId("280117631")
             .currencyPair(CurrencyPair.BTC_AUD)

--- a/xchange-stream-coinmate/src/main/java/info/bitrich/xchangestream/coinmate/v2/CoinmateStreamingAdapter.java
+++ b/xchange-stream-coinmate/src/main/java/info/bitrich/xchangestream/coinmate/v2/CoinmateStreamingAdapter.java
@@ -31,7 +31,7 @@ public class CoinmateStreamingAdapter {
     coinmateWebSocketUserTrades.forEach(
         (coinmateWebSocketUserTrade) -> {
           userTrades.add(
-              new UserTrade.Builder()
+              UserTrade.builder()
                   .type(
                       (coinmateWebSocketUserTrade.getUserOrderType().equals("SELL"))
                           ? Order.OrderType.ASK

--- a/xchange-stream-ftx/src/main/java/info/bitrich/xchangestream/ftx/FtxStreamingAdapters.java
+++ b/xchange-stream-ftx/src/main/java/info/bitrich/xchangestream/ftx/FtxStreamingAdapters.java
@@ -223,7 +223,7 @@ public class FtxStreamingAdapters {
     JsonNode data = jsonNode.get("data");
 
     Builder userTradeBuilder =
-        new Builder()
+        UserTrade.builder()
             .currencyPair(new CurrencyPair(data.get("market").asText()))
             .type("buy".equals(data.get("side").asText()) ? OrderType.BID : OrderType.ASK)
             .instrument(new CurrencyPair(data.get("market").asText()))

--- a/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingTradeService.java
+++ b/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingTradeService.java
@@ -206,7 +206,7 @@ public class KrakenStreamingTradeService implements StreamingTradeService {
 
         CurrencyPair currencyPair = new CurrencyPair(dto.pair);
         result.add(
-            new UserTrade.Builder()
+            UserTrade.builder()
                 .id(tradeId) // The tradeId should be the key of the map, postxid can be null and is
                 // not unique as required for a tradeId
                 .orderId(dto.ordertxid)

--- a/xchange-stream-krakenfutures/src/main/java/info/bitrich/xchangestream/krakenfutures/KrakenFuturesStreamingAdapters.java
+++ b/xchange-stream-krakenfutures/src/main/java/info/bitrich/xchangestream/krakenfutures/KrakenFuturesStreamingAdapters.java
@@ -73,7 +73,7 @@ public class KrakenFuturesStreamingAdapters {
     public static List<UserTrade> adaptUserTrades(KrakenFuturesStreamingFillsDeltaResponse fills) {
         List<UserTrade> userTrades = new ArrayList<>();
 
-        fills.getFills().forEach(krakenFuturesStreamingFill -> userTrades.add(new UserTrade.Builder()
+        fills.getFills().forEach(krakenFuturesStreamingFill -> userTrades.add(UserTrade.builder()
                         .price(krakenFuturesStreamingFill.getPrice())
                         .originalAmount(krakenFuturesStreamingFill.getQty())
                         .id(krakenFuturesStreamingFill.getFill_id())

--- a/xchange-stream-lgo/src/main/java/info/bitrich/xchangestream/lgo/LgoAdapter.java
+++ b/xchange-stream-lgo/src/main/java/info/bitrich/xchangestream/lgo/LgoAdapter.java
@@ -135,7 +135,7 @@ public class LgoAdapter {
   }
 
   static UserTrade adaptUserTrade(CurrencyPair currencyPair, LgoMatchOrderEvent event) {
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(event.getOrderType())
         .originalAmount(event.getFilledQuantity())
         .currencyPair(currencyPair)

--- a/xchange-stream-lgo/src/test/java/info/bitrich/xchangestream/lgo/LgoStreamingTradeServiceTest.java
+++ b/xchange-stream-lgo/src/test/java/info/bitrich/xchangestream/lgo/LgoStreamingTradeServiceTest.java
@@ -254,7 +254,7 @@ public class LgoStreamingTradeServiceTest {
     assertThat(trades.get(0))
         .usingRecursiveComparison()
         .isEqualTo(
-            new UserTrade.Builder()
+            UserTrade.builder()
                 .type(Order.OrderType.ASK)
                 .originalAmount(new BigDecimal("0.50000000"))
                 .currencyPair(CurrencyPair.BTC_USD)

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/TheRockAdapters.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/TheRockAdapters.java
@@ -108,7 +108,7 @@ public final class TheRockAdapters {
     final String tradeId = String.valueOf(trade.getId());
     // return new UserTrade(trade.getSide() == Side.sell ? OrderType.ASK : BID, trade.getAmount(),
     // currencyPair, trade.getPrice(), trade.getDate(), tradeId);
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .id(tradeId)
         .originalAmount(trade.getAmount())
         .currencyPair(currencyPair)

--- a/xchange-yobit/src/main/java/org/knowm/xchange/yobit/YoBitAdapters.java
+++ b/xchange-yobit/src/main/java/org/knowm/xchange/yobit/YoBitAdapters.java
@@ -242,7 +242,7 @@ public class YoBitAdapters {
 
     Date time = DateUtils.fromUnixTime(Long.parseLong(timestamp));
 
-    return new UserTrade.Builder()
+    return UserTrade.builder()
         .type(adaptType(type))
         .originalAmount(new BigDecimal(amount))
         .currencyPair(adaptCurrencyPair(pair))


### PR DESCRIPTION
Replaced explicit `UserTrade.Builder` constructor call with equivalent `builder()` method call