### PR TITLE
[CORE] orderbook recheckidx fix

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/OrderBook.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/OrderBook.java
@@ -16,8 +16,6 @@ import lombok.Getter;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.instrument.Instrument;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** DTO representing the exchange order book */
 public final class OrderBook implements Serializable {

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/OrderBook.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/OrderBook.java
@@ -19,40 +19,28 @@ import org.knowm.xchange.instrument.Instrument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * DTO representing the exchange order book
- */
+/** DTO representing the exchange order book */
 public final class OrderBook implements Serializable {
 
   private static final long serialVersionUID = -7788306758114464314L;
-  @JsonIgnore
-  public final StampedLock lock = new StampedLock();
+  @JsonIgnore public final StampedLock lock = new StampedLock();
 
-  /**
-   * the asks
-   */
-  @Getter
-  private final List<LimitOrder> asks;
+  /** the asks */
+  @Getter private final List<LimitOrder> asks;
 
-  /**
-   * the bids
-   */
-  @Getter
-  private final List<LimitOrder> bids;
+  /** the bids */
+  @Getter private final List<LimitOrder> bids;
 
-  /**
-   * the timestamp of the orderbook according to the exchange's server, null if not provided
-   */
-  @Getter
-  private Date timeStamp;
+  /** the timestamp of the orderbook according to the exchange's server, null if not provided */
+  @Getter private Date timeStamp;
 
   /**
    * Constructor
    *
    * @param timeStamp - the timestamp of the orderbook according to the exchange's server, null if
-   *                  not provided
-   * @param asks      The ASK orders
-   * @param bids      The BID orders
+   *     not provided
+   * @param asks The ASK orders
+   * @param bids The BID orders
    */
   @JsonCreator
   public OrderBook(
@@ -67,10 +55,10 @@ public final class OrderBook implements Serializable {
    * Constructor
    *
    * @param timeStamp - the timestamp of the orderbook according to the exchange's server, null if
-   *                  not provided
-   * @param asks      The ASK orders
-   * @param bids      The BID orders
-   * @param sort      True if the asks and bids need to be sorted
+   *     not provided
+   * @param asks The ASK orders
+   * @param bids The BID orders
+   * @param sort True if the asks and bids need to be sorted
    */
   public OrderBook(Date timeStamp, List<LimitOrder> asks, List<LimitOrder> bids, boolean sort) {
 
@@ -90,9 +78,9 @@ public final class OrderBook implements Serializable {
    * Constructor
    *
    * @param timeStamp - the timestamp of the orderbook according to the exchange's server, null if
-   *                  not provided
-   * @param asks      The ASK orders
-   * @param bids      The BID orders
+   *     not provided
+   * @param asks The ASK orders
+   * @param bids The BID orders
    */
   public OrderBook(Date timeStamp, Stream<LimitOrder> asks, Stream<LimitOrder> bids) {
 
@@ -103,10 +91,10 @@ public final class OrderBook implements Serializable {
    * Constructor
    *
    * @param timeStamp - the timestamp of the orderbook according to the exchange's server, null if
-   *                  not provided
-   * @param asks      The ASK orders
-   * @param bids      The BID orders
-   * @param sort      True if the asks and bids need to be sorted
+   *     not provided
+   * @param asks The ASK orders
+   * @param bids The BID orders
+   * @param sort True if the asks and bids need to be sorted
    */
   public OrderBook(Date timeStamp, Stream<LimitOrder> asks, Stream<LimitOrder> bids, boolean sort) {
 
@@ -224,31 +212,27 @@ public final class OrderBook implements Serializable {
     }
   }
 
-
-  private final Logger LOG = LoggerFactory.getLogger(OrderBook.class);
-
-
   /**
    * @return true, if wee need to run binarySearch again
    */
   private boolean recheckIdx(List<LimitOrder> limitOrders, LimitOrder limitOrder, int idx) {
-      switch (idx) {
-        case 0: {
+    switch (idx) {
+      case 0:
+        {
           if (!limitOrders.isEmpty()) {
-            //if not equals, need to recheck
+            // if not equals, need to recheck
             return limitOrders.get(0).compareTo(limitOrder) != 0;
-          } else
-            return true;
+          } else return true;
         }
-        case -1: {
+      case -1:
+        {
           if (limitOrders.isEmpty()) {
             return false;
-          } else
-            return limitOrders.get(0).compareTo(limitOrder) <= 0;
+          } else return limitOrders.get(0).compareTo(limitOrder) <= 0;
         }
-        default:
-          return true;
-      }
+      default:
+        return true;
+    }
   }
 
   // Replace timeStamp if the provided date is non-null and in the future

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/OrderBook.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/OrderBook.java
@@ -232,34 +232,23 @@ public final class OrderBook implements Serializable {
    * @return true, if wee need to run binarySearch again
    */
   private boolean recheckIdx(List<LimitOrder> limitOrders, LimitOrder limitOrder, int idx) {
-    try {
       switch (idx) {
         case 0: {
           if (!limitOrders.isEmpty()) {
             //if not equals, need to recheck
             return limitOrders.get(0).compareTo(limitOrder) != 0;
-          } else {
+          } else
             return true;
-          }
         }
         case -1: {
           if (limitOrders.isEmpty()) {
             return false;
-          } else {
+          } else
             return limitOrders.get(0).compareTo(limitOrder) <= 0;
-          }
         }
         default:
           return true;
       }
-    } catch (IndexOutOfBoundsException e) {
-      for (LimitOrder lo : limitOrders) {
-        LOG.error("limitOrders {}", lo);
-      }
-      LOG.error("limitOrder {}", limitOrder);
-      LOG.error("idx {}", idx);
-      throw e;
-    }
   }
 
   // Replace timeStamp if the provided date is non-null and in the future

--- a/xchange-core/src/test/java/org/knowm/xchange/dto/marketdata/ConcurrencyTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/dto/marketdata/ConcurrencyTest.java
@@ -20,11 +20,11 @@ public class ConcurrencyTest {
 
   public static void main(String[] args) throws InterruptedException, ExecutionException {
     OrderBook orderBook1 =
-        new OrderBook(new Date(), initOrderBookAsks(), initOrderBookBids(), true);
+        new OrderBook(new Date(), initOrderBookAsks(), new ArrayList<>(), true);
     OrderBook orderBook2 =
-        new OrderBook(new Date(), initOrderBookAsks(), initOrderBookBids(), true);
+        new OrderBook(new Date(), initOrderBookAsks(), new ArrayList<>(), true);
     OrderBookOld orderBookOld =
-        new OrderBookOld(new Date(), initOrderBookAsks(), initOrderBookBids(), true);
+        new OrderBookOld(new Date(), initOrderBookAsks(), new ArrayList<>(), true);
     ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(50);
     newWay(orderBook1, executor);
     executor.awaitTermination(100L, TimeUnit.SECONDS);
@@ -114,7 +114,7 @@ public class ConcurrencyTest {
 
   public static void updateOrderBook1(OrderBook orderBook, boolean oldWay) {
     Random rand = new Random(123);
-    for (int i = 0; i < 100000; i++) {
+    for (int i = 0; i < 10000; i++) {
       OrderBookUpdate orderBookUpdateAsk =
           new OrderBookUpdate(
               OrderType.ASK,
@@ -145,7 +145,7 @@ public class ConcurrencyTest {
 
   public static void updateOrderBookOld1(OrderBookOld orderBookOld) {
     Random rand = new Random(123);
-    for (int i = 0; i < 100000; i++) {
+    for (int i = 0; i < 10000; i++) {
       OrderBookUpdate orderBookUpdateAsk =
           new OrderBookUpdate(
               OrderType.ASK,
@@ -171,7 +171,7 @@ public class ConcurrencyTest {
 
   private static void updateOrderBook2(OrderBook orderBook, boolean oldWay) {
     Random rand = new Random(123);
-    for (int i = 0; i < 100000; i++) {
+    for (int i = 0; i < 10000; i++) {
       LimitOrder bookUpdateAsk =
           new LimitOrder(
               OrderType.ASK,
@@ -202,7 +202,7 @@ public class ConcurrencyTest {
 
   private static void updateOrderBookOld2(OrderBookOld orderBookOld) {
     Random rand = new Random(123);
-    for (int i = 0; i < 100000; i++) {
+    for (int i = 0; i < 10000; i++) {
       LimitOrder bookUpdateAsk =
           new LimitOrder(
               OrderType.ASK,
@@ -227,7 +227,7 @@ public class ConcurrencyTest {
   }
 
   private static void readOrderBook(OrderBook orderBook, boolean oldWay) {
-    for (int i = 0; i < 1200000; i++) {
+    for (int i = 0; i < 10000; i++) {
       int temp = 0;
       if (oldWay) {
         synchronized (orderBook) {
@@ -252,7 +252,7 @@ public class ConcurrencyTest {
   }
 
   private static void readOrderBookOld(OrderBookOld orderBookOld) {
-    for (int i = 0; i < 1200000; i++) {
+    for (int i = 0; i < 120000; i++) {
       int temp = 0;
       synchronized (orderBookOld) {
         for (LimitOrder ask : orderBookOld.getAsks()) {

--- a/xchange-core/src/test/java/org/knowm/xchange/dto/marketdata/ConcurrencyTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/dto/marketdata/ConcurrencyTest.java
@@ -19,10 +19,8 @@ public class ConcurrencyTest {
   static Instrument inst = new CurrencyPair("BTC/USDT");
 
   public static void main(String[] args) throws InterruptedException, ExecutionException {
-    OrderBook orderBook1 =
-        new OrderBook(new Date(), initOrderBookAsks(), new ArrayList<>(), true);
-    OrderBook orderBook2 =
-        new OrderBook(new Date(), initOrderBookAsks(), new ArrayList<>(), true);
+    OrderBook orderBook1 = new OrderBook(new Date(), initOrderBookAsks(), new ArrayList<>(), true);
+    OrderBook orderBook2 = new OrderBook(new Date(), initOrderBookAsks(), new ArrayList<>(), true);
     OrderBookOld orderBookOld =
         new OrderBookOld(new Date(), initOrderBookAsks(), new ArrayList<>(), true);
     ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(50);

--- a/xchange-core/src/test/java/org/knowm/xchange/dto/marketdata/OrderBookTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/dto/marketdata/OrderBookTest.java
@@ -9,7 +9,6 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import org.junit.Before;
@@ -196,22 +195,24 @@ public class OrderBookTest {
     LimitOrder higherBidOrder =
         new LimitOrder(
             OrderType.BID, BigDecimal.ONE, CurrencyPair.BTC_USD, "", null, new BigDecimal("10.5"));
-    //idx!= -1,0
-    assertThat(method.invoke(orderBook, new ArrayList<LimitOrder>(),sameBidOrder, 1)).isEqualTo(true);
-    //idx=0, empty List
-    assertThat(method.invoke(orderBook, new ArrayList<LimitOrder>(),sameBidOrder, 0)).isEqualTo(true);
-    //idx=0, order equals
-    assertThat(method.invoke(orderBook, orderBook.getBids(),sameBidOrder, 0)).isEqualTo(false);
-    //idx=0, smallerBidOrder
-    assertThat(method.invoke(orderBook, orderBook.getBids(),smallerBidOrder, 0)).isEqualTo(true);
-    //idx=-1, empty List
-    assertThat(method.invoke(orderBook, new ArrayList<LimitOrder>(),sameBidOrder, -1)).isEqualTo(false);
-    //idx=-1, order equals
-    assertThat(method.invoke(orderBook, orderBook.getBids(),sameBidOrder, -1)).isEqualTo(true);
-    //idx=-1, smaller order
-    assertThat(method.invoke(orderBook, orderBook.getBids(),smallerBidOrder, -1)).isEqualTo(true);
-    //idx=-1, higher order
-    assertThat(method.invoke(orderBook, orderBook.getBids(),higherBidOrder, -1)).isEqualTo(false);
+    // idx!= -1,0
+    assertThat(method.invoke(orderBook, new ArrayList<LimitOrder>(), sameBidOrder, 1))
+        .isEqualTo(true);
+    // idx=0, empty List
+    assertThat(method.invoke(orderBook, new ArrayList<LimitOrder>(), sameBidOrder, 0))
+        .isEqualTo(true);
+    // idx=0, order equals
+    assertThat(method.invoke(orderBook, orderBook.getBids(), sameBidOrder, 0)).isEqualTo(false);
+    // idx=0, smallerBidOrder
+    assertThat(method.invoke(orderBook, orderBook.getBids(), smallerBidOrder, 0)).isEqualTo(true);
+    // idx=-1, empty List
+    assertThat(method.invoke(orderBook, new ArrayList<LimitOrder>(), sameBidOrder, -1))
+        .isEqualTo(false);
+    // idx=-1, order equals
+    assertThat(method.invoke(orderBook, orderBook.getBids(), sameBidOrder, -1)).isEqualTo(true);
+    // idx=-1, smaller order
+    assertThat(method.invoke(orderBook, orderBook.getBids(), smallerBidOrder, -1)).isEqualTo(true);
+    // idx=-1, higher order
+    assertThat(method.invoke(orderBook, orderBook.getBids(), higherBidOrder, -1)).isEqualTo(false);
   }
-
 }


### PR DESCRIPTION
In the previous implementation there was a bug if the size of the order array was zero.
I did not go through all the check options. And limited myself to only the two most common options. I do not want to make a mistake somewhere again.
add tests to recheckIdx method