### PR TITLE
[okx-stream] convert contract to volume

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/dto/Order.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/Order.java
@@ -10,6 +10,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
+import lombok.Setter;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
@@ -32,7 +33,8 @@ public abstract class Order implements Serializable {
   private final OrderType type;
 
   /** Amount to be ordered / amount that was ordered */
-  private final BigDecimal originalAmount;
+  @Setter
+  private BigDecimal originalAmount;
 
   /** The instrument could be a currency pair of derivative */
   private final Instrument instrument;

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/Trade.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/Trade.java
@@ -7,12 +7,15 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.Objects;
+import lombok.Getter;
+import lombok.Setter;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 
 /** Data object representing a Trade */
+@Getter
 @JsonDeserialize(builder = Trade.Builder.class)
 public class Trade implements Serializable {
 
@@ -22,7 +25,8 @@ public class Trade implements Serializable {
   protected final OrderType type;
 
   /** Amount that was traded */
-  protected final BigDecimal originalAmount;
+  @Setter
+  protected BigDecimal originalAmount;
 
   /** The instrument */
   protected final Instrument instrument;
@@ -74,21 +78,6 @@ public class Trade implements Serializable {
     this.takerOrderId = takerOrderId;
   }
 
-  public OrderType getType() {
-
-    return type;
-  }
-
-  public BigDecimal getOriginalAmount() {
-
-    return originalAmount;
-  }
-
-  public Instrument getInstrument() {
-
-    return instrument;
-  }
-
   /**
    * @deprecated CurrencyPair is a subtype of Instrument - this method will throw an exception if
    *     the order was for a derivative
@@ -105,29 +94,6 @@ public class Trade implements Serializable {
           "The instrument of this order is not a currency pair: " + instrument);
     }
     return (CurrencyPair) instrument;
-  }
-
-  public BigDecimal getPrice() {
-
-    return price;
-  }
-
-  public Date getTimestamp() {
-
-    return timestamp;
-  }
-
-  public String getId() {
-
-    return id;
-  }
-
-  public String getMakerOrderId() {
-    return makerOrderId;
-  }
-
-  public String getTakerOrderId() {
-    return takerOrderId;
   }
 
   @Override

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinExchange.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinExchange.java
@@ -35,7 +35,7 @@ public class OkCoinExchange extends BaseExchange {
   private static int futuresLeverageOfConfig(ExchangeSpecification exchangeSpecification) {
 
     if (exchangeSpecification.getExchangeSpecificParameters().containsKey("Futures_Leverage")) {
-      return Integer.valueOf(
+      return Integer.parseInt(
           (String) exchangeSpecification.getExchangeSpecificParameters().get("Futures_Leverage"));
     } else {
       // default choice of 10x leverage is "safe" choice and default by OkCoin.

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinUtils.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinUtils.java
@@ -21,7 +21,7 @@ public class OkCoinUtils {
   }
 
   public static String getErrorMessage(int errorCode) {
-    // https://www.okex.com/rest_request.html
+    // https://www.okx.com/docs-v5/en/#error-code-rest-api
     switch (errorCode) {
       case (1002):
         return "The transaction amount exceed the balance";

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/v3/dto/account/BillType.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/v3/dto/account/BillType.java
@@ -3,7 +3,7 @@ package org.knowm.xchange.okcoin.v3.dto.account;
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 
-/** https://www.okex.com/docs/en/#futures-query */
+/** https://www.okx.com/docs/en/#futures-query */
 @AllArgsConstructor
 public enum BillType {
   open_long("1"),

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/dto/OkexResponse.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/dto/OkexResponse.java
@@ -1,8 +1,10 @@
 package org.knowm.xchange.okex.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
 
 /** Author: Max Gao (gaamox@tutanota.com) Created: 08-06-2021 */
+@Getter
 public class OkexResponse<V> {
 
   private final String code;
@@ -20,18 +22,6 @@ public class OkexResponse<V> {
 
   public boolean isSuccess() {
     return "0".equals(code);
-  }
-
-  public V getData() {
-    return data;
-  }
-
-  public String getCode() {
-    return code;
-  }
-
-  public String getMsg() {
-    return msg;
   }
 
   @Override

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/dto/account/OkexAccountConfig.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/dto/account/OkexAccountConfig.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 
 /** Author: Max Gao (gaamox@tutanota.com) Created: 08-06-2021 */
 
-/** https://www.okex.com/docs-v5/en/#rest-api-account-get-account-configuration * */
+/** https://www.okx.com/docs-v5/en/#rest-api-account-get-account-configuration * */
 @Getter
 @NoArgsConstructor
 public class OkexAccountConfig {

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/dto/account/OkexAssetBalance.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/dto/account/OkexAssetBalance.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 
 /* Author: Ali Gokalp Peker (aligokalppeker@yahoo.com) Created: 23-10-2021 */
 
-/** <a href="https://www.okex.com/docs-v5/en/#rest-api-funding-get-balance">...</a> * */
+/** <a href="https://www.okx.com/docs-v5/en/#rest-api-funding-get-balance">...</a> * */
 @Getter
 @NoArgsConstructor
 public class OkexAssetBalance {

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/dto/account/OkexWalletBalance.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/dto/account/OkexWalletBalance.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 
 /** Author: Max Gao (gaamox@tutanota.com) Created: 08-06-2021 */
 
-/** https://www.okex.com/docs-v5/en/#rest-api-account-get-balance * */
+/** https://www.okx.com/docs-v5/en/#rest-api-account-get-balance * */
 @Getter
 @NoArgsConstructor
 public class OkexWalletBalance {

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/dto/marketdata/OkexCurrency.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/dto/marketdata/OkexCurrency.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /** Author: Max Gao (gaamox@tutanota.com) Created: 08-06-2021 */
-/** https://www.okex.com/docs-v5/en/#rest-api-funding-get-currencies * */
+/** https://www.okx.com/docs-v5/en/#rest-api-funding-get-currencies * */
 @Getter
 @NoArgsConstructor
 public class OkexCurrency {

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/dto/marketdata/OkexInstrument.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/dto/marketdata/OkexInstrument.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /* Author: Max Gao (gaamox@tutanota.com) Created: 08-06-2021 */
-/** <a href="https://www.okex.com/docs-v5/en/#rest-api-public-data-get-instruments">...</a> * */
+/** <a href="https://www.okx.com/docs-v5/en/#rest-api-public-data-get-instruments">...</a> * */
 @Getter
 @NoArgsConstructor
 public class OkexInstrument {

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/dto/marketdata/OkexPublicOrder.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/dto/marketdata/OkexPublicOrder.java
@@ -1,7 +1,6 @@
 package org.knowm.xchange.okex.dto.marketdata;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -9,11 +8,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.io.IOException;
 import java.math.BigDecimal;
+import lombok.Getter;
 
 @JsonDeserialize(using = OkexPublicOrder.OkexOrderDeserializer.class)
 public class OkexPublicOrder {
 
+  @Getter
   private final BigDecimal price;
+  @Getter
   private final BigDecimal volume;
   private final Integer liquidatedOrders;
   private final Integer activeOrders;
@@ -25,16 +27,6 @@ public class OkexPublicOrder {
     this.volume = volume;
     this.liquidatedOrders = liquidatedOrders;
     this.activeOrders = activeOrders;
-  }
-
-  public BigDecimal getPrice() {
-
-    return price;
-  }
-
-  public BigDecimal getVolume() {
-
-    return volume;
   }
 
   @Override
@@ -55,15 +47,15 @@ public class OkexPublicOrder {
 
     @Override
     public OkexPublicOrder deserialize(JsonParser jsonParser, DeserializationContext ctxt)
-        throws IOException, JsonProcessingException {
+        throws IOException {
 
       ObjectCodec oc = jsonParser.getCodec();
       JsonNode node = oc.readTree(jsonParser);
       if (node.isArray()) {
         BigDecimal price = new BigDecimal(node.path(0).asText());
         BigDecimal volume = new BigDecimal(node.path(1).asText());
-        Integer liquidatedOrders = new Integer(node.path(2).asText());
-        Integer activeOrders = new Integer(node.path(3).asText());
+        Integer liquidatedOrders = Integer.valueOf(node.path(2).asText());
+        Integer activeOrders = Integer.valueOf(node.path(3).asText());
 
         return new OkexPublicOrder(price, volume, liquidatedOrders, activeOrders);
       }

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/dto/trade/OkexOrderRequest.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/dto/trade/OkexOrderRequest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 
 /* Author: Max Gao (gaamox@tutanota.com) Created: 09-06-2021 */
-/** <a href="https://www.okex.com/docs-v5/en/#rest-api-trade-place-order">...</a> * */
+/** <a href="https://www.okx.com/docs-v5/en/#rest-api-trade-place-order">...</a> * */
 @Builder
 public class OkexOrderRequest {
   @JsonProperty("instId")

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/service/OkexBaseService.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/service/OkexBaseService.java
@@ -42,7 +42,7 @@ public class OkexBaseService extends BaseResilientExchangeService<OkexExchange>
             exchange.getExchangeSpecification().getExchangeSpecificParametersItem("passphrase");
   }
 
-  /** <a href="https://www.okex.com/docs-v5/en/#error-code">...</a> * */
+  /** <a href="https://www.okx.com/docs-v5/en/#error-code">...</a> * */
   protected ExchangeException handleError(OkexException exception) {
     if (exception.getMessage().contains("Requests too frequent")) {
       return new RateLimitExceededException(exception);

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/service/OkexDigest.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/service/OkexDigest.java
@@ -15,7 +15,7 @@ public class OkexDigest extends BaseParamsDigest {
     return secretKeyBase64 == null ? null : new OkexDigest(secretKeyBase64);
   }
 
-  /** https://www.okex.com/docs-v5/en/#rest-api-authentication-signature * */
+  /** <a href="https://www.okx.com/docs-v5/en/#rest-api-authentication-signature">...</a> * */
   @Override
   public String digestParams(RestInvocation restInvocation) {
 

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/service/OkexMarketDataService.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/service/OkexMarketDataService.java
@@ -34,13 +34,13 @@ public class OkexMarketDataService extends OkexMarketDataServiceRaw implements M
   @Override
   public OrderBook getOrderBook(Instrument instrument, Object... args) throws IOException {
     return OkexAdapters.adaptOrderBook(
-        getOkexOrderbook(OkexAdapters.adaptInstrument(instrument)), instrument);
+        getOkexOrderbook(OkexAdapters.adaptInstrument(instrument)), instrument, exchange.getExchangeMetaData());
   }
 
   @Override
   public Trades getTrades(Instrument instrument, Object... args) throws IOException {
     return OkexAdapters.adaptTrades(
-        getOkexTrades(OkexAdapters.adaptInstrument(instrument), 100).getData(), instrument);
+        getOkexTrades(OkexAdapters.adaptInstrument(instrument), 100).getData(), instrument, exchange.getExchangeMetaData());
   }
 
   @Override

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/service/OkexTradeServiceRaw.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/service/OkexTradeServiceRaw.java
@@ -156,7 +156,7 @@ public class OkexTradeServiceRaw extends OkexBaseService {
     }
   }
 
-  /** <a href="https://www.okex.com/docs-v5/en/#rest-api-trade-place-order">...</a> */
+  /** <a href="https://www.okx.com/docs-v5/en/#rest-api-trade-place-order">...</a> */
   public OkexResponse<List<OkexOrderResponse>> placeOkexOrder(OkexOrderRequest order)
       throws IOException {
     try {
@@ -182,7 +182,7 @@ public class OkexTradeServiceRaw extends OkexBaseService {
     }
   }
 
-  /** <a href="https://www.okex.com/docs-v5/en/#rest-api-trade-place-multiple-orders">...</a> */
+  /** <a href="https://www.okx.com/docs-v5/en/#rest-api-trade-place-multiple-orders">...</a> */
   public OkexResponse<List<OkexOrderResponse>> placeOkexOrder(List<OkexOrderRequest> orders)
       throws IOException {
     try {
@@ -208,7 +208,7 @@ public class OkexTradeServiceRaw extends OkexBaseService {
     }
   }
 
-  /** <a href="https://www.okex.com/docs-v5/en/#rest-api-trade-cancel-order">...</a> */
+  /** <a href="https://www.okx.com/docs-v5/en/#rest-api-trade-cancel-order">...</a> */
   public OkexResponse<List<OkexOrderResponse>> cancelOkexOrder(OkexCancelOrderRequest order)
       throws IOException {
     try {
@@ -234,7 +234,7 @@ public class OkexTradeServiceRaw extends OkexBaseService {
     }
   }
 
-  /** <a href="https://www.okex.com/docs-v5/en/#rest-api-trade-cancel-multiple-orders">...</a> */
+  /** <a href="https://www.okx.com/docs-v5/en/#rest-api-trade-cancel-multiple-orders">...</a> */
   public OkexResponse<List<OkexOrderResponse>> cancelOkexOrder(List<OkexCancelOrderRequest> orders)
       throws IOException {
     try {
@@ -260,7 +260,7 @@ public class OkexTradeServiceRaw extends OkexBaseService {
     }
   }
 
-  /** <a href="https://www.okex.com/docs-v5/en/#rest-api-trade-amend-order">...</a> */
+  /** <a href="https://www.okx.com/docs-v5/en/#rest-api-trade-amend-order">...</a> */
   public OkexResponse<List<OkexOrderResponse>> amendOkexOrder(OkexAmendOrderRequest order)
       throws IOException {
     try {
@@ -286,7 +286,7 @@ public class OkexTradeServiceRaw extends OkexBaseService {
     }
   }
 
-  /** <a href="https://www.okex.com/docs-v5/en/#rest-api-trade-amend-multiple-orders">...</a> */
+  /** <a href="https://www.okx.com/docs-v5/en/#rest-api-trade-amend-multiple-orders">...</a> */
   public OkexResponse<List<OkexOrderResponse>> amendOkexOrder(List<OkexAmendOrderRequest> orders)
       throws IOException {
     try {

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/service/params/OkexTickerParams.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/service/params/OkexTickerParams.java
@@ -1,37 +1,18 @@
 /** */
 package org.knowm.xchange.okex.service.params;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.knowm.xchange.service.marketdata.params.Params;
 
 /**
  * @author leeyazhou
  */
+@Setter
+@Getter
 public class OkexTickerParams implements Params {
   private String instType;
   private String uly;
   private String instFamily;
 
-  public String getInstType() {
-    return instType;
-  }
-
-  public void setInstType(String instType) {
-    this.instType = instType;
-  }
-
-  public String getUly() {
-    return uly;
-  }
-
-  public void setUly(String uly) {
-    this.uly = uly;
-  }
-
-  public String getInstFamily() {
-    return instFamily;
-  }
-
-  public void setInstFamily(String instFamily) {
-    this.instFamily = instFamily;
-  }
 }

--- a/xchange-stream-okex/src/main/java/info/bitrich/xchangestream/okex/OkexStreamingExchange.java
+++ b/xchange-stream-okex/src/main/java/info/bitrich/xchangestream/okex/OkexStreamingExchange.java
@@ -37,7 +37,7 @@ public class OkexStreamingExchange extends OkexExchange implements StreamingExch
   @Override
   public Completable connect(ProductSubscription... args) {
     this.streamingService = new OkexStreamingService(getApiUrl(), this.exchangeSpecification);
-    this.streamingMarketDataService = new OkexStreamingMarketDataService(streamingService);
+    this.streamingMarketDataService = new OkexStreamingMarketDataService(streamingService, exchangeMetaData);
     this.streamingTradeService = new OkexStreamingTradeService(streamingService, exchangeMetaData);
 
     return streamingService.connect();

--- a/xchange-stream-okex/src/main/java/info/bitrich/xchangestream/okex/OkexStreamingMarketDataService.java
+++ b/xchange-stream-okex/src/main/java/info/bitrich/xchangestream/okex/OkexStreamingMarketDataService.java
@@ -1,20 +1,39 @@
 package info.bitrich.xchangestream.okex;
 
-import static info.bitrich.xchangestream.okex.OkexStreamingService.*;
+import static info.bitrich.xchangestream.okex.OkexStreamingService.FUNDING_RATE;
+import static info.bitrich.xchangestream.okex.OkexStreamingService.ORDERBOOK;
+import static info.bitrich.xchangestream.okex.OkexStreamingService.ORDERBOOK5;
+import static info.bitrich.xchangestream.okex.OkexStreamingService.TICKERS;
+import static info.bitrich.xchangestream.okex.OkexStreamingService.TRADES;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
 import info.bitrich.xchangestream.service.netty.StreamingObjectMapperHelper;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.subjects.PublishSubject;
+import java.math.BigDecimal;
 import java.sql.Timestamp;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.knowm.xchange.dto.Order;
-import org.knowm.xchange.dto.marketdata.*;
+import org.knowm.xchange.dto.marketdata.FundingRate;
+import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.marketdata.OrderBookUpdate;
+import org.knowm.xchange.dto.marketdata.Ticker;
+import org.knowm.xchange.dto.marketdata.Trade;
+import org.knowm.xchange.dto.meta.ExchangeMetaData;
 import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.okex.OkexAdapters;
-import org.knowm.xchange.okex.dto.marketdata.*;
+import org.knowm.xchange.okex.dto.marketdata.OkexFundingRate;
+import org.knowm.xchange.okex.dto.marketdata.OkexOrderbook;
+import org.knowm.xchange.okex.dto.marketdata.OkexPublicOrder;
+import org.knowm.xchange.okex.dto.marketdata.OkexTicker;
+import org.knowm.xchange.okex.dto.marketdata.OkexTrade;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,13 +42,15 @@ public class OkexStreamingMarketDataService implements StreamingMarketDataServic
   private static final Logger LOG = LoggerFactory.getLogger(OkexStreamingMarketDataService.class);
 
   private final OkexStreamingService service;
+  private final ExchangeMetaData exchangeMetaData;
 
   private final ObjectMapper mapper = StreamingObjectMapperHelper.getObjectMapper();
   private final Map<Instrument, PublishSubject<List<OrderBookUpdate>>>
       orderBookUpdatesSubscriptions;
 
-  public OkexStreamingMarketDataService(OkexStreamingService service) {
+  public OkexStreamingMarketDataService(OkexStreamingService service,ExchangeMetaData exchangeMetaData) {
     this.service = service;
+    this.exchangeMetaData = exchangeMetaData;
     this.orderBookUpdatesSubscriptions = new ConcurrentHashMap<>();
   }
 
@@ -68,7 +89,7 @@ public class OkexStreamingMarketDataService implements StreamingMarketDataServic
                       jsonNode.get("data"),
                       mapper.getTypeFactory().constructCollectionType(List.class, OkexTrade.class));
               return Observable.fromIterable(
-                  OkexAdapters.adaptTrades(okexTradeList, instrument).getTrades());
+                  OkexAdapters.adaptTrades(okexTradeList, instrument,exchangeMetaData).getTrades());
             });
   }
 
@@ -112,16 +133,17 @@ public class OkexStreamingMarketDataService implements StreamingMarketDataServic
                           .getTypeFactory()
                           .constructCollectionType(List.class, OkexOrderbook.class));
               if ("snapshot".equalsIgnoreCase(action)) {
-                OrderBook orderBook = OkexAdapters.adaptOrderBook(okexOrderbooks, instrument);
+                OrderBook orderBook = OkexAdapters.adaptOrderBook(okexOrderbooks, instrument,exchangeMetaData);
                 orderBookMap.put(instId, orderBook);
                 return Observable.just(orderBook);
               } else if ("update".equalsIgnoreCase(action)) {
                 OrderBook orderBook = orderBookMap.getOrDefault(instId, null);
                 if (orderBook == null) {
-                  LOG.error(String.format("Failed to get orderBook, instId=%s.", instId));
+                  LOG.error("Failed to get orderBook, instId={}.", instId);
                   return Observable.fromIterable(new LinkedList<>());
                 }
                 Date timestamp = new Timestamp(Long.parseLong(okexOrderbooks.get(0).getTs()));
+                BigDecimal contractValue = exchangeMetaData.getInstruments().get(instrument).getContractValue();
                 okexOrderbooks
                     .get(0)
                     .getAsks()
@@ -129,7 +151,7 @@ public class OkexStreamingMarketDataService implements StreamingMarketDataServic
                         okexPublicOrder ->
                             orderBook.update(
                                 OkexAdapters.adaptLimitOrder(
-                                    okexPublicOrder, instrument, Order.OrderType.ASK, timestamp)));
+                                    okexPublicOrder, instrument, Order.OrderType.ASK, timestamp,contractValue)));
                 okexOrderbooks
                     .get(0)
                     .getBids()
@@ -137,7 +159,7 @@ public class OkexStreamingMarketDataService implements StreamingMarketDataServic
                         okexPublicOrder ->
                             orderBook.update(
                                 OkexAdapters.adaptLimitOrder(
-                                    okexPublicOrder, instrument, Order.OrderType.BID, timestamp)));
+                                    okexPublicOrder, instrument, Order.OrderType.BID, timestamp,contractValue)));
                 if (orderBookUpdatesSubscriptions.get(instrument) != null) {
                   orderBookUpdatesSubscriptions(
                       instrument,
@@ -148,8 +170,7 @@ public class OkexStreamingMarketDataService implements StreamingMarketDataServic
                 return Observable.just(orderBook);
 
               } else {
-                LOG.error(
-                    String.format("Unexpected books action=%s, message=%s", action, jsonNode));
+                LOG.error("Unexpected books action={}, message={}", action, jsonNode);
                 return Observable.fromIterable(new LinkedList<>());
               }
             });


### PR DESCRIPTION
okx future uses contracts for volume, instead of the usual volume in units of the base currency.
So we have to convert the volume according to the instrument metadata. 
Brought to the correct form ws getTrades and ws getOrderBook