### PR TITLE
feat(bitstamp): add Earn API support

### DIFF
--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAuthenticatedV2.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/BitstampAuthenticatedV2.java
@@ -2,11 +2,13 @@ package org.knowm.xchange.bitstamp;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -15,6 +17,10 @@ import org.knowm.xchange.bitstamp.dto.BitstampException;
 import org.knowm.xchange.bitstamp.dto.BitstampTransferBalanceResponse;
 import org.knowm.xchange.bitstamp.dto.account.BitstampBalance;
 import org.knowm.xchange.bitstamp.dto.account.BitstampDepositAddress;
+import org.knowm.xchange.bitstamp.dto.account.BitstampEarnSettingRequest;
+import org.knowm.xchange.bitstamp.dto.account.BitstampEarnSubscribeRequest;
+import org.knowm.xchange.bitstamp.dto.account.BitstampEarnSubscription;
+import org.knowm.xchange.bitstamp.dto.account.BitstampEarnTransaction;
 import org.knowm.xchange.bitstamp.dto.account.BitstampRippleDepositAddress;
 import org.knowm.xchange.bitstamp.dto.account.BitstampWithdrawal;
 import org.knowm.xchange.bitstamp.dto.account.DepositTransaction;
@@ -671,6 +677,66 @@ public interface BitstampAuthenticatedV2 {
       @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
       @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
       @HeaderParam("X-Auth-Version") String version)
