### PR TITLE
Kraken: add support for OHLC Streaming

### DIFF
--- a/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingAdapters.java
+++ b/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingAdapters.java
@@ -1,26 +1,37 @@
 package info.bitrich.xchangestream.kraken;
 
-import static info.bitrich.xchangestream.kraken.KrakenStreamingChecksum.*;
+import static info.bitrich.xchangestream.kraken.KrakenStreamingChecksum.createCrcChecksum;
 
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.node.*;
-import com.google.common.collect.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Streams;
-import java.math.*;
-import java.util.*;
-import java.util.concurrent.atomic.*;
-import java.util.stream.*;
-import org.knowm.xchange.dto.*;
-import org.knowm.xchange.dto.marketdata.*;
-import org.knowm.xchange.dto.trade.*;
-import org.knowm.xchange.instrument.*;
-import org.knowm.xchange.kraken.*;
-import org.knowm.xchange.kraken.dto.trade.*;
-import org.knowm.xchange.utils.*;
-import org.slf4j.*;
+import info.bitrich.xchangestream.kraken.dto.KrakenStreamingOhlc;
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.marketdata.Ticker;
+import org.knowm.xchange.dto.marketdata.Trade;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.instrument.Instrument;
+import org.knowm.xchange.kraken.KrakenAdapters;
+import org.knowm.xchange.kraken.dto.trade.KrakenType;
+import org.knowm.xchange.utils.DateUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Kraken streaming adapters */
 public class KrakenStreamingAdapters {
+
   private static final Logger LOG = LoggerFactory.getLogger(KrakenStreamingAdapters.class);
 
   static final String ASK_SNAPSHOT = "as";
@@ -221,6 +232,22 @@ public class KrakenStreamingAdapters {
         .type(nextNodeAsOrderType(iterator))
         .instrument(instrument)
         .build();
+  }
+
+  public static KrakenStreamingOhlc adaptOhlc(Instrument instrument, ArrayNode arrayNode) {
+    ArrayNode data = (ArrayNode) arrayNode.get(1);
+
+    return new KrakenStreamingOhlc(
+        (long) (Double.parseDouble(data.get(0).textValue()) * 1000), // time in millis since epoch
+        (long) (Double.parseDouble(data.get(1).textValue()) * 1000),
+        // etime time in millis since epoch
+        arrayNodeItemAsDecimal(data, 2), // open
+        arrayNodeItemAsDecimal(data, 3), // high
+        arrayNodeItemAsDecimal(data, 4), // low
+        arrayNodeItemAsDecimal(data, 5), // close
+        arrayNodeItemAsDecimal(data, 6), // vwap
+        arrayNodeItemAsDecimal(data, 7), // volume
+        arrayNodeItemAsDecimal(data, 8).longValue()); // count
   }
 
   /**

--- a/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingMarketDataService.java
+++ b/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingMarketDataService.java
@@ -4,15 +4,20 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
+import info.bitrich.xchangestream.kraken.dto.KrakenStreamingOhlc;
 import info.bitrich.xchangestream.kraken.dto.enums.KrakenSubscriptionName;
 import io.reactivex.Observable;
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.TreeSet;
+import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trade;
 import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.kraken.dto.marketdata.KrakenOHLC;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,6 +93,20 @@ public class KrakenStreamingMarketDataService implements StreamingMarketDataServ
                 Observable.fromIterable(
                     KrakenStreamingAdapters.adaptTrades(currencyPair, arrayNode)));
   }
+
+
+  public Observable<KrakenStreamingOhlc> getOHLC(
+      CurrencyPair currencyPair, Integer interval) {
+    String channelName = getChannelName(KrakenSubscriptionName.ohlc, currencyPair);
+    // args[0] is reserved for an optional order boo depth, we'll use  args[1] for the interval
+    Object[] args = new Object[2];
+    args[0] = null;
+    args[1] = interval;
+
+    return subscribe(channelName, MIN_DATA_ARRAY_SIZE, args)
+        .map( arrayNode -> KrakenStreamingAdapters.adaptOhlc(currencyPair, arrayNode));
+  }
+
 
   public Observable<ArrayNode> subscribe(String channelName, int maxItems, Object... args) {
     return service

--- a/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/dto/KrakenSubscriptionConfig.java
+++ b/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/dto/KrakenSubscriptionConfig.java
@@ -33,16 +33,18 @@ public class KrakenSubscriptionConfig {
   private Integer interval;
 
   public KrakenSubscriptionConfig(KrakenSubscriptionName name) {
-    this(name, null, null);
+    this(name, null, null, null);
   }
 
   @JsonCreator
   public KrakenSubscriptionConfig(
       @JsonProperty("name") KrakenSubscriptionName name,
       @JsonProperty("depth") Integer depth,
+      @JsonProperty("interval") Integer interval,
       @JsonProperty("token") String token) {
     this.name = name;
     this.depth = depth;
+    this.interval = interval;
     this.token = token;
   }
 

--- a/xchange-stream-service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
+++ b/xchange-stream-service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
@@ -45,15 +45,19 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class NettyStreamingService<T> extends ConnectableService {
+
   private final Logger LOG = LoggerFactory.getLogger(this.getClass());
 
   protected static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(10);
@@ -215,13 +219,16 @@ public abstract class NettyStreamingService<T> extends ConnectableService {
                               p.addLast(sslCtx.newHandler(ch.alloc(), host, port));
                             }
                             p.addLast(new HttpClientCodec());
-                            if (enableLoggingHandler)
+                            if (enableLoggingHandler) {
                               p.addLast(new LoggingHandler(loggingHandlerLevel));
-                            if (compressedMessages)
+                            }
+                            if (compressedMessages) {
                               p.addLast(WebSocketClientCompressionHandler.INSTANCE);
+                            }
                             p.addLast(new HttpObjectAggregator(8192));
-                            if (idleTimeoutSeconds > 0)
+                            if (idleTimeoutSeconds > 0) {
                               p.addLast(new IdleStateHandler(idleTimeoutSeconds, 0, 0));
+                            }
                             WebSocketClientExtensionHandler clientExtensionHandler =
                                 getWebSocketClientExtensionHandler();
                             if (clientExtensionHandler != null) {
@@ -348,7 +355,15 @@ public abstract class NettyStreamingService<T> extends ConnectableService {
       throws IOException;
 
   public String getSubscriptionUniqueId(String channelName, Object... args) {
-    return channelName;
+
+    if (args == null || args.length == 0) {
+      return channelName;
+    }
+
+    List<String> collect = Arrays.stream(args).map(String::valueOf).collect(Collectors.toList());
+    String argsString = String.join("-", collect);
+
+    return channelName + "_" + argsString;
   }
 
   /**
@@ -392,8 +407,8 @@ public abstract class NettyStreamingService<T> extends ConnectableService {
   }
 
   public Observable<T> subscribeChannel(String channelName, Object... args) {
-    final String channelId = getSubscriptionUniqueId(channelName, args);
-    LOG.info("Subscribing to channel {}", channelId);
+    final String subscriptionUniqueId = getSubscriptionUniqueId(channelName, args);
+    LOG.info("Subscribing to subscriptionUniqueId={}, args={}", subscriptionUniqueId, args);
 
     return Observable.<T>create(
             e -> {
@@ -401,7 +416,7 @@ public abstract class NettyStreamingService<T> extends ConnectableService {
                 e.onError(new NotConnectedException());
               }
               channels.computeIfAbsent(
-                  channelId,
+                  subscriptionUniqueId,
                   cid -> {
                     Subscription newSubscription = new Subscription(e, channelName, args);
                     try {
@@ -417,13 +432,13 @@ public abstract class NettyStreamingService<T> extends ConnectableService {
             })
         .doOnDispose(
             () -> {
-              if (channels.remove(channelId) != null) {
+              if (channels.remove(subscriptionUniqueId) != null) {
                 try {
-                  sendMessage(getUnsubscribeMessage(channelId, args));
+                  sendMessage(getUnsubscribeMessage(subscriptionUniqueId, args));
                 } catch (IOException e) {
-                  LOG.debug("Failed to unsubscribe channel: {} {}", channelId, e.toString());
+                  LOG.debug("Failed to unsubscribe channel: {} {}", subscriptionUniqueId, e.toString());
                 } catch (Exception e) {
-                  LOG.warn("Failed to unsubscribe channel: {}", channelId, e);
+                  LOG.warn("Failed to unsubscribe channel: {}", subscriptionUniqueId, e);
                 }
               }
             })
@@ -454,13 +469,18 @@ public abstract class NettyStreamingService<T> extends ConnectableService {
 
   protected void handleMessage(T message) {
     String channel = getChannel(message);
-    if (!StringUtil.isNullOrEmpty(channel)) handleChannelMessage(channel, message);
+    if (!StringUtil.isNullOrEmpty(channel)) {
+      handleChannelMessage(channel, message);
+    }
   }
 
   protected void handleError(T message, Throwable t) {
     String channel = getChannel(message);
-    if (!StringUtil.isNullOrEmpty(channel)) handleChannelError(channel, t);
-    else LOG.error("handleError cannot parse channel from message: {}", message);
+    if (!StringUtil.isNullOrEmpty(channel)) {
+      handleChannelError(channel, t);
+    } else {
+      LOG.error("handleError cannot parse channel from message: {}", message);
+    }
   }
 
   protected void handleIdle(ChannelHandlerContext ctx) {


### PR DESCRIPTION
This PR adds support for OHLC Streaming for Kraken. It requires a (backward-compatible) change to NettyStreamingService in order to allow streaming of OHLC for multiple intervals for the same currrency pair.
Without this change the channelId won't be unique and interfere with each other.