### PR TITLE
[general] Fix conflicting config with code formatter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,7 @@
                     <nrOfIndentSpace>4</nrOfIndentSpace>
                     <sortPlugins>groupId,artifactId</sortPlugins>
                     <expandEmptyElements>false</expandEmptyElements>
+                    <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Fixed `sortpom-maven-plugin` config so that it doesn't remove the space in empty xml tags left by code formatter, like 
`<dependencyConvergence />` -> `<dependencyConvergence/>`