+      throws BitstampException, IOException;
+
+  @GET
+  @Path("earn/subscriptions/")
+  List<BitstampEarnSubscription> getEarnSubscriptions(
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version)
+      throws BitstampException, IOException;
+
+  @GET
+  @Path("earn/transactions/")
+  List<BitstampEarnTransaction> getEarnTransactions(
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version,
+      @QueryParam("limit") Integer limit,
+      @QueryParam("offset") Integer offset,
+      @QueryParam("currency") String currency,
+      @QueryParam("quote_currency") String quoteCurrency)
+      throws BitstampException, IOException;
+
+  @POST
+  @Path("earn/subscribe/")
+  @Consumes(MediaType.APPLICATION_JSON)
+  void subscribeToEarn(
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version,
+      BitstampEarnSubscribeRequest request)
+      throws BitstampException, IOException;
+
+  @POST
+  @Path("earn/unsubscribe/")
+  @Consumes(MediaType.APPLICATION_JSON)
+  void unsubscribeFromEarn(
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version,
+      BitstampEarnSubscribeRequest request)
+      throws BitstampException, IOException;
+
+  @POST
+  @Path("earn/subscriptions/setting/")
+  @Consumes(MediaType.APPLICATION_JSON)
+  void manageEarnSubscriptionSetting(
+      @HeaderParam("X-Auth") String apiKey,
+      @HeaderParam("X-Auth-Signature") ParamsDigest signer,
+      @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<String> nonce,
+      @HeaderParam("X-Auth-Timestamp") SynchronizedValueFactory<String> timeStamp,
+      @HeaderParam("X-Auth-Version") String version,
+      BitstampEarnSettingRequest request)
       throws BitstampException, IOException;
 
   @POST

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/config/converter/StringToCurrencyConverter.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/config/converter/StringToCurrencyConverter.java
@@ -1,0 +1,13 @@
+package org.knowm.xchange.bitstamp.config.converter;
+
+import com.fasterxml.jackson.databind.util.StdConverter;
+import org.knowm.xchange.currency.Currency;
+
+/** Converts string value to {@code Currency} */
+public class StringToCurrencyConverter extends StdConverter<String, Currency> {
+
+  @Override
+  public Currency convert(String value) {
+    return value != null ? Currency.getInstance(value) : null;
+  }
+}

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/config/converter/StringToDateConverter.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/config/converter/StringToDateConverter.java
@@ -1,0 +1,14 @@
+package org.knowm.xchange.bitstamp.config.converter;
+
+import com.fasterxml.jackson.databind.util.StdConverter;
+import java.util.Date;
+import org.knowm.xchange.bitstamp.BitstampUtils;
+
+/** Converts string value to {@code Date} using BitstampUtils.parseDate */
+public class StringToDateConverter extends StdConverter<String, Date> {
+
+  @Override
+  public Date convert(String value) {
+    return BitstampUtils.parseDate(value);
+  }
+}

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/BitstampEarnSettingRequest.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/BitstampEarnSettingRequest.java
@@ -1,0 +1,22 @@
+package org.knowm.xchange.bitstamp.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Value;
+
+@Value
+public class BitstampEarnSettingRequest {
+
+  @JsonProperty("setting")
+  Setting setting;
+
+  @JsonProperty("currency")
+  String currency;
+
+  @JsonProperty("earn_type")
+  BitstampEarnType earnType;
+
+  public enum Setting {
+    OPT_IN,
+    OPT_OUT
+  }
+}

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/BitstampEarnSubscribeRequest.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/BitstampEarnSubscribeRequest.java
@@ -1,0 +1,21 @@
+package org.knowm.xchange.bitstamp.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import lombok.Value;
+
+@Value
+public class BitstampEarnSubscribeRequest {
+
+  @JsonProperty("currency")
+  String currency;
+
+  @JsonProperty("earn_type")
+  BitstampEarnType earnType;
+
+  @JsonProperty("earn_term")
+  BitstampEarnTerm earnTerm;
+
+  @JsonProperty("amount")
+  BigDecimal amount;
+}

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/BitstampEarnSubscription.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/BitstampEarnSubscription.java
@@ -1,0 +1,49 @@
+package org.knowm.xchange.bitstamp.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.jackson.Jacksonized;
+import org.knowm.xchange.bitstamp.config.converter.StringToCurrencyConverter;
+import org.knowm.xchange.currency.Currency;
+
+@Getter
+@ToString
+@Builder
+@Jacksonized
+public class BitstampEarnSubscription {
+
+  @JsonProperty("currency")
+  @JsonDeserialize(converter = StringToCurrencyConverter.class)
+  private final Currency currency;
+
+  @JsonProperty("type")
+  private final BitstampEarnType type;
+
+  @JsonProperty("term")
+  private final BitstampEarnTerm term;
+
+  @JsonProperty("estimated_annual_yield")
+  private final BigDecimal estimatedAnnualYield;
+
+  @JsonProperty("distribution_period")
+  private final String distributionPeriod;
+
+  @JsonProperty("activation_period")
+  private final String activationPeriod;
+
+  @JsonProperty("minimum_subscription_amount")
+  private final BigDecimal minimumSubscriptionAmount;
+
+  @JsonProperty("amount")
+  private final BigDecimal amount;
+
+  @JsonProperty("available_amount")
+  private final BigDecimal availableAmount;
+
+  @JsonProperty("amount_earned")
+  private final BigDecimal amountEarned;
+}

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/BitstampEarnTerm.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/BitstampEarnTerm.java
@@ -1,0 +1,6 @@
+package org.knowm.xchange.bitstamp.dto.account;
+
+public enum BitstampEarnTerm {
+  FLEXIBLE,
+  FIXED
+}

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/BitstampEarnTransaction.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/BitstampEarnTransaction.java
@@ -1,0 +1,54 @@
+package org.knowm.xchange.bitstamp.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.math.BigDecimal;
+import java.util.Date;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.jackson.Jacksonized;
+import org.knowm.xchange.bitstamp.config.converter.StringToCurrencyConverter;
+import org.knowm.xchange.bitstamp.config.converter.StringToDateConverter;
+import org.knowm.xchange.currency.Currency;
+
+@Getter
+@ToString
+@Builder
+@Jacksonized
+public class BitstampEarnTransaction {
+
+  @JsonProperty("datetime")
+  @JsonDeserialize(converter = StringToDateConverter.class)
+  private final Date datetime;
+
+  @JsonProperty("type")
+  private final TransactionType type;
+
+  @JsonProperty("amount")
+  private final BigDecimal amount;
+
+  @JsonProperty("currency")
+  @JsonDeserialize(converter = StringToCurrencyConverter.class)
+  private final Currency currency;
+
+  @JsonProperty("value")
+  private final BigDecimal value;
+
+  @JsonProperty("quote_currency")
+  @JsonDeserialize(converter = StringToCurrencyConverter.class)
+  private final Currency quoteCurrency;
+
+  @JsonProperty("status")
+  private final TransactionStatus status;
+
+  public enum TransactionType {
+    SUBSCRIBE,
+    UNSUBSCRIBE,
+    REWARD_RECEIVED
+  }
+
+  public enum TransactionStatus {
+    COMPLETED
+  }
+}

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/BitstampEarnType.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/BitstampEarnType.java
@@ -1,0 +1,6 @@
+package org.knowm.xchange.bitstamp.dto.account;
+
+public enum BitstampEarnType {
+  STAKING,
+  LENDING
+}

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountService.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountService.java
@@ -10,6 +10,10 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitstamp.BitstampAdapters;
 import org.knowm.xchange.bitstamp.BitstampUtils;
 import org.knowm.xchange.bitstamp.dto.account.BitstampDepositAddress;
