### PR TITLE
[Bitstamp] Implement client code for withdrawal-fees endpoint

### DIFF
--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAuthenticatedV2.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAuthenticatedV2.java
@@ -17,6 +17,7 @@ import org.knowm.xchange.bitstamp.dto.account.BitstampDepositAddress;
 import org.knowm.xchange.bitstamp.dto.account.BitstampRippleDepositAddress;
 import org.knowm.xchange.bitstamp.dto.account.BitstampWithdrawal;
 import org.knowm.xchange.bitstamp.dto.account.DepositTransaction;
+import org.knowm.xchange.bitstamp.dto.account.WithdrawalFee;
 import org.knowm.xchange.bitstamp.dto.account.WithdrawalRequest;
 import org.knowm.xchange.bitstamp.dto.trade.BitstampCancelAllOrdersResponse;
 import org.knowm.xchange.bitstamp.dto.trade.BitstampOrder;
@@ -653,6 +654,16 @@ public interface BitstampAuthenticatedV2 {
       @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
       @HeaderParam("X-Auth-Version") String version,
       @FormParam("timedelta") Long timeDelta)
+      throws BitstampException, IOException;
+
+  @POST
+  @Path("fees/withdrawal/")
+  WithdrawalFee[] getWithdrawalFees(
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version)
       throws BitstampException, IOException;
 
   @POST

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAuthenticatedV2.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAuthenticatedV2.java
@@ -10,6 +10,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.List;
 import org.knowm.xchange.bitstamp.dto.BitstampException;
 import org.knowm.xchange.bitstamp.dto.BitstampTransferBalanceResponse;
 import org.knowm.xchange.bitstamp.dto.account.BitstampBalance;
