### PR TITLE
Add lightweight ExchangeHealthCheck utility (xchange-core)

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/utils/ExchangeHealthCheck.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/utils/ExchangeHealthCheck.java
@@ -1,0 +1,55 @@
+package org.knowm.xchange.utils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+/**
+ * Small utility that provides a simple HTTP/REST health check for exchange endpoints.
+ * Intended to be lightweight and dependency-free (Java 11+ HttpClient).
+ *
+ * Usage:
+ *   boolean ok = ExchangeHealthCheck.isEndpointHealthy("https://api.exchange.com/ping", 2000);
+ */
+public final class ExchangeHealthCheck {
+
+  private ExchangeHealthCheck() { }
+
+  /**
+   * Performs a GET request to the given URL and returns true when the HTTP response
+   * status code indicates success (2xx) and the request completes within timeoutMs.
+   *
+   * This utility is intentionally minimal: it does not parse JSON or handle auth;
+   * it's for quick sanity checks in examples or CI smoke-tests.
+   *
+   * @param url the endpoint to check (including scheme)
+   * @param timeoutMs request timeout in milliseconds
+   * @return true if endpoint responds with 2xx within timeout; false otherwise
+   */
+  public static boolean isEndpointHealthy(String url, int timeoutMs) {
+    HttpClient client = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofMillis(timeoutMs))
+        .build();
+
+    HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(url))
+        .timeout(Duration.ofMillis(timeoutMs))
+        .GET()
+        .build();
+
+    try {
+      HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
+      int code = response.statusCode();
+      return code >= 200 && code < 300;
+    } catch (IOException | InterruptedException | IllegalArgumentException e) {
+      // InterruptedException: restore interrupt flag
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Adds a small utility ExchangeHealthCheck under xchange-core/src/main/java/org/knowm/xchange/utils/ that performs a basic HTTP GET health check for exchange REST endpoints using Java 11 HttpClient.

Why

Useful for examples, quick CLI tools, integration smoke-tests and CI steps that need to verify an exchange endpoint is reachable before running heavier tests.

Dependency-free (no new libraries) and minimal surface area.

Behavior

isEndpointHealthy(String url, int timeoutMs) returns true for 2xx responses within timeout; otherwise false.

No JSON parsing or authentication handled — intentionally minimal.

Notes

This is intended as a developer convenience helper. If maintainers prefer a dedicated test-helper module or a different package, happy to move it.

I did not add unit tests that perform real network calls; a follow-up could add mock-based tests or a CI job that runs an offline-mode test.

Testing
Local manual verification against a few public endpoints (e.g. Bitstamp system time endpoint).

If this is acceptable, I can add a short unit test with a mocked HttpClient (or use WireMock) in a follow-up PR.