### PR TITLE
Fix flaky De/Serialization and Tests

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/account/LedgerEntry.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/account/LedgerEntry.java
@@ -1,12 +1,24 @@
 package org.knowm.xchange.bitfinex.v2.dto.account;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import java.util.Date;
 import lombok.Data;
 
 /** https://docs.bitfinex.com/reference#rest-auth-ledgers */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({
+  "id",
+  "currency",
+  "placeHolder0",
+  "timestamp",
+  "placeHolder1",
+  "amount",
+  "balance",
+  "placeHolder2",
+  "description"
+})
 @Data
 public class LedgerEntry {
 

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/account/Movement.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/account/Movement.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import java.util.Date;
 import lombok.Value;
@@ -11,6 +12,30 @@ import lombok.Value;
 /** https://docs.bitfinex.com/reference#rest-auth-movements */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+  "ID",
+  "CURRENCY",
+  "CURRENCY_NAME",
+  "nullField1",
+  "nullField2",
+  "MTS_STARTED",
+  "MTS_UPDATED",
+  "nullField3",
+  "nullField4",
+  "STATUS",
+  "nullField5",
+  "nullField6",
+  "AMOUNT",
+  "FEES",
+  "nullField7",
+  "nullField8",
+  "DESTINATION_ADDRESS",
+  "nullField9",
+  "nullField10",
+  "nullField11",
+  "TRANSACTION_ID",
+  "nullField12"
+})
 @Value
 public class Movement {
   /* Movement identifier */

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/account/TransferBetweenWalletsResponse.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/account/TransferBetweenWalletsResponse.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bitfinex.v2.dto.account;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import java.util.Date;
 import lombok.AccessLevel;
@@ -9,6 +10,16 @@ import lombok.Value;
 
 /** see https://docs.bitfinex.com/reference#rest-auth-transfer */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({
+  "timestamp",
+  "type",
+  "messageId",
+  "placeHolder0",
+  "transfer",
+  "code",
+  "status",
+  "text"
+})
 @Value
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 public class TransferBetweenWalletsResponse {
@@ -38,6 +49,16 @@ public class TransferBetweenWalletsResponse {
   }
 
   @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+  @JsonPropertyOrder({
+    "timestamp",
+    "walletFrom",
+    "walletTo",
+    "placeHolder0",
+    "currency",
+    "currencyTo",
+    "placeHolder1",
+    "amount"
+  })
   @Value
   @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
   public static class Transfer {

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/account/Wallet.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/account/Wallet.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bitfinex.v2.dto.account;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,15 @@ import lombok.Value;
 
 /** https://docs.bitfinex.com/reference#rest-auth-wallets */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({
+  "walletType",
+  "currency",
+  "balance",
+  "unsettledInterest",
+  "availableBalance",
+  "lastChange",
+  "tradeDetails"
+})
 @Value
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 public class Wallet {

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexCandle.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexCandle.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bitfinex.v2.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -12,6 +13,7 @@ import lombok.extern.jackson.Jacksonized;
  * @author cyrus13 *
  */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({"timestamp", "open", "close", "high", "low", "volume"})
 @Jacksonized
 @Data
 @Builder

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexFundingOrder.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexFundingOrder.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bitfinex.v2.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ import lombok.Value;
  * @see https://docs.bitfinex.com/reference#rest-public-book
  */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({"rate", "period", "count", "amount"})
 @Value
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 public class BitfinexFundingOrder {

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexFundingRawOrder.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexFundingRawOrder.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bitfinex.v2.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -11,6 +12,7 @@ import lombok.Value;
  *     of R0)
  */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({"id", "period", "rate", "amount"})
 @Value
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 public class BitfinexFundingRawOrder {

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexPublicFundingTrade.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexPublicFundingTrade.java
@@ -1,11 +1,13 @@
 package org.knowm.xchange.bitfinex.v2.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import lombok.Getter;
 import lombok.ToString;
 
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({"tradeId", "timestamp", "amount", "rate", "period"})
 @Getter
 @ToString
 public class BitfinexPublicFundingTrade {

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexPublicTrade.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexPublicTrade.java
@@ -1,10 +1,12 @@
 package org.knowm.xchange.bitfinex.v2.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import org.knowm.xchange.dto.Order.OrderType;
 
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({"tradeId", "timestamp", "amount", "price"})
 public class BitfinexPublicTrade {
 
   private long tradeId;

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexStats.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexStats.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bitfinex.v2.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import java.util.Date;
 import lombok.AccessLevel;
@@ -11,6 +12,7 @@ import lombok.Value;
  * @see https://docs.bitfinex.com/reference#rest-public-stats1
  */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({"millisecondTimestamp", "value"})
 @Value
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 public class BitfinexStats {

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexTickerFundingCurrency.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexTickerFundingCurrency.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bitfinex.v2.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,6 +13,25 @@ import lombok.ToString;
 @NoArgsConstructor
 @Getter
 @ToString
+@JsonPropertyOrder({
+    "symbol",
+    "frr",
+    "bid",
+    "bidPeriod",
+    "bidSize",
+    "ask",
+    "askPeriod",
+    "askSize",
+    "dailyChange",
+    "dailyChangePerc",
+    "lastPrice",
+    "volume",
+    "high",
+    "low",
+    "placeHolder0",
+    "placeHolder1",
+    "frrAmountAvailable"
+})
 public class BitfinexTickerFundingCurrency implements BitfinexTicker {
 
   private String symbol;

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexTickerTraidingPair.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexTickerTraidingPair.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bitfinex.v2.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,6 +13,19 @@ import lombok.ToString;
 @NoArgsConstructor
 @Getter
 @ToString
+@JsonPropertyOrder({
+    "symbol",
+    "bid",
+    "bidSize",
+    "ask",
+    "askSize",
+    "dailyChange",
+    "dailyChangePerc",
+    "lastPrice",
+    "volume",
+    "high",
+    "low"
+})
 public class BitfinexTickerTraidingPair implements BitfinexTicker {
 
   private String symbol;

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexTradingOrder.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexTradingOrder.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bitfinex.v2.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ import lombok.Value;
  * @see https://docs.bitfinex.com/reference#rest-public-book
  */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({"price", "count", "amount"})
 @Value
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 public class BitfinexTradingOrder {

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexTradingRawOrder.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/BitfinexTradingRawOrder.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bitfinex.v2.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -11,6 +12,7 @@ import lombok.Value;
  *     of R0)
  */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({"orderId", "price", "amount"})
 @Value
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 public class BitfinexTradingRawOrder {

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/Status.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/marketdata/Status.java
@@ -2,6 +2,7 @@ package org.knowm.xchange.bitfinex.v2.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import lombok.Getter;
 import lombok.Setter;
@@ -9,6 +10,32 @@ import lombok.ToString;
 
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({
+  "symbol",
+  "timestamp",
+  "placeHolder0",
+  "derivPrice",
+  "spotPrice",
+  "placeHolder1",
+  "insuranceFundBalance",
+  "placeHolder2",
+  "nextFundingEvtTimestampMillis",
+  "nextFundingAccrued",
+  "nextFundingStep",
+  "placeHolder4",
+  "currentFunding",
+  "placeHolder5",
+  "placeHolder6",
+  "markPrice",
+  "placeHolder7",
+  "placeHolder8",
+  "openInterest",
+  "placeHolder9",
+  "placeHolder10",
+  "placeHolder11",
+  "clampMin",
+  "clampMax"
+})
 @Setter
 @Getter
 @ToString

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/trade/ActiveOrder.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/trade/ActiveOrder.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bitfinex.v2.dto.trade;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import java.util.Date;
 import lombok.Getter;
@@ -9,6 +10,33 @@ import lombok.ToString;
 
 /** https://docs.bitfinex.com/v2/reference#rest-auth-trades-hist */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({
+  "id",
+  "gid",
+  "cid",
+  "symbol",
+  "timestampCreate",
+  "timestampUpdate",
+  "amount",
+  "amountOrig",
+  "type",
+  "typePrev",
+  "placeHolder0",
+  "placeHolder1",
+  "flags",
+  "orderStatus",
+  "placeHolder2",
+  "placeHolder3",
+  "price",
+  "priceAvg",
+  "priceTrailing",
+  "priceAuxLimit",
+  "placeHolder4",
+  "placeHolder5",
+  "placeHolder6",
+  "hidden",
+  "placedId"
+})
 @Setter
 @Getter
 @ToString

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/trade/OrderTrade.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/trade/OrderTrade.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bitfinex.v2.dto.trade;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import java.util.Date;
 import lombok.Getter;
@@ -9,6 +10,19 @@ import lombok.ToString;
 
 /** https://docs.bitfinex.com/reference#rest-auth-order-trades */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({
+  "id",
+  "symbol",
+  "timestamp",
+  "orderId",
+  "execAmount",
+  "execPrice",
+  "placeHolder1",
+  "placeHolder2",
+  "maker",
+  "fee",
+  "feeCurrency"
+})
 @Setter
 @Getter
 @ToString

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/trade/Position.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/trade/Position.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bitfinex.v2.dto.trade;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import lombok.Getter;
 import lombok.Setter;
@@ -8,6 +9,28 @@ import lombok.ToString;
 
 /** https://docs.bitfinex.com/v2/reference#rest-auth-positions */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({
+  "symbol",
+  "status",
+  "amount",
+  "basePrice",
+  "marginFunding",
+  "marginFundingType",
+  "pl",
+  "plPercent",
+  "priceLiq",
+  "leverage",
+  "placeHolder0",
+  "positionId",
+  "timestampCreate",
+  "timestampUpdate",
+  "placeHolder1",
+  "type",
+  "placeHolder2",
+  "collateral",
+  "collateralMin",
+  "meta"
+})
 @Setter
 @Getter
 @ToString

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/trade/Trade.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v2/dto/trade/Trade.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bitfinex.v2.dto.trade;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import java.util.Date;
 import lombok.Getter;
@@ -9,6 +10,19 @@ import lombok.ToString;
 
 /** https://docs.bitfinex.com/v2/reference#rest-auth-trades-hist */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({
+  "id",
+  "symbol",
+  "timestamp",
+  "orderId",
+  "execAmount",
+  "execPrice",
+  "orderType",
+  "orderPrice",
+  "maker",
+  "fee",
+  "feeCurrency"
+})
 @Setter
 @Getter
 @ToString

--- a/xchange-bitget/src/main/java/org/knowm/xchange/bitget/dto/marketdata/BitgetMarketDepthDto.java
+++ b/xchange-bitget/src/main/java/org/knowm/xchange/bitget/dto/marketdata/BitgetMarketDepthDto.java
@@ -2,6 +2,7 @@ package org.knowm.xchange.bitget.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
@@ -27,6 +28,7 @@ public class BitgetMarketDepthDto {
   @Builder
   @Jacksonized
   @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+  @JsonPropertyOrder({"price", "size"})
   public static class PriceSizeEntry {
     BigDecimal price;
 

--- a/xchange-coinegg/src/main/java/org/knowm/xchange/coinegg/dto/marketdata/CoinEggOrders.java
+++ b/xchange-coinegg/src/main/java/org/knowm/xchange/coinegg/dto/marketdata/CoinEggOrders.java
@@ -2,6 +2,8 @@ package org.knowm.xchange.coinegg.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import java.math.BigDecimal;
 
 public class CoinEggOrders {
@@ -24,6 +26,7 @@ public class CoinEggOrders {
   }
 
   @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+  @JsonPropertyOrder({"price", "quantity"})
   public static class CoinEggOrder {
 
     @JsonProperty() private BigDecimal price;

--- a/xchange-coinex/src/main/java/org/knowm/xchange/coinex/dto/marketdata/CoinexMarketDepth.java
+++ b/xchange-coinex/src/main/java/org/knowm/xchange/coinex/dto/marketdata/CoinexMarketDepth.java
@@ -2,6 +2,7 @@ package org.knowm.xchange.coinex.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -49,6 +50,7 @@ public class CoinexMarketDepth {
   @Builder
   @Jacksonized
   @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+  @JsonPropertyOrder({"price", "size"})
   public static class PriceSizeEntry {
     BigDecimal price;
 

--- a/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/dto/marketdata/GateioOrderBook.java
+++ b/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/dto/marketdata/GateioOrderBook.java
@@ -2,6 +2,7 @@ package org.knowm.xchange.gateio.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
@@ -33,6 +34,7 @@ public class GateioOrderBook {
   @Builder
   @Jacksonized
   @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+  @JsonPropertyOrder({"price", "size"})
   public static class PriceSizeEntry {
 
     BigDecimal price;

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v2/dto/marketdata/GeminiCandle.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v2/dto/marketdata/GeminiCandle.java
@@ -1,11 +1,13 @@
 package org.knowm.xchange.gemini.v2.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import lombok.Data;
 
 /** https://docs.gemini.com/rest-api/#candles */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({"time", "open", "high", "low", "close", "volume"})
 @Data
 public class GeminiCandle {
   private Long time;

--- a/xchange-lgo/src/main/java/org/knowm/xchange/lgo/dto/marketdata/LgoCandlestick.java
+++ b/xchange-lgo/src/main/java/org/knowm/xchange/lgo/dto/marketdata/LgoCandlestick.java
@@ -3,10 +3,12 @@ package org.knowm.xchange.lgo.dto.marketdata;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import java.util.Date;
 
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({"time", "low", "high", "open", "close", "volume"})
 public class LgoCandlestick {
 
   private final Date time;

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/v3/dto/marketdata/OkexOrderBookEntry.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/v3/dto/marketdata/OkexOrderBookEntry.java
@@ -3,11 +3,13 @@ package org.knowm.xchange.okcoin.v3.dto.marketdata;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import lombok.Data;
 
 @Data
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({"price", "volume", "numOrdersOnLevel"})
 public class OkexOrderBookEntry {
 
   private BigDecimal price;

--- a/xchange-stream-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexWebSocketTickerTransaction.java
+++ b/xchange-stream-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexWebSocketTickerTransaction.java
@@ -1,11 +1,16 @@
 package info.bitrich.xchangestream.bitfinex.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexTicker;
 
 /** Created by Lukas Zaoralek on 8.11.17. */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({
+  "channelId",
+  "tickerArr"
+})
 public class BitfinexWebSocketTickerTransaction {
 
   public String channelId;

--- a/xchange-stream-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexWebSocketTrade.java
+++ b/xchange-stream-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexWebSocketTrade.java
@@ -1,11 +1,13 @@
 package info.bitrich.xchangestream.bitfinex.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexTrade;
 
 /** Created by Lukas Zaoralek on 7.11.17. */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({"tradeId", "timestamp", "amount", "price"})
 public class BitfinexWebSocketTrade {
   public long tradeId;
   public long timestamp;

--- a/xchange-stream-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexWebsocketUpdateTrade.java
+++ b/xchange-stream-bitfinex/src/main/java/info/bitrich/xchangestream/bitfinex/dto/BitfinexWebsocketUpdateTrade.java
@@ -1,10 +1,12 @@
 package info.bitrich.xchangestream.bitfinex.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexTrade;
 
 /** Created by Lukas Zaoralek on 8.11.17. */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({"type", "trade"})
 public class BitfinexWebsocketUpdateTrade extends BitfinexWebSocketTradesTransaction {
   public String type;
   public BitfinexWebSocketTrade trade;

--- a/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexStreamingTest.java
+++ b/xchange-stream-bitmex/src/test/java/info/bitrich/xchangestream/bitmex/BitmexStreamingTest.java
@@ -1,5 +1,6 @@
 package info.bitrich.xchangestream.bitmex;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -8,12 +9,15 @@ import org.junit.Test;
  * @author Foat Akhmadeev 13/06/2018
  */
 public class BitmexStreamingTest {
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
   @Test
   public void shouldGetCorrectSubscribeMessage() throws IOException {
     BitmexStreamingService service = new BitmexStreamingService("url", "api", "secret");
 
     Assert.assertEquals(
-        "{\"op\":\"subscribe\",\"args\":[\"name\"]}", service.getSubscribeMessage("name"));
+        objectMapper.readTree("{\"op\":\"subscribe\",\"args\":[\"name\"]}"),
+        objectMapper.readTree(service.getSubscribeMessage("name")));
   }
 
   @Test
@@ -21,6 +25,7 @@ public class BitmexStreamingTest {
     BitmexStreamingService service = new BitmexStreamingService("url", "api", "secret");
 
     Assert.assertEquals(
-        "{\"op\":\"unsubscribe\",\"args\":[\"name\"]}", service.getUnsubscribeMessage("name"));
+        objectMapper.readTree("{\"op\":\"unsubscribe\",\"args\":[\"name\"]}"),
+        objectMapper.readTree(service.getUnsubscribeMessage("name")));
   }
 }

--- a/xchange-stream-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/dto/CoinbaseProWebSocketSubscriptionMessage.java
+++ b/xchange-stream-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/dto/CoinbaseProWebSocketSubscriptionMessage.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import info.bitrich.xchangestream.core.ProductSubscription;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -116,7 +116,7 @@ public class CoinbaseProWebSocketSubscriptionMessage {
       CoinbaseProOrderBookMode orderBookMode,
       CoinbaseProWebsocketAuthData authData) {
     List<CoinbaseProProductSubscription> channels = new ArrayList<>(3);
-    Map<String, List<Instrument>> pairs = new HashMap<>(3);
+    Map<String, List<Instrument>> pairs = new LinkedHashMap<>(3);
 
     pairs.put(orderBookMode.getName(), productSubscription.getOrderBook());
     pairs.put("ticker", productSubscription.getTicker());

--- a/xchange-stream-coinbasepro/src/test/java/info/bitrich/xchangestream/coinbasepro/dto/CoinbaseProWebSocketSubscriptionMessageTest.java
+++ b/xchange-stream-coinbasepro/src/test/java/info/bitrich/xchangestream/coinbasepro/dto/CoinbaseProWebSocketSubscriptionMessageTest.java
@@ -30,8 +30,8 @@ public class CoinbaseProWebSocketSubscriptionMessageTest {
     String serialized = mapper.writeValueAsString(message);
 
     Assert.assertEquals(
-        "{\"type\":\"subscribe\",\"channels\":[{\"name\":\"matches\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"ticker\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"level2\",\"product_ids\":[\"BTC-USD\"]}]}",
-        serialized);
+        mapper.readTree("{\"type\":\"subscribe\",\"channels\":[{\"name\":\"level2\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"ticker\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"matches\",\"product_ids\":[\"BTC-USD\"]}]}"),
+        mapper.readTree(serialized));
   }
 
   @Test
@@ -53,8 +53,8 @@ public class CoinbaseProWebSocketSubscriptionMessageTest {
     String serialized = mapper.writeValueAsString(message);
 
     Assert.assertEquals(
-        "{\"type\":\"subscribe\",\"channels\":[{\"name\":\"matches\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"ticker\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"full\",\"product_ids\":[\"BTC-USD\"]}]}",
-        serialized);
+        mapper.readTree("{\"type\":\"subscribe\",\"channels\":[{\"product_ids\":[\"BTC-USD\"],\"name\":\"full\"},{\"product_ids\":[\"BTC-USD\"],\"name\":\"ticker\"},{\"product_ids\":[\"BTC-USD\"],\"name\":\"matches\"}]}"),
+        mapper.readTree(serialized));
   }
 
   @Test
@@ -76,7 +76,7 @@ public class CoinbaseProWebSocketSubscriptionMessageTest {
     String serialized = mapper.writeValueAsString(message);
 
     Assert.assertEquals(
-        "{\"type\":\"subscribe\",\"channels\":[{\"name\":\"matches\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"level2_batch\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"ticker\",\"product_ids\":[\"BTC-USD\"]}]}",
-        serialized);
+        mapper.readTree("{\"type\":\"subscribe\",\"channels\":[{\"product_ids\":[\"BTC-USD\"],\"name\":\"level2_batch\"},{\"product_ids\":[\"BTC-USD\"],\"name\":\"ticker\"},{\"product_ids\":[\"BTC-USD\"],\"name\":\"matches\"}]}"),
+        mapper.readTree(serialized));
   }
 }

--- a/xchange-stream-gateio/src/main/java/info/bitrich/xchangestream/gateio/dto/response/orderbook/OrderBookPayload.java
+++ b/xchange-stream-gateio/src/main/java/info/bitrich/xchangestream/gateio/dto/response/orderbook/OrderBookPayload.java
@@ -2,6 +2,7 @@ package info.bitrich.xchangestream.gateio.dto.response.orderbook;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -35,6 +36,7 @@ public class OrderBookPayload {
   @Builder
   @Jacksonized
   @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+  @JsonPropertyOrder({"price", "size"})
   public static class PriceSizeEntry {
 
     BigDecimal price;

--- a/xchange-stream-poloniex2/src/main/java/info/bitrich/xchangestream/poloniex2/dto/PoloniexWebSocketEventsTransaction.java
+++ b/xchange-stream-poloniex2/src/main/java/info/bitrich/xchangestream/poloniex2/dto/PoloniexWebSocketEventsTransaction.java
@@ -3,6 +3,7 @@ package info.bitrich.xchangestream.poloniex2.dto;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import info.bitrich.xchangestream.service.netty.StreamingObjectMapperHelper;
@@ -13,6 +14,7 @@ import org.knowm.xchange.dto.Order;
 
 /** Created by Lukas Zaoralek on 11.11.17. */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({"channelId", "seqId", "events"})
 public class PoloniexWebSocketEventsTransaction {
   private Long channelId;
   private Long seqId;

--- a/xchange-stream-poloniex2/src/main/java/info/bitrich/xchangestream/poloniex2/dto/PoloniexWebSocketTickerTransaction.java
+++ b/xchange-stream-poloniex2/src/main/java/info/bitrich/xchangestream/poloniex2/dto/PoloniexWebSocketTickerTransaction.java
@@ -1,6 +1,7 @@
 package info.bitrich.xchangestream.poloniex2.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.poloniex.dto.marketdata.PoloniexMarketData;
@@ -8,6 +9,7 @@ import org.knowm.xchange.poloniex.dto.marketdata.PoloniexTicker;
 
 /** Created by Lukas Zaoralek on 11.11.17. */
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({"channelId", "timestamp", "ticker"})
 public class PoloniexWebSocketTickerTransaction {
   public String channelId;
   public String timestamp;


### PR DESCRIPTION
Seeing two types of flakiness that this PR attempts to address: JSON String Equality assertions, and JSON property ordering flakiness.

**Solution:**

Firstly, across the XChange test suite, there are several instances of tests that validate a JSON object. The JSON specification is inherently unordered, and thus, a simple string equality may fail if because we rely upon `jackson` producing ordered JSON. `jackson` internally uses a Hash-based datastructure, so iteration order is not guaranteed to be deterministic. For example:

```java
// Flaky!
Assert.assertEquals(
        "{\"op\":\"subscribe\",\"args\":[\"name\"]}",
        service.getSubscribeMessage("name") // Could be "{\"args\":[\"name\"],\"op\":\"subscribe\"}"
);
// Works:
Assert.assertEquals(
        objectMapper.readTree("{\"op\":\"subscribe\",\"args\":[\"name\"]}"),
        objectMapper.readTree(service.getSubscribeMessage("name"))
);
```



Second: Many of the DTO objects that are parsed by XChange via `jackson` rely on ordered arrays, e.g. a `[price, size]` array. However, we cannot rely upon the order that class fields are declared in the class source, as Java Class' `getDeclaredFields()` is explicitly nondeterministic. Thus, annotating DTO objects that have `JsonFormat.Shape.ARRAY` with a `@JsonPropertyOrder` ([doc](https://fasterxml.github.io/jackson-annotations/javadoc/2.8/com/fasterxml/jackson/annotation/JsonPropertyOrder.html)) is best practice and prevents deserialization errors (or worse -- incorrectly parsed data that doesn't throw an error). An example:

```java
@JsonFormat(shape = JsonFormat.Shape.ARRAY)
@JsonPropertyOrder({"orderId", "price", "amount"}) /* NEW */
public class BitfinexTradingRawOrder {
  long orderId;
  BigDecimal price;
  BigDecimal amount;
}

// Before JsonPropertyOrder: Parsing [1, 2.0, 3.0] could result in:
// price: 2.0, amount: 3.0 (correct) or
// Thrown Error (parsing long from decimal type)
// price: 3.0, amount: 2.0 (silent failure)
```

**Reproduction:**

These are most likely to cause test failures / flaky behavior if XChange is compiled and tested with different JVM/JDK distributions running on different architectures, so is somewhat of a preemptive measure. The tests can be shown to be flaky via [NonDex](https://github.com/TestingResearchIllinois/NonDex) and the following command:

```bash
# Should pass: (Using coinegg module for example. Many modules are applicable)
mvn test -pl xchange-coinegg
# Should fail before this PR, pass after this PR:
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -pl xchange-coinegg -DnondexRuns=10
```

Happy to iterate on this!