### PR TITLE
xchange-002: add default cast for instrument to currency pair

### DIFF
--- a/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/BitsoMarketDataService.java
+++ b/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/BitsoMarketDataService.java
@@ -7,6 +7,7 @@ import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trades;
+import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 
 /**
@@ -24,8 +25,18 @@ public class BitsoMarketDataService extends BitsoMarketDataServiceRaw implements
   }
 
   @Override
+  public Ticker getTicker(Instrument instrument, Object... args) throws IOException {
+    return getTicker((CurrencyPair) instrument, args);
+  }
+
+  @Override
   public OrderBook getOrderBook(CurrencyPair currencyPair, Object... args) throws IOException {
     return BitsoAdapters.adaptOrderBook(getBitsoOrderBook(currencyPair), currencyPair, 1000);
+  }
+
+  @Override
+  public OrderBook getOrderBook(Instrument instrument, Object... args) throws IOException {
+    return getOrderBook((CurrencyPair) instrument, args);
   }
 
   @Override


### PR DESCRIPTION
Goal: add support in Bitso for getOrderBook by Instrument as support for getOrderBook by CurrencyPair has been deprecated