### PR TITLE
[general] Add getting of exchange health

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/meta/BinanceSystemStatus.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/meta/BinanceSystemStatus.java
@@ -1,19 +1,21 @@
 package org.knowm.xchange.binance.dto.meta;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
 
+@Value
+@Builder
+@Jacksonized
 public class BinanceSystemStatus {
 
   // 0: normal，1：system maintenance
-  @JsonProperty private String status;
+  @JsonProperty
+  String status;
+
   // normal or system maintenance
-  @JsonProperty private String msg;
+  @JsonProperty
+  String msg;
 
-  public String getStatus() {
-    return status;
-  }
-
-  public String getMsg() {
-    return msg;
-  }
 }

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceMarketDataService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceMarketDataService.java
@@ -21,6 +21,7 @@ import org.knowm.xchange.dto.marketdata.FundingRates;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trades;
+import org.knowm.xchange.dto.meta.ExchangeHealth;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.instrument.Instrument;
@@ -34,6 +35,20 @@ public class BinanceMarketDataService extends BinanceMarketDataServiceRaw
       BinanceExchange exchange, ResilienceRegistries resilienceRegistries) {
     super(exchange, resilienceRegistries);
   }
+
+
+  @Override
+  public ExchangeHealth getExchangeHealth() {
+    try {
+      if (getSystemStatus().getStatus().equals("0")) {
+        return ExchangeHealth.ONLINE;
+      }
+    } catch (IOException e) {
+      return ExchangeHealth.OFFLINE;
+    }
+    return ExchangeHealth.OFFLINE;
+  }
+
 
   /**
    * optional parameters provided in the args array:

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceUsAccountService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceUsAccountService.java
@@ -88,6 +88,6 @@ public class BinanceUsAccountService extends BinanceAccountService {
   @Override
   public BinanceSystemStatus getSystemStatus() {
     LOG.warn("getSystemStatus: {}", NOT_SUPPORTED);
-    return new BinanceSystemStatus();
+    return BinanceSystemStatus.builder().build();
   }
 }

--- a/xchange-binance/src/test/java/org/knowm/xchange/binance/service/marketdata/MarketDataServiceIntegration.java
+++ b/xchange-binance/src/test/java/org/knowm/xchange/binance/service/marketdata/MarketDataServiceIntegration.java
@@ -9,9 +9,16 @@ import org.knowm.xchange.binance.BinanceExchangeIntegration;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
+import org.knowm.xchange.dto.meta.ExchangeHealth;
 import org.knowm.xchange.instrument.Instrument;
 
 public class MarketDataServiceIntegration extends BinanceExchangeIntegration {
+
+  @Test
+  public void exchange_health() {
+    assertThat(exchange.getMarketDataService().getExchangeHealth()).isEqualTo(ExchangeHealth.ONLINE);
+  }
+
 
   @Test
   public void valid_timestamp() {

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/meta/ExchangeHealth.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/meta/ExchangeHealth.java
@@ -1,0 +1,11 @@
+package org.knowm.xchange.dto.meta;
+
+public enum ExchangeHealth {
+  ONLINE,
+  OFFLINE,
+
+  /**
+   * Can only cancel the order but not place order
+   */
+  CANCEL_ONLY;
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/service/marketdata/MarketDataService.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/marketdata/MarketDataService.java
@@ -4,7 +4,13 @@ import java.io.IOException;
 import java.util.List;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
