### PR TITLE
Change MathContext to 64, as 32 is not enough for some coins

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/utils/BigDecimalUtils.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/utils/BigDecimalUtils.java
@@ -14,7 +14,7 @@ public class BigDecimalUtils {
 
   public static BigDecimal roundToStepSize(
       BigDecimal value, BigDecimal stepSize, RoundingMode roundingMode) {
-    BigDecimal divided = value.divide(stepSize, MathContext.DECIMAL32).setScale(0, roundingMode);
-    return divided.multiply(stepSize, MathContext.DECIMAL32).stripTrailingZeros();
+    BigDecimal divided = value.divide(stepSize, MathContext.DECIMAL64).setScale(0, roundingMode);
+    return divided.multiply(stepSize, MathContext.DECIMAL64).stripTrailingZeros();
   }
 }


### PR DESCRIPTION
Turns out, that DECIMAL32 is not enough. For example for TRX:
<img width="844" alt="Screenshot 2023-12-07 at 13 48 01" src="https://github.com/knowm/XChange/assets/49660/5de0a9fe-0c5d-4b35-b67a-e114b356bc9d">
