### PR TITLE
feat(Kraken): add Earn Allocations API support

### DIFF
--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAuthenticated.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAuthenticated.java
@@ -11,11 +11,13 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Map;
 import org.knowm.xchange.kraken.dto.KrakenResult;
+import org.knowm.xchange.kraken.dto.account.KrakenEarnAllocationsRequest;
 import org.knowm.xchange.kraken.dto.account.KrakenExtendedBalance;
 import org.knowm.xchange.kraken.dto.account.results.DepositStatusResult;
 import org.knowm.xchange.kraken.dto.account.results.KrakenBalanceResult;
 import org.knowm.xchange.kraken.dto.account.results.KrakenDepositAddressResult;
 import org.knowm.xchange.kraken.dto.account.results.KrakenDepositMethodsResults;
+import org.knowm.xchange.kraken.dto.account.results.KrakenEarnAllocationsResult;
 import org.knowm.xchange.kraken.dto.account.results.KrakenLedgerResult;
 import org.knowm.xchange.kraken.dto.account.results.KrakenQueryLedgerResult;
 import org.knowm.xchange.kraken.dto.account.results.KrakenTradeBalanceInfoResult;
@@ -339,5 +341,15 @@ public interface KrakenAuthenticated extends Kraken {
       @HeaderParam("API-Key") String apiKey,
       @HeaderParam("API-Sign") ParamsDigest signer,
       @FormParam("nonce") SynchronizedValueFactory<Long> nonce)
