### PR TITLE
[kraken] Mapping costmin into Instrument::counterMinimumAmount

### DIFF
--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java
@@ -493,7 +493,6 @@ public class KrakenAdapters {
       KrakenAssetPair krakenPair, InstrumentMetaData originalMeta) {
     // Normalize order minimum into base units
     BigDecimal minimumAmount = krakenPair.getOrderMin().multiply(krakenPair.getVolumeMultiplier());
-    BigDecimal counterMinimumAmount = krakenPair.getCostMin();
     // effective step size in base units
     // stepSize = lot_multiplier × 10^(-lot_decimals)
     BigDecimal volumeStepSize =
@@ -512,7 +511,7 @@ public class KrakenAdapters {
         .tradingFeeCurrency(
             KrakenUtils.translateKrakenCurrencyCode(krakenPair.getFeeVolumeCurrency()))
         .minimumAmount(minimumAmount)
-        .counterMinimumAmount(counterMinimumAmount)
+        .counterMinimumAmount(krakenPair.getCostMin())
         .priceScale(krakenPair.getPairScale())
         .priceStepSize(krakenPair.getTickSize())
         .volumeScale(krakenPair.getVolumeLotScale())

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java
@@ -493,6 +493,7 @@ public class KrakenAdapters {
       KrakenAssetPair krakenPair, InstrumentMetaData originalMeta) {
     // Normalize order minimum into base units
     BigDecimal minimumAmount = krakenPair.getOrderMin().multiply(krakenPair.getVolumeMultiplier());
+    BigDecimal counterMinimumAmount = krakenPair.getCostMin();
     // effective step size in base units
     // stepSize = lot_multiplier × 10^(-lot_decimals)
     BigDecimal volumeStepSize =
@@ -511,6 +512,7 @@ public class KrakenAdapters {
         .tradingFeeCurrency(
             KrakenUtils.translateKrakenCurrencyCode(krakenPair.getFeeVolumeCurrency()))
         .minimumAmount(minimumAmount)
+        .counterMinimumAmount(counterMinimumAmount)
         .priceScale(krakenPair.getPairScale())
         .priceStepSize(krakenPair.getTickSize())
         .volumeScale(krakenPair.getVolumeLotScale())

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/marketdata/KrakenAssetPair.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/dto/marketdata/KrakenAssetPair.java
@@ -59,4 +59,7 @@ public class KrakenAssetPair {
 
   @JsonProperty("ordermin")
   BigDecimal orderMin;
+
+  @JsonProperty("costmin")
+  BigDecimal costMin;
 }

--- a/xchange-kraken/src/test/java/org/knowm/xchange/kraken/dto/marketdata/KrakenAssetPairsJSONTest.java
+++ b/xchange-kraken/src/test/java/org/knowm/xchange/kraken/dto/marketdata/KrakenAssetPairsJSONTest.java
@@ -47,6 +47,7 @@ public class KrakenAssetPairsJSONTest {
             .marginCall(new BigDecimal(80))
             .marginStop(new BigDecimal(40))
             .orderMin(new BigDecimal("0.002"))
+            .costMin(new BigDecimal("0.5"))
             .build();
   }
 
@@ -93,6 +94,7 @@ public class KrakenAssetPairsJSONTest {
         .isEqualTo(expectedAssetPairInfo.getVolumeMultiplier());
     assertThat(krakenAssetPairInfo.getFees().size()).isEqualTo(9);
     assertThat(krakenAssetPairInfo.getOrderMin()).isEqualTo(expectedAssetPairInfo.getOrderMin());
+    assertThat(krakenAssetPairInfo.getCostMin()).isEqualTo(expectedAssetPairInfo.getCostMin());
 
     KrakenFee deserializedFee = krakenAssetPairInfo.getFees().get(0);
     KrakenFee expectedFee = expectedAssetPairInfo.getFees().get(0);

--- a/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/marketdata/example-assetpairs-data.json
+++ b/xchange-kraken/src/test/resources/org/knowm/xchange/kraken/dto/marketdata/example-assetpairs-data.json
@@ -5494,7 +5494,9 @@
       ],
       "fee_volume_currency": "ZUSD",
       "margin_call": 80,
-      "margin_stop": 40
+      "margin_stop": 40,
+      "ordermin": "0.00005",
+      "costmin": "1"
     },
     "XXBTZCAD.d": {
       "altname": "XBTCAD.d",
@@ -6103,7 +6105,8 @@
       "fee_volume_currency": "ZUSD",
       "margin_call": 80,
       "margin_stop": 40,
-      "ordermin": "0.002"
+      "ordermin": "0.002",
+      "costmin": "0.5"
     },
     "XXBTZUSD.d": {
       "altname": "XBTUSD.d",


### PR DESCRIPTION
This PR adds support to  `counterMinimumAmount` for Intruments in Kraken adapter.

It fixes #5224