+import org.knowm.xchange.bitstamp.dto.account.BitstampEarnSettingRequest;
+import org.knowm.xchange.bitstamp.dto.account.BitstampEarnTerm;
+import org.knowm.xchange.bitstamp.dto.account.BitstampEarnTransaction;
+import org.knowm.xchange.bitstamp.dto.account.BitstampEarnType;
 import org.knowm.xchange.bitstamp.dto.account.BitstampWithdrawal;
 import org.knowm.xchange.bitstamp.dto.trade.BitstampUserTransaction;
 import org.knowm.xchange.currency.Currency;
@@ -166,5 +170,82 @@ public class BitstampAccountService extends BitstampAccountServiceRaw implements
   public Map<Instrument, Fee> getDynamicTradingFeesByInstrument(String... category)
       throws IOException {
     return BitstampAdapters.adaptTradingFees(getTradingFees());
+  }
+
+  /**
+   * Get Earn transaction history.
+   *
+   * <p><strong>Note:</strong> Query parameters (limit, offset, currency, quoteCurrency) are
+   * currently not supported due to Bitstamp API signature validation requirements for authenticated
+   * GET requests. All parameters are ignored and the endpoint is called without query parameters.
+   * For filtering and pagination, use {@link #getEarnTransactions()} and filter the results
+   * client-side.
+   *
+   * @param limit Maximum number of transactions to return (ignored - not supported)
+   * @param offset Number of transactions to skip (ignored - not supported)
+   * @param currency Optional currency filter (ignored - not supported)
+   * @param quoteCurrency Optional quote currency for value calculation (ignored - not supported)
+   * @return List of Earn transactions
+   * @throws IOException if the request fails
+   */
+  public List<BitstampEarnTransaction> getEarnTransactions(
+      Integer limit, Integer offset, Currency currency, Currency quoteCurrency) throws IOException {
+    String currencyCode = currency != null ? currency.getCurrencyCode() : null;
+    String quoteCurrencyCode = quoteCurrency != null ? quoteCurrency.getCurrencyCode() : null;
+    return getEarnTransactions(limit, offset, currencyCode, quoteCurrencyCode);
+  }
+
+  /**
+   * Get Earn transaction history.
+   *
+   * @return List of Earn transactions
+   * @throws IOException if the request fails
+   */
+  public List<BitstampEarnTransaction> getEarnTransactions() throws IOException {
+    return getEarnTransactions(null, null, (Currency) null, (Currency) null);
+  }
+
+  /**
+   * Subscribe to an Earn product.
+   *
+   * @param currency The currency to subscribe to
+   * @param earnType The earn type: "STAKING" or "LENDING"
+   * @param earnTerm The earn term: "FLEXIBLE" or "FIXED"
+   * @param amount The amount to subscribe
+   * @throws IOException if the request fails
+   */
+  public void subscribeToEarn(
+      Currency currency, BitstampEarnType earnType, BitstampEarnTerm earnTerm, BigDecimal amount)
+      throws IOException {
+    super.subscribeToEarn(currency.getCurrencyCode(), earnType, earnTerm, amount);
+  }
+
+  /**
+   * Unsubscribe from an Earn product.
+   *
+   * @param currency The currency to unsubscribe from
+   * @param earnType The earn type: "STAKING" or "LENDING"
+   * @param earnTerm The earn term: "FLEXIBLE" or "FIXED"
+   * @param amount The amount to unsubscribe
+   * @throws IOException if the request fails
+   */
+  public void unsubscribeFromEarn(
+      Currency currency, BitstampEarnType earnType, BitstampEarnTerm earnTerm, BigDecimal amount)
+      throws IOException {
+    super.unsubscribeFromEarn(currency.getCurrencyCode(), earnType, earnTerm, amount);
+  }
+
+  /**
+   * Manage Earn subscription settings (opt in/opt out).
+   *
+   * @param setting The setting: "OPT_IN" or "OPT_OUT"
+   * @param currency The currency
+   * @param earnType The earn type: "STAKING" or "LENDING"
+   * @throws IOException if the request fails
+   */
+  public void manageEarnSubscriptionSetting(
+      BitstampEarnSettingRequest.Setting setting, Currency currency, BitstampEarnType earnType)
+      throws IOException {
+    super.manageEarnSubscriptionSetting(setting, currency.getCurrencyCode(), earnType);
   }
 }

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountServiceRaw.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountServiceRaw.java
@@ -15,6 +15,12 @@ import org.knowm.xchange.bitstamp.dto.BitstampException;
 import org.knowm.xchange.bitstamp.dto.BitstampTransferBalanceResponse;
 import org.knowm.xchange.bitstamp.dto.account.BitstampBalance;
 import org.knowm.xchange.bitstamp.dto.account.BitstampDepositAddress;
