### PR TITLE
[fix]When using a proxy with WebSocket, the DNS resolution should be performed within the proxy server.

### DIFF
--- a/xchange-stream-service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
+++ b/xchange-stream-service-netty/src/main/java/info/bitrich/xchangestream/service/netty/NettyStreamingService.java
@@ -200,14 +200,17 @@ public abstract class NettyStreamingService<T> extends ConnectableService {
                   eventLoopGroup = new NioEventLoopGroup(2);
                 }
 
-                new Bootstrap()
+                Bootstrap bootstrap = new Bootstrap()
                     .group(eventLoopGroup)
                     .option(
                         ChannelOption.CONNECT_TIMEOUT_MILLIS,
-                        java.lang.Math.toIntExact(connectionTimeout.toMillis()))
+                        Math.toIntExact(connectionTimeout.toMillis()))
                     .option(ChannelOption.SO_KEEPALIVE, true)
-                    .channel(NioSocketChannel.class)
-                    .handler(
+                    .channel(NioSocketChannel.class);
+                if (socksProxyHost != null) {
+                  bootstrap.disableResolver();
+                }
+                bootstrap.handler(
                         new ChannelInitializer<SocketChannel>() {
                           @Override
                           protected void initChannel(SocketChannel ch) {


### PR DESCRIPTION
Some exchanges use DNS and CDN technologies. If the domain name is resolved locally, it will return the IP address of the nearest server to the exchange from the local network. In this case, the SOCKS client will pass this IP to the proxy server, and the proxy server will attempt to connect using this IP, leading to a timeout. The best approach is to have the proxy server handle the DNS resolution.

Here is an analysis of part of the Netty source code:
1. `Bootstrap.java`
![image](https://github.com/user-attachments/assets/ccfdde83-803c-4d56-9b47-2509b46f4dde)
![image](https://github.com/user-attachments/assets/dfd94723-5674-43cd-a1f5-77cac5f6fa7c)
2.`Socks5ProxyHandler.java`
![image](https://github.com/user-attachments/assets/912496ee-ec4a-4d52-870a-091f513911ee)