+      throws IOException;
+
+  @POST
+  @Path("private/Earn/Allocations")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  KrakenEarnAllocationsResult getEarnAllocations(
+      @HeaderParam("API-Key") String apiKey,
+      @HeaderParam("API-Sign") ParamsDigest signer,
+      KrakenEarnAllocationsRequest request)
       throws IOException;
 }

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/KrakenEarnAllocation.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/KrakenEarnAllocation.java
@@ -1,0 +1,28 @@
+package org.knowm.xchange.kraken.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.jackson.Jacksonized;
+
+@Getter
+@ToString
+@Builder
+@Jacksonized
+public class KrakenEarnAllocation {
+  @JsonProperty("amount_allocated")
+  private final KrakenEarnAmountAllocated amountAllocated;
+
+  @JsonProperty("native_asset")
+  private final String nativeAsset;
+
+  @JsonProperty("payout")
+  private final KrakenEarnPayout payout;
+
+  @JsonProperty("strategy_id")
+  private final String strategyId;
+
+  @JsonProperty("total_rewarded")
+  private final KrakenEarnAmount totalRewarded;
+}

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/KrakenEarnAllocationDetail.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/KrakenEarnAllocationDetail.java
@@ -1,0 +1,27 @@
+package org.knowm.xchange.kraken.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.util.Date;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.jackson.Jacksonized;
+
+@Getter
+@ToString
+@Builder
+@Jacksonized
+public class KrakenEarnAllocationDetail {
+  @JsonProperty("native")
+  private final BigDecimal nativeAmount;
+
+  @JsonProperty("converted")
+  private final BigDecimal convertedAmount;
+
+  @JsonProperty("created_at")
+  private final Date createdAt;
+
+  @JsonProperty("expires")
+  private final Date expires;
+}

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/KrakenEarnAllocations.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/KrakenEarnAllocations.java
@@ -1,0 +1,27 @@
+package org.knowm.xchange.kraken.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.jackson.Jacksonized;
+
+@Getter
+@ToString
+@Builder
+@Jacksonized
+public class KrakenEarnAllocations {
+  @JsonProperty("converted_asset")
+  private final String convertedAsset;
+
+  @JsonProperty("items")
+  private final List<KrakenEarnAllocation> items;
+
+  @JsonProperty("total_allocated")
+  private final BigDecimal totalAllocated;
+
+  @JsonProperty("total_rewarded")
+  private final BigDecimal totalRewarded;
+}

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/KrakenEarnAllocationsRequest.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/KrakenEarnAllocationsRequest.java
@@ -1,0 +1,21 @@
+package org.knowm.xchange.kraken.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class KrakenEarnAllocationsRequest {
+  @JsonProperty("nonce")
+  Long nonce;
+
+  @JsonProperty("ascending")
+  Boolean ascending;
+
+  @JsonProperty("converted_asset")
+  String convertedAsset;
+
+  @JsonProperty("hide_zero_allocations")
+  Boolean hideZeroAllocations;
+}

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/KrakenEarnAmount.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/KrakenEarnAmount.java
@@ -1,0 +1,20 @@
+package org.knowm.xchange.kraken.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.jackson.Jacksonized;
+
+@Getter
+@ToString
+@Builder
+@Jacksonized
+public class KrakenEarnAmount {
+  @JsonProperty("native")
+  private final BigDecimal nativeAmount;
+
+  @JsonProperty("converted")
+  private final BigDecimal convertedAmount;
+}

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/KrakenEarnAmountAllocated.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/KrakenEarnAmountAllocated.java
@@ -1,0 +1,48 @@
+package org.knowm.xchange.kraken.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.jackson.Jacksonized;
+
+@Getter
+@ToString
+@Builder
+@Jacksonized
+public class KrakenEarnAmountAllocated {
+  @JsonProperty("bonding")
+  private final State bonding;
+
+  @JsonProperty("exit_queue")
+  private final State exitQueue;
+
+  @JsonProperty("unbonding")
+  private final State unbonding;
+
+  @JsonProperty("pending")
+  private final KrakenEarnAmount pending;
+
+  @JsonProperty("total")
+  private final KrakenEarnAmount total;
+
+  @Getter
+  @ToString
+  @Builder
+  @Jacksonized
+  public static class State {
+    @JsonProperty("native")
+    private final BigDecimal nativeAmount;
+
+    @JsonProperty("converted")
+    private final BigDecimal convertedAmount;
+
+    @JsonProperty("allocation_count")
+    private final Integer allocationCount;
+
+    @JsonProperty("allocations")
+    private final List<KrakenEarnAllocationDetail> allocations;
+  }
+}

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/KrakenEarnPayout.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/KrakenEarnPayout.java
@@ -1,0 +1,26 @@
+package org.knowm.xchange.kraken.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Date;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.jackson.Jacksonized;
+
+@Getter
+@ToString
+@Builder
+@Jacksonized
+public class KrakenEarnPayout {
+  @JsonProperty("accumulated_reward")
+  private final KrakenEarnAmount accumulatedReward;
+
+  @JsonProperty("estimated_reward")
+  private final KrakenEarnAmount estimatedReward;
+
+  @JsonProperty("period_start")
+  private final Date periodStart;
+
+  @JsonProperty("period_end")
+  private final Date periodEnd;
+}

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/results/KrakenEarnAllocationsResult.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/account/results/KrakenEarnAllocationsResult.java
@@ -1,0 +1,13 @@
+package org.knowm.xchange.kraken.dto.account.results;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.knowm.xchange.kraken.dto.KrakenResult;
+import org.knowm.xchange.kraken.dto.account.KrakenEarnAllocations;
+
+public class KrakenEarnAllocationsResult extends KrakenResult<KrakenEarnAllocations> {
+
+  public KrakenEarnAllocationsResult(
+      @JsonProperty("result") KrakenEarnAllocations result, @JsonProperty("error") String[] error) {
+    super(result, error);
+  }
+}

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenAccountServiceRaw.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenAccountServiceRaw.java
@@ -17,6 +17,8 @@ import org.knowm.xchange.kraken.KrakenUtils;
 import org.knowm.xchange.kraken.dto.account.DepostitStatus;
 import org.knowm.xchange.kraken.dto.account.KrakenDepositAddress;
 import org.knowm.xchange.kraken.dto.account.KrakenDepositMethods;
