### PR TITLE
Use JSON assert to improve test stability

### DIFF
--- a/xchange-stream-bitmex/pom.xml
+++ b/xchange-stream-bitmex/pom.xml
@@ -50,6 +50,13 @@
         </profile>
     </profiles>
 
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.knowm.xchange</groupId>
@@ -65,6 +72,12 @@
             <groupId>org.knowm.xchange</groupId>
             <artifactId>xchange-bitmex</artifactId>
             <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexStreamingTest.java
+++ b/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexStreamingTest.java
@@ -1,24 +1,27 @@
 package info.bitrich.xchangestream.bitmex;
 
 import java.io.IOException;
-import org.junit.Assert;
+
+import org.json.JSONException;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /** @author Foat Akhmadeev 13/06/2018 */
 public class BitmexStreamingTest {
   @Test
-  public void shouldGetCorrectSubscribeMessage() throws IOException {
+  public void shouldGetCorrectSubscribeMessage() throws IOException, JSONException {
     BitmexStreamingService service = new BitmexStreamingService("url", "api", "secret");
 
-    Assert.assertEquals(
-        "{\"op\":\"subscribe\",\"args\":[\"name\"]}", service.getSubscribeMessage("name"));
+    JSONAssert.assertEquals(
+        "{\"op\":\"subscribe\",\"args\":[\"name\"]}", service.getSubscribeMessage("name"), JSONCompareMode.NON_EXTENSIBLE);
   }
 
   @Test
-  public void shouldGetCorrectUnsubscribeMessage() throws IOException {
+  public void shouldGetCorrectUnsubscribeMessage() throws IOException, JSONException {
     BitmexStreamingService service = new BitmexStreamingService("url", "api", "secret");
 
-    Assert.assertEquals(
-        "{\"op\":\"unsubscribe\",\"args\":[\"name\"]}", service.getUnsubscribeMessage("name"));
+    JSONAssert.assertEquals(
+        "{\"op\":\"unsubscribe\",\"args\":[\"name\"]}", service.getUnsubscribeMessage("name"), JSONCompareMode.NON_EXTENSIBLE);
   }
 }

--- a/xchange-stream-coinbasepro/pom.xml
+++ b/xchange-stream-coinbasepro/pom.xml
@@ -19,6 +19,12 @@
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.knowm.xchange</groupId>
             <artifactId>xchange-stream-service-netty</artifactId>
             <version>${project.parent.version}</version>

--- a/xchange-stream-coinbasepro/src/test/java/info/bitrich/xchangestream/coinbasepro/dto/CoinbaseProWebSocketSubscriptionMessageTest.java
+++ b/xchange-stream-coinbasepro/src/test/java/info/bitrich/xchangestream/coinbasepro/dto/CoinbaseProWebSocketSubscriptionMessageTest.java
@@ -4,15 +4,18 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import info.bitrich.xchangestream.core.ProductSubscription;
+import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /** Created by luca on 5/3/17. */
 public class CoinbaseProWebSocketSubscriptionMessageTest {
 
   @Test
-  public void testWebSocketMessageSerialization() throws JsonProcessingException {
+  public void testWebSocketMessageSerialization() throws JsonProcessingException, JSONException {
 
     ProductSubscription productSubscription =
         ProductSubscription.create()
@@ -28,13 +31,13 @@ public class CoinbaseProWebSocketSubscriptionMessageTest {
 
     String serialized = mapper.writeValueAsString(message);
 
-    Assert.assertEquals(
+    JSONAssert.assertEquals(
         "{\"type\":\"subscribe\",\"channels\":[{\"name\":\"matches\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"ticker\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"level2\",\"product_ids\":[\"BTC-USD\"]}]}",
-        serialized);
+        serialized, JSONCompareMode.NON_EXTENSIBLE);
   }
 
   @Test
-  public void testWebSocketMessageSerializationL3Orderbook() throws JsonProcessingException {
+  public void testWebSocketMessageSerializationL3Orderbook() throws JsonProcessingException, JSONException {
 
     ProductSubscription productSubscription =
         ProductSubscription.create()
@@ -50,13 +53,13 @@ public class CoinbaseProWebSocketSubscriptionMessageTest {
 
     String serialized = mapper.writeValueAsString(message);
 
-    Assert.assertEquals(
+    JSONAssert.assertEquals(
         "{\"type\":\"subscribe\",\"channels\":[{\"name\":\"matches\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"ticker\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"full\",\"product_ids\":[\"BTC-USD\"]}]}",
-        serialized);
+        serialized, JSONCompareMode.NON_EXTENSIBLE);
   }
 
   @Test
-  public void testWebSocketMessageSerializationBatch() throws JsonProcessingException {
+  public void testWebSocketMessageSerializationBatch() throws JsonProcessingException, JSONException {
 
     ProductSubscription productSubscription =
             ProductSubscription.create()
@@ -72,8 +75,8 @@ public class CoinbaseProWebSocketSubscriptionMessageTest {
 
     String serialized = mapper.writeValueAsString(message);
 
-    Assert.assertEquals(
+    JSONAssert.assertEquals(
             "{\"type\":\"subscribe\",\"channels\":[{\"name\":\"matches\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"level2_batch\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"ticker\",\"product_ids\":[\"BTC-USD\"]}]}",
-            serialized);
+            serialized, JSONCompareMode.NON_EXTENSIBLE);
   }
 }


### PR DESCRIPTION
This PR fixes the non deterministic behaviour of 2 tests in the module `xchange-stream-bitmex` and 3 tests in the module `xchange-stream-coinbasepro`. This happens as the test assumes the order of keys in a JSON, which is not guaranteed. It has been detected using [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

### Reproduction of issue
1. `mvn install -pl xchange-stream-bitmex`
2. `mvn -pl xchange-stream-bitmex edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=info.bitrich.xchangestream.bitmex.BitmexStreamingTest`
3. mvn install -pl xchange-stream-coinbasepro -am -DskipTests
4. mvn -pl xchange-stream-coinbasepro edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=info.bitrich.xchangestream.coinbasepro.dto.CoinbaseProWebSocketSubscriptionMessageTest

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.735 s <<< FAILURE! -- in info.bitrich.xchangestream.bitmex.BitmexStreamingTest
[ERROR] info.bitrich.xchangestream.bitmex.BitmexStreamingTest.shouldGetCorrectSubscribeMessage -- Time elapsed: 0.717 s <<< FAILURE!
org.junit.ComparisonFailure: expected:<{"[op":"subscribe","args":["name"]]}> but was:<{"[args":["name"],"op":"subscribe"]}>
[ERROR] info.bitrich.xchangestream.bitmex.BitmexStreamingTest.shouldGetCorrectUnsubscribeMessage -- Time elapsed: 0.002 s <<< FAILURE!
org.junit.ComparisonFailure: expected:<{"[op":"unsubscribe","args":["name"]]}> but was:<{"[args":["name"],"op":"unsubscribe"]}>
	at org.junit.Assert.assertEquals(Assert.java:117)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at info.bitrich.xchangestream.bitmex.BitmexStreamingTest.shouldGetCorrectUnsubscribeMessage(BitmexStreamingTest.java:21)

[INFO] Running info.bitrich.xchangestream.coinbasepro.dto.CoinbaseProWebSocketSubscriptionMessageTest
[ERROR] Tests run: 3, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 0.410 s <<< FAILURE! -- in info.bitrich.xchangestream.coinbasepro.dto.CoinbaseProWebSocketSubscriptionMessageTest
[ERROR] info.bitrich.xchangestream.coinbasepro.dto.CoinbaseProWebSocketSubscriptionMessageTest.testWebSocketMessageSerializationBatch -- Time elapsed: 0.333 s <<< FAILURE!
org.junit.ComparisonFailure: expected:<{"[type":"subscribe","channels":[{"name":"matches","product_ids":["BTC-USD"]},{"name":"level2_batch","product_ids":["BTC-USD"]},{"name":"ticker","product_ids":["BTC-USD"]}]]}> but was:<{"[channels":[{"product_ids":["BTC-USD"],"name":"matches"},{"product_ids":["BTC-USD"],"name":"level2_batch"},{"product_ids":["BTC-USD"],"name":"ticker"}],"type":"subscribe"]}>
	at org.junit.Assert.assertEquals(Assert.java:117)
	at org.junit.Assert.assertEquals(Assert.java:146)
```

### Root cause
The test uses [BitmexStreamingService](https://github.com/knowm/XChange/blob/develop/xchange-stream-bitmex/src/main/java/info/bitrich/xchangestream/bitmex/BitmexStreamingService.java#L227) to serialize an `BitmexWebSocketSubscriptionMessage` object using jackson library's object mapper. This does not guarantee ordering of fields in the resulting JSON string because internally Jackson uses Java's `getDeclaredFields()` which is unordered [Doc](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--). 

Stack trace from `writeValueAsString` to `getDeclaredFields`:

```
java.base/java.lang.Class.getDeclaredFields(Class.java:2248)
com.fasterxml.jackson.databind.introspect.AnnotatedFieldCollector._findFields(AnnotatedFieldCollector.java:73)
com.fasterxml.jackson.databind.introspect.AnnotatedFieldCollector.collect(AnnotatedFieldCollector.java:48)
com.fasterxml.jackson.databind.introspect.AnnotatedFieldCollector.collectFields(AnnotatedFieldCollector.java:43)
com.fasterxml.jackson.databind.introspect.AnnotatedClass._fields(AnnotatedClass.java:371)
com.fasterxml.jackson.databind.introspect.AnnotatedClass.fields(AnnotatedClass.java:343)
com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector._addFields(POJOPropertiesCollector.java:494)
com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector.collectAll(POJOPropertiesCollector.java:421)
com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector.getJsonValueAccessor(POJOPropertiesCollector.java:270)
com.fasterxml.jackson.databind.introspect.BasicBeanDescription.findJsonValueAccessor(BasicBeanDescription.java:258)
com.fasterxml.jackson.databind.ser.BasicSerializerFactory.findSerializerByAnnotations(BasicSerializerFactory.java:391)
com.fasterxml.jackson.databind.ser.BeanSerializerFactory._createSerializer2(BeanSerializerFactory.java:225)
com.fasterxml.jackson.databind.ser.BeanSerializerFactory.createSerializer(BeanSerializerFactory.java:174)
com.fasterxml.jackson.databind.SerializerProvider._createUntypedSerializer(SerializerProvider.java:1501)
com.fasterxml.jackson.databind.SerializerProvider._createAndCacheUntypedSerializer(SerializerProvider.java:1449)
com.fasterxml.jackson.databind.SerializerProvider.findValueSerializer(SerializerProvider.java:550)
com.fasterxml.jackson.databind.SerializerProvider.findTypedValueSerializer(SerializerProvider.java:828)
com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:308)
com.fasterxml.jackson.databind.ObjectMapper._writeValueAndClose(ObjectMapper.java:4624)
com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString(ObjectMapper.java:3869)
```

This can cause test flakiness as detected by the tool.


### Fix
There are 2 approaches:
1. Not using additional external library: jackson is already present in the module and this can be used to convert JSON strings to a JSON tree and compare.
Code change: https://github.com/rRajivramachandran/XChange/commit/ca3b36f1614c7308b40cf0abb7b305c98c95616b

Potential future issue:
In case that the JSON value is an array consisting of more elements in future(which is currently the case for `xchange-stream-bitmex`), this approach wont work unless the array elements are ordered in the same way in both strings.  For example:     `Assert.assertEquals(
        objectMapper.readTree("{\"args\":[\"name1\",\"name2\"]}"), objectMapper.readTree("{\"args\":[\"name2\",\"name1\"]}"));`
would fail

To handle this a lot of boilerplate would have to be written and maintained. In this regard I prefer approach 2

2. Using external library specifically for JSON assertions which handles these cases and many more under the hood: [Skyscreamer JSONssert](https://github.com/skyscreamer/JSONassert)
The library is well known and widely used. It has [modes](http://jsonassert.skyscreamer.org/apidocs/org/skyscreamer/jsonassert/JSONCompareMode.html) to compare two JSON strings which allows mentioning if array orderings must be strictly verified and also if the difference between the two objects can be any extra fields. Using this will prevent having to maintain any custom logic which is outside the scope of this project just for the sake of tests. This is the apporoach in the PR

As a developer you would have a better idea on the use cases and future extensions of the project. So, I would request your opinion and I am open to updating this PR. 

 
### Verification of fix
- All tests in the class pass(`mvn -pl xchange-stream-bitmex test -Dtest=info.bitrich.xchangestream.bitmex.BitmexStreamingTest`)
- All tests in class pass when run with nondex(`mvn -pl xchange-stream-bitmex edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=info.bitrich.xchangestream.bitmex.BitmexStreamingTest`)
- All tests in the class pass(`mvn -pl xchange-stream-coinbasepro test -Dtest=info.bitrich.xchangestream.coinbasepro.dto.CoinbaseProWebSocketSubscriptionMessageTest`)
- All tests in class pass when run with nondex(`mvn -pl xchange-stream-coinbasepro edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=info.bitrich.xchangestream.coinbasepro.dto.CoinbaseProWebSocketSubscriptionMessageTest`