### PR TITLE
[general] Define slf4j-api version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,6 +353,12 @@
         <version>${version.qos.logback}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${version.slf4j}</version>
+      </dependency>
+
       <!-- jwt for auth -->
       <dependency>
         <groupId>com.auth0</groupId>


### PR DESCRIPTION
Defined the used version of `log4j-api` so that it is not overwritten via transitive dependencies