+import org.knowm.xchange.kraken.dto.account.KrakenEarnAllocations;
+import org.knowm.xchange.kraken.dto.account.KrakenEarnAllocationsRequest;
 import org.knowm.xchange.kraken.dto.account.KrakenExtendedBalance;
 import org.knowm.xchange.kraken.dto.account.KrakenLedger;
 import org.knowm.xchange.kraken.dto.account.KrakenTradeBalanceInfo;
@@ -29,6 +31,7 @@ import org.knowm.xchange.kraken.dto.account.WithdrawStatus;
 import org.knowm.xchange.kraken.dto.account.results.DepositStatusResult;
 import org.knowm.xchange.kraken.dto.account.results.KrakenBalanceResult;
 import org.knowm.xchange.kraken.dto.account.results.KrakenDepositAddressResult;
+import org.knowm.xchange.kraken.dto.account.results.KrakenEarnAllocationsResult;
 import org.knowm.xchange.kraken.dto.account.results.KrakenLedgerResult;
 import org.knowm.xchange.kraken.dto.account.results.KrakenQueryLedgerResult;
 import org.knowm.xchange.kraken.dto.account.results.KrakenTradeBalanceInfoResult;
@@ -381,5 +384,21 @@ public class KrakenAccountServiceRaw extends KrakenBaseService {
             .getExchangeSpecification()
             .getExchangeSpecificParameters()
             .getOrDefault("cacheDepositMethods", false);
+  }
+
+  public KrakenEarnAllocations getEarnAllocations(
+      Boolean ascending, String convertedAsset, Boolean hideZeroAllocations) throws IOException {
+    KrakenEarnAllocationsRequest request =
+        KrakenEarnAllocationsRequest.builder()
+            .nonce(exchange.getNonceFactory().createValue())
+            .ascending(ascending)
+            .convertedAsset(convertedAsset)
+            .hideZeroAllocations(hideZeroAllocations)
+            .build();
+
+    KrakenEarnAllocationsResult result =
+        kraken.getEarnAllocations(
+            exchange.getExchangeSpecification().getApiKey(), signatureCreator, request);
+    return checkResult(result);
   }
 }

