### PR TITLE
Add RateLimitLogger to unify rate-limit warnings

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/utils/RateLimitLogger.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/utils/RateLimitLogger.java
@@ -1,0 +1,35 @@
+/**
+ * RateLimitLogger.java
+ * Utility class to log API rate-limit warnings consistently across all exchange modules.
+ *
+ * Author: Marta Nowak
+ * Date: 2025-11-01
+ */
+
+package org.knowm.xchange.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RateLimitLogger {
+
+  private static final Logger log = LoggerFactory.getLogger(RateLimitLogger.class);
+  private static long lastWarningTime = 0L;
+  private static final long WARNING_INTERVAL_MS = 30_000; // 30s
+
+  private RateLimitLogger() {}
+
+  /**
+   * Logs a rate-limit warning message if not logged recently.
+   *
+   * @param exchangeName Exchange identifier
+   * @param message Optional message
+   */
+  public static void warn(String exchangeName, String message) {
+    long now = System.currentTimeMillis();
+    if (now - lastWarningTime > WARNING_INTERVAL_MS) {
+      log.warn("[{}] API rate limit approaching. {}", exchangeName, message);
+      lastWarningTime = now;
+    }
+  }
+}


### PR DESCRIPTION
### Summary
This PR adds a new helper class `RateLimitLogger` to `xchange-core` to standardize how API rate-limit warnings are logged.

### Motivation
Different exchange modules currently log rate-limit issues inconsistently.  
The new class ensures that all such warnings:
- follow the same format
- are throttled to avoid log flooding
- improve observability for developers and CI systems

### Changes
- Added new file: `xchange-core/src/main/java/org/knowm/xchange/utils/RateLimitLogger.java`
- Updated `xchange-binance` and `xchange-kraken` modules to use it (example in next commit)

### Benefits
✅ Unified rate-limit log format  
✅ Reduced log spam  
✅ Easier future maintenance

### Checklist
- [x] Code compiles successfully
- [x] Unit-tested locally
- [x] No external dependency added
- [x] Backward compatible
- [ ] Additional integrations planned (stream modules)

### Example output
