### PR TITLE
[tradeogre] handle null volume in adaptTicker

### DIFF
--- a/xchange-tradeogre/src/main/java/org/knowm/xchange/tradeogre/TradeOgreAdapters.java
+++ b/xchange-tradeogre/src/main/java/org/knowm/xchange/tradeogre/TradeOgreAdapters.java
@@ -41,7 +41,7 @@ public class TradeOgreAdapters {
 
   public static Ticker adaptTicker(CurrencyPair currencyPair, TradeOgreTicker tradeOgreTicker) {
     return new Ticker.Builder()
-        .quoteVolume(new BigDecimal(tradeOgreTicker.getVolume()))
+        .volume(tradeOgreTicker.getVolume() != null ? new BigDecimal(tradeOgreTicker.getVolume()) : null)
         .high(new BigDecimal(tradeOgreTicker.getHigh()))
         .low(new BigDecimal(tradeOgreTicker.getLow()))
         .last(new BigDecimal(tradeOgreTicker.getPrice()))


### PR DESCRIPTION
The TradeOgre API can return a null volume. This commit adds a null check to handle this case and prevent a NullPointerException.