### PR TITLE
Add ExchangeVersionLogger utility class

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/utils/ExchangeVersionLogger.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/utils/ExchangeVersionLogger.java
@@ -1,0 +1,20 @@
+package org.knowm.xchange.utils;
+
+/**
+ * Simple helper to log current XChange version for debugging and CI builds.
+ * 
+ * Example usage:
+ *   ExchangeVersionLogger.printVersion();
+ */
+public class ExchangeVersionLogger {
+
+    private static final String VERSION = "5.2.3-SNAPSHOT";
+
+    private ExchangeVersionLogger() {
+        // Prevent instantiation
+    }
+
+    public static void printVersion() {
+        System.out.println("XChange Core version: " + VERSION);
+    }
+}


### PR DESCRIPTION

This pull request introduces a small utility class ExchangeVersionLogger to print the current XChange version at runtime.
It can be useful for developers verifying the library version used in CI pipelines, example apps, or runtime environments.

Changes:

Added new utility file ExchangeVersionLogger.java in xchange-core/utils

Provides static printVersion() method returning "XChange Core version: 5.2.3-SNAPSHOT"

Test example:

import org.knowm.xchange.utils.ExchangeVersionLogger;

public class VersionTest {
    public static void main(String[] args) {
        ExchangeVersionLogger.printVersion();
    }
}