### PR TITLE
[CORE] netty version bump to 4.2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
-                <version>4.2.2.Final</version>
+                <version>4.2.7.Final</version>
             </dependency>
 
             <!-- for streaming-->

--- a/xchange-binance/pom.xml
+++ b/xchange-binance/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>1.81</version>
+            <version>1.80</version>
         </dependency>
         <dependency>
             <groupId>org.knowm.xchange</groupId>


### PR DESCRIPTION
resolve conflict
lower version org.bouncycastle.bcpkix-jdk18on from 1.81
to 1.80
we need netty 4.2.3+ due to better compatibility with Java 25
