### PR TITLE
[bitmex] Add new ticker state value

### DIFF
--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/dto/account/BitmexTicker.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/dto/account/BitmexTicker.java
@@ -345,6 +345,9 @@ public class BitmexTicker {
     @JsonProperty("Unlisted")
     UNLISTED,
 
+    @JsonProperty("Delisted")
+    DELISTED,
+
     @JsonProperty("Expired")
     EXPIRED,
 
@@ -353,6 +356,9 @@ public class BitmexTicker {
 
     @JsonProperty("Cleared")
     CLEARED,
+
+    @JsonEnumDefaultValue
+    UNKNOWN,
   }
 
   @Data


### PR DESCRIPTION
Bitmex introduced new value for ticker state `DELISTED` causing the unmarschalling exception:

```
Caused by: si.mazi.rescu.HttpStatusIOException: Cannot deserialize value of type `org.knowm.xchange.bitmex.dto.account.BitmexTicker$State` from String "Delisted": not one of the values accepted for Enum class: [Expired, Unlisted, Settled, Open, Cleared, Closed]
```

Can be easily reproduced by running integration tests.

- Added new value and a default unmarshalling to `UNKNOWN`

