### PR TITLE
[binance] Make concludeHostParams overridable to customize endpoints (private static → protected)

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceExchange.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceExchange.java
@@ -156,7 +156,7 @@ public class BinanceExchange extends BaseExchange implements Exchange {
   }
 
   /** Adjust host parameters depending on exchange specific parameters */
-  private static void concludeHostParams(ExchangeSpecification exchangeSpecification) {
+  protected void concludeHostParams(ExchangeSpecification exchangeSpecification) {
     if (exchangeSpecification.getExchangeSpecificParametersItem(EXCHANGE_TYPE) != null) {
       switch ((ExchangeType)
           exchangeSpecification.getExchangeSpecificParametersItem(EXCHANGE_TYPE)) {

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexExchange.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexExchange.java
@@ -42,7 +42,7 @@ public class BitmexExchange extends BaseExchange {
       };
 
   /** Adjust host parameters depending on exchange specific parameters */
-  private static void concludeHostParams(ExchangeSpecification exchangeSpecification) {
+  protected void concludeHostParams(ExchangeSpecification exchangeSpecification) {
 
     if (exchangeSpecification.getExchangeSpecificParameters() != null) {
       if (exchangeSpecification

--- a/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/CoinbaseProExchange.java
+++ b/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/CoinbaseProExchange.java
@@ -26,7 +26,7 @@ public class CoinbaseProExchange extends BaseExchange {
   private static ResilienceRegistries RESILIENCE_REGISTRIES;
 
   /** Adjust host parameters depending on exchange specific parameters */
-  private static void concludeHostParams(ExchangeSpecification exchangeSpecification) {
+  protected void concludeHostParams(ExchangeSpecification exchangeSpecification) {
 
     if (exchangeSpecification.getExchangeSpecificParameters() != null) {
       final boolean useSandbox =

--- a/xchange-coinsph/src/main/java/org/knowm/xchange/coinsph/CoinsphExchange.java
+++ b/xchange-coinsph/src/main/java/org/knowm/xchange/coinsph/CoinsphExchange.java
@@ -197,7 +197,7 @@ public class CoinsphExchange extends BaseExchange implements Exchange {
   }
 
   /** Adjust host parameters depending on exchange specific parameters */
-  private static void concludeHostParams(ExchangeSpecification exchangeSpecification) {
+  protected void concludeHostParams(ExchangeSpecification exchangeSpecification) {
     if (Boolean.TRUE.equals(exchangeSpecification.getExchangeSpecificParametersItem(USE_SANDBOX))) {
       exchangeSpecification.setSslUri(SANDBOX_URL);
       // Update host if necessary for sandbox

--- a/xchange-dvchain/src/main/java/org/knowm/xchange/dvchain/DVChainExchange.java
+++ b/xchange-dvchain/src/main/java/org/knowm/xchange/dvchain/DVChainExchange.java
@@ -14,7 +14,7 @@ public class DVChainExchange extends BaseExchange {
       new CurrentTimeIncrementalNonceFactory(TimeUnit.SECONDS);
 
   /** Adjust host parameters depending on exchange specific parameters */
-  private static void concludeHostParams(ExchangeSpecification exchangeSpecification) {
+  protected void concludeHostParams(ExchangeSpecification exchangeSpecification) {
 
     if (exchangeSpecification.getExchangeSpecificParameters() != null) {
       if (exchangeSpecification

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/GeminiExchange.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/GeminiExchange.java
@@ -29,7 +29,7 @@ public class GeminiExchange extends BaseExchange {
   }
 
   /** Adjust host parameters depending on exchange specific parameters */
-  private static void concludeHostParams(ExchangeSpecification exchangeSpecification) {
+  protected void concludeHostParams(ExchangeSpecification exchangeSpecification) {
 
     if (exchangeSpecification.getExchangeSpecificParameters() != null) {
       if (exchangeSpecification

--- a/xchange-krakenfutures/src/main/java/org/knowm/xchange/krakenfutures/KrakenFuturesExchange.java
+++ b/xchange-krakenfutures/src/main/java/org/knowm/xchange/krakenfutures/KrakenFuturesExchange.java
@@ -46,7 +46,7 @@ public class KrakenFuturesExchange extends BaseExchange implements Exchange {
             ((KrakenFuturesMarketDataServiceRaw) marketDataService).getKrakenFuturesInstruments());
   }
 
-  private void concludeHostParams(ExchangeSpecification exchangeSpecification) {
+  protected void concludeHostParams(ExchangeSpecification exchangeSpecification) {
     if (exchangeSpecification.getExchangeSpecificParameters() != null) {
       if (Boolean.TRUE.equals(
           exchangeSpecification.getExchangeSpecificParametersItem(USE_SANDBOX))) {

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinExchange.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinExchange.java
@@ -28,7 +28,7 @@ public class KucoinExchange extends BaseExchange implements Exchange {
 
   private static ResilienceRegistries RESILIENCE_REGISTRIES;
 
-  private void concludeHostParams(ExchangeSpecification exchangeSpecification) {
+  protected void concludeHostParams(ExchangeSpecification exchangeSpecification) {
     if (exchangeSpecification.getExchangeSpecificParameters() != null) {
       if (Boolean.TRUE.equals(
           exchangeSpecification.getExchangeSpecificParametersItem(USE_SANDBOX))) {

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinExchange.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinExchange.java
@@ -13,7 +13,7 @@ import si.mazi.rescu.SynchronizedValueFactory;
 public class OkCoinExchange extends BaseExchange {
 
   /** Adjust host parameters depending on exchange specific parameters */
-  private static void concludeHostParams(ExchangeSpecification exchangeSpecification) {
+  protected void concludeHostParams(ExchangeSpecification exchangeSpecification) {
 
     if (exchangeSpecification.getExchangeSpecificParameters() != null) {
       if (exchangeSpecification.getExchangeSpecificParametersItem("Use_Intl").equals(true)

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/OkexExchange.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/OkexExchange.java
@@ -29,7 +29,7 @@ public class OkexExchange extends BaseExchange {
   public String accountLevel = "1";
 
   /** Adjust host parameters depending on exchange specific parameters */
-  private static void concludeHostParams(ExchangeSpecification exchangeSpecification) {
+  protected void concludeHostParams(ExchangeSpecification exchangeSpecification) {
     if (exchangeSpecification.getExchangeSpecificParameters() != null) {
       final boolean useAWS =
           Boolean.TRUE.equals(


### PR DESCRIPTION
Summary

Change BinanceExchange#concludeHostParams from private static void to protected void so subclasses can override it. This enables adjusting sslUri (and related host params) before super.applySpecification(...) runs.

Change
```
- private static void concludeHostParams(ExchangeSpecification exchangeSpecification)
+ protected void concludeHostParams(ExchangeSpecification exchangeSpecification)

```
And it’s invoked from:

```
@Override
public void applySpecification(ExchangeSpecification exchangeSpecification) {
  concludeHostParams(exchangeSpecification);
  super.applySpecification(exchangeSpecification);
}
```

Motivation

In local and test environments, we run the app against a mock server / reverse proxy. With the current hard-coded endpoints, changing sslUri isn’t possible without altering core code. Allowing an override lets consumers redirect Binance endpoints (e.g., to a proxy) cleanly in a subclass.

Alternative considered

Expose all hard-coded endpoints via configuration and have BinanceExchange honor them. That would be more comprehensive but larger in scope. This PR is a low-hanging fruit that unblocks real use cases immediately with minimal surface change.

Backward compatibility

No public API removed; default behavior is unchanged unless overridden.

Moving from private static to protected does not break existing clients.

Example usage
```
public class BinanceExchangeProxy extends BinanceExchange {
  @Override
  protected void concludeHostParams(ExchangeSpecification spec) {
    spec.setSslUri("https://binance-proxy.test.mydomain.io:30443");
  }
}
```

Testing

Verified default flow keeps original endpoints.

Verified subclass can redirect sslUri to a mock/proxy and requests succeed.