### PR TITLE
[bitfinex] fix bitcoin cash withdrawal and deposit address

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAccountServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAccountServiceRaw.java
@@ -174,7 +174,7 @@ public class BitfinexAccountServiceRaw extends BitfinexBaseService {
     } else if ("IOT".equalsIgnoreCase(currency)) {
       type = "iota";
     } else if ("BCH".equalsIgnoreCase(currency)) {
-      type = "bab";
+      type = "bchn";
     } else if ("BTG".equalsIgnoreCase(currency)) {
       type = "bgold";
     } else if ("DASH".equalsIgnoreCase(currency)) {

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexUtils.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexUtils.java
@@ -113,7 +113,7 @@ public final class BitfinexUtils {
       case "BTG":
         return "bgold";
       case "BCH":
-        return "bcash";
+        return "bchn";
       case "USDT":
         return "tetheruso";
       default:


### PR DESCRIPTION
I haven't found any documentation for this API change but I did test it and it is working.

At least the official "up-to-date listing of supported currencies" has `bchn` instead of `bab` or `bcash`: https://api.bitfinex.com/v2/conf/pub:map:currency:label
The listing is mentioned in both https://docs.bitfinex.com/v1/reference/rest-auth-withdrawal and https://docs.bitfinex.com/v1/reference/rest-auth-deposit.