### PR TITLE
[Kraken] - Improve performance of checksum computation

### DIFF
--- a/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingChecksum.java
+++ b/xchange-stream-kraken/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingChecksum.java
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.CRC32;
+import org.apache.commons.lang3.StringUtils;
 import org.knowm.xchange.dto.trade.LimitOrder;
 
 public class KrakenStreamingChecksum {
@@ -23,10 +24,7 @@ public class KrakenStreamingChecksum {
                 public String load(BigDecimal key) throws Exception {
                   String result = key.toPlainString();
                   result = result.replace(".", "");
-                  while (result.startsWith("0")) {
-                    result = result.replaceFirst("0", "");
-                  }
-                  return result;
+                  return StringUtils.stripStart(result, "0");
                 }
               });
 


### PR DESCRIPTION
The original code is compiling a Regex in a loop which is inefficient in an active system. What I'm seeing is that most of the time, I/O threads spend on this Pattern compilation.

`
nioEventLoopGroup-18-1" #76 [85] prio=10 os_prio=0 cpu=78812.80ms elapsed=7034.36s tid=0x00007f4404302110 nid=85 runnable  [0x00007f44746ce000]
   java.lang.Thread.State: RUNNABLE
        at java.util.regex.Pattern$CharProperty.study(java.base@21.0.4/Pattern.java:4119)
        at java.util.regex.Pattern$Start.<init>(java.base@21.0.4/Pattern.java:3777)
        at java.util.regex.Pattern.compile(java.base@21.0.4/Pattern.java:1967)
        at java.util.regex.Pattern.<init>(java.base@21.0.4/Pattern.java:1576)
        at java.util.regex.Pattern.compile(java.base@21.0.4/Pattern.java:1101)
        at java.lang.String.replaceFirst(java.base@21.0.4/String.java:3025)
        at info.bitrich.xchangestream.kraken.KrakenStreamingChecksum$1.load(KrakenStreamingChecksum.java:27)
        at info.bitrich.xchangestream.kraken.KrakenStreamingChecksum$1.load(KrakenStreamingChecksum.java:21)
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3574)
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2316)
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2190)
        - locked <0x00000000eaa1d588> (a com.google.common.cache.LocalCache$StrongAccessEntry)
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2080)
        at com.google.common.cache.LocalCache.get(LocalCache.java:4017)
        at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4040)
        at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4989)
        at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4996)
        at info.bitrich.xchangestream.kraken.KrakenStreamingChecksum.addBigDecimalToCrcString(KrakenStreamingChecksum.java:34)
        at info.bitrich.xchangestream.kraken.KrakenStreamingChecksum.addOrderToCrcString(KrakenStreamingChecksum.java:38)
        at info.bitrich.xchangestream.kraken.KrakenStreamingChecksum.lambda$createCrcString$1(KrakenStreamingChecksum.java:49)
        at info.bitrich.xchangestream.kraken.KrakenStreamingChecksum$$Lambda/0x00007f4478cf79a8.accept(Unknown Source)
        at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(java.base@21.0.4/ForEachOps.java:184)
        at java.util.stream.SliceOps$1$1.accept(java.base@21.0.4/SliceOps.java:200)
        at java.util.TreeMap$KeySpliterator.tryAdvance(java.base@21.0.4/TreeMap.java:3123)
        at java.util.stream.ReferencePipeline.forEachWithCancel(java.base@21.0.4/ReferencePipeline.java:129)
        at java.util.stream.AbstractPipeline.copyIntoWithCancel(java.base@21.0.4/AbstractPipeline.java:527)
        at java.util.stream.AbstractPipeline.copyInto(java.base@21.0.4/AbstractPipeline.java:513)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(java.base@21.0.4/AbstractPipeline.java:499)
        at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(java.base@21.0.4/ForEachOps.java:151)
        at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(java.base@21.0.4/ForEachOps.java:174)
        at java.util.stream.AbstractPipeline.evaluate(java.base@21.0.4/AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.forEach(java.base@21.0.4/ReferencePipeline.java:596)
        at info.bitrich.xchangestream.kraken.KrakenStreamingChecksum.createCrcString(KrakenStreamingChecksum.java:49)
        at info.bitrich.xchangestream.kraken.KrakenStreamingChecksum.createCrcChecksum(KrakenStreamingChecksum.java:60)
        at info.bitrich.xchangestream.kraken.KrakenStreamingAdapters.adaptOrderbookMessage(KrakenStreamingAdapters.java:103)
        at info.bitrich.xchangestream.kraken.KrakenStreamingMarketDataService.lambda$getOrderBook$0(KrakenStreamingMarketDataService.java:52)
`