### PR TITLE
Improve the efficiency of StreamingAccountService when obtaining balances

### DIFF
--- a/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingAccountService.java
+++ b/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingAccountService.java
@@ -7,6 +7,8 @@ import org.knowm.xchange.exceptions.ExchangeSecurityException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.account.AccountService;
 
+import java.util.Set;
+
 public interface StreamingAccountService {
 
   /**
@@ -30,6 +32,29 @@ public interface StreamingAccountService {
    * @return {@link Observable} that emits {@link Balance} when exchange sends the update.
    */
   default Observable<Balance> getBalanceChanges(Currency currency, Object... args) {
+    throw new NotYetImplementedForExchangeException("getBalanceChanges");
+  }
+
+  /**
+   * Get the changes of account balance for the logged-in user.
+   *
+   * <p><strong>Warning:</strong> there are currently no guarantees that messages will arrive in
+   * order, that messages will not be skipped, or that any initial state message will be sent on
+   * connection. Most exchanges have a recommended approach for managing this, involving timestamps,
+   * sequence numbers and a separate REST API for re-sync when inconsistencies appear. You should
+   * implement these approaches, if required, by combining calls to this method with {@link
+   * AccountService#getAccountInfo()}.
+   *
+   * <p><strong>Emits</strong> {@link
+   * info.bitrich.xchangestream.service.exception.NotConnectedException} When not connected to the
+   * WebSocket API.
+   *
+   * <p><strong>Immediately throws</strong> {@link ExchangeSecurityException} if called without
+   * authentication details
+   *
+   * @return {@link Observable} that emits {@link Set<Balance>} when exchange sends the update.
+   */
+  default Observable<Set<Balance>> getBalancesChanges(Object... args) {
     throw new NotYetImplementedForExchangeException("getBalanceChanges");
   }
 }

--- a/xchange-stream-kraken-v2/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingAccountService.java
+++ b/xchange-stream-kraken-v2/src/main/java/info/bitrich/xchangestream/kraken/KrakenStreamingAccountService.java
@@ -8,6 +8,9 @@ import io.reactivex.rxjava3.core.Observable;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.dto.account.Balance;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
 public class KrakenStreamingAccountService implements StreamingAccountService {
 
   private final KrakenStreamingService service;
@@ -26,4 +29,15 @@ public class KrakenStreamingAccountService implements StreamingAccountService {
         .map(KrakenStreamingAdapters::toBalance);
   }
 
+  @Override
+  public Observable<Set<Balance>> getBalancesChanges(Object... args) {
+    return service
+            .subscribeChannel(ChannelType.BALANCES.getValue())
+            .map(KrakenBalancesMessage.class::cast)
+            .map(message ->
+                    message.getData().stream()
+                      .map(KrakenStreamingAdapters::toBalance)
+                      .collect(Collectors.toSet())
+            );
+  }
 }

--- a/xchange-stream-kraken-v2/src/test/java/info/bitrich/xchangestream/kraken/KrakenStreamingAccountServiceTest.java
+++ b/xchange-stream-kraken-v2/src/test/java/info/bitrich/xchangestream/kraken/KrakenStreamingAccountServiceTest.java
@@ -10,6 +10,8 @@ import info.bitrich.xchangestream.kraken.dto.response.KrakenMessage;
 import io.reactivex.rxjava3.core.Observable;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -64,6 +66,38 @@ class KrakenStreamingAccountServiceTest {
         .usingComparatorForType(BigDecimal::compareTo, BigDecimal.class)
         .usingRecursiveComparison()
         .isEqualTo(expected);
+
+  }
+
+  @Test
+  void allBalances() throws Exception {
+    KrakenMessage notification = readMessage("sample-messages/balance.json");
+
+    when(krakenStreamingService.subscribeChannel(eq("balances")))
+            .thenReturn(Observable.just(notification));
+
+    var observable = krakenStreamingAccountService.getBalancesChanges();
+
+    var testObserver = observable.test();
+
+    var actual = testObserver.awaitCount(1).values();
+
+    testObserver.dispose();
+
+    Set<Balance> expected =
+            Set.of(Balance.builder()
+                    .available(new BigDecimal("42.06583427604872431142"))
+                    .currency(Currency.EUR)
+                    .total(new BigDecimal("31.7815"))
+                    .available(new BigDecimal("31.7815"))
+                    .build());
+
+    assertThat(actual).hasSize(1);
+
+    assertThat(actual).first()
+            .usingComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+            .usingRecursiveComparison()
+            .isEqualTo(expected);
 
   }
 


### PR DESCRIPTION
Some exchanges (e.g., Kraken) deliver all balances when subscribing "balances," but the actual implementation requires multiple subscribes to get all account balances.
This PR proposes a more efficient approach by adding the "getBalancesChanges" method, returning Set<Balance> with all balances per currency.