### PR TITLE
bugfix/ETD-1130 - added LedgerType SALE for tx - spend and received

### DIFF
--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/LedgerType.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/LedgerType.java
@@ -23,7 +23,8 @@ public enum LedgerType {
   STAKING,
   ROLLOVER,
   TRANSFER,
-  ADJUSTMENT;
+  ADJUSTMENT,
+  SALE;
 
   private static final Map<String, LedgerType> fromString = new HashMap<>();
 

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/LedgerType.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/LedgerType.java
@@ -24,7 +24,9 @@ public enum LedgerType {
   ROLLOVER,
   TRANSFER,
   ADJUSTMENT,
-  SALE;
+  SALE,
+  SPEND,
+  RECEIVE;
 
   private static final Map<String, LedgerType> fromString = new HashMap<>();
 


### PR DESCRIPTION
https://support.kraken.com/hc/en-us/articles/360001169383-How-to-interpret-Ledger-history-fields

"sale" = this shows only as a filter option when viewing your Ledger history while signed in to your account, it is not shown in history exports. "Sale" is a filter that brings up all "Spend" and "Receive" entries from orders placed via the new Kraken app or Buy Crypto button.