-import org.knowm.xchange.dto.marketdata.*;
+import org.knowm.xchange.dto.marketdata.CandleStickData;
+import org.knowm.xchange.dto.marketdata.FundingRate;
+import org.knowm.xchange.dto.marketdata.FundingRates;
+import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.marketdata.Ticker;
+import org.knowm.xchange.dto.marketdata.Trades;
+import org.knowm.xchange.dto.meta.ExchangeHealth;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
@@ -24,6 +30,15 @@ import org.knowm.xchange.service.trade.params.CandleStickDataParams;
  * some kind
  */
 public interface MarketDataService extends BaseService {
+
+  /**
+   * Get exchange health
+   *
+   * @return The exchange health
+   */
+  default ExchangeHealth getExchangeHealth() {
+    return ExchangeHealth.ONLINE;
+  }
 
   /**
    * Get a ticker representing the current exchange rate

--- a/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/Gateio.java
+++ b/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/Gateio.java
@@ -6,15 +6,24 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
-import org.knowm.xchange.gateio.dto.GateioException;
-import org.knowm.xchange.gateio.dto.marketdata.*;
-
 import java.io.IOException;
 import java.util.List;
+import org.knowm.xchange.gateio.dto.GateioException;
+import org.knowm.xchange.gateio.dto.marketdata.GateioCurrencyChain;
+import org.knowm.xchange.gateio.dto.marketdata.GateioCurrencyInfo;
+import org.knowm.xchange.gateio.dto.marketdata.GateioCurrencyPairDetails;
+import org.knowm.xchange.gateio.dto.marketdata.GateioOrderBook;
+import org.knowm.xchange.gateio.dto.marketdata.GateioServerTime;
+import org.knowm.xchange.gateio.dto.marketdata.GateioTicker;
 
 @Path("api/v4")
 @Produces(MediaType.APPLICATION_JSON)
 public interface Gateio {
+
+  @GET
+  @Path("spot/time")
+  GateioServerTime getServerTime() throws IOException, GateioException;
+
 
   @GET
   @Path("spot/currencies")

--- a/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/config/Config.java
+++ b/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/config/Config.java
@@ -1,15 +1,22 @@
 package org.knowm.xchange.gateio.config;
 
+import java.time.Clock;
 import lombok.Data;
 import si.mazi.rescu.IRestProxyFactory;
 import si.mazi.rescu.RestProxyFactoryImpl;
 
 @Data
-public class Config {
+public final class Config {
 
   private Class<? extends IRestProxyFactory> restProxyFactoryClass = RestProxyFactoryImpl.class;
 
+  private Clock clock;
+
   private static Config instance = new Config();
+
+  private Config() {
+    clock = Clock.systemDefaultZone();
+  }
 
   public static Config getInstance() {
     return instance;

--- a/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/dto/marketdata/GateioServerTime.java
+++ b/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/dto/marketdata/GateioServerTime.java
@@ -1,0 +1,17 @@
+package org.knowm.xchange.gateio.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.jackson.Jacksonized;
+
+@Data
+@Builder
+@Jacksonized
+public class GateioServerTime {
+
+  @JsonProperty("server_time")
+  Instant time;
+
+}

--- a/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/service/GateioMarketDataService.java
+++ b/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/service/GateioMarketDataService.java
@@ -1,6 +1,8 @@
 package org.knowm.xchange.gateio.service;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -11,10 +13,12 @@ import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
+import org.knowm.xchange.dto.meta.ExchangeHealth;
 import org.knowm.xchange.dto.meta.InstrumentMetaData;
 import org.knowm.xchange.gateio.GateioAdapters;
 import org.knowm.xchange.gateio.GateioErrorAdapter;
 import org.knowm.xchange.gateio.GateioExchange;
+import org.knowm.xchange.gateio.config.Config;
 import org.knowm.xchange.gateio.dto.GateioException;
 import org.knowm.xchange.gateio.dto.marketdata.GateioCurrencyInfo;
 import org.knowm.xchange.gateio.dto.marketdata.GateioCurrencyPairDetails;
@@ -31,10 +35,26 @@ public class GateioMarketDataService extends GateioMarketDataServiceRaw implemen
   }
 
   @Override
+  public ExchangeHealth getExchangeHealth() {
+    try {
+      Instant serverTime = getGateioServerTime().getTime();
+      Instant localTime = Instant.now(Config.getInstance().getClock());
+
+      // timestamps shouldn't diverge by more than 10 minutes
+      if (Duration.between(serverTime, localTime).toMinutes() < 10) {
+        return ExchangeHealth.ONLINE;
+      }
+    } catch (GateioException | IOException e) {
+      return ExchangeHealth.OFFLINE;
+    }
+
+    return ExchangeHealth.OFFLINE;
+  }
+
+  @Override
   public Ticker getTicker(CurrencyPair currencyPair, Object... args) throws IOException {
     return getTicker((Instrument) currencyPair, args);
   }
-
 
   @Override
   public Ticker getTicker(Instrument instrument, Object... args) throws IOException {

--- a/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/service/GateioMarketDataServiceRaw.java
+++ b/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/service/GateioMarketDataServiceRaw.java
@@ -9,6 +9,7 @@ import org.knowm.xchange.gateio.dto.marketdata.GateioCurrencyChain;
 import org.knowm.xchange.gateio.dto.marketdata.GateioCurrencyInfo;
 import org.knowm.xchange.gateio.dto.marketdata.GateioCurrencyPairDetails;
 import org.knowm.xchange.gateio.dto.marketdata.GateioOrderBook;
+import org.knowm.xchange.gateio.dto.marketdata.GateioServerTime;
 import org.knowm.xchange.gateio.dto.marketdata.GateioTicker;
 import org.knowm.xchange.instrument.Instrument;
 
@@ -16,6 +17,11 @@ public class GateioMarketDataServiceRaw extends GateioBaseService {
 
   public GateioMarketDataServiceRaw(GateioExchange exchange) {
     super(exchange);
+  }
+
+
+  public GateioServerTime getGateioServerTime() throws IOException {
+    return gateio.getServerTime();
   }
 
 

--- a/xchange-gateio-v4/src/test/java/org/knowm/xchange/gateio/service/GateioMarketDataServiceIntegration.java
+++ b/xchange-gateio-v4/src/test/java/org/knowm/xchange/gateio/service/GateioMarketDataServiceIntegration.java
@@ -1,0 +1,20 @@
+package org.knowm.xchange.gateio.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.dto.meta.ExchangeHealth;
+import org.knowm.xchange.gateio.GateioExchange;
+
+class GateioMarketDataServiceIntegration {
+
+  GateioExchange exchange = ExchangeFactory.INSTANCE.createExchange(GateioExchange.class);
+
+  @Test
+  void exchange_health() {
+    ExchangeHealth actual = exchange.getMarketDataService().getExchangeHealth();
+    assertThat(actual).isEqualTo(ExchangeHealth.ONLINE);
+  }
+
+}


### PR DESCRIPTION
I think we need some exchange-health related functionality moved in core. Some exchanges provide a dedicated endpoint (e.g. binance), some not (e.g. gateio).

- Added exchange health to the core services
- Added sample implementation for binance (using `system/status` endpoint)
- Added sample implementation for gateio-v4 (using `spot/time` endpoint)