### PR TITLE
Fix TradeOgre currency pair adapter

### DIFF
--- a/xchange-tradeogre/src/main/java/org/knowm/xchange/tradeogre/TradeOgreAdapters.java
+++ b/xchange-tradeogre/src/main/java/org/knowm/xchange/tradeogre/TradeOgreAdapters.java
@@ -23,7 +23,7 @@ import org.knowm.xchange.tradeogre.dto.trade.TradeOgreOrder;
 public class TradeOgreAdapters {
 
   public static String adaptCurrencyPair(CurrencyPair currencyPair) {
-    return currencyPair.getCounter().toString() + "-" + currencyPair.getBase().toString();
+    return currencyPair.getBase().toString() + "-" + currencyPair.getCounter().toString();
   }
 
   public static CurrencyPair adaptTradeOgreCurrencyPair(String currencyPair) {

--- a/xchange-tradeogre/src/test/java/org/knowm/xchange/tradeogre/TestTradeOgreAdapters.java
+++ b/xchange-tradeogre/src/test/java/org/knowm/xchange/tradeogre/TestTradeOgreAdapters.java
@@ -9,7 +9,7 @@ public class TestTradeOgreAdapters {
   @Test
   public void testAdaptCurrencyPair() {
     CurrencyPair market = CurrencyPair.ETH_BTC;
-    Assert.assertEquals("BTC-ETH", TradeOgreAdapters.adaptCurrencyPair(market));
+    Assert.assertEquals("ETH-BTC", TradeOgreAdapters.adaptCurrencyPair(market));
   }
 
   @Test


### PR DESCRIPTION
The TradeOgre exchange uses a base-counter currency pair format, but the adapter was incorrectly formatting it as counter-base. This commit fixes the adapter to correctly format the currency pair as base-counter.