### PR TITLE
[bitmex] Fix NPE

### DIFF
--- a/xchange-bitmex/src/test/java/org/knowm/xchange/bitmex/service/BitmexMarketDataServiceIntegration.java
+++ b/xchange-bitmex/src/test/java/org/knowm/xchange/bitmex/service/BitmexMarketDataServiceIntegration.java
@@ -56,7 +56,7 @@ class BitmexMarketDataServiceIntegration extends BitmexIntegrationTestParent {
               assertThat(ticker.getInstrument()).isNotNull();
               assertThat(ticker.getLast()).isNotNull();
 
-              if (ticker.getBid().signum() > 0 && ticker.getAsk().signum() > 0) {
+              if (ticker.getBid() != null && ticker.getAsk() != null && ticker.getBid().signum() > 0 && ticker.getAsk().signum() > 0) {
                 assertThat(ticker.getBid()).isLessThan(ticker.getAsk());
               }
             });

--- a/xchange-bitmex/src/test/resources/logback.xml
+++ b/xchange-bitmex/src/test/resources/logback.xml
@@ -18,6 +18,6 @@
 
     <!-- Define logging for organization applications only -->
 <!--    <logger name="org.knowm.xchange" level="DEBUG"/>-->
-<!--    <logger name="si.mazi.rescu" level="<Root level="WARN">"/>-->
+<!--    <logger name="si.mazi.rescu" level="TRACE"/>-->
 
 </configuration>


### PR DESCRIPTION
- Fixed `NullPointerException` in integration test
- Fixed config

If there is not enough liquidity on the market, ask or bid in ticker can be null, e.g.

<img width="519" height="451" alt="image" src="https://github.com/user-attachments/assets/e217e998-689e-4edb-a3c0-1e61fff8b718" />
