### PR TITLE
[coinex] Extend error mapping

### DIFF
--- a/xchange-coinex/src/main/java/org/knowm/xchange/coinex/CoinexErrorAdapter.java
+++ b/xchange-coinex/src/main/java/org/knowm/xchange/coinex/CoinexErrorAdapter.java
@@ -4,17 +4,22 @@ import lombok.experimental.UtilityClass;
 import org.knowm.xchange.coinex.dto.CoinexException;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.InstrumentNotValidException;
+import org.knowm.xchange.exceptions.OrderAmountUnderMinimumException;
 import org.knowm.xchange.exceptions.OrderNotValidException;
 
 @UtilityClass
 public class CoinexErrorAdapter {
 
+  public final int AMOUNT_TOO_SMALL = 3127;
   public final int ORDER_NOT_FOUND = 3600;
   public final int INVALID_MARKET_CODE = 3639;
 
   public ExchangeException adapt(CoinexException e) {
 
     switch (e.getCode()) {
+      case AMOUNT_TOO_SMALL:
+        return new OrderAmountUnderMinimumException(e.getMessage(), e);
+
       case ORDER_NOT_FOUND:
         return new OrderNotValidException(e.getMessage(), e);
 


### PR DESCRIPTION
Added error mapping in case order amount is too small, e.g.

```json
{
  "code": 3127,
  "data": {},
  "message": "amount too small"
}
```