### PR TITLE
[kraken] add different network support for currency deposit addresses

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/exceptions/DepositAddressAmbiguousException.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/exceptions/DepositAddressAmbiguousException.java
@@ -1,0 +1,25 @@
+package org.knowm.xchange.exceptions;
+
+import java.util.List;
+import lombok.Getter;
+
+/** Exception indicating a requested deposit address has multiple networks and network required */
+@Getter
+public class DepositAddressAmbiguousException extends ExchangeException {
+  private final List<String> networks;
+
+  public DepositAddressAmbiguousException(List<String> networks) {
+    super("Deposit Address Not Found");
+    this.networks = networks;
+  }
+
+  public DepositAddressAmbiguousException(List<String> networks, String message) {
+    super(message);
+    this.networks = networks;
+  }
+
+  public DepositAddressAmbiguousException(List<String> networks, String message, Throwable cause) {
+    super(message, cause);
+    this.networks = networks;
+  }
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/exceptions/DepositAddressCreationException.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/exceptions/DepositAddressCreationException.java
@@ -1,0 +1,17 @@
+package org.knowm.xchange.exceptions;
+
+/** Exception indicating a deposit address could not be created */
+public class DepositAddressCreationException extends ExchangeException {
+
+  public DepositAddressCreationException() {
+    super("Deposit Address Could Not Be Created");
+  }
+
+  public DepositAddressCreationException(String message) {
+    super(message);
+  }
+
+  public DepositAddressCreationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/exceptions/DepositAddressNotFoundException.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/exceptions/DepositAddressNotFoundException.java
@@ -1,0 +1,17 @@
+package org.knowm.xchange.exceptions;
+
+/** Exception indicating a requested deposit address was not found */
+public class DepositAddressNotFoundException extends ExchangeException {
+
+  public DepositAddressNotFoundException() {
+    super("Deposit Address Not Found");
+  }
+
+  public DepositAddressNotFoundException(String message) {
+    super(message);
+  }
+
+  public DepositAddressNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/service/account/AccountService.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/account/AccountService.java
@@ -15,6 +15,7 @@ import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.service.BaseService;
+import org.knowm.xchange.service.account.params.RequestDepositAddressParams;
 import org.knowm.xchange.service.trade.params.DefaultWithdrawFundsParams;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.WithdrawFundsParams;
@@ -129,6 +130,24 @@ public interface AccountService extends BaseService {
    * Request a digital currency address to fund this account. Allows to fund the exchange account
    * with digital currency from an external address
    *
+   * @param params The deposit address request parameters
+   * @return the internal deposit address to send funds to
+   * @throws ExchangeException - Indication that the exchange reported some kind of error with the
+   *     request or response
+   * @throws NotAvailableFromExchangeException - Indication that the exchange does not support the
+   *     requested function or data
+   * @throws NotYetImplementedForExchangeException - Indication that the exchange supports the
+   *     requested function or data, but it has not yet been implemented
+   * @throws IOException - Indication that a networking error occurred while fetching JSON data
+   */
+  default String requestDepositAddress(RequestDepositAddressParams params) throws IOException {
+    return requestDepositAddress(params.getCurrency(), params.getExtraArguments());
+  }
+
+  /**
+   * Request a digital currency address to fund this account. Allows to fund the exchange account
+   * with digital currency from an external address
+   *
    * @param currency The digital currency that corresponds to the desired deposit address.
    * @return the internal deposit address to send funds to
    * @throws ExchangeException - Indication that the exchange reported some kind of error with the
@@ -142,6 +161,25 @@ public interface AccountService extends BaseService {
   default AddressWithTag requestDepositAddressData(Currency currency, String... args)
       throws IOException {
     throw new NotYetImplementedForExchangeException("requestDepositAddressData");
+  }
+
+  /**
+   * Request a digital currency address to fund this account. Allows to fund the exchange account
+   * with digital currency from an external address
+   *
+   * @param params The deposit address request parameters
+   * @return the internal deposit address to send funds to
+   * @throws ExchangeException - Indication that the exchange reported some kind of error with the
+   *     request or response
+   * @throws NotAvailableFromExchangeException - Indication that the exchange does not support the
+   *     requested function or data
+   * @throws NotYetImplementedForExchangeException - Indication that the exchange supports the
+   *     requested function or data, but it has not yet been implemented
+   * @throws IOException - Indication that a networking error occurred while fetching JSON data
+   */
+  default AddressWithTag requestDepositAddressData(RequestDepositAddressParams params)
+      throws IOException {
+    return requestDepositAddressData(params.getCurrency(), params.getExtraArguments());
   }
 
   /**

--- a/xchange-core/src/main/java/org/knowm/xchange/service/account/params/DefaultRequestDepositAddressParams.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/account/params/DefaultRequestDepositAddressParams.java
@@ -1,0 +1,27 @@
+package org.knowm.xchange.service.account.params;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+import lombok.extern.jackson.Jacksonized;
+import org.knowm.xchange.currency.Currency;
+
+@Value
+@NonFinal
+@Builder
+@Jacksonized
+public class DefaultRequestDepositAddressParams implements RequestDepositAddressParams {
+  Currency currency;
+  String network;
+
+  @Builder.Default boolean newAddress = false;
+
+  String[] extraArguments;
+
+  public static DefaultRequestDepositAddressParams create(Currency currency, String... args) {
+    return DefaultRequestDepositAddressParams.builder()
+        .currency(currency)
+        .extraArguments(args)
+        .build();
+  }
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/service/account/params/RequestDepositAddressParams.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/account/params/RequestDepositAddressParams.java
@@ -1,0 +1,13 @@
+package org.knowm.xchange.service.account.params;
+
+import org.knowm.xchange.currency.Currency;
+
+public interface RequestDepositAddressParams {
+  Currency getCurrency();
+
+  String getNetwork();
+
+  boolean isNewAddress();
+
+  String[] getExtraArguments();
+}

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java
@@ -18,6 +18,7 @@ import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.OrderStatus;
 import org.knowm.xchange.dto.Order.OrderType;
+import org.knowm.xchange.dto.account.AddressWithTag;
 import org.knowm.xchange.dto.account.Balance;
 import org.knowm.xchange.dto.account.Fee;
 import org.knowm.xchange.dto.account.FundingRecord;
@@ -332,8 +333,10 @@ public class KrakenAdapters {
     return krakenType.equals(KrakenType.BUY) ? OrderType.BID : OrderType.ASK;
   }
 
-  public static String adaptKrakenDepositAddress(KrakenDepositAddress[] krakenDepositAddress) {
-    return krakenDepositAddress[0].getAddress();
+  public static AddressWithTag adaptKrakenDepositAddress(KrakenDepositAddress[] krakenDepositAddress) {
+    return AddressWithTag.builder()
+        .address(krakenDepositAddress[0].getAddress())
+        .addressTag(krakenDepositAddress[0].getTag()).build();
   }
 
   public static String adaptOrderId(KrakenOrderResponse orderResponse) {

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java
@@ -333,10 +333,12 @@ public class KrakenAdapters {
     return krakenType.equals(KrakenType.BUY) ? OrderType.BID : OrderType.ASK;
   }
 
-  public static AddressWithTag adaptKrakenDepositAddress(KrakenDepositAddress[] krakenDepositAddress) {
+  public static AddressWithTag adaptKrakenDepositAddress(
+      KrakenDepositAddress[] krakenDepositAddress) {
     return AddressWithTag.builder()
         .address(krakenDepositAddress[0].getAddress())
-        .addressTag(krakenDepositAddress[0].getTag()).build();
+        .addressTag(krakenDepositAddress[0].getTag())
+        .build();
   }
 
   public static String adaptOrderId(KrakenOrderResponse orderResponse) {

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenAccountService.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenAccountService.java
@@ -11,9 +11,12 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.account.AccountInfo;
+import org.knowm.xchange.dto.account.AddressWithTag;
 import org.knowm.xchange.dto.account.Fee;
 import org.knowm.xchange.dto.account.FundingRecord;
 import org.knowm.xchange.dto.account.Wallet;
+import org.knowm.xchange.exceptions.DepositAddressCreationException;
+import org.knowm.xchange.exceptions.DepositAddressNotFoundException;
 import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.kraken.KrakenAdapters;
 import org.knowm.xchange.kraken.KrakenUtils;
@@ -22,6 +25,8 @@ import org.knowm.xchange.kraken.dto.account.KrakenLedger;
 import org.knowm.xchange.kraken.dto.account.KrakenTradeBalanceInfo;
 import org.knowm.xchange.kraken.dto.account.LedgerType;
 import org.knowm.xchange.service.account.AccountService;
+import org.knowm.xchange.service.account.params.DefaultRequestDepositAddressParams;
+import org.knowm.xchange.service.account.params.RequestDepositAddressParams;
 import org.knowm.xchange.service.trade.params.DefaultTradeHistoryParamsTimeSpan;
 import org.knowm.xchange.service.trade.params.DefaultWithdrawFundsParams;
 import org.knowm.xchange.service.trade.params.HistoryParamsFundingType;
@@ -90,49 +95,87 @@ public class KrakenAccountService extends KrakenAccountServiceRaw implements Acc
   }
 
   @Override
+  public AddressWithTag requestDepositAddressData(Currency currency, String... args)
+      throws IOException {
+    return requestDepositAddressData(DefaultRequestDepositAddressParams.create(currency, args));
+  }
+
+  @Override
   public String requestDepositAddress(Currency currency, String... args) throws IOException {
+    return requestDepositAddressData(DefaultRequestDepositAddressParams.create(currency, args))
+        .getAddress();
+  }
+
+  @Override
+  public String requestDepositAddress(RequestDepositAddressParams requestDepositAddressParams)
+      throws IOException {
+    return requestDepositAddressData(requestDepositAddressParams).getAddress();
+  }
+
+  @Override
+  public AddressWithTag requestDepositAddressData(
+      RequestDepositAddressParams requestDepositAddressParams) throws IOException {
+    Currency currency = requestDepositAddressParams.getCurrency();
+    boolean newAddress = requestDepositAddressParams.isNewAddress();
+    String depositMethod = null;
+
     KrakenDepositAddress[] depositAddresses;
     if (Currency.BTC.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "Bitcoin", false);
+      depositAddresses = getDepositAddresses(currency.toString(), "Bitcoin", newAddress);
     } else if (Currency.LTC.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "Litecoin", false);
+      depositAddresses = getDepositAddresses(currency.toString(), "Litecoin", newAddress);
     } else if (Currency.ETH.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "Ethereum (ERC20)", false);
+      depositAddresses = getDepositAddresses(currency.toString(), "Ethereum (ERC20)", newAddress);
     } else if (Currency.ZEC.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "Zcash (Transparent)", false);
+      depositAddresses =
+          getDepositAddresses(currency.toString(), "Zcash (Transparent)", newAddress);
     } else if (Currency.ADA.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "ADA", false);
+      depositAddresses = getDepositAddresses(currency.toString(), "ADA", newAddress);
     } else if (Currency.XMR.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "Monero", false);
+      depositAddresses = getDepositAddresses(currency.toString(), "Monero", newAddress);
     } else if (Currency.XRP.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "Ripple XRP", false);
+      depositAddresses = getDepositAddresses(currency.toString(), "Ripple XRP", newAddress);
     } else if (Currency.XLM.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "Stellar XLM", false);
+      depositAddresses = getDepositAddresses(currency.toString(), "Stellar XLM", newAddress);
     } else if (Currency.BCH.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "Bitcoin Cash", false);
+      depositAddresses = getDepositAddresses(currency.toString(), "Bitcoin Cash", newAddress);
     } else if (Currency.REP.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "REP", false);
+      depositAddresses = getDepositAddresses(currency.toString(), "REP", newAddress);
     } else if (Currency.USD.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "SynapsePay (US Wire)", false);
+      depositAddresses =
+          getDepositAddresses(currency.toString(), "SynapsePay (US Wire)", newAddress);
     } else if (Currency.XDG.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "Dogecoin", false);
+      depositAddresses = getDepositAddresses(currency.toString(), "Dogecoin", newAddress);
     } else if (Currency.MLN.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "MLN", false);
+      depositAddresses = getDepositAddresses(currency.toString(), "MLN", newAddress);
     } else if (Currency.GNO.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "GNO", false);
+      depositAddresses = getDepositAddresses(currency.toString(), "GNO", newAddress);
     } else if (Currency.QTUM.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "QTUM", false);
+      depositAddresses = getDepositAddresses(currency.toString(), "QTUM", newAddress);
     } else if (Currency.XTZ.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "XTZ", false);
+      depositAddresses = getDepositAddresses(currency.toString(), "XTZ", newAddress);
     } else if (Currency.ATOM.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "Cosmos", false);
+      depositAddresses = getDepositAddresses(currency.toString(), "Cosmos", newAddress);
     } else if (Currency.EOS.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "EOS", false);
+      depositAddresses = getDepositAddresses(currency.toString(), "EOS", newAddress);
     } else if (Currency.DASH.equals(currency)) {
-      depositAddresses = getDepositAddresses(currency.toString(), "Dash", false);
+      depositAddresses = getDepositAddresses(currency.toString(), "Dash", newAddress);
     } else {
-      throw new RuntimeException("Not implemented yet, Kraken works only for BTC and LTC");
+      depositMethod = findDepositMethod(currency, requestDepositAddressParams.getNetwork());
+      depositAddresses = getDepositAddresses(currency.toString(), depositMethod, newAddress);
     }
+
+    if (depositAddresses.length == 0 && !newAddress) {
+      throw new DepositAddressNotFoundException(
+          String.format("No deposit addresses found for %s method: %s", currency, depositMethod));
+    }
+
+    if (depositAddresses.length == 0) {
+      throw new DepositAddressCreationException(
+          String.format(
+              "Deposit address could not be created for %s method: %s", currency, depositMethod));
+    }
+
     return KrakenAdapters.adaptKrakenDepositAddress(depositAddresses);
   }
 

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenAccountServiceRaw.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenAccountServiceRaw.java
@@ -38,11 +38,14 @@ import org.knowm.xchange.kraken.dto.account.results.WithdrawResult;
 import org.knowm.xchange.kraken.dto.account.results.WithdrawStatusResult;
 import org.knowm.xchange.utils.DateUtils;
 
-/** @author jamespedwards42 */
+/**
+ * @author jamespedwards42
+ */
 @Slf4j
 public class KrakenAccountServiceRaw extends KrakenBaseService {
 
-  private ConcurrentHashMap<String, KrakenDepositMethods[]> depositMethods = new ConcurrentHashMap<>();
+  private ConcurrentHashMap<String, KrakenDepositMethods[]> depositMethods =
+      new ConcurrentHashMap<>();
 
   /**
    * Constructor
@@ -88,14 +91,16 @@ public class KrakenAccountServiceRaw extends KrakenBaseService {
       throws IOException {
     if (shouldCacheDepositMethods()) {
       try {
-        return depositMethods.computeIfAbsent(String.format("%s%s", assetPairs, assets), k -> {
-          try {
-            return getDepositMethodsFromRemote(assetPairs, assets);
-          } catch (IOException e) {
-            throw new RuntimeException(e);
-          }
-        });
-      } catch(RuntimeException e) {
+        return depositMethods.computeIfAbsent(
+            String.format("%s%s", assetPairs, assets),
+            k -> {
+              try {
+                return getDepositMethodsFromRemote(assetPairs, assets);
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            });
+      } catch (RuntimeException e) {
         if (e.getCause() instanceof IOException) {
           throw (IOException) e.getCause();
         }

--- a/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/BaseWiremockTest.java
+++ b/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/BaseWiremockTest.java
@@ -2,8 +2,11 @@ package org.knowm.xchange.kraken.service;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.collect.ImmutableMap;
+import lombok.SneakyThrows;
+import org.apache.commons.io.IOUtils;
 import org.junit.Rule;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeFactory;
@@ -17,6 +20,8 @@ public class BaseWiremockTest {
 
   @Rule public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
   public Exchange createExchange() {
     KrakenUtils.setKrakenAssets(ASSETS);
     KrakenUtils.setKrakenAssetPairs(ASSET_PAIRS);
@@ -29,6 +34,11 @@ public class BaseWiremockTest {
     specification.setShouldLoadRemoteMetaData(false);
     exchange.applySpecification(specification);
     return exchange;
+  }
+
+  @SneakyThrows
+  protected byte[] loadFile(String path) {
+    return IOUtils.toByteArray(getClass().getResourceAsStream(path));
   }
 
   public static final ImmutableMap<String, KrakenAsset> ASSETS =

--- a/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/KrakenAccountServiceTest.java
+++ b/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/KrakenAccountServiceTest.java
@@ -162,7 +162,9 @@ public class KrakenAccountServiceTest extends BaseWiremockTest {
                         loadFile(
                             "/org/knowm/xchange/kraken/dto/account/example-deposit-addresses-trx.json"))));
 
-    exchange.getExchangeSpecification().setExchangeSpecificParametersItem("cacheDepositMethods", true);
+    exchange
+        .getExchangeSpecification()
+        .setExchangeSpecificParametersItem("cacheDepositMethods", true);
 
     DefaultRequestDepositAddressParams params =
         DefaultRequestDepositAddressParams.builder().currency(Currency.TRX).build();
@@ -199,7 +201,9 @@ public class KrakenAccountServiceTest extends BaseWiremockTest {
     DefaultRequestDepositAddressParams params =
         DefaultRequestDepositAddressParams.builder().currency(Currency.TRX).build();
 
-    exchange.getExchangeSpecification().setExchangeSpecificParametersItem("cacheDepositMethods", false);
+    exchange
+        .getExchangeSpecification()
+        .setExchangeSpecificParametersItem("cacheDepositMethods", false);
 
     classUnderTest.requestDepositAddress(params);
     classUnderTest.requestDepositAddress(params);

--- a/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/KrakenAccountServiceTest.java
+++ b/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/KrakenAccountServiceTest.java
@@ -1,0 +1,135 @@
+package org.knowm.xchange.kraken.service;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Before;
+import org.junit.Test;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.dto.account.AddressWithTag;
+import org.knowm.xchange.exceptions.DepositAddressAmbiguousException;
+import org.knowm.xchange.service.account.params.DefaultRequestDepositAddressParams;
+
+@Slf4j
+public class KrakenAccountServiceTest extends BaseWiremockTest {
+
+  private KrakenAccountService classUnderTest;
+
+  @Before
+  public void setup() {
+    classUnderTest = (KrakenAccountService) createExchange().getAccountService();
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRequestDepositAddressUnknownCurrency() {
+    stubFor(
+        post(urlPathEqualTo("/0/private/DepositMethods"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        loadFile(
+                            "/org/knowm/xchange/kraken/dto/account/example-deposit-methods-trx.json"))));
+
+    stubFor(
+        post(urlPathEqualTo("/0/private/DepositAddresses"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        loadFile(
+                            "/org/knowm/xchange/kraken/dto/account/example-deposit-addresses-trx.json"))));
+
+    DefaultRequestDepositAddressParams params =
+        DefaultRequestDepositAddressParams.builder().currency(Currency.TRX).build();
+
+    String address = classUnderTest.requestDepositAddress(params);
+
+    assertThat(address).isEqualTo("TYAnp8VW1aq5Jbtxgoai7BDo3jKSRe6VNR");
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRequestDepositAddressKnownCurrency() {
+    stubFor(
+        post(urlPathEqualTo("/0/private/DepositAddresses"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        loadFile(
+                            "/org/knowm/xchange/kraken/dto/account/example-deposit-addresses.json"))));
+
+    DefaultRequestDepositAddressParams params =
+        DefaultRequestDepositAddressParams.builder().currency(Currency.BTC).build();
+
+    String address = classUnderTest.requestDepositAddress(params);
+
+    assertThat(address).isEqualTo("testBtcAddress");
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRequestDepositAddressUnknownCurrencyMultipleMethods() {
+    stubFor(
+        post(urlPathEqualTo("/0/private/DepositMethods"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        loadFile(
+                            "/org/knowm/xchange/kraken/dto/account/example-deposit-methods-usdt.json"))));
+
+    assertThatThrownBy(
+            () -> {
+              DefaultRequestDepositAddressParams params =
+                  DefaultRequestDepositAddressParams.builder().currency(Currency.USDT).build();
+
+              classUnderTest.requestDepositAddress(params);
+            })
+        .isInstanceOf(DepositAddressAmbiguousException.class);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testRequestDepositAddressUnknownCurrencyMultipleMethodsWithNetwork() {
+    stubFor(
+        post(urlPathEqualTo("/0/private/DepositMethods"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        loadFile(
+                            "/org/knowm/xchange/kraken/dto/account/example-deposit-methods-xrp.json"))));
+
+    stubFor(
+        post(urlPathEqualTo("/0/private/DepositAddresses"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        loadFile(
+                            "/org/knowm/xchange/kraken/dto/account/example-deposit-addresses-xrp.json"))));
+
+    DefaultRequestDepositAddressParams params =
+        DefaultRequestDepositAddressParams.builder().currency(Currency.XRP).build();
+
+    AddressWithTag address = classUnderTest.requestDepositAddressData(params);
+
+    assertThat(address.getAddress()).isEqualTo("testXrpAddress");
+    assertThat(address.getAddressTag()).isEqualTo("123");
+  }
+}

--- a/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/account/example-deposit-addresses-trx.json
+++ b/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/account/example-deposit-addresses-trx.json
@@ -1,0 +1,10 @@
+{
+  "error": [],
+  "result": [
+    {
+      "address": "TYAnp8VW1aq5Jbtxgoai7BDo3jKSRe6VNR",
+      "expiretm": "0",
+      "new": true
+    }
+  ]
+}

--- a/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/account/example-deposit-addresses-xrp.json
+++ b/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/account/example-deposit-addresses-xrp.json
@@ -1,0 +1,11 @@
+{
+  "error": [],
+  "result": [
+    {
+      "address": "testXrpAddress",
+      "expiretm": "0",
+      "new": true,
+      "tag": "123"
+    }
+  ]
+}

--- a/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/account/example-deposit-addresses.json
+++ b/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/account/example-deposit-addresses.json
@@ -1,0 +1,10 @@
+{
+  "error": [],
+  "result": [
+    {
+      "address": "testBtcAddress",
+      "expiretm": "0",
+      "new": true
+    }
+  ]
+}

--- a/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/account/example-deposit-methods-trx.json
+++ b/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/account/example-deposit-methods-trx.json
@@ -1,0 +1,11 @@
+{
+  "error": [],
+  "result": [
+    {
+      "method": "Tron",
+      "limit": false,
+      "gen-address": true,
+      "minimum": "2.000000"
+    }
+  ]
+}

--- a/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/account/example-deposit-methods-usdt.json
+++ b/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/account/example-deposit-methods-usdt.json
@@ -1,0 +1,42 @@
+{
+  "error": [],
+  "result": [
+    {
+      "method": "USDT - Ethereum (Unified)",
+      "limit": false,
+      "gen-address": true,
+      "minimum": "7.11000000"
+    },
+    {
+      "method": "Tether USD (TRC20)",
+      "limit": false,
+      "gen-address": true,
+      "minimum": "5.00000000"
+    },
+    {
+      "method": "Tether USD (SPL)",
+      "limit": false,
+      "fee": "0.00000000",
+      "gen-address": true,
+      "minimum": "0.40000000"
+    },
+    {
+      "method": "USDT - Polygon (Unified)",
+      "limit": false,
+      "gen-address": true,
+      "minimum": "2.00000000"
+    },
+    {
+      "method": "USDT - Arbitrum One (Unified)",
+      "limit": false,
+      "gen-address": true,
+      "minimum": "2.50000000"
+    },
+    {
+      "method": "USDT - Optimism (Unified)",
+      "limit": false,
+      "gen-address": true,
+      "minimum": "2.50000000"
+    }
+  ]
+}

--- a/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/account/example-deposit-methods-xrp.json
+++ b/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/account/example-deposit-methods-xrp.json
@@ -1,0 +1,11 @@
+{
+  "error": [],
+  "result": [
+    {
+      "method": "Ripple XRP",
+      "limit": false,
+      "gen-address": true,
+      "minimum": "1"
+    }
+  ]
+}


### PR DESCRIPTION
The current implementation doesn't allow for getting addresses with tags (eg XRP) and also if you have currencies with multiple methods (eg USDT, USDC) it is not supported.

This PR introduces a new change to the AccountService interface to allow for more structured complex deposit address requests with a default to the current methods.

It implements this new method on Kraken also inferring the appropriate method where possible with some clear exceptions if it isn't able to do so, so the user can refine their request if desired.