### PR TITLE
[general] Move jsr310 dependency version to parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,13 @@
                 <version>${version.fasterxml}</version>
             </dependency>
 
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${version.fasterxml}</version>
+
+            </dependency>
+
             <!-- Rest client -->
             <dependency>
                 <groupId>com.github.mmazi</groupId>

--- a/xchange-bitget/pom.xml
+++ b/xchange-bitget/pom.xml
@@ -25,7 +25,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${version.fasterxml}</version>
         </dependency>
 
         <dependency>

--- a/xchange-coinex/pom.xml
+++ b/xchange-coinex/pom.xml
@@ -25,7 +25,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${version.fasterxml}</version>
         </dependency>
 
         <dependency>

--- a/xchange-gateio-v4/pom.xml
+++ b/xchange-gateio-v4/pom.xml
@@ -19,7 +19,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${version.fasterxml}</version>
         </dependency>
 
         <dependency>

--- a/xchange-gateio/pom.xml
+++ b/xchange-gateio/pom.xml
@@ -28,7 +28,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${version.fasterxml}</version>
         </dependency>
 
         <dependency>

--- a/xchange-stream-gateio/pom.xml
+++ b/xchange-stream-gateio/pom.xml
@@ -15,7 +15,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${version.fasterxml}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Moved version definition of `<artifactId>jackson-datatype-jsr310</artifactId>` to parent