### PR TITLE
[gateio-v4] Extend error mapping

### DIFF
--- a/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/GateioErrorAdapter.java
+++ b/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/GateioErrorAdapter.java
@@ -1,7 +1,14 @@
 package org.knowm.xchange.gateio;
 
 import lombok.experimental.UtilityClass;
-import org.knowm.xchange.exceptions.*;
+import org.knowm.xchange.exceptions.ExchangeException;
+import org.knowm.xchange.exceptions.ExchangeSecurityException;
+import org.knowm.xchange.exceptions.FundsExceededException;
+import org.knowm.xchange.exceptions.InstrumentNotValidException;
+import org.knowm.xchange.exceptions.InternalServerException;
+import org.knowm.xchange.exceptions.OrderAmountUnderMinimumException;
+import org.knowm.xchange.exceptions.OrderNotValidException;
+import org.knowm.xchange.exceptions.RateLimitExceededException;
 import org.knowm.xchange.gateio.dto.GateioException;
 
 @UtilityClass
@@ -42,7 +49,7 @@ public class GateioErrorAdapter {
         return new InternalServerException(e.getMessage(), e);
 
       case INVALID_PARAM_VALUE:
-        if (e.getMessage().contains("below minimum")) {
+        if (e.getMessage().contains("below minimum") || e.getMessage().contains("too small")) {
           return new OrderAmountUnderMinimumException(e.getMessage(), e);
         }
         else {


### PR DESCRIPTION
Added mapping of error when order size is too small, for example:

```
{
  "label": "INVALID_PARAM_VALUE",
  "message": "Your order size 0.600000 USDT is too small. The minimum is 3 USDT"
}
```