+import org.knowm.xchange.bitstamp.dto.account.BitstampEarnSettingRequest;
+import org.knowm.xchange.bitstamp.dto.account.BitstampEarnSubscribeRequest;
+import org.knowm.xchange.bitstamp.dto.account.BitstampEarnSubscription;
+import org.knowm.xchange.bitstamp.dto.account.BitstampEarnTerm;
+import org.knowm.xchange.bitstamp.dto.account.BitstampEarnTransaction;
+import org.knowm.xchange.bitstamp.dto.account.BitstampEarnType;
 import org.knowm.xchange.bitstamp.dto.account.BitstampRippleDepositAddress;
 import org.knowm.xchange.bitstamp.dto.account.BitstampWithdrawal;
 import org.knowm.xchange.bitstamp.dto.account.DepositTransaction;
@@ -586,6 +592,102 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
               comment);
 
       return checkAndReturnWithdrawal(response);
+    } catch (BitstampException e) {
+      throw handleError(e);
+    }
+  }
+
+  public List<BitstampEarnSubscription> getEarnSubscriptions() throws IOException {
+    try {
+      return bitstampAuthenticatedV2.getEarnSubscriptions(
+          apiKeyForV2Requests, signatureCreatorV2, uuidNonceFactory, timestampFactory, API_VERSION);
+    } catch (BitstampException e) {
+      throw handleError(e);
+    }
+  }
+
+  /**
+   * Get Earn transaction history.
+   *
+   * <p><strong>Note:</strong> Query parameters are currently not supported due to Bitstamp API
+   * signature validation requirements. All parameters are ignored and the endpoint is called
+   * without query parameters.
+   *
+   * @param limit Maximum number of transactions to return (ignored - not supported)
+   * @param offset Number of transactions to skip (ignored - not supported)
+   * @param currency Optional currency filter (ignored - not supported)
+   * @param quoteCurrency Optional quote currency for value calculation (ignored - not supported)
+   * @return List of Earn transactions
+   * @throws IOException if the request fails
+   */
+  public List<BitstampEarnTransaction> getEarnTransactions(
+      Integer limit, Integer offset, String currency, String quoteCurrency) throws IOException {
+    try {
+      // Query parameters cause signature validation failures - always call without them
+      return bitstampAuthenticatedV2.getEarnTransactions(
+          apiKeyForV2Requests,
+          signatureCreatorV2,
+          uuidNonceFactory,
+          timestampFactory,
+          API_VERSION,
+          null, // limit ignored
+          null, // offset ignored
+          null, // currency ignored
+          null); // quoteCurrency ignored
+    } catch (BitstampException e) {
+      throw handleError(e);
+    }
+  }
+
+  public void subscribeToEarn(
+      String currency, BitstampEarnType earnType, BitstampEarnTerm earnTerm, BigDecimal amount)
+      throws IOException {
+    try {
+      BitstampEarnSubscribeRequest request =
+          new BitstampEarnSubscribeRequest(currency, earnType, earnTerm, amount);
+      bitstampAuthenticatedV2.subscribeToEarn(
+          apiKeyForV2Requests,
+          signatureCreatorV2,
+          uuidNonceFactory,
+          timestampFactory,
+          API_VERSION,
+          request);
+    } catch (BitstampException e) {
+      throw handleError(e);
+    }
+  }
+
+  public void unsubscribeFromEarn(
+      String currency, BitstampEarnType earnType, BitstampEarnTerm earnTerm, BigDecimal amount)
+      throws IOException {
+    try {
+      BitstampEarnSubscribeRequest request =
+          new BitstampEarnSubscribeRequest(currency, earnType, earnTerm, amount);
+      bitstampAuthenticatedV2.unsubscribeFromEarn(
+          apiKeyForV2Requests,
+          signatureCreatorV2,
+          uuidNonceFactory,
+          timestampFactory,
+          API_VERSION,
+          request);
+    } catch (BitstampException e) {
+      throw handleError(e);
+    }
+  }
+
+  public void manageEarnSubscriptionSetting(
+      BitstampEarnSettingRequest.Setting setting, String currency, BitstampEarnType earnType)
+      throws IOException {
+    try {
+      BitstampEarnSettingRequest request =
+          new BitstampEarnSettingRequest(setting, currency, earnType);
+      bitstampAuthenticatedV2.manageEarnSubscriptionSetting(
+          apiKeyForV2Requests,
+          signatureCreatorV2,
+          uuidNonceFactory,
+          timestampFactory,
+          API_VERSION,
+          request);
     } catch (BitstampException e) {
       throw handleError(e);
     }

--- a/xchange-bitstamp/src/test/java/org/knowm/xchange/bitstamp/BitstampUtilsTest.java
+++ b/xchange-bitstamp/src/test/java/org/knowm/xchange/bitstamp/BitstampUtilsTest.java
@@ -41,7 +41,20 @@ public class BitstampUtilsTest {
 
     assertThatThrownBy(() -> BitstampUtils.parseDate(strDateWithInvalidFormat))
         .isInstanceOf(ExchangeException.class)
-        .hasMessage("Illegal date/time format");
+        .hasMessage("Illegal date/time format: " + strDateWithInvalidFormat);
+  }
+
+  @Test
+  public void testParseDateWithIso8601Format() {
+    final String strDateIso8601 = "2025-11-15T02:09:13+00:00";
+
+    // strDateIso8601 converted at https://www.epochconverter.com
+    final long epochMillis = 1763172553000L;
+
+    final Date convertedDate = BitstampUtils.parseDate(strDateIso8601);
+
+    assertThat(convertedDate).isNotNull();
+    assertThat(convertedDate.getTime()).isEqualTo(epochMillis);
   }
 
   @Test

--- a/xchange-bitstamp/src/test/java/org/knowm/xchange/bitstamp/dto/account/BitstampEarnSubscriptionJSONTest.java
+++ b/xchange-bitstamp/src/test/java/org/knowm/xchange/bitstamp/dto/account/BitstampEarnSubscriptionJSONTest.java
@@ -1,0 +1,53 @@
+package org.knowm.xchange.bitstamp.dto.account;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.knowm.xchange.currency.Currency;
+
+public class BitstampEarnSubscriptionJSONTest {
+
+  @Test
+  public void testUnmarshal() throws IOException {
+    InputStream is =
+        BitstampEarnSubscriptionJSONTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitstamp/dto/account/earn-subscriptions.json");
+
+    ObjectMapper mapper = new ObjectMapper();
+    CollectionType collectionType =
+        mapper.getTypeFactory().constructCollectionType(List.class, BitstampEarnSubscription.class);
+
+    List<BitstampEarnSubscription> subscriptions = mapper.readValue(is, collectionType);
+
+    assertThat(subscriptions).isNotEmpty();
+    BitstampEarnSubscription subscription = subscriptions.get(0);
+
+    assertThat(subscription.getCurrency()).isNotNull();
+    assertThat(subscription.getType()).isIn(BitstampEarnType.STAKING, BitstampEarnType.LENDING);
+    assertThat(subscription.getTerm()).isIn(BitstampEarnTerm.FLEXIBLE, BitstampEarnTerm.FIXED);
+    assertThat(subscription.getEstimatedAnnualYield()).isNotNull();
+    assertThat(subscription.getAmount()).isNotNull();
+  }
+
+  @Test
+  public void testUnmarshalSingle() throws IOException {
+    InputStream is =
+        BitstampEarnSubscriptionJSONTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitstamp/dto/account/earn-subscription-single.json");
+
+    ObjectMapper mapper = new ObjectMapper();
+    BitstampEarnSubscription subscription = mapper.readValue(is, BitstampEarnSubscription.class);
+
+    assertThat(subscription.getCurrency()).isEqualTo(Currency.ETH);
+    assertThat(subscription.getType()).isEqualTo(BitstampEarnType.STAKING);
+    assertThat(subscription.getTerm()).isEqualTo(BitstampEarnTerm.FLEXIBLE);
+    assertThat(subscription.getEstimatedAnnualYield()).isNotNull();
+    assertThat(subscription.getAmount()).isNotNull();
+    assertThat(subscription.getAvailableAmount()).isNotNull();
+  }
+}

--- a/xchange-bitstamp/src/test/java/org/knowm/xchange/bitstamp/dto/account/BitstampEarnTransactionJSONTest.java
+++ b/xchange-bitstamp/src/test/java/org/knowm/xchange/bitstamp/dto/account/BitstampEarnTransactionJSONTest.java
@@ -1,0 +1,68 @@
+package org.knowm.xchange.bitstamp.dto.account;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.knowm.xchange.currency.Currency;
+
+public class BitstampEarnTransactionJSONTest {
+
+  @Test
+  public void testUnmarshal() throws IOException {
+    InputStream is =
+        BitstampEarnTransactionJSONTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitstamp/dto/account/earn-transactions.json");
+
+    ObjectMapper mapper = new ObjectMapper();
+    CollectionType collectionType =
+        mapper.getTypeFactory().constructCollectionType(List.class, BitstampEarnTransaction.class);
+
+    List<BitstampEarnTransaction> transactions = mapper.readValue(is, collectionType);
+
+    assertThat(transactions).isNotEmpty();
+    BitstampEarnTransaction transaction = transactions.get(0);
+
+    assertThat(transaction.getCurrency()).isNotNull();
+    assertThat(transaction.getType()).isNotNull();
+    assertThat(transaction.getAmount()).isNotNull();
+    assertThat(transaction.getDatetime()).isNotNull();
+    assertThat(transaction.getStatus()).isNotNull();
+  }
+
+  @Test
+  public void testUnmarshalSingle() throws IOException {
+    InputStream is =
+        BitstampEarnTransactionJSONTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitstamp/dto/account/earn-transaction-single.json");
+
+    ObjectMapper mapper = new ObjectMapper();
+    BitstampEarnTransaction transaction = mapper.readValue(is, BitstampEarnTransaction.class);
+
+    assertThat(transaction.getCurrency()).isEqualTo(Currency.getInstance("SUI"));
+    assertThat(transaction.getType())
+        .isEqualTo(BitstampEarnTransaction.TransactionType.REWARD_RECEIVED);
+    assertThat(transaction.getAmount()).isNotNull();
+    assertThat(transaction.getDatetime()).isNotNull();
+    assertThat(transaction.getStatus())
+        .isEqualTo(BitstampEarnTransaction.TransactionStatus.COMPLETED);
+    assertThat(transaction.getQuoteCurrency()).isEqualTo(Currency.USD);
+  }
+
+  @Test
+  public void testUnmarshalWithIso8601Date() throws IOException {
+    InputStream is =
+        BitstampEarnTransactionJSONTest.class.getResourceAsStream(
+            "/org/knowm/xchange/bitstamp/dto/account/earn-transaction-single.json");
+
+    ObjectMapper mapper = new ObjectMapper();
+    BitstampEarnTransaction transaction = mapper.readValue(is, BitstampEarnTransaction.class);
+
+    // Verify ISO 8601 date format is parsed correctly
+    assertThat(transaction.getDatetime()).isNotNull();
+  }
+}

--- a/xchange-bitstamp/src/test/resources/org/knowm/xchange/bitstamp/dto/account/earn-subscription-single.json
+++ b/xchange-bitstamp/src/test/resources/org/knowm/xchange/bitstamp/dto/account/earn-subscription-single.json
@@ -1,0 +1,12 @@
+{
+  "currency": "ETH",
+  "type": "STAKING",
+  "term": "FLEXIBLE",
+  "estimated_annual_yield": "4.5",
+  "distribution_period": "DAILY",
+  "activation_period": "IMMEDIATE",
+  "minimum_subscription_amount": "0.1",
+  "amount": "10.5",
+  "available_amount": "10.5",
+  "amount_earned": "0.25"
+}

--- a/xchange-bitstamp/src/test/resources/org/knowm/xchange/bitstamp/dto/account/earn-subscriptions.json
+++ b/xchange-bitstamp/src/test/resources/org/knowm/xchange/bitstamp/dto/account/earn-subscriptions.json
@@ -1,0 +1,26 @@
+[
+  {
+    "currency": "ETH",
+    "type": "STAKING",
+    "term": "FLEXIBLE",
+    "estimated_annual_yield": "4.5",
+    "distribution_period": "DAILY",
+    "activation_period": "IMMEDIATE",
+    "minimum_subscription_amount": "0.1",
+    "amount": "10.5",
+    "available_amount": "10.5",
+    "amount_earned": "0.25"
+  },
+  {
+    "currency": "BTC",
+    "type": "LENDING",
+    "term": "FIXED",
+    "estimated_annual_yield": "3.2",
+    "distribution_period": "WEEKLY",
+    "activation_period": "1_DAY",
+    "minimum_subscription_amount": "0.01",
+    "amount": "1.5",
+    "available_amount": "1.5",
+    "amount_earned": "0.05"
+  }
+]

--- a/xchange-bitstamp/src/test/resources/org/knowm/xchange/bitstamp/dto/account/earn-transaction-single.json
+++ b/xchange-bitstamp/src/test/resources/org/knowm/xchange/bitstamp/dto/account/earn-transaction-single.json
@@ -1,0 +1,9 @@
+{
+  "datetime": "2025-11-15T02:09:13+00:00",
+  "type": "REWARD_RECEIVED",
+  "amount": "0.00353037",
+  "currency": "SUI",
+  "value": "0.01",
+  "quote_currency": "USD",
+  "status": "COMPLETED"
+}

--- a/xchange-bitstamp/src/test/resources/org/knowm/xchange/bitstamp/dto/account/earn-transactions.json
+++ b/xchange-bitstamp/src/test/resources/org/knowm/xchange/bitstamp/dto/account/earn-transactions.json
@@ -1,0 +1,29 @@
+[
+  {
+    "datetime": "2025-11-15T02:09:13+00:00",
+    "type": "REWARD_RECEIVED",
+    "amount": "0.00353037",
+    "currency": "SUI",
+    "value": "0.01",
+    "quote_currency": "USD",
+    "status": "COMPLETED"
+  },
+  {
+    "datetime": "2025-11-15T02:08:30+00:00",
+    "type": "REWARD_RECEIVED",
+    "amount": "0.00011206",
+    "currency": "LTC",
+    "value": "0.01",
+    "quote_currency": "USD",
+    "status": "COMPLETED"
+  },
+  {
+    "datetime": "2025-11-15T01:30:00+00:00",
+    "type": "SUBSCRIBE",
+    "amount": "10.5",
+    "currency": "ETH",
+    "value": "25000.00",
+    "quote_currency": "USD",
+    "status": "COMPLETED"
+  }
+]


### PR DESCRIPTION
Add support for Bitstamp Earn API endpoints:
- Get Earn subscriptions
- Get Earn transaction history
- Subscribe/Unsubscribe to Earn products
- Manage Earn subscription settings (opt in/opt out)

New DTOs:
- BitstampEarnSubscription
- BitstampEarnTransaction
- BitstampEarnSubscribeRequest
- BitstampEarnSettingRequest

Note: Query parameters for getEarnTransactions() are not supported due to Bitstamp API signature validation limitations. The endpoint works correctly when called without query parameters.

Also updated BitstampUtils.parseDate() to support ISO 8601 date format with timezone (e.g., "2025-11-15T02:09:13+00:00") in addition to the legacy format.