### PR TITLE
Add RateLimitLogger utility for consistent API limit warnings

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/utils/RateLimitLogger.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/utils/RateLimitLogger.java
@@ -1,0 +1,20 @@
+package org.knowm.xchange.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility for logging API rate limit warnings consistently across exchanges.
+ */
+public final class RateLimitLogger {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RateLimitLogger.class);
+
+  private RateLimitLogger() {}
+
+  public static void warn(String exchangeName, int remaining, int limit) {
+    if (remaining < limit * 0.1) {
+      LOG.warn("[{}] Approaching API rate limit: {} of {} requests left", exchangeName, remaining, limit);
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a small utility class (`RateLimitLogger`) to standardize 
API rate limit warning messages across all exchange modules.

- New file: RateLimitLogger.java in xchange-core/utils
- Helps developers debug rate throttling issues
- Designed to be lightweight and dependency-free
