### PR TITLE
OKEX: Adapt only USDC to use the unified pair

### DIFF
--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/OkexAdapters.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/OkexAdapters.java
@@ -441,8 +441,8 @@ public class OkexAdapters {
       CurrencyPair pair = (CurrencyPair) instrument;
       String base = pair.getBase().getCurrencyCode();
       String counter = pair.getCounter().getCurrencyCode();
-      // Normalize stablecoin quotes
-      if ("USDT".equals(counter) || "USDC".equals(counter)) {
+      // Adapt for USDC after delist: https://www.okx.com/docs-v5/log_en/#2025-08-20-unified-usd-orderbook-revamp
+      if ("USDC".equals(counter)) {
         counter = "USD";
       }
 

--- a/xchange-okex/src/test/java/org/knowm/xchange/okex/OkexPublicDataIntegration.java
+++ b/xchange-okex/src/test/java/org/knowm/xchange/okex/OkexPublicDataIntegration.java
@@ -81,7 +81,7 @@ public class OkexPublicDataIntegration {
     Ticker swapTicker = exchange.getMarketDataService().getTicker(instrument);
 
     assertThat(spotTicker.getInstrument().getBase()).isEqualTo(currencyPair.getBase());
-    assertThat(spotTicker.getInstrument().getCounter()).isEqualTo(Currency.USD);
+    assertThat(spotTicker.getInstrument().getCounter()).isEqualTo(Currency.USDT);
     assertThat(swapTicker.getInstrument()).isEqualTo(instrument);
   }
 
@@ -141,7 +141,7 @@ public class OkexPublicDataIntegration {
         .isEqualTo("BTC-USDT-SWAP");
     assertThat(OkexAdapters.adaptOkexInstrumentId("BTC-USDT"))
         .isEqualTo(new CurrencyPair("BTC/USDT"));
-    assertThat(OkexAdapters.adaptInstrument(new CurrencyPair("BTC/USDT"))).isEqualTo("BTC-USD");
+    assertThat(OkexAdapters.adaptInstrument(new CurrencyPair("BTC/USDT"))).isEqualTo("BTC-USDT");
     assertThat(OkexAdapters.adaptInstrument(new CurrencyPair("BTC/USDC"))).isEqualTo("BTC-USD");
   }
 }


### PR DESCRIPTION
Clarified after chatting with their API guys, the rules apply ONLY to USDC, and USDT must follow the usual format.