### PR TITLE
feat(kucoin): add Earn holdings API support

### DIFF
--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinAccountService.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinAccountService.java
@@ -22,6 +22,7 @@ import org.knowm.xchange.kucoin.dto.request.ApplyWithdrawApiRequest;
 import org.knowm.xchange.kucoin.dto.request.CreateDepositAddressApiRequest;
 import org.knowm.xchange.kucoin.dto.response.AccountBalancesResponse;
 import org.knowm.xchange.kucoin.dto.response.DepositAddressResponse;
+import org.knowm.xchange.kucoin.dto.response.KucoinEarnHoldingsResponse;
 import org.knowm.xchange.kucoin.service.params.KucoinWithdrawFundsParams;
 import org.knowm.xchange.service.account.AccountService;
 import org.knowm.xchange.service.trade.params.HistoryParamsFundingType;
@@ -173,6 +174,20 @@ public class KucoinAccountService extends KucoinAccountServiceRaw implements Acc
 
       return createDepositAddress(request);
 
+    } catch (KucoinException e) {
+      throw KucoinErrorAdapter.adapt(e);
+    }
+  }
+
+  public KucoinEarnHoldingsResponse getEarnHoldings(
+      String currency,
+      String productId,
+      String productCategory,
+      Integer currentPage,
+      Integer pageSize)
+      throws IOException {
+    try {
+      return super.getEarnHoldings(currency, productId, productCategory, currentPage, pageSize);
     } catch (KucoinException e) {
       throw KucoinErrorAdapter.adapt(e);
     }

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinAccountServiceRaw.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinAccountServiceRaw.java
@@ -17,6 +17,7 @@ import org.knowm.xchange.kucoin.dto.response.ApplyWithdrawResponse;
 import org.knowm.xchange.kucoin.dto.response.DepositAddressResponse;
 import org.knowm.xchange.kucoin.dto.response.DepositResponse;
 import org.knowm.xchange.kucoin.dto.response.InternalTransferResponse;
+import org.knowm.xchange.kucoin.dto.response.KucoinEarnHoldingsResponse;
 import org.knowm.xchange.kucoin.dto.response.Pagination;
 import org.knowm.xchange.kucoin.dto.response.WithdrawalResponse;
 
@@ -209,6 +210,32 @@ public class KucoinAccountServiceRaw extends KucoinBaseService {
     return decorateApiCall(
             () ->
                 depositAPI.getDepositAddresses(apiKey, digest, nonceFactory, passphrase, currency))
+        .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+        .call()
+        .getData();
+  }
+
+  public KucoinEarnHoldingsResponse getEarnHoldings(
+      String currency,
+      String productId,
+      String productCategory,
+      Integer currentPage,
+      Integer pageSize)
+      throws IOException {
+    checkAuthenticated();
+    return decorateApiCall(
+            () ->
+                accountApi.getEarnHoldings(
+                    apiKey,
+                    digest,
+                    nonceFactory,
+                    passphrase,
+                    currency,
+                    productId,
+                    productCategory,
+                    currentPage,
+                    pageSize))
+        .withRetry(retry("getEarnHoldings"))
         .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
         .call()
         .getData();

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/KucoinEarnHolding.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/KucoinEarnHolding.java
@@ -1,0 +1,60 @@
+package org.knowm.xchange.kucoin.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import lombok.Data;
+
+/** DTO for Kucoin Earn Holding */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KucoinEarnHolding {
+
+  @JsonProperty("orderId")
+  private String orderId;
+
+  @JsonProperty("productId")
+  private String productId;
+
+  @JsonProperty("productCategory")
+  private String productCategory;
+
+  @JsonProperty("productType")
+  private String productType;
+
+  @JsonProperty("currency")
+  private String currency;
+
+  @JsonProperty("incomeCurrency")
+  private String incomeCurrency;
+
+  @JsonProperty("returnRate")
+  private BigDecimal returnRate;
+
+  @JsonProperty("holdAmount")
+  private BigDecimal holdAmount;
+
+  @JsonProperty("redeemedAmount")
+  private BigDecimal redeemedAmount;
+
+  @JsonProperty("redeemingAmount")
+  private BigDecimal redeemingAmount;
+
+  @JsonProperty("lockStartTime")
+  private Long lockStartTime;
+
+  @JsonProperty("lockEndTime")
+  private Long lockEndTime;
+
+  @JsonProperty("purchaseTime")
+  private Long purchaseTime;
+
+  @JsonProperty("redeemPeriod")
+  private Integer redeemPeriod;
+
+  @JsonProperty("status")
+  private String status;
+
+  @JsonProperty("earlyRedeemSupported")
+  private Integer earlyRedeemSupported;
+}

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/KucoinEarnHoldingsResponse.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/KucoinEarnHoldingsResponse.java
@@ -1,0 +1,27 @@
+package org.knowm.xchange.kucoin.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Data;
+
+/** DTO for Kucoin Earn Holdings paginated response */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KucoinEarnHoldingsResponse {
+
+  @JsonProperty("totalNum")
+  private Integer totalNum;
+
+  @JsonProperty("totalPage")
+  private Integer totalPage;
+
+  @JsonProperty("currentPage")
+  private Integer currentPage;
+
+  @JsonProperty("pageSize")
+  private Integer pageSize;
+
+  @JsonProperty("items")
+  private List<KucoinEarnHolding> items;
+}

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/AccountAPI.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/AccountAPI.java
@@ -19,6 +19,7 @@ import org.knowm.xchange.kucoin.dto.response.AccountBalancesResponse;
 import org.knowm.xchange.kucoin.dto.response.AccountLedgersResponse;
 import org.knowm.xchange.kucoin.dto.response.AccountResponse;
 import org.knowm.xchange.kucoin.dto.response.InternalTransferResponse;
+import org.knowm.xchange.kucoin.dto.response.KucoinEarnHoldingsResponse;
 import org.knowm.xchange.kucoin.dto.response.KucoinResponse;
 import org.knowm.xchange.kucoin.dto.response.Pagination;
 import si.mazi.rescu.ParamsDigest;
@@ -112,4 +113,31 @@ public interface AccountAPI {
       @HeaderParam(APIConstants.API_HEADER_PASSPHRASE) String apiPassphrase,
       @PathParam("accountId") String accountId)
       throws IOException;
+
+  /**
+   * Get account holdings for earn products.
+   *
+   * @param currency The code of the currency (optional)
+   * @param productId Product ID (optional)
+   * @param productCategory Product category: DEMAND, ACTIVITY, STAKING, KCS_STAKING, ETH2
+   *     (optional)
+   * @param currentPage Current request page (optional, default: 1)
+   * @param pageSize Number of results per request, minimum 10, maximum 500 (optional, default: 15)
+   * @return The earn holdings
+   * @throws IOException on socket errors.
+   * @throws KucoinException when errors are returned from the exchange.
+   */
+  @GET
+  @Path("v1/earn/hold-assets")
+  KucoinResponse<KucoinEarnHoldingsResponse> getEarnHoldings(
+      @HeaderParam(APIConstants.API_HEADER_KEY) String apiKey,
+      @HeaderParam(APIConstants.API_HEADER_SIGN) ParamsDigest signature,
+      @HeaderParam(APIConstants.API_HEADER_TIMESTAMP) SynchronizedValueFactory<Long> nonce,
+      @HeaderParam(APIConstants.API_HEADER_PASSPHRASE) String apiPassphrase,
+      @QueryParam("currency") String currency,
+      @QueryParam("productId") String productId,
+      @QueryParam("productCategory") String productCategory,
+      @QueryParam("currentPage") Integer currentPage,
+      @QueryParam("pageSize") Integer pageSize)
+      throws IOException, KucoinException;
 }

--- a/xchange-kucoin/src/test/java/org/knowm/xchange/kucoin/dto/account/KucoinEarnHoldingsJSONTest.java
+++ b/xchange-kucoin/src/test/java/org/knowm/xchange/kucoin/dto/account/KucoinEarnHoldingsJSONTest.java
@@ -1,0 +1,67 @@
+package org.knowm.xchange.kucoin.dto.account;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import org.junit.Test;
+import org.knowm.xchange.kucoin.dto.response.KucoinEarnHolding;
+import org.knowm.xchange.kucoin.dto.response.KucoinEarnHoldingsResponse;
+import org.knowm.xchange.kucoin.dto.response.KucoinResponse;
+
+public class KucoinEarnHoldingsJSONTest {
+
+  @Test
+  public void testEarnHoldingsUnmarshal() throws IOException {
+    InputStream is =
+        KucoinEarnHoldingsJSONTest.class.getResourceAsStream(
+            "/org/knowm/xchange/kucoin/dto/account/example-earn-holdings.json");
+    ObjectMapper mapper = new ObjectMapper();
+    KucoinResponse<KucoinEarnHoldingsResponse> kucoinResult =
+        mapper.readValue(
+            is,
+            mapper
+                .getTypeFactory()
+                .constructParametricType(KucoinResponse.class, KucoinEarnHoldingsResponse.class));
+    KucoinEarnHoldingsResponse holdings = kucoinResult.getData();
+
+    assertThat(holdings).isNotNull();
+    assertThat(holdings.getTotalNum()).isEqualTo(2);
+    assertThat(holdings.getTotalPage()).isEqualTo(1);
+    assertThat(holdings.getCurrentPage()).isEqualTo(1);
+    assertThat(holdings.getPageSize()).isEqualTo(15);
+    assertThat(holdings.getItems()).isNotNull();
+    assertThat(holdings.getItems()).hasSize(2);
+
+    // Test first holding
+    KucoinEarnHolding holding1 = holdings.getItems().get(0);
+    assertThat(holding1.getOrderId()).isEqualTo("2767291");
+    assertThat(holding1.getProductId()).isEqualTo("2611");
+    assertThat(holding1.getProductCategory()).isEqualTo("KCS_STAKING");
+    assertThat(holding1.getProductType()).isEqualTo("DEMAND");
+    assertThat(holding1.getCurrency()).isEqualTo("KCS");
+    assertThat(holding1.getIncomeCurrency()).isEqualTo("KCS");
+    assertThat(holding1.getReturnRate()).isEqualByComparingTo(new BigDecimal("0.03471727"));
+    assertThat(holding1.getHoldAmount()).isEqualByComparingTo(new BigDecimal("1.5"));
+    assertThat(holding1.getRedeemedAmount()).isEqualByComparingTo(new BigDecimal("0.05"));
+    assertThat(holding1.getRedeemingAmount()).isEqualByComparingTo(new BigDecimal("0"));
+    assertThat(holding1.getLockStartTime()).isEqualTo(1701252000000L);
+    assertThat(holding1.getLockEndTime()).isNull();
+    assertThat(holding1.getPurchaseTime()).isEqualTo(1729257513000L);
+    assertThat(holding1.getRedeemPeriod()).isEqualTo(3);
+    assertThat(holding1.getStatus()).isEqualTo("HOLDING");
+    assertThat(holding1.getEarlyRedeemSupported()).isEqualTo(0);
+
+    // Test second holding
+    KucoinEarnHolding holding2 = holdings.getItems().get(1);
+    assertThat(holding2.getOrderId()).isEqualTo("2767292");
+    assertThat(holding2.getProductId()).isEqualTo("2172");
+    assertThat(holding2.getProductCategory()).isEqualTo("DEMAND");
+    assertThat(holding2.getCurrency()).isEqualTo("BTC");
+    assertThat(holding2.getHoldAmount()).isEqualByComparingTo(new BigDecimal("0.1"));
+    assertThat(holding2.getReturnRate()).isEqualByComparingTo(new BigDecimal("0.00047208"));
+    assertThat(holding2.getRedeemedAmount()).isEqualByComparingTo(new BigDecimal("0.001"));
+  }
+}

--- a/xchange-kucoin/src/test/resources/org/knowm/xchange/kucoin/dto/account/example-earn-holdings.json
+++ b/xchange-kucoin/src/test/resources/org/knowm/xchange/kucoin/dto/account/example-earn-holdings.json
@@ -1,0 +1,47 @@
+{
+  "code": "200000",
+  "data": {
+    "totalNum": 2,
+    "totalPage": 1,
+    "currentPage": 1,
+    "pageSize": 15,
+    "items": [
+      {
+        "orderId": "2767291",
+        "productId": "2611",
+        "productCategory": "KCS_STAKING",
+        "productType": "DEMAND",
+        "currency": "KCS",
+        "incomeCurrency": "KCS",
+        "returnRate": "0.03471727",
+        "holdAmount": "1.5",
+        "redeemedAmount": "0.05",
+        "redeemingAmount": "0",
+        "lockStartTime": 1701252000000,
+        "lockEndTime": null,
+        "purchaseTime": 1729257513000,
+        "redeemPeriod": 3,
+        "status": "HOLDING",
+        "earlyRedeemSupported": 0
+      },
+      {
+        "orderId": "2767292",
+        "productId": "2172",
+        "productCategory": "DEMAND",
+        "productType": "DEMAND",
+        "currency": "BTC",
+        "incomeCurrency": "BTC",
+        "returnRate": "0.00047208",
+        "holdAmount": "0.1",
+        "redeemedAmount": "0.001",
+        "redeemingAmount": "0",
+        "lockStartTime": 1644807600000,
+        "lockEndTime": null,
+        "purchaseTime": 1644807600000,
+        "redeemPeriod": 0,
+        "status": "HOLDING",
+        "earlyRedeemSupported": 0
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds support for retrieving Kucoin Earn holdings via the /api/v1/earn/hold-assets endpoint, enabling users to fetch their staking, savings, and other earn product positions.

API Integration
  • Added getEarnHoldings() method to AccountAPI interface
      • Supports optional query parameters: currency, productId, productCategory, currentPage, pageSize
      • Endpoint: GET /api/v1/earn/hold-assets
  • Implemented service methods:
      • KucoinAccountServiceRaw.getEarnHoldings() Raw API call with error handling
      • KucoinAccountService.getEarnHoldings() High-level service method