### PR TITLE
[gateio] Extend currencies payload

### DIFF
--- a/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/dto/marketdata/GateioCurrencyInfo.java
+++ b/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/dto/marketdata/GateioCurrencyInfo.java
@@ -1,9 +1,14 @@
 package org.knowm.xchange.gateio.dto.marketdata;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.math.BigDecimal;
+import java.util.List;
 import lombok.Builder;
 import lombok.Data;
 import lombok.extern.jackson.Jacksonized;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.gateio.config.converter.StringToCurrencyConverter;
 
 @Data
 @Builder
@@ -11,7 +16,8 @@ import lombok.extern.jackson.Jacksonized;
 public class GateioCurrencyInfo {
 
   @JsonProperty("currency")
-  String currencyWithChain;
+  @JsonDeserialize(converter = StringToCurrencyConverter.class)
+  Currency currency;
 
   @JsonProperty("delisted")
   Boolean delisted;
@@ -28,8 +34,14 @@ public class GateioCurrencyInfo {
   @JsonProperty("trade_disabled")
   Boolean tradeDisabled;
 
+  @JsonProperty("fixed_rate")
+  BigDecimal fixedFeeRate;
+
   @JsonProperty("chain")
-  String chain;
+  String mainChain;
+
+  @JsonProperty("chains")
+  List<Chain> chains;
 
   public boolean isWithdrawEnabled() {
     return (withdrawDisabled != null) && !withdrawDisabled;
@@ -37,5 +49,35 @@ public class GateioCurrencyInfo {
 
   public boolean isDepositEnabled() {
     return (depositDisabled != null) && !depositDisabled;
+  }
+
+  @Data
+  @Builder
+  @Jacksonized
+  public static class Chain {
+
+    @JsonProperty("name")
+    String name;
+
+    @JsonProperty("addr")
+    String address;
+
+    @JsonProperty("withdraw_disabled")
+    Boolean withdrawDisabled;
+
+    @JsonProperty("withdraw_delayed")
+    Boolean withdrawDelayed;
+
+    @JsonProperty("deposit_disabled")
+    Boolean depositDisabled;
+
+    public boolean isWithdrawEnabled() {
+      return (withdrawDisabled != null) && !withdrawDisabled;
+    }
+
+    public boolean isDepositEnabled() {
+      return (depositDisabled != null) && !depositDisabled;
+    }
+
   }
 }

--- a/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/service/GateioMarketDataService.java
+++ b/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/service/GateioMarketDataService.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -101,9 +100,7 @@ public class GateioMarketDataService extends GateioMarketDataServiceRaw
       List<GateioCurrencyInfo> currencyInfos = getGateioCurrencyInfos();
       return currencyInfos.stream()
           .filter(gateioCurrencyInfo -> !gateioCurrencyInfo.getDelisted())
-          .map(o -> StringUtils.removeEnd(o.getCurrencyWithChain(), "_" + o.getChain()))
-          .distinct()
-          .map(Currency::getInstance)
+          .map(GateioCurrencyInfo::getCurrency)
           .collect(Collectors.toList());
     } catch (GateioException e) {
       throw GateioErrorAdapter.adapt(e);

--- a/xchange-gateio-v4/src/test/java/org/knowm/xchange/gateio/GateioIntegrationTestParent.java
+++ b/xchange-gateio-v4/src/test/java/org/knowm/xchange/gateio/GateioIntegrationTestParent.java
@@ -1,0 +1,27 @@
+package org.knowm.xchange.gateio;
+
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.dto.meta.ExchangeHealth;
+
+public class GateioIntegrationTestParent {
+
+  protected static GateioExchange exchange;
+
+  @BeforeAll
+  static void init() {
+    if (exchange == null) {
+      exchange = ExchangeFactory.INSTANCE.createExchange(GateioExchange.class);
+    }
+  }
+
+  @BeforeEach
+  void exchange_online() {
+    // skip if offline
+    assumeThat(exchange.getMarketDataService().getExchangeHealth())
+        .isEqualTo(ExchangeHealth.ONLINE);
+  }
+}

--- a/xchange-gateio-v4/src/test/java/org/knowm/xchange/gateio/service/GateioMarketDataServiceIntegration.java
+++ b/xchange-gateio-v4/src/test/java/org/knowm/xchange/gateio/service/GateioMarketDataServiceIntegration.java
@@ -6,22 +6,19 @@ import java.io.IOException;
 import java.util.List;
 import org.apache.commons.lang3.ObjectUtils;
 import org.junit.jupiter.api.Test;
-import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
-import org.knowm.xchange.dto.meta.ExchangeHealth;
-import org.knowm.xchange.gateio.GateioExchange;
+import org.knowm.xchange.gateio.GateioIntegrationTestParent;
 
-class GateioMarketDataServiceIntegration {
-
-  GateioExchange exchange = ExchangeFactory.INSTANCE.createExchange(GateioExchange.class);
+class GateioMarketDataServiceIntegration extends GateioIntegrationTestParent {
 
   @Test
-  void exchange_health() {
-    ExchangeHealth actual = exchange.getMarketDataService().getExchangeHealth();
-    assertThat(actual).isEqualTo(ExchangeHealth.ONLINE);
+  void valid_currencies() throws IOException {
+    List<Currency> actual = ((GateioMarketDataService) exchange.getMarketDataService()).getCurrencies();
+    assertThat(actual).isNotEmpty();
   }
 
   @Test

--- a/xchange-gateio-v4/src/test/java/org/knowm/xchange/gateio/service/GateioMarketDataServiceRawTest.java
+++ b/xchange-gateio-v4/src/test/java/org/knowm/xchange/gateio/service/GateioMarketDataServiceRawTest.java
@@ -8,12 +8,15 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.gateio.GateioExchangeWiremock;
 import org.knowm.xchange.gateio.dto.marketdata.GateioCurrencyChain;
 import org.knowm.xchange.gateio.dto.marketdata.GateioCurrencyInfo;
+import org.knowm.xchange.gateio.dto.marketdata.GateioCurrencyInfo.Chain;
 import org.knowm.xchange.gateio.dto.marketdata.GateioCurrencyPairDetails;
 import org.knowm.xchange.gateio.dto.marketdata.GateioOrderBook;
 import org.knowm.xchange.gateio.dto.marketdata.GateioOrderBook.PriceSizeEntry;
@@ -27,19 +30,35 @@ public class GateioMarketDataServiceRawTest extends GateioExchangeWiremock {
   public void getCurrencies_valid() throws IOException {
     List<GateioCurrencyInfo> actual = gateioMarketDataServiceRaw.getGateioCurrencyInfos();
 
-    assertThat(actual).hasSize(5);
+    assertThat(actual).hasSize(2);
 
     GateioCurrencyInfo actualBtc = actual.get(0);
 
     GateioCurrencyInfo expectedBtc =
         GateioCurrencyInfo.builder()
-            .currencyWithChain("BTC")
+            .currency(Currency.BTC)
             .delisted(false)
             .withdrawDisabled(false)
             .withdrawDelayed(false)
             .depositDisabled(false)
             .tradeDisabled(false)
-            .chain("BTC")
+            .mainChain("BTC")
+            .chains(Stream.of(
+                Chain.builder()
+                    .name("BTC")
+                    .address("")
+                    .depositDisabled(false)
+                    .withdrawDelayed(false)
+                    .withdrawDisabled(false)
+                    .build(),
+                Chain.builder()
+                    .name("BSC")
+                    .address("0x7130d2a12b9bcbfae4f2634d864a1ee1ce3ead9c")
+                    .depositDisabled(false)
+                    .withdrawDelayed(false)
+                    .withdrawDisabled(false)
+                    .build()
+            ).collect(Collectors.toList()))
             .build();
 
     assertThat(actualBtc).usingRecursiveComparison().isEqualTo(expectedBtc);

--- a/xchange-gateio-v4/src/test/resources/__files/api_v4_spot_currencies.json
+++ b/xchange-gateio-v4/src/test/resources/__files/api_v4_spot_currencies.json
@@ -1,47 +1,105 @@
 [
   {
     "currency": "BTC",
+    "name": "Bitcoin",
     "delisted": false,
     "withdraw_disabled": false,
     "withdraw_delayed": false,
     "deposit_disabled": false,
     "trade_disabled": false,
-    "chain": "BTC"
-  },
-  {
-    "currency": "BTC_BSC",
-    "delisted": false,
-    "withdraw_disabled": false,
-    "withdraw_delayed": false,
-    "deposit_disabled": false,
-    "trade_disabled": false,
-    "chain": "BSC"
-  },
-  {
-    "currency": "BTC_HT",
-    "delisted": false,
-    "withdraw_disabled": true,
-    "withdraw_delayed": false,
-    "deposit_disabled": true,
-    "trade_disabled": false,
-    "chain": "HT"
+    "fixed_rate": "",
+    "chain": "BTC",
+    "chains": [
+      {
+        "name": "BTC",
+        "addr": "",
+        "withdraw_disabled": false,
+        "withdraw_delayed": false,
+        "deposit_disabled": false
+      },
+      {
+        "name": "BSC",
+        "addr": "0x7130d2a12b9bcbfae4f2634d864a1ee1ce3ead9c",
+        "withdraw_disabled": false,
+        "withdraw_delayed": false,
+        "deposit_disabled": false
+      }
+    ]
   },
   {
     "currency": "ETH",
+    "name": "Ethereum",
     "delisted": false,
     "withdraw_disabled": false,
     "withdraw_delayed": false,
     "deposit_disabled": false,
     "trade_disabled": false,
-    "chain": "ETH"
-  },
-  {
-    "currency": "ETH_BSC",
-    "delisted": false,
-    "withdraw_disabled": false,
-    "withdraw_delayed": false,
-    "deposit_disabled": false,
-    "trade_disabled": false,
-    "chain": "BSC"
+    "fixed_rate": "",
+    "chain": "ETH",
+    "chains": [
+      {
+        "name": "ETH",
+        "addr": "",
+        "withdraw_disabled": false,
+        "withdraw_delayed": false,
+        "deposit_disabled": false
+      },
+      {
+        "name": "ARBEVM",
+        "addr": "",
+        "withdraw_disabled": false,
+        "withdraw_delayed": false,
+        "deposit_disabled": false
+      },
+      {
+        "name": "ARBNOVA",
+        "addr": "",
+        "withdraw_disabled": false,
+        "withdraw_delayed": false,
+        "deposit_disabled": false
+      },
+      {
+        "name": "BASEEVM",
+        "addr": "",
+        "withdraw_disabled": false,
+        "withdraw_delayed": false,
+        "deposit_disabled": false
+      },
+      {
+        "name": "BSC",
+        "addr": "0x2170ed0880ac9a755fd29b2688956bd959f933f8",
+        "withdraw_disabled": false,
+        "withdraw_delayed": false,
+        "deposit_disabled": false
+      },
+      {
+        "name": "LINEAETH",
+        "addr": "",
+        "withdraw_disabled": false,
+        "withdraw_delayed": false,
+        "deposit_disabled": false
+      },
+      {
+        "name": "MANTAETH",
+        "addr": "",
+        "withdraw_disabled": false,
+        "withdraw_delayed": false,
+        "deposit_disabled": false
+      },
+      {
+        "name": "OPETH",
+        "addr": "",
+        "withdraw_disabled": false,
+        "withdraw_delayed": false,
+        "deposit_disabled": false
+      },
+      {
+        "name": "ZKSERA",
+        "addr": "",
+        "withdraw_disabled": false,
+        "withdraw_delayed": false,
+        "deposit_disabled": false
+      }
+    ]
   }
 ]

--- a/xchange-gateio-v4/src/test/resources/rest/spot.http
+++ b/xchange-gateio-v4/src/test/resources/rest/spot.http
@@ -100,7 +100,8 @@ SIGN: {{sign}}
 Timestamp: {{timestamp}}
 Content-Type: application/json
 
-###
+
+### Retrieve ticker information
 GET {{api_v4}}/spot/tickers
 Content-Type: application/json
 

--- a/xchange-gateio-v4/src/test/resources/rest/spot.http
+++ b/xchange-gateio-v4/src/test/resources/rest/spot.http
@@ -1,3 +1,7 @@
+### List all currencies' details
+GET {{api_v4}}/spot/currencies
+
+
 ### List personal trading history
 < {%
   import {gen_sign} from 'sign.js'
@@ -43,7 +47,7 @@ Content-Type: application/json
   gen_sign(request);
 %}
 
-GET {{api_v4}}/spot/orders?currency_pair=VAI_USDT&status=finished
+GET {{api_v4}}/spot/orders?currency_pair=SRT_USDT&status=finished
 KEY: {{api_key}}
 SIGN: {{sign}}
 Timestamp: {{timestamp}}
@@ -94,5 +98,9 @@ GET {{api_v4}}/spot/orders/745504484392?currency_pair=BTC_USDT
 KEY: {{api_key}}
 SIGN: {{sign}}
 Timestamp: {{timestamp}}
+Content-Type: application/json
+
+###
+GET {{api_v4}}/spot/tickers
 Content-Type: application/json
 


### PR DESCRIPTION
Gate.io changed the payload returned by `/spot/currencies`

- Adapted parsing of payload
- Extended integration tests
- Added rest request