### PR TITLE
Add ExchangeInfoLogger utility class for quick debugging

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/utils/ExchangeInfoLogger.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/utils/ExchangeInfoLogger.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025
+ * Utility class for XChange
+ */
+
+package org.knowm.xchange.utils;
+
+import org.knowm.xchange.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simple helper for logging exchange information.
+ * Useful for debugging connection setup or verifying exchange identity.
+ */
+public final class ExchangeInfoLogger {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ExchangeInfoLogger.class);
+
+  private ExchangeInfoLogger() {
+    // Utility class
+  }
+
+  public static void printExchangeInfo(Exchange exchange) {
+    String name = exchange.getDefaultExchangeSpecification().getExchangeName();
+    String uri = exchange.getDefaultExchangeSpecification().getSslUri();
+    LOG.info("🔗 Connected to Exchange: {} ({})", name, uri);
+  }
+}


### PR DESCRIPTION
This PR introduces a new helper class ExchangeInfoLogger under xchange-core/utils.
It provides a simple static method to log exchange connection information such as name and URI.

Motivation:
When testing or debugging API connectivity, developers often need to confirm which exchange instance they are connected to.
This utility simplifies that process by providing a clean, reusable logging method.

Impact:

Non-breaking addition

Uses SLF4J for consistent logging

Can be reused across all exchange modules