### PR TITLE
Create ExchangeHealthCheckService.java

### DIFF
--- a/ExchangeHealthCheckService.java
+++ b/ExchangeHealthCheckService.java
@@ -1,0 +1,40 @@
+package org.knowm.xchange.service.utils;
+
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.service.marketdata.MarketDataService;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.marketdata.Ticker;
+
+import java.time.Duration;
+
+/**
+ * Utility service to perform a lightweight health check on an Exchange.
+ * Useful for bots, uptime monitors, and dashboards.
+ *
+ * Example:
+ *   Exchange bitstamp = ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class);
+ *   boolean isHealthy = ExchangeHealthCheckService.isExchangeHealthy(bitstamp, Duration.ofSeconds(3));
+ */
+public final class ExchangeHealthCheckService {
+
+  private ExchangeHealthCheckService() {}
+
+  /**
+   * Pings the exchange via a simple ticker call.
+   *
+   * @param exchange Exchange instance
+   * @param timeout Duration in which the response should arrive
+   * @return true if the exchange responded successfully within the timeout
+   */
+  public static boolean isExchangeHealthy(Exchange exchange, Duration timeout) {
+    MarketDataService marketDataService = exchange.getMarketDataService();
+    long start = System.currentTimeMillis();
+    try {
+      Ticker ticker = marketDataService.getTicker(CurrencyPair.BTC_USD);
+      long elapsed = System.currentTimeMillis() - start;
+      return ticker != null && elapsed <= timeout.toMillis();
+    } catch (Exception e) {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a new utility class `ExchangeHealthCheckService` located under `xchange-core/src/main/java/org/knowm/xchange/service/utils/`.
escription

The new service allows developers to easily check whether an exchange is reachable and responding within a given timeout period. It uses a lightweight ticker request to verify API responsiveness.
hy it’s useful

* Helps bots and automated trading systems detect downtime early
* Useful for monitoring dashboards and exchange status aggregators
* Keeps core consistent with XChange’s modular utility style
* Adds no new dependencies or external API calls

### Example usage

`java
Exchange bitstamp = ExchangeFactory.INSTANCE.createExchange(BitstampExchange.class);
boolean healthy = ExchangeHealthCheckService.isExchangeHealthy(bitstamp, Duration.ofSeconds(3));
System.out.println("Bitstamp API healthy: " + healthy);
```

Tests

Basic test coverage can be added under `xchange-core/src/test/java/org/knowm/xchange/service/utils/ExchangeHealthCheckServiceTest.java`.