--- a/xchange-kraken/src/test/java/org/knowm/xchange/kraken/dto/account/KrakenEarnAllocationsJSONTest.java
+++ b/xchange-kraken/src/test/java/org/knowm/xchange/kraken/dto/account/KrakenEarnAllocationsJSONTest.java
@@ -1,0 +1,84 @@
+package org.knowm.xchange.kraken.dto.account;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+import org.knowm.xchange.kraken.dto.account.results.KrakenEarnAllocationsResult;
+
+public class KrakenEarnAllocationsJSONTest {
+
+  @Test
+  public void testEarnAllocationsUnmarshal() throws IOException {
+
+    // Read in the JSON from the example resources
+    InputStream is =
+        KrakenEarnAllocationsJSONTest.class.getResourceAsStream(
+            "/org/knowm/xchange/kraken/dto/account/example-earnallocations-data.json");
+
+    // Use Jackson to parse it
+    ObjectMapper mapper = new ObjectMapper();
+    KrakenEarnAllocationsResult krakenResult =
+        mapper.readValue(is, KrakenEarnAllocationsResult.class);
+    KrakenEarnAllocations allocations = krakenResult.getResult();
+
+    assertThat(allocations).isNotNull();
+    assertThat(allocations.getConvertedAsset()).isEqualTo("USD");
+    assertThat(allocations.getTotalAllocated()).isEqualByComparingTo(new BigDecimal("1000.50"));
+    assertThat(allocations.getTotalRewarded()).isEqualByComparingTo(new BigDecimal("5.25"));
+    assertThat(allocations.getItems()).hasSize(2);
+
+    // Test first allocation (BTC)
+    KrakenEarnAllocation btcAllocation = allocations.getItems().get(0);
+    assertThat(btcAllocation.getNativeAsset()).isEqualTo("BTC");
+    assertThat(btcAllocation.getStrategyId()).isEqualTo("strategy-1");
+
+    // Test amount allocated
+    KrakenEarnAmountAllocated amountAllocated = btcAllocation.getAmountAllocated();
+    assertThat(amountAllocated).isNotNull();
+    assertThat(amountAllocated.getTotal().getNativeAmount())
+        .isEqualByComparingTo(new BigDecimal("0.1"));
+    assertThat(amountAllocated.getTotal().getConvertedAmount())
+        .isEqualByComparingTo(new BigDecimal("5000.00"));
+
+    // Test pending
+    assertThat(amountAllocated.getPending().getNativeAmount())
+        .isEqualByComparingTo(new BigDecimal("0.01"));
+    assertThat(amountAllocated.getPending().getConvertedAmount())
+        .isEqualByComparingTo(new BigDecimal("500.00"));
+
+    // Test bonding state
+    KrakenEarnAmountAllocated.State bonding = amountAllocated.getBonding();
+    assertThat(bonding).isNotNull();
+    assertThat(bonding.getNativeAmount()).isEqualByComparingTo(new BigDecimal("0.05"));
+    assertThat(bonding.getAllocationCount()).isEqualTo(1);
+    assertThat(bonding.getAllocations()).hasSize(1);
+    assertThat(bonding.getAllocations().get(0).getNativeAmount())
+        .isEqualByComparingTo(new BigDecimal("0.05"));
+
+    // Test total rewarded
+    assertThat(btcAllocation.getTotalRewarded().getNativeAmount())
+        .isEqualByComparingTo(new BigDecimal("0.001"));
+    assertThat(btcAllocation.getTotalRewarded().getConvertedAmount())
+        .isEqualByComparingTo(new BigDecimal("50.00"));
+
+    // Test payout
+    KrakenEarnPayout payout = btcAllocation.getPayout();
+    assertThat(payout).isNotNull();
+    assertThat(payout.getAccumulatedReward().getNativeAmount())
+        .isEqualByComparingTo(new BigDecimal("0.0005"));
+    assertThat(payout.getEstimatedReward().getNativeAmount())
+        .isEqualByComparingTo(new BigDecimal("0.0005"));
+
+    // Test second allocation (ETH)
+    KrakenEarnAllocation ethAllocation = allocations.getItems().get(1);
+    assertThat(ethAllocation.getNativeAsset()).isEqualTo("ETH");
+    assertThat(ethAllocation.getStrategyId()).isEqualTo("strategy-2");
+    assertThat(ethAllocation.getAmountAllocated().getBonding()).isNull();
+    assertThat(ethAllocation.getAmountAllocated().getUnbonding()).isNull();
+    assertThat(ethAllocation.getAmountAllocated().getExitQueue()).isNull();
+  }
+}

--- a/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/KrakenDigestTest.java
+++ b/xchange-kraken/src/test/java/org/knowm/xchange/kraken/service/KrakenDigestTest.java
@@ -30,4 +30,22 @@ class KrakenDigestTest {
 
     assertThat(actual).isEqualTo(expected);
   }
+
+  @Test
+  void signatureWithJsonBody() {
+    var krakenDigest = KrakenDigest.createInstance("abc");
+
+    when(restInvocation.getPath()).thenReturn("/0/private/Earn/Allocations");
+    when(restInvocation.getRequestBody())
+        .thenReturn("{\"nonce\":\"1756856074101\",\"ascending\":true}");
+    when(restInvocation.getParamValue(any(), eq("nonce"))).thenReturn(null);
+
+    String actual = krakenDigest.digestParams(restInvocation);
+
+    // Verify signature is generated and is a valid base64 string
+    assertThat(actual).isNotNull().isNotEmpty();
+    // The signature should be different from the FormParam version due to different path
+    // but should still be a valid base64 encoded string
+    assertThat(actual).matches("^[A-Za-z0-9+/]+=*$");
+  }
 }

