### PR TITLE
[coinsph] fix for order book depth issue

### DIFF
--- a/xchange-stream-coinsph/src/main/java/info/bitrich/xchangestream/coinsph/CoinsphStreamingService.java
+++ b/xchange-stream-coinsph/src/main/java/info/bitrich/xchangestream/coinsph/CoinsphStreamingService.java
@@ -1,22 +1,26 @@
 package info.bitrich.xchangestream.coinsph;
 
-import static info.bitrich.xchangestream.coinsph.CoinsphStreamingExchange.PUBLIC_API_URI;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import info.bitrich.xchangestream.service.netty.JsonNettyStreamingService;
 import info.bitrich.xchangestream.service.netty.StreamingObjectMapperHelper;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandler;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Observable;
+import org.knowm.xchange.coinsph.service.CoinsphAccountServiceRaw;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.knowm.xchange.coinsph.service.CoinsphAccountServiceRaw;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.stream.Collectors;
+
+import static info.bitrich.xchangestream.coinsph.CoinsphStreamingExchange.PUBLIC_API_URI;
 
 public class CoinsphStreamingService extends JsonNettyStreamingService {
   private static final Logger LOG = LoggerFactory.getLogger(CoinsphStreamingService.class);
@@ -140,6 +144,7 @@ public class CoinsphStreamingService extends JsonNettyStreamingService {
 
   private String formatChannelName(String e, JsonNode message) {
     switch (e) {
+      case "depth":
       case "depthUpdate":
         return String.format("%s@depth", message.get("s").asText().toLowerCase());
       case "24hrTicker":
@@ -191,7 +196,7 @@ public class CoinsphStreamingService extends JsonNettyStreamingService {
     com.fasterxml.jackson.databind.node.ObjectNode subscribeMessage =
         objectMapper.createObjectNode();
     subscribeMessage.put("method", SUBSCRIBE);
-    subscribeMessage.set("params", objectMapper.valueToTree(new String[] {channelName}));
+    subscribeMessage.set("params", getSubscribeParams(channelName, args));
     subscribeMessage.put("id", getTimestamp());
     return objectMapper.writeValueAsString(subscribeMessage);
   }
@@ -209,9 +214,21 @@ public class CoinsphStreamingService extends JsonNettyStreamingService {
     com.fasterxml.jackson.databind.node.ObjectNode unsubscribeMessage =
         objectMapper.createObjectNode();
     unsubscribeMessage.put("method", UNSUBSCRIBE);
-    unsubscribeMessage.set("params", objectMapper.valueToTree(new String[] {channelName}));
+    unsubscribeMessage.set("params", getSubscribeParams(channelName, args));
     unsubscribeMessage.put("id", getTimestamp());
     return objectMapper.writeValueAsString(unsubscribeMessage);
+  }
+
+  private JsonNode getSubscribeParams(String channelName, Object... args) {
+
+    if (args == null || args.length == 0) {
+      return objectMapper.valueToTree(new String[] {channelName});
+    }
+
+    List<String> collect = Arrays.stream(args).map(String::valueOf).collect(Collectors.toList());
+    String argsString = String.join("@", collect);
+
+    return objectMapper.valueToTree(new String[] {channelName + argsString});
   }
 
   // Helper to get a unique ID for subscription messages (required by Coins.ph)
@@ -383,5 +400,10 @@ public class CoinsphStreamingService extends JsonNettyStreamingService {
   public Completable disconnect() {
     closeListenKey(); // Clean up listen key on disconnect
     return super.disconnect();
+  }
+
+  @Override
+  public String getSubscriptionUniqueId(String channelName, Object... args) {
+    return channelName;
   }
 }


### PR DESCRIPTION
This pull request introduces several updates to the `CoinsphStreamingService` class, focusing on improving subscription handling and code organization. Key changes include the introduction of a helper method for subscription parameters, updates to subscription and unsubscription message generation, and minor refactoring for better readability.

### Subscription handling improvements:
* Added a new helper method, `getSubscribeParams`, to generate subscription parameters dynamically based on `channelName` and optional arguments. This ensures flexibility in handling different subscription scenarios.
* Updated the `getSubscribeMessage` and `getUnsubscribeMessage` methods to use `getSubscribeParams` for creating the `params` field in JSON messages. [[1]](diffhunk://#diff-1e468948af89ae90b8af50518bdb3dc823beba48df100bb480aa25199e60d76aL194-R199) [[2]](diffhunk://#diff-1e468948af89ae90b8af50518bdb3dc823beba48df100bb480aa25199e60d76aL212-R233)

### Code organization and readability:
* Refactored imports to group static imports and improve readability.
* Added a new case `"depth"` to the `formatChannelName` method to handle additional event types.
* Implemented the `getSubscriptionUniqueId` method to return the `channelName`, ensuring compatibility with the subscription management system.