@@ -647,7 +648,7 @@ public interface BitstampAuthenticatedV2 {
   @POST
   @Path("withdrawal-requests/")
   @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-  WithdrawalRequest[] getWithdrawalRequests(
+  List<WithdrawalRequest> getWithdrawalRequests(
       @HeaderParam("X-Auth") String apiKey,
       @HeaderParam("X-Auth-Signature") ParamsDigest signer,
       @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
@@ -658,7 +659,7 @@ public interface BitstampAuthenticatedV2 {
 
   @POST
   @Path("fees/withdrawal/")
-  WithdrawalFee[] getWithdrawalFees(
+  List<WithdrawalFee> getWithdrawalFees(
       @HeaderParam("X-Auth") String apiKey,
       @HeaderParam("X-Auth-Signature") ParamsDigest signer,
       @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/WithdrawalFee.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/WithdrawalFee.java
@@ -1,12 +1,12 @@
 package org.knowm.xchange.bitstamp.dto.account;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
 import lombok.Builder;
 import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
 import org.knowm.xchange.currency.Currency;
 
+@Jacksonized
 @Value
 @Builder
 public class WithdrawalFee {
@@ -16,14 +16,4 @@ public class WithdrawalFee {
   BigDecimal fee;
 
   Currency currency;
-
-  @JsonCreator
-  public WithdrawalFee(
-      @JsonProperty("network") String network,
-      @JsonProperty("fee") BigDecimal fee,
-      @JsonProperty("currency") Currency currency) {
-    this.network = network;
-    this.fee = fee;
-    this.currency = currency;
-  }
 }

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/WithdrawalFee.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/WithdrawalFee.java
@@ -1,0 +1,25 @@
+package org.knowm.xchange.bitstamp.dto.account;
+
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import org.knowm.xchange.currency.Currency;
+
+@Getter
+@ToString
+@Builder
+@AllArgsConstructor
+public class WithdrawalFee {
+
+  private String network;
+
+  private BigDecimal fee;
+
+  private Currency currency;
+
+  public WithdrawalFee() {
+    super();
+  }
+}

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/WithdrawalFee.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/WithdrawalFee.java
@@ -1,5 +1,7 @@
 package org.knowm.xchange.bitstamp.dto.account;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
 import lombok.Builder;
 import lombok.Value;
@@ -14,4 +16,14 @@ public class WithdrawalFee {
   BigDecimal fee;
 
   Currency currency;
+
+  @JsonCreator
+  public WithdrawalFee(
+      @JsonProperty("network") String network,
+      @JsonProperty("fee") BigDecimal fee,
+      @JsonProperty("currency") Currency currency) {
+    this.network = network;
+    this.fee = fee;
+    this.currency = currency;
+  }
 }

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/WithdrawalFee.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/WithdrawalFee.java
@@ -1,16 +1,12 @@
 package org.knowm.xchange.bitstamp.dto.account;
 
 import java.math.BigDecimal;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.Value;
 import org.knowm.xchange.currency.Currency;
 
-@Getter
-@ToString
+@Value
 @Builder
-@AllArgsConstructor
 public class WithdrawalFee {
 
   private String network;
@@ -18,8 +14,4 @@ public class WithdrawalFee {
   private BigDecimal fee;
 
   private Currency currency;
-
-  public WithdrawalFee() {
-    super();
-  }
 }

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/WithdrawalFee.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/WithdrawalFee.java
@@ -9,9 +9,9 @@ import org.knowm.xchange.currency.Currency;
 @Builder
 public class WithdrawalFee {
 
-  private String network;
+  String network;
 
-  private BigDecimal fee;
+  BigDecimal fee;
 
-  private Currency currency;
+  Currency currency;
 }

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountServiceRaw.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountServiceRaw.java
@@ -350,16 +350,13 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
   public List<WithdrawalRequest> getWithdrawalRequests(Long timeDelta) throws IOException {
 
     try {
-      final List<WithdrawalRequest> response =
-          Arrays.asList(
-              bitstampAuthenticatedV2.getWithdrawalRequests(
+      return bitstampAuthenticatedV2.getWithdrawalRequests(
                   apiKeyForV2Requests,
                   signatureCreatorV2,
                   uuidNonceFactory,
                   timestampFactory,
                   API_VERSION,
-                  timeDelta));
-      return response;
+                  timeDelta);
     } catch (BitstampException e) {
       throw handleError(e);
     }
@@ -368,13 +365,12 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
   public List<WithdrawalFee> getWithdrawalFees() throws IOException {
 
     try {
-      return Arrays.asList(
-              bitstampAuthenticatedV2.getWithdrawalFees(
+      return bitstampAuthenticatedV2.getWithdrawalFees(
                   apiKeyForV2Requests,
                   signatureCreatorV2,
                   uuidNonceFactory,
                   timestampFactory,
-                  API_VERSION));
+                  API_VERSION);
     } catch (BitstampException e) {
       throw handleError(e);
     }

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountServiceRaw.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountServiceRaw.java
@@ -19,6 +19,7 @@ import org.knowm.xchange.bitstamp.dto.account.BitstampDepositAddress;
 import org.knowm.xchange.bitstamp.dto.account.BitstampRippleDepositAddress;
 import org.knowm.xchange.bitstamp.dto.account.BitstampWithdrawal;
 import org.knowm.xchange.bitstamp.dto.account.DepositTransaction;
+import org.knowm.xchange.bitstamp.dto.account.WithdrawalFee;
 import org.knowm.xchange.bitstamp.dto.account.WithdrawalRequest;
 import org.knowm.xchange.bitstamp.dto.trade.BitstampUserTransaction;
 import org.knowm.xchange.client.ExchangeRestProxyBuilder;
@@ -359,6 +360,21 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
                   API_VERSION,
                   timeDelta));
       return response;
+    } catch (BitstampException e) {
+      throw handleError(e);
+    }
+  }
+
+  public List<WithdrawalFee> getWithdrawalFees() throws IOException {
+
+    try {
+      return Arrays.asList(
+              bitstampAuthenticatedV2.getWithdrawalFees(
+                  apiKeyForV2Requests,
+                  signatureCreatorV2,
+                  uuidNonceFactory,
+                  timestampFactory,
+                  API_VERSION));
     } catch (BitstampException e) {
       throw handleError(e);
     }

--- a/xchange-bitstamp/src/test/java/org/knowm/xchange/bitstamp/dto/account/WithdrawalFeesJSONTest.java
+++ b/xchange-bitstamp/src/test/java/org/knowm/xchange/bitstamp/dto/account/WithdrawalFeesJSONTest.java
@@ -1,0 +1,35 @@
+package org.knowm.xchange.bitstamp.dto.account;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.Test;
+
+public class WithdrawalFeesJSONTest {
+
+  @Test
+  public void testUnmarshal() throws IOException {
+
+    // Read in the JSON from the example resources
+    InputStream is =
+        WithdrawalFeesJSONTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitstamp/dto/account/withdrawal-fees.json");
+
+    // Use Jackson to parse it
+    ObjectMapper mapper = new ObjectMapper();
+
+    List<WithdrawalFee> withdrawalFees =
+        mapper.readValue(
+            is,
+            mapper.getTypeFactory().constructCollectionType(List.class, WithdrawalFee.class));
+
+    assertThat(withdrawalFees.size()).isEqualTo(1);
+    assertThat(withdrawalFees.get(0).getNetwork()).isEqualTo("bitcoin");
+    assertThat(withdrawalFees.get(0).getCurrency().getCurrencyCode()).isEqualToIgnoringCase("btc");
+    assertThat(withdrawalFees.get(0).getFee()).isEqualTo(new BigDecimal("0.00015000"));
+  }
+}

--- a/xchange-bitstamp/src/test/resources/org/knowm/xchange/bitstamp/dto/account/withdrawal-fees.json
+++ b/xchange-bitstamp/src/test/resources/org/knowm/xchange/bitstamp/dto/account/withdrawal-fees.json
@@ -1,0 +1,7 @@
+[
+  {
+    "currency": "btc",
+    "fee": "0.00015000",
+    "network": "bitcoin"
+  }
+]

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitstamp/account/BitstampAccountDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitstamp/account/BitstampAccountDemo.java
@@ -8,6 +8,7 @@ import org.knowm.xchange.bitstamp.dto.account.BitstampBalance;
 import org.knowm.xchange.bitstamp.dto.account.BitstampDepositAddress;
 import org.knowm.xchange.bitstamp.dto.account.BitstampWithdrawal;
 import org.knowm.xchange.bitstamp.dto.account.DepositTransaction;
+import org.knowm.xchange.bitstamp.dto.account.WithdrawalFee;
 import org.knowm.xchange.bitstamp.dto.account.WithdrawalRequest;
 import org.knowm.xchange.bitstamp.service.BitstampAccountServiceRaw;
 import org.knowm.xchange.currency.Currency;
@@ -65,6 +66,12 @@ public class BitstampAccountDemo {
     System.out.println("Unconfirmed deposits:");
     for (DepositTransaction unconfirmedDeposit : unconfirmedDeposits) {
       System.out.println(unconfirmedDeposit);
+    }
+
+    final List<WithdrawalFee> withdrawalFees = accountService.getWithdrawalFees();
+    System.out.println("Withdrawal requests:");
+    for (WithdrawalFee withdrawalFee : withdrawalFees) {
+      System.out.println(withdrawalFee);
     }
 
     final List<WithdrawalRequest> withdrawalRequests =


### PR DESCRIPTION
The Bitstamp V2 API has [an endpoint for requesting all withdrawal fees](https://www.bitstamp.net/api/#tag/Fees/operation/GetAllWithdrawalFees):

`https://www.bitstamp.net/api/v2/fees/withdrawal/`

This code implements the client code necessary to call that endpoint with the XChange lib: a `WithdrawalFee` object, the web service skeleton in `BitstampAuthenticatedV2`, and the implementation in the `BitstampAccountServiceRaw` class.