### PR TITLE
[okex-stream] all login-required channels become invalid after a network disconnection and reconnection

### DIFF
--- a/xchange-stream-okex/src/main/java/info/bitrich/xchangestream/okex/OkexStreamingService.java
+++ b/xchange-stream-okex/src/main/java/info/bitrich/xchangestream/okex/OkexStreamingService.java
@@ -54,6 +54,10 @@ public class OkexStreamingService extends JsonNettyStreamingService {
 
   private final ExchangeSpecification xSpec;
 
+  private volatile boolean loginDone = false;
+
+  private volatile boolean needToResubscribeChannels = false;
+
   public OkexStreamingService(String apiUrl, ExchangeSpecification exchangeSpecification) {
     super(apiUrl);
     this.xSpec = exchangeSpecification;
@@ -61,6 +65,7 @@ public class OkexStreamingService extends JsonNettyStreamingService {
 
   @Override
   public Completable connect() {
+    loginDone = xSpec.getApiKey() == null;
     Completable conn = super.connect();
     return conn.andThen(
         (CompletableSource)
@@ -80,6 +85,14 @@ public class OkexStreamingService extends JsonNettyStreamingService {
                 completable.onError(e);
               }
             });
+  }
+
+  @Override
+  public void resubscribeChannels() {
+    needToResubscribeChannels = true;
+    if (loginDone) {
+      super.resubscribeChannels();
+    }
   }
 
   public void login() throws JsonProcessingException {
@@ -122,6 +135,18 @@ public class OkexStreamingService extends JsonNettyStreamingService {
       }
       LOG.error("Error parsing incoming message to JSON: {}", message);
       return;
+    }
+    // Retry after a successful login
+    if (jsonNode.has("event")) {
+      String event = jsonNode.get("event").asText();
+      if ("login".equals(event)) {
+        loginDone = true;
+        if (needToResubscribeChannels) {
+          this.resubscribeChannels();
+          needToResubscribeChannels = false;
+        }
+        return;
+      }
     }
 
     if (processArrayMessageSeparately() && jsonNode.isArray()) {


### PR DESCRIPTION
**fix(okex): Fix issue with resubscribing to channels after login**
- Added `loginDone` and `needToResubscribeChannels` flags
- Initialized the `loginDone` flag during connection setup
- Implemented the `resubscribeChannels` method to decide whether to resubscribe based on login status
- Checked if channel resubscription is needed after a successful login

**Steps to Reproduce:**  
1. Use the `getUserTrades` method to subscribe to order events.  
2. Disconnect and then reconnect the network.  
3. Place order on OKX; the order events will not be received.

![image](https://github.com/user-attachments/assets/92c44b99-4857-4242-8ceb-1b0deeb7c023)
![image](https://github.com/user-attachments/assets/7ab4c815-2f67-45c9-baab-bec2aa6f85be)

