### PR TITLE
compatible BinanceKline closed

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/marketdata/BinanceKline.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/marketdata/BinanceKline.java
@@ -38,11 +38,7 @@ public final class BinanceKline {
     this.numberOfTrades = Long.parseLong(obj[8].toString());
     this.takerBuyBaseAssetVolume = new BigDecimal(obj[9].toString());
     this.takerBuyQuoteAssetVolume = new BigDecimal(obj[10].toString());
-    if ("0".equals(obj[11])) {
-      this.closed = false;
-    } else {
-      this.closed = (Boolean) obj[11];
-    }
+    this.closed = Boolean.parseBoolean(obj[11].toString());
   }
 
   public BigDecimal getAveragePrice() {

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/marketdata/BinanceKline.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/marketdata/BinanceKline.java
@@ -38,7 +38,11 @@ public final class BinanceKline {
     this.numberOfTrades = Long.parseLong(obj[8].toString());
     this.takerBuyBaseAssetVolume = new BigDecimal(obj[9].toString());
     this.takerBuyQuoteAssetVolume = new BigDecimal(obj[10].toString());
-    this.closed = (Boolean) obj[11];
+    if ("0".equals(obj[11])) {
+      this.closed = false;
+    } else {
+      this.closed = (Boolean) obj[11];
+    }
   }
 
   public BigDecimal getAveragePrice() {


### PR DESCRIPTION
fix #4817 
it try to compatible `closed` field which is predicated from the official document 
<img width="469" alt="image" src="https://github.com/knowm/XChange/assets/3363787/5ca137d7-c89a-4df9-9eb4-6e8ef9086968">
