### PR TITLE
Added Bitstamp instant_and_market_orders mapping

### DIFF
--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAdapters.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAdapters.java
@@ -425,6 +425,7 @@ public final class BitstampAdapters {
         .counterMinimumAmount(minOrder)
         .priceScale(pairInfo.getCounterDecimals())
         .volumeScale(pairInfo.getBaseDecimals())
+        .marketOrderEnabled(pairInfo.isMarketOrdersEnabled())
         .build();
   }
 

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/marketdata/BitstampPairInfo.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/marketdata/BitstampPairInfo.java
@@ -31,4 +31,10 @@ public class BitstampPairInfo {
   @JsonProperty("description")
   String description;
 
+  @JsonProperty("instant_and_market_orders")
+  String instantAndMarketOrders;
+
+  public boolean isMarketOrdersEnabled(){
+    return "Enabled".equals(instantAndMarketOrders);
+  }
 }


### PR DESCRIPTION
Added missing mapping of field "instant_and_market_orders" in /v2/trading-pairs-info/ endpoint