--- a/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/account/example-earnallocations-data.json
+++ b/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/account/example-earnallocations-data.json
@@ -1,0 +1,112 @@
+{
+  "error": [],
+  "result": {
+    "converted_asset": "USD",
+    "total_allocated": "1000.50",
+    "total_rewarded": "5.25",
+    "items": [
+      {
+        "native_asset": "BTC",
+        "strategy_id": "strategy-1",
+        "amount_allocated": {
+          "total": {
+            "native": "0.1",
+            "converted": "5000.00"
+          },
+          "pending": {
+            "native": "0.01",
+            "converted": "500.00"
+          },
+          "bonding": {
+            "native": "0.05",
+            "converted": "2500.00",
+            "allocation_count": 1,
+            "allocations": [
+              {
+                "native": "0.05",
+                "converted": "2500.00",
+                "created_at": 1609459200000,
+                "expires": 1612137600000
+              }
+            ]
+          },
+          "unbonding": {
+            "native": "0.02",
+            "converted": "1000.00",
+            "allocation_count": 1,
+            "allocations": [
+              {
+                "native": "0.02",
+                "converted": "1000.00",
+                "created_at": 1609459200000,
+                "expires": 1612137600000
+              }
+            ]
+          },
+          "exit_queue": {
+            "native": "0.02",
+            "converted": "1000.00",
+            "allocation_count": 1,
+            "allocations": [
+              {
+                "native": "0.02",
+                "converted": "1000.00",
+                "created_at": 1609459200000,
+                "expires": 1612137600000
+              }
+            ]
+          }
+        },
+        "total_rewarded": {
+          "native": "0.001",
+          "converted": "50.00"
+        },
+        "payout": {
+          "accumulated_reward": {
+            "native": "0.0005",
+            "converted": "25.00"
+          },
+          "estimated_reward": {
+            "native": "0.0005",
+            "converted": "25.00"
+          },
+          "period_start": 1609459200000,
+          "period_end": 1612137600000
+        }
+      },
+      {
+        "native_asset": "ETH",
+        "strategy_id": "strategy-2",
+        "amount_allocated": {
+          "total": {
+            "native": "1.5",
+            "converted": "3000.00"
+          },
+          "pending": {
+            "native": "0.1",
+            "converted": "200.00"
+          },
+          "bonding": null,
+          "unbonding": null,
+          "exit_queue": null
+        },
+        "total_rewarded": {
+          "native": "0.015",
+          "converted": "30.00"
+        },
+        "payout": {
+          "accumulated_reward": {
+            "native": "0.01",
+            "converted": "20.00"
+          },
+          "estimated_reward": {
+            "native": "0.005",
+            "converted": "10.00"
+          },
+          "period_start": 1609459200000,
+          "period_end": 1612137600000
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
    feat(Kraken): Add Earn Allocations API support
    
    - Add DTOs for Kraken Earn Allocations API:
      - KrakenEarnAllocation, KrakenEarnAllocationDetail, KrakenEarnAllocationState
      - KrakenEarnAllocations, KrakenEarnAllocationsRequest
      - KrakenEarnAmount, KrakenEarnAmountAllocated, KrakenEarnPayout
      - KrakenEarnAllocationsResult
    
    - Add getEarnAllocations endpoint to KrakenAuthenticated interface
    - Implement getEarnAllocations in KrakenAccountServiceRaw and KrakenAccountService
    - Update KrakenDigest to support JSON request body signature generation
      by extracting nonce from JSON body when FormParam is not available
    
    This implementation supports the /private/Earn/Allocations endpoint
    which returns a list of earn allocations with details about allocated
    amounts, rewards, and payout information.