### PR TITLE
Update LedgerType.java

### DIFF
--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/LedgerType.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/LedgerType.java
@@ -26,6 +26,7 @@ public enum LedgerType {
   ADJUSTMENT,
   SALE,
   SPEND,
+  REWARD,
   RECEIVE;
 
   private static final Map<String, LedgerType> fromString = new HashMap<>();


### PR DESCRIPTION
We've seen responses from kraken with type reward.

`Not supported kraken ledger type: reward (through reference chain: org.knowm.xchange.kraken.dto.account.results.KrakenLedgerResult["result"]->org.knowm.xchange.kraken.dto.account.results.KrakenLedgerResult$KrakenLedgers["ledger"]->java.util.LinkedHashMap["XXXXXXXXXXXX"]->org.knowm.xchange.kraken.dto.account.KrakenLedger["type"])`