### PR TITLE
feat(coinmate): add metadata endpoints

### DIFF
--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/Coinmate.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/Coinmate.java
@@ -27,6 +27,7 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.math.BigDecimal;
+import org.knowm.xchange.coinmate.dto.account.CoinmateCurrencyInfo;
 import org.knowm.xchange.coinmate.dto.marketdata.CoinmateOrderBook;
 import org.knowm.xchange.coinmate.dto.marketdata.CoinmateQuickRate;
 import org.knowm.xchange.coinmate.dto.marketdata.CoinmateTicker;

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/Coinmate.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/Coinmate.java
@@ -33,6 +33,7 @@ import org.knowm.xchange.coinmate.dto.marketdata.CoinmateQuickRate;
 import org.knowm.xchange.coinmate.dto.marketdata.CoinmateTicker;
 import org.knowm.xchange.coinmate.dto.marketdata.CoinmateTickers;
 import org.knowm.xchange.coinmate.dto.marketdata.CoinmateTransactions;
+import org.knowm.xchange.coinmate.dto.metadata.CoinmateTradingPairs;
 import org.knowm.xchange.dto.meta.ExchangeMetaData;
 
 /**
@@ -79,4 +80,8 @@ public interface Coinmate {
   CoinmateQuickRate getSellQuickRate(
       @FormParam("amount") BigDecimal amount, @FormParam("currencyPair") String currencyPair)
       throws IOException;
+
+  @GET
+  @Path("tradingPairs")
+  CoinmateTradingPairs getTradingPairs() throws IOException;
 }

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateAuthenticated.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateAuthenticated.java
@@ -150,6 +150,12 @@ public interface CoinmateAuthenticated extends Coinmate {
       @FormParam("orderId") String orderId)
       throws IOException;
 
+  /**
+   * Creates a limit buy order.
+   *
+   * @param stopPrice DEPRECATED: Disabled by Coinmate API as of 2025-02-27.
+   * @param trailing DEPRECATED: Disabled by Coinmate API as of 2025-02-27.
+   */
   @POST
   @Path("buyLimit")
   CoinmateTradeResponse buyLimit(
@@ -160,14 +166,20 @@ public interface CoinmateAuthenticated extends Coinmate {
       @FormParam("amount") BigDecimal amount,
       @FormParam("price") BigDecimal price,
       @FormParam("currencyPair") String currencyPair,
-      @FormParam("stopPrice") BigDecimal stopPrice,
+      @Deprecated @FormParam("stopPrice") BigDecimal stopPrice,
       @FormParam("hidden") Integer hidden,
       @FormParam("postOnly") Integer postOnly,
       @FormParam("immediateOrCancel") Integer immediateOrCancel,
-      @FormParam("trailing") Integer trailing,
+      @Deprecated @FormParam("trailing") Integer trailing,
       @FormParam("clientOrderId") String clientOrderId)
       throws IOException;
 
+  /**
+   * Creates a limit sell order.
+   *
+   * @param stopPrice DEPRECATED: Disabled by Coinmate API as of 2025-02-27.
+   * @param trailing DEPRECATED: Disabled by Coinmate API as of 2025-02-27.
+   */
   @POST
   @Path("sellLimit")
   CoinmateTradeResponse sellLimit(
@@ -178,11 +190,11 @@ public interface CoinmateAuthenticated extends Coinmate {
       @FormParam("amount") BigDecimal amount,
       @FormParam("price") BigDecimal price,
       @FormParam("currencyPair") String currencyPair,
-      @FormParam("stopPrice") BigDecimal stopPrice,
+      @Deprecated @FormParam("stopPrice") BigDecimal stopPrice,
       @FormParam("hidden") Integer hidden,
       @FormParam("postOnly") Integer postOnly,
       @FormParam("immediateOrCancel") Integer immediateOrCancel,
-      @FormParam("trailing") Integer trailing,
+      @Deprecated @FormParam("trailing") Integer trailing,
       @FormParam("clientOrderId") String clientOrderId)
       throws IOException;
 
@@ -498,6 +510,12 @@ public interface CoinmateAuthenticated extends Coinmate {
       @FormParam("transactionId") Long transactionId)
       throws IOException;
 
+  /**
+   * Replaces an existing order with a new limit buy order.
+   *
+   * @param stopPrice DEPRECATED: Disabled by Coinmate API as of 2025-02-27.
+   * @param trailing DEPRECATED: Disabled by Coinmate API as of 2025-02-27.
+   */
   @POST
   @Path("replaceByBuyLimit")
   CoinmateReplaceResponse replaceByBuyLimit(
@@ -509,14 +527,20 @@ public interface CoinmateAuthenticated extends Coinmate {
       @FormParam("price") BigDecimal price,
       @FormParam("currencyPair") String currencyPair,
       @FormParam("orderIdToBeReplaced") String orderIdToBeReplaced,
-      @FormParam("stopPrice") BigDecimal stopPrice,
+      @Deprecated @FormParam("stopPrice") BigDecimal stopPrice,
       @FormParam("hidden") Integer hidden,
       @FormParam("postOnly") Integer postOnly,
       @FormParam("immediateOrCancel") Integer immediateOrCancel,
-      @FormParam("trailing") Integer trailing,
+      @Deprecated @FormParam("trailing") Integer trailing,
       @FormParam("clientOrderId") String clientOrderId)
       throws IOException;
 
+  /**
+   * Replaces an existing order with a new limit sell order.
+   *
+   * @param stopPrice DEPRECATED: Disabled by Coinmate API as of 2025-02-27.
+   * @param trailing DEPRECATED: Disabled by Coinmate API as of 2025-02-27.
+   */
   @POST
   @Path("replaceBySellLimit")
   CoinmateReplaceResponse replaceBySellLimit(
@@ -528,11 +552,11 @@ public interface CoinmateAuthenticated extends Coinmate {
       @FormParam("price") BigDecimal price,
       @FormParam("currencyPair") String currencyPair,
       @FormParam("orderIdToBeReplaced") String orderIdToBeReplaced,
-      @FormParam("stopPrice") BigDecimal stopPrice,
+      @Deprecated @FormParam("stopPrice") BigDecimal stopPrice,
       @FormParam("hidden") Integer hidden,
       @FormParam("postOnly") Integer postOnly,
       @FormParam("immediateOrCancel") Integer immediateOrCancel,
-      @FormParam("trailing") Integer trailing,
+      @Deprecated @FormParam("trailing") Integer trailing,
       @FormParam("clientOrderId") String clientOrderId)
       throws IOException;
 

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateAuthenticated.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateAuthenticated.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import org.knowm.xchange.coinmate.dto.account.AmountType;
 import org.knowm.xchange.coinmate.dto.account.CoinmateBalance;
+import org.knowm.xchange.coinmate.dto.account.CoinmateCurrencies;
 import org.knowm.xchange.coinmate.dto.account.CoinmateDepositAddresses;
 import org.knowm.xchange.coinmate.dto.account.CoinmateTradingFeesResponse;
 import org.knowm.xchange.coinmate.dto.account.FeePriority;
@@ -81,6 +82,15 @@ public interface CoinmateAuthenticated extends Coinmate {
       @FormParam("signature") ParamsDigest signer,
       @FormParam("nonce") SynchronizedValueFactory<Long> nonce,
       @FormParam("currencyPair") String currencyPair)
+      throws IOException;
+
+  @POST
+  @Path("currencies")
+  CoinmateCurrencies getCurrencies(
+      @FormParam("publicKey") String publicKey,
+      @FormParam("clientId") String clientId,
+      @FormParam("signature") ParamsDigest signer,
+      @FormParam("nonce") SynchronizedValueFactory<Long> nonce)
       throws IOException;
 
   // trade

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/account/CoinmateCurrencies.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/account/CoinmateCurrencies.java
@@ -1,0 +1,16 @@
+package org.knowm.xchange.coinmate.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import org.knowm.xchange.coinmate.dto.CoinmateBaseResponse;
+
+public class CoinmateCurrencies extends CoinmateBaseResponse<List<CoinmateCurrencyInfo>> {
+
+  public CoinmateCurrencies(
+      @JsonProperty("error") boolean error,
+      @JsonProperty("errorMessage") String errorMessage,
+      @JsonProperty("data") List<CoinmateCurrencyInfo> data) {
+    super(error, errorMessage, data);
+  }
+}
+

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/account/CoinmateCurrencyInfo.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/account/CoinmateCurrencyInfo.java
@@ -1,0 +1,34 @@
+package org.knowm.xchange.coinmate.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class CoinmateCurrencyInfo {
+
+  private final String currency;
+  private final String currencyName;
+  private final boolean depositEnabled;
+  private final boolean withdrawEnabled;
+  private final int precision;
+  private final List<CoinmateNetworkInfo> networks;
+
+  @JsonCreator
+  public CoinmateCurrencyInfo(
+      @JsonProperty("currency") String currency,
+      @JsonProperty("currencyName") String currencyName,
+      @JsonProperty("depositEnabled") boolean depositEnabled,
+      @JsonProperty("withdrawEnabled") boolean withdrawEnabled,
+      @JsonProperty("precision") int precision,
+      @JsonProperty("networks") List<CoinmateNetworkInfo> networks) {
+    this.currency = currency;
+    this.currencyName = currencyName;
+    this.depositEnabled = depositEnabled;
+    this.withdrawEnabled = withdrawEnabled;
+    this.precision = precision;
+    this.networks = networks;
+  }
+}
+

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/account/CoinmateDepositInfo.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/account/CoinmateDepositInfo.java
@@ -1,0 +1,34 @@
+package org.knowm.xchange.coinmate.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import lombok.Data;
+
+@Data
+public class CoinmateDepositInfo {
+
+  private final boolean enabled;
+  private final BigDecimal fixFee;
+  private final BigDecimal percentageFee;
+  private final BigDecimal minAmount;
+  private final BigDecimal maxAmount;
+  private final int minConfirmations;
+
+  @JsonCreator
+  public CoinmateDepositInfo(
+      @JsonProperty("enabled") boolean enabled,
+      @JsonProperty("fixFee") BigDecimal fixFee,
+      @JsonProperty("percentageFee") BigDecimal percentageFee,
+      @JsonProperty("minAmount") BigDecimal minAmount,
+      @JsonProperty("maxAmount") BigDecimal maxAmount,
+      @JsonProperty("minConfirmations") int minConfirmations) {
+    this.enabled = enabled;
+    this.fixFee = fixFee;
+    this.percentageFee = percentageFee;
+    this.minAmount = minAmount;
+    this.maxAmount = maxAmount;
+    this.minConfirmations = minConfirmations;
+  }
+}
+

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/account/CoinmateNetworkInfo.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/account/CoinmateNetworkInfo.java
@@ -1,0 +1,24 @@
+package org.knowm.xchange.coinmate.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class CoinmateNetworkInfo {
+
+  private final String network;
+  private final CoinmateDepositInfo deposit;
+  private final CoinmateWithdrawInfo withdraw;
+
+  @JsonCreator
+  public CoinmateNetworkInfo(
+      @JsonProperty("network") String network,
+      @JsonProperty("deposit") CoinmateDepositInfo deposit,
+      @JsonProperty("withdraw") CoinmateWithdrawInfo withdraw) {
+    this.network = network;
+    this.deposit = deposit;
+    this.withdraw = withdraw;
+  }
+}
+

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/account/CoinmateWithdrawFee.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/account/CoinmateWithdrawFee.java
@@ -1,0 +1,25 @@
+package org.knowm.xchange.coinmate.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import lombok.Data;
+
+@Data
+public class CoinmateWithdrawFee {
+
+  private final BigDecimal fixFee;
+  private final BigDecimal percentageFee;
+  private final String variant;
+
+  @JsonCreator
+  public CoinmateWithdrawFee(
+      @JsonProperty("fixFee") BigDecimal fixFee,
+      @JsonProperty("percentageFee") BigDecimal percentageFee,
+      @JsonProperty("variant") String variant) {
+    this.fixFee = fixFee;
+    this.percentageFee = percentageFee;
+    this.variant = variant;
+  }
+}
+

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/account/CoinmateWithdrawInfo.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/account/CoinmateWithdrawInfo.java
@@ -1,0 +1,32 @@
+package org.knowm.xchange.coinmate.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class CoinmateWithdrawInfo {
+
+  private final boolean enabled;
+  private final boolean requiresTag;
+  private final List<CoinmateWithdrawFee> fee;
+  private final BigDecimal minAmount;
+  private final BigDecimal max24hLimit;
+
+  @JsonCreator
+  public CoinmateWithdrawInfo(
+      @JsonProperty("enabled") boolean enabled,
+      @JsonProperty("requiresTag") boolean requiresTag,
+      @JsonProperty("fee") List<CoinmateWithdrawFee> fee,
+      @JsonProperty("minAmount") BigDecimal minAmount,
+      @JsonProperty("max24hLimit") BigDecimal max24hLimit) {
+    this.enabled = enabled;
+    this.requiresTag = requiresTag;
+    this.fee = fee;
+    this.minAmount = minAmount;
+    this.max24hLimit = max24hLimit;
+  }
+}
+

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/metadata/CoinmateTradingPairsEntry.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/metadata/CoinmateTradingPairsEntry.java
@@ -2,7 +2,9 @@ package org.knowm.xchange.coinmate.dto.metadata;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 
+@Data
 public class CoinmateTradingPairsEntry {
 
   @JsonProperty("name")
@@ -52,71 +54,5 @@ public class CoinmateTradingPairsEntry {
     this.tradesWebSocketChannelId = tradesWebSocketChannelId;
     this.orderBookWebSocketChannelId = orderBookWebSocketChannelId;
     this.tradeStatisticsWebSocketChannelId = tradeStatisticsWebSocketChannelId;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public String getBaseCurrency() {
-    return baseCurrency;
-  }
-
-  public String getCounterCurrency() {
-    return counterCurrency;
-  }
-
-  public int getPriceScale() {
-    return priceScale;
-  }
-
-  public int getVolumeScale() {
-    return volumeScale;
-  }
-
-  public double getMinAmount() {
-    return minAmount;
-  }
-
-  public String getTradesWebSocketChannelId() {
-    return tradesWebSocketChannelId;
-  }
-
-  public String getOrderBookWebSocketChannelId() {
-    return orderBookWebSocketChannelId;
-  }
-
-  public String getTradeStatisticsWebSocketChannelId() {
-    return tradeStatisticsWebSocketChannelId;
-  }
-
-  @Override
-  public String toString() {
-    return "CoinmateTradingPairs{"
-        + "name='"
-        + name
-        + '\''
-        + ", baseCurrency='"
-        + baseCurrency
-        + '\''
-        + ", counterCurrency='"
-        + counterCurrency
-        + '\''
-        + ", priceScale="
-        + priceScale
-        + ", volumeScale="
-        + volumeScale
-        + ", minAmount="
-        + minAmount
-        + ", tradesWebSocketChannelId='"
-        + tradesWebSocketChannelId
-        + '\''
-        + ", orderBookWebSocketChannelId='"
-        + orderBookWebSocketChannelId
-        + '\''
-        + ", tradeStatisticsWebSocketChannelId='"
-        + tradeStatisticsWebSocketChannelId
-        + '\''
-        + '}';
   }
 }

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateAccountServiceRaw.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateAccountServiceRaw.java
@@ -32,6 +32,7 @@ import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinmate.CoinmateAuthenticated;
 import org.knowm.xchange.coinmate.dto.account.AmountType;
 import org.knowm.xchange.coinmate.dto.account.CoinmateBalance;
+import org.knowm.xchange.coinmate.dto.account.CoinmateCurrencies;
 import org.knowm.xchange.coinmate.dto.account.CoinmateDepositAddresses;
 import org.knowm.xchange.coinmate.dto.account.CoinmateTradingFeesResponse;
 import org.knowm.xchange.coinmate.dto.account.CoinmateTradingFeesResponseData;
@@ -93,6 +94,19 @@ public class CoinmateAccountServiceRaw extends CoinmateBaseService {
     throwExceptionIfError(response);
 
     return response.getData();
+  }
+
+  public CoinmateCurrencies getCoinmateCurrencies() throws IOException {
+    CoinmateCurrencies currencies =
+        coinmateAuthenticated.getCurrencies(
+            exchange.getExchangeSpecification().getApiKey(),
+            exchange.getExchangeSpecification().getUserName(),
+            signatureCreator,
+            exchange.getNonceFactory());
+
+    throwExceptionIfError(currencies);
+
+    return currencies;
   }
 
   public Long coinmateWithdrawVirtualCurrency(

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateMetadataServiceRaw.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateMetadataServiceRaw.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.coinmate.Coinmate;
+import org.knowm.xchange.coinmate.dto.metadata.CoinmateTradingPairs;
 import org.knowm.xchange.dto.meta.ExchangeMetaData;
 
 public class CoinmateMetadataServiceRaw extends CoinmateBaseService {
@@ -20,5 +21,13 @@ public class CoinmateMetadataServiceRaw extends CoinmateBaseService {
     ExchangeMetaData metaData = coinmate.getMetadata();
 
     return metaData;
+  }
+
+  public CoinmateTradingPairs getCoinmateTradingPairs() throws IOException {
+    CoinmateTradingPairs tradingPairs = coinmate.getTradingPairs();
+
+    throwExceptionIfError(tradingPairs);
+
+    return tradingPairs;
   }
 }

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateTradeServiceRaw.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateTradeServiceRaw.java
@@ -207,15 +207,21 @@ public class CoinmateTradeServiceRaw extends CoinmateBaseService {
     return response;
   }
 
+  /**
+   * Creates a limit buy order.
+   *
+   * @param stopPrice DEPRECATED: Disabled by Coinmate API as of 2025-02-27.
+   * @param trailing DEPRECATED: Disabled by Coinmate API as of 2025-02-27.
+   */
   public CoinmateTradeResponse buyCoinmateLimit(
       BigDecimal amount,
       BigDecimal price,
       String currencyPair,
-      BigDecimal stopPrice,
+      @Deprecated BigDecimal stopPrice,
       Integer hidden,
       Integer postOnly,
       Integer immediateOrCancel,
-      Integer trailing,
+      @Deprecated Integer trailing,
       String clientOrderId)
       throws IOException {
     CoinmateTradeResponse response =
@@ -239,15 +245,21 @@ public class CoinmateTradeServiceRaw extends CoinmateBaseService {
     return response;
   }
 
+  /**
+   * Creates a limit sell order.
+   *
+   * @param stopPrice DEPRECATED: Disabled by Coinmate API as of 2025-02-27.
+   * @param trailing DEPRECATED: Disabled by Coinmate API as of 2025-02-27.
+   */
   public CoinmateTradeResponse sellCoinmateLimit(
       BigDecimal amount,
       BigDecimal price,
       String currencyPair,
-      BigDecimal stopPrice,
+      @Deprecated BigDecimal stopPrice,
       Integer hidden,
       Integer postOnly,
       Integer immediateOrCancel,
-      Integer trailing,
+      @Deprecated Integer trailing,
       String clientOrderId)
       throws IOException {
     CoinmateTradeResponse response =
@@ -271,16 +283,22 @@ public class CoinmateTradeServiceRaw extends CoinmateBaseService {
     return response;
   }
 
+  /**
+   * Replaces an existing order with a new limit buy order.
+   *
+   * @param stopPrice DEPRECATED: Disabled by Coinmate API as of 2025-02-27.
+   * @param trailing DEPRECATED: Disabled by Coinmate API as of 2025-02-27.
+   */
   public CoinmateReplaceResponse coinmateReplaceByBuyLimit(
       String orderId,
       BigDecimal amount,
       BigDecimal price,
       String currencyPair,
-      BigDecimal stopPrice,
+      @Deprecated BigDecimal stopPrice,
       Integer hidden,
       Integer postOnly,
       Integer immediateOrCancel,
-      Integer trailing,
+      @Deprecated Integer trailing,
       String clientOrderId)
       throws IOException {
     CoinmateReplaceResponse response =
@@ -305,16 +323,22 @@ public class CoinmateTradeServiceRaw extends CoinmateBaseService {
     return response;
   }
 
+  /**
+   * Replaces an existing order with a new limit sell order.
+   *
+   * @param stopPrice DEPRECATED: Disabled by Coinmate API as of 2025-02-27.
+   * @param trailing DEPRECATED: Disabled by Coinmate API as of 2025-02-27.
+   */
   public CoinmateReplaceResponse coinmateReplaceBySellLimit(
       String orderId,
       BigDecimal amount,
       BigDecimal price,
       String currencyPair,
-      BigDecimal stopPrice,
+      @Deprecated BigDecimal stopPrice,
       Integer hidden,
       Integer postOnly,
       Integer immediateOrCancel,
-      Integer trailing,
+      @Deprecated Integer trailing,
       String clientOrderId)
       throws IOException {
     CoinmateReplaceResponse response =

--- a/xchange-coinmate/src/test/java/org/knowm/xchange/coinmate/dto/account/CurrenciesJSONTest.java
+++ b/xchange-coinmate/src/test/java/org/knowm/xchange/coinmate/dto/account/CurrenciesJSONTest.java
@@ -1,0 +1,65 @@
+package org.knowm.xchange.coinmate.dto.account;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import org.junit.Test;
+
+public class CurrenciesJSONTest {
+
+  @Test
+  public void testUnmarshal() throws IOException {
+
+    InputStream is =
+        CurrenciesJSONTest.class.getResourceAsStream(
+            "/org/knowm/xchange/coinmate/dto/account/example-currencies.json");
+
+    ObjectMapper mapper = new ObjectMapper();
+    CoinmateCurrencies currencies = mapper.readValue(is, CoinmateCurrencies.class);
+
+    assertThat(currencies.isError()).isFalse();
+    assertThat(currencies.getData()).hasSize(2);
+
+    // Test BTC currency
+    CoinmateCurrencyInfo btc = currencies.getData().get(0);
+    assertThat(btc.getCurrency()).isEqualTo("BTC");
+    assertThat(btc.getCurrencyName()).isEqualTo("Bitcoin");
+    assertThat(btc.isDepositEnabled()).isTrue();
+    assertThat(btc.isWithdrawEnabled()).isTrue();
+    assertThat(btc.getPrecision()).isEqualTo(8);
+    assertThat(btc.getNetworks()).hasSize(2);
+
+    // Test BTC main network
+    CoinmateNetworkInfo btcMainNet = btc.getNetworks().get(0);
+    assertThat(btcMainNet.getNetwork()).isEqualTo("BTC");
+    assertThat(btcMainNet.getDeposit().isEnabled()).isTrue();
+    assertThat(btcMainNet.getDeposit().getFixFee()).isEqualTo(BigDecimal.ZERO);
+    assertThat(btcMainNet.getDeposit().getMinAmount()).isEqualByComparingTo("0.0001");
+    assertThat(btcMainNet.getDeposit().getMinConfirmations()).isEqualTo(2);
+
+    assertThat(btcMainNet.getWithdraw().isEnabled()).isTrue();
+    assertThat(btcMainNet.getWithdraw().isRequiresTag()).isFalse();
+    assertThat(btcMainNet.getWithdraw().getFee()).hasSize(2);
+    assertThat(btcMainNet.getWithdraw().getFee().get(0).getVariant()).isEqualTo("HIGH");
+    assertThat(btcMainNet.getWithdraw().getFee().get(0).getFixFee())
+        .isEqualByComparingTo("0.00002");
+    assertThat(btcMainNet.getWithdraw().getMinAmount()).isEqualByComparingTo("0.00001");
+    assertThat(btcMainNet.getWithdraw().getMax24hLimit()).isEqualByComparingTo("100");
+
+    // Test XRP currency
+    CoinmateCurrencyInfo xrp = currencies.getData().get(1);
+    assertThat(xrp.getCurrency()).isEqualTo("XRP");
+    assertThat(xrp.getCurrencyName()).isEqualTo("Ripple");
+    assertThat(xrp.getNetworks()).hasSize(1);
+
+    // Test XRP network with requiresTag
+    CoinmateNetworkInfo xrpNet = xrp.getNetworks().get(0);
+    assertThat(xrpNet.getWithdraw().isRequiresTag()).isTrue();
+    assertThat(xrpNet.getWithdraw().getFee()).hasSize(1);
+    assertThat(xrpNet.getWithdraw().getFee().get(0).getFixFee()).isEqualByComparingTo("0.02");
+  }
+}
+

--- a/xchange-coinmate/src/test/resources/org/knowm/xchange/coinmate/dto/account/example-currencies.json
+++ b/xchange-coinmate/src/test/resources/org/knowm/xchange/coinmate/dto/account/example-currencies.json
@@ -1,0 +1,98 @@
+{
+  "error": false,
+  "errorMessage": null,
+  "data": [
+    {
+      "currency": "BTC",
+      "currencyName": "Bitcoin",
+      "depositEnabled": true,
+      "withdrawEnabled": true,
+      "precision": 8,
+      "networks": [
+        {
+          "network": "BTC",
+          "deposit": {
+            "enabled": true,
+            "fixFee": 0,
+            "percentageFee": 0,
+            "minAmount": 0.0001,
+            "minConfirmations": 2
+          },
+          "withdraw": {
+            "enabled": true,
+            "requiresTag": false,
+            "fee": [
+              {
+                "fixFee": 0.00002,
+                "percentageFee": 0,
+                "variant": "HIGH"
+              },
+              {
+                "fixFee": 0.00001,
+                "percentageFee": 0,
+                "variant": "LOW"
+              }
+            ],
+            "minAmount": 0.00001,
+            "max24hLimit": 100
+          }
+        },
+        {
+          "network": "BTC_LIGHTNING",
+          "deposit": {
+            "enabled": true,
+            "fixFee": 0,
+            "percentageFee": 0,
+            "minAmount": 1.0E-7,
+            "maxAmount": 0.03,
+            "minConfirmations": 2
+          },
+          "withdraw": {
+            "enabled": true,
+            "requiresTag": false,
+            "fee": [
+              {
+                "fixFee": 0,
+                "percentageFee": 0
+              }
+            ],
+            "minAmount": 1.0E-7,
+            "max24hLimit": 1
+          }
+        }
+      ]
+    },
+    {
+      "currency": "XRP",
+      "currencyName": "Ripple",
+      "depositEnabled": true,
+      "withdrawEnabled": true,
+      "precision": 8,
+      "networks": [
+        {
+          "network": "XRP",
+          "deposit": {
+            "enabled": true,
+            "fixFee": 0,
+            "percentageFee": 0,
+            "minAmount": 0,
+            "minConfirmations": 1
+          },
+          "withdraw": {
+            "enabled": true,
+            "requiresTag": true,
+            "fee": [
+              {
+                "fixFee": 0.02,
+                "percentageFee": 0
+              }
+            ],
+            "minAmount": 20,
+            "max24hLimit": 50000
+          }
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
# Changes
- Added /currencies endpoint - returns currency info, fees, and deposit/withdrawal limits
- Added /tradingPairs endpoint - returns trading pair info with price scales and minimum amounts
- Added adapters to convert Coinmate responses to XChange metadata format
- Refactored DTOs to use Lombok
- Deprecated stopPrice and trailing parameters (Coinmate disabled them)