### PR TITLE
[bybit] fix date parse locale

### DIFF
--- a/xchange-bybit/src/main/java/org/knowm/xchange/bybit/BybitAdapters.java
+++ b/xchange-bybit/src/main/java/org/knowm/xchange/bybit/BybitAdapters.java
@@ -56,7 +56,7 @@ import org.knowm.xchange.instrument.Instrument;
 public class BybitAdapters {
 
   private static final ThreadLocal<SimpleDateFormat> OPTION_DATE_FORMAT =
-      ThreadLocal.withInitial(() -> new SimpleDateFormat("ddMMMyy"));
+      ThreadLocal.withInitial(() -> new SimpleDateFormat("ddMMMyy", Locale.US));
   public static final List<String> QUOTE_CURRENCIES =
       Arrays.asList("USDT", "USDC", "USDE", "EUR", "BRL", "PLN", "TRY", "SOL", "BTC", "ETH", "DAI",
           "BRZ");


### PR DESCRIPTION
Get the parse date argment `Locale.US` back since pr #4912 removed it.