### PR TITLE
Improve StreamingAccountService.getBalanceChanges javadoc, explaining the effect of setting the currency to null.

### DIFF
--- a/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingAccountService.java
+++ b/xchange-stream-core/src/main/java/info/bitrich/xchangestream/core/StreamingAccountService.java
@@ -26,7 +26,7 @@ public interface StreamingAccountService {
    * <p><strong>Immediately throws</strong> {@link ExchangeSecurityException} if called without
    * authentication details
    *
-   * @param currency Currency to monitor.
+   * @param currency Currency to monitor. When 'null', monitors all currency balances.
    * @return {@link Observable} that emits {@link Balance} when exchange sends the update.
    */
   default Observable<Balance> getBalanceChanges(Currency currency, Object... args) {


### PR DESCRIPTION
As I had doubts about how this works, I believe it can help others understand it better.