### PR TITLE
Enable Compilation on JDK21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <version.java>1.8</version.java>
+    <version.java>8</version.java>
     <version.assertj>3.25.3</version.assertj>
     <version.commons.lang3>3.14.0</version.commons.lang3>
     <version.fasterxml>2.14.3</version.fasterxml>
@@ -501,10 +501,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
+        <version>3.13.0</version>
         <configuration>
-          <source>${version.java}</source>
-          <target>${version.java}</target>
+          <release>${version.java}</release>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
         </configuration>


### PR DESCRIPTION
The currently used lombok version is not compatible with JDK 21.
In addition, Its advised to switch from source/target to release (see https://openjdk.org/jeps/247 for details), introduced in Java 9.
The maven compiler plugin with translate this automatically to the old source/target/bootclasspath options for Java 8 compilers.