### PR TITLE
[core] Add adapting of price to step size

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/utils/OrderValuesHelper.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/utils/OrderValuesHelper.java
@@ -90,6 +90,11 @@ public class OrderValuesHelper {
     if (scale != null) {
       result = result.setScale(scale, roundingMode);
     }
+
+    BigDecimal stepSize = metaData.getPriceStepSize();
+    if (stepSize != null && stepSize.signum() != 0) {
+      result = BigDecimalUtils.roundToStepSize(result, stepSize, roundingMode);
+    }
     return result;
   }
 }


### PR DESCRIPTION
Added adapting the price to the step-size. 

For example, `bitmex` needs price of `ETH_USDT` to be adapted to smallest step `0.05`