### PR TITLE
[binance] Fix NPE

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAdapters.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAdapters.java
@@ -1,23 +1,5 @@
 package org.knowm.xchange.binance;
 
-import java.math.BigDecimal;
-import java.math.MathContext;
-import java.math.RoundingMode;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import org.knowm.xchange.binance.dto.account.AssetDetail;
 import org.knowm.xchange.binance.dto.account.BinanceAccountInformation;
 import org.knowm.xchange.binance.dto.account.futures.BinanceFutureAccountInformation;
@@ -44,24 +26,24 @@ import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.account.Balance;
 import org.knowm.xchange.dto.account.OpenPosition;
 import org.knowm.xchange.dto.account.Wallet;
-import org.knowm.xchange.dto.marketdata.CandleStick;
-import org.knowm.xchange.dto.marketdata.CandleStickData;
-import org.knowm.xchange.dto.marketdata.FundingRate;
-import org.knowm.xchange.dto.marketdata.FundingRates;
-import org.knowm.xchange.dto.marketdata.Ticker;
-import org.knowm.xchange.dto.marketdata.Trade;
-import org.knowm.xchange.dto.marketdata.Trades;
+import org.knowm.xchange.dto.marketdata.*;
 import org.knowm.xchange.dto.meta.CurrencyMetaData;
 import org.knowm.xchange.dto.meta.ExchangeMetaData;
 import org.knowm.xchange.dto.meta.InstrumentMetaData;
 import org.knowm.xchange.dto.meta.WalletHealth;
-import org.knowm.xchange.dto.trade.LimitOrder;
-import org.knowm.xchange.dto.trade.MarketOrder;
-import org.knowm.xchange.dto.trade.OpenOrders;
-import org.knowm.xchange.dto.trade.StopOrder;
-import org.knowm.xchange.dto.trade.UserTrade;
-import org.knowm.xchange.dto.trade.UserTrades;
+import org.knowm.xchange.dto.trade.*;
 import org.knowm.xchange.instrument.Instrument;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class BinanceAdapters {
   private static final DateTimeFormatter DATE_TIME_FMT =
@@ -259,6 +241,11 @@ public class BinanceAdapters {
 
   public static Ticker toTicker(BinanceTicker24h binanceTicker24h, boolean isFuture) {
     Instrument instrument = adaptSymbol(binanceTicker24h.getSymbol(), isFuture);
+
+    if (instrument == null) {
+        return null;
+    }
+
     return new Ticker.Builder()
         .instrument(instrument)
         .open(binanceTicker24h.getOpenPrice())

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceMarketDataService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceMarketDataService.java
@@ -1,11 +1,5 @@
 package org.knowm.xchange.binance.service;
 
-import java.io.IOException;
-import java.time.Instant;
-import java.util.Date;
-import java.util.List;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.knowm.xchange.binance.BinanceAdapters;
 import org.knowm.xchange.binance.BinanceErrorAdapter;
 import org.knowm.xchange.binance.BinanceExchange;
@@ -16,17 +10,21 @@ import org.knowm.xchange.client.ResilienceRegistries;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.derivative.FuturesContract;
 import org.knowm.xchange.dto.Order.OrderType;
-import org.knowm.xchange.dto.marketdata.FundingRate;
-import org.knowm.xchange.dto.marketdata.FundingRates;
-import org.knowm.xchange.dto.marketdata.OrderBook;
-import org.knowm.xchange.dto.marketdata.Ticker;
-import org.knowm.xchange.dto.marketdata.Trades;
+import org.knowm.xchange.dto.marketdata.*;
 import org.knowm.xchange.dto.meta.ExchangeHealth;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 import org.knowm.xchange.service.marketdata.params.Params;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class BinanceMarketDataService extends BinanceMarketDataServiceRaw
     implements MarketDataService {
@@ -88,6 +86,7 @@ public class BinanceMarketDataService extends BinanceMarketDataServiceRaw
       return ticker24hAllProducts(isFutures).stream()
           .filter(BinanceTicker24h::isValid)
           .map(binanceTicker24h -> BinanceAdapters.toTicker(binanceTicker24h, isFutures))
+          .filter(Objects::nonNull)
           .collect(Collectors.toList());
     } catch (BinanceException e) {
       throw BinanceErrorAdapter.adapt(e);

--- a/xchange-binance/src/test/java/org/knowm/xchange/binance/BinanceIntegrationTestParent.java
+++ b/xchange-binance/src/test/java/org/knowm/xchange/binance/BinanceIntegrationTestParent.java
@@ -1,0 +1,27 @@
+package org.knowm.xchange.binance;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.dto.meta.ExchangeHealth;
+
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+public class BinanceIntegrationTestParent {
+
+  protected static BinanceExchange exchange;
+
+  @BeforeClass
+  public static void init() {
+    if (exchange == null) {
+      exchange = ExchangeFactory.INSTANCE.createExchange(BinanceExchange.class);
+    }
+  }
+
+  @Before
+  public void exchange_online() {
+    // skip if offline
+    assumeThat(exchange.getMarketDataService().getExchangeHealth())
+        .isEqualTo(ExchangeHealth.ONLINE);
+  }
+}

--- a/xchange-binance/src/test/java/org/knowm/xchange/binance/service/BinanceMarketDataServiceIntegration.java
+++ b/xchange-binance/src/test/java/org/knowm/xchange/binance/service/BinanceMarketDataServiceIntegration.java
@@ -1,0 +1,71 @@
+package org.knowm.xchange.binance.service;
+
+import org.junit.Test;
+import org.knowm.xchange.binance.BinanceIntegrationTestParent;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.marketdata.Ticker;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BinanceMarketDataServiceIntegration extends BinanceIntegrationTestParent {
+
+    @Test
+    public void valid_single_ticker() throws IOException {
+        Ticker ticker = exchange.getMarketDataService().getTicker(CurrencyPair.BTC_USDT);
+
+        assertThat(ticker.getInstrument()).isEqualTo(CurrencyPair.BTC_USDT);
+        assertThat(ticker.getLast()).isNotNull();
+
+        if (ticker.getBid().signum() > 0 && ticker.getAsk().signum() > 0) {
+            assertThat(ticker.getBid()).isLessThan(ticker.getAsk());
+        }
+    }
+
+    @Test
+    public void valid_tickers() throws IOException {
+        List<Ticker> tickers = exchange.getMarketDataService().getTickers(null);
+        assertThat(tickers).isNotEmpty();
+
+        assertThat(tickers)
+                .allSatisfy(
+                        ticker -> {
+                            assertThat(ticker.getInstrument()).isNotNull();
+                            assertThat(ticker.getLast()).isNotNull();
+
+                            if (ticker.getBid().signum() > 0 && ticker.getAsk().signum() > 0) {
+                                assertThat(ticker.getBid()).isLessThan(ticker.getAsk());
+                            }
+                        });
+    }
+
+    @Test
+    public void valid_orderbook() throws IOException {
+        OrderBook orderBook = exchange.getMarketDataService().getOrderBook(CurrencyPair.BTC_USDT);
+
+        assertThat(orderBook.getBids()).isNotEmpty();
+        assertThat(orderBook.getAsks()).isNotEmpty();
+
+        assertThat(orderBook.getAsks().get(0).getLimitPrice())
+                .isGreaterThan(orderBook.getBids().get(0).getLimitPrice());
+
+        assertThat(orderBook.getBids())
+                .allSatisfy(
+                        limitOrder -> {
+                            assertThat(limitOrder.getInstrument()).isEqualTo(CurrencyPair.BTC_USDT);
+                            assertThat(limitOrder.getType()).isEqualTo(Order.OrderType.BID);
+                        });
+
+        assertThat(orderBook.getAsks())
+                .allSatisfy(
+                        limitOrder -> {
+                            assertThat(limitOrder.getInstrument()).isEqualTo(CurrencyPair.BTC_USDT);
+                            assertThat(limitOrder.getType()).isEqualTo(Order.OrderType.ASK);
+                        });
+    }
+
+}


### PR DESCRIPTION
- Fixed possible NPE when symbol is not found in adapters map. 
Currently is reproduceable with symbol `AXSBIDR` after running integration test `BinanceMarketDataServiceIntegration`

- Added integration test