### PR TITLE
[OKX] get candles history, add Instrument method, deprecated Currency

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/CandleStickData.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/CandleStickData.java
@@ -3,20 +3,18 @@ package org.knowm.xchange.dto.marketdata;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
+import lombok.Getter;
 import org.knowm.xchange.instrument.Instrument;
 
 public class CandleStickData implements Serializable {
 
+  @Getter
   private final Instrument instrument;
   private final List<CandleStick> candleSticks;
 
   public CandleStickData(Instrument instrument, List<CandleStick> candleSticks) {
     this.instrument = instrument;
     this.candleSticks = candleSticks;
-  }
-
-  public Instrument getInstrument() {
-    return instrument;
   }
 
   public List<CandleStick> getCandleSticks() {

--- a/xchange-core/src/main/java/org/knowm/xchange/service/marketdata/MarketDataService.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/marketdata/MarketDataService.java
@@ -208,8 +208,25 @@ public interface MarketDataService extends BaseService {
    *     requested function or data, but it has not yet been implemented
    * @throws IOException - Indication that a networking error occurred while fetching JSON data
    */
+  @Deprecated
   default CandleStickData getCandleStickData(
       CurrencyPair currencyPair, CandleStickDataParams params) throws IOException {
+    throw new NotYetImplementedForExchangeException("getCandleStickData");
+  }
+
+  /**
+   * Get the CandleStickData for given currency between startDate to endDate.
+   *
+   * @param Instrument Instrument.
+   * @param params     Params for query, including start(e.g. march 2022.) and end date, period etc.,
+   * @return The CandleStickData, null if some sort of error occurred. Implementers should log the error.
+   * @throws ExchangeException                     - Indication that the exchange reported some kind of error with the request or response
+   * @throws NotAvailableFromExchangeException     - Indication that the exchange does not support the requested function or data
+   * @throws NotYetImplementedForExchangeException - Indication that the exchange supports the requested function or data, but it has not yet been implemented
+   * @throws IOException                           - Indication that a networking error occurred while fetching JSON data
+   */
+  default CandleStickData getCandleStickData(
+      Instrument Instrument, CandleStickDataParams params) throws IOException {
     throw new NotYetImplementedForExchangeException("getCandleStickData");
   }
 

--- a/xchange-core/src/main/java/org/knowm/xchange/service/marketdata/MarketDataService.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/marketdata/MarketDataService.java
@@ -217,7 +217,7 @@ public interface MarketDataService extends BaseService {
   /**
    * Get the CandleStickData for given currency between startDate to endDate.
    *
-   * @param Instrument Instrument.
+   * @param instrument instrument.
    * @param params     Params for query, including start(e.g. march 2022.) and end date, period etc.,
    * @return The CandleStickData, null if some sort of error occurred. Implementers should log the error.
    * @throws ExchangeException                     - Indication that the exchange reported some kind of error with the request or response
@@ -226,7 +226,7 @@ public interface MarketDataService extends BaseService {
    * @throws IOException                           - Indication that a networking error occurred while fetching JSON data
    */
   default CandleStickData getCandleStickData(
-      Instrument Instrument, CandleStickDataParams params) throws IOException {
+      Instrument instrument, CandleStickDataParams params) throws IOException {
     throw new NotYetImplementedForExchangeException("getCandleStickData");
   }
 

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/Okex.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/Okex.java
@@ -27,6 +27,7 @@ public interface Okex {
   String instrumentsPath = "/public/instruments"; // Stated as 20 req/2 sec
   String tickerPath = "/market/ticker"; // Stated as 20 req/2 sec
   String tickersPath = "/market/tickers"; // Stated as 20 req/2 sec
+  String candlesHistoryPath = "/market/history-candles"; // Stated as 20 req/2 sec
 
   // To avoid 429s, actual req/second may need to be lowered!
   Map<String, List<Integer>> publicPathRateLimits =
@@ -35,6 +36,7 @@ public interface Okex {
           put(instrumentsPath, Arrays.asList(8, 1));
           put(tickerPath, Arrays.asList(8, 1));
           put(tickersPath, Arrays.asList(8, 1));
+          put(candlesHistoryPath, Arrays.asList(8, 1));
         }
       };
 
@@ -78,7 +80,7 @@ public interface Okex {
       throws IOException, OkexException;
 
   @GET
-  @Path("/market/history-candles")
+  @Path(candlesHistoryPath)
   OkexResponse<List<OkexCandleStick>> getHistoryCandles(
       @QueryParam("instId") String instrument,
       @QueryParam("after") String after,

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/OkexAdapters.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/OkexAdapters.java
@@ -621,7 +621,7 @@ public class OkexAdapters {
   }
 
   public static CandleStickData adaptCandleStickData(
-      List<OkexCandleStick> okexCandleStickList, CurrencyPair currencyPair) {
+      List<OkexCandleStick> okexCandleStickList, Instrument instrument) {
     CandleStickData candleStickData = null;
     if (!okexCandleStickList.isEmpty()) {
       List<CandleStick> candleStickList = new ArrayList<>();
@@ -637,7 +637,7 @@ public class OkexAdapters {
                 .quotaVolume(new BigDecimal(okexCandleStick.getVolumeCcy()))
                 .build());
       }
-      candleStickData = new CandleStickData(currencyPair, candleStickList);
+      candleStickData = new CandleStickData(instrument, candleStickList);
     }
     return candleStickData;
   }

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/service/OkexCandleStickPeriodType.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/service/OkexCandleStickPeriodType.java
@@ -1,5 +1,7 @@
 package org.knowm.xchange.okex.service;
 
+import lombok.Getter;
+
 public enum OkexCandleStickPeriodType {
   CANDLE_STICK_1M(1, "1m"),
   CANDLE_STICK_3M(3, "3m"),
@@ -10,10 +12,11 @@ public enum OkexCandleStickPeriodType {
   CANDLE_STICK_2H(2 * 60, "2H"),
   CANDLE_STICK_4H(4 * 60, "4H");
   private final long periodInSecs;
+  @Getter
   private final String fieldValue;
 
   OkexCandleStickPeriodType(long periodInMinutes, String fieldValue) {
-    this.periodInSecs = periodInMinutes * 1000;
+    this.periodInSecs = periodInMinutes * 60;
     this.fieldValue = fieldValue;
   }
 
@@ -37,7 +40,4 @@ public enum OkexCandleStickPeriodType {
     return result;
   }
 
-  public String getFieldValue() {
-    return fieldValue;
-  }
 }

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/service/OkexMarketDataService.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/service/OkexMarketDataService.java
@@ -54,7 +54,12 @@ public class OkexMarketDataService extends OkexMarketDataServiceRaw implements M
   }
 
   @Override
-  public CandleStickData getCandleStickData(CurrencyPair currencyPair, CandleStickDataParams params)
+  public CandleStickData getCandleStickData(CurrencyPair currencyPair, CandleStickDataParams params) {
+    return getCandleStickData(currencyPair, params);
+  }
+
+  @Override
+  public CandleStickData getCandleStickData(Instrument instrument, CandleStickDataParams params)
       throws IOException {
 
     if (!(params instanceof DefaultCandleStickParam)) {
@@ -76,12 +81,12 @@ public class OkexMarketDataService extends OkexMarketDataServiceRaw implements M
 
     OkexResponse<List<OkexCandleStick>> historyCandle =
         getHistoryCandle(
-            OkexAdapters.adaptInstrument(currencyPair),
+            OkexAdapters.adaptInstrument(instrument),
             String.valueOf(defaultCandleStickParam.getEndDate().getTime()),
             String.valueOf(defaultCandleStickParam.getStartDate().getTime()),
             periodType.getFieldValue(),
             limit);
-    return OkexAdapters.adaptCandleStickData(historyCandle.getData(), currencyPair);
+    return OkexAdapters.adaptCandleStickData(historyCandle.getData(), instrument);
   }
 
   @Override

--- a/xchange-okex/src/main/java/org/knowm/xchange/okex/service/OkexMarketDataServiceRaw.java
+++ b/xchange-okex/src/main/java/org/knowm/xchange/okex/service/OkexMarketDataServiceRaw.java
@@ -24,6 +24,7 @@ import org.knowm.xchange.utils.DateUtils;
 
 /** Author: Max Gao (gaamox@tutanota.com) Created: 08-06-2021 */
 public class OkexMarketDataServiceRaw extends OkexBaseService {
+
   public OkexMarketDataServiceRaw(
       OkexExchange exchange, ResilienceRegistries resilienceRegistries) {
     super(exchange, resilienceRegistries);
@@ -34,15 +35,15 @@ public class OkexMarketDataServiceRaw extends OkexBaseService {
       throws OkexException, IOException {
     try {
       return decorateApiCall(
-              () ->
-                  okex.getInstruments(
-                      instrumentType,
-                      underlying,
-                      instrumentId,
-                      (String)
-                          exchange
-                              .getExchangeSpecification()
-                              .getExchangeSpecificParametersItem(PARAM_SIMULATED)))
+          () ->
+              okex.getInstruments(
+                  instrumentType,
+                  underlying,
+                  instrumentId,
+                  (String)
+                      exchange
+                          .getExchangeSpecification()
+                          .getExchangeSpecificParametersItem(PARAM_SIMULATED)))
           .withRateLimiter(rateLimiter(Okex.instrumentsPath))
           .call();
     } catch (OkexException e) {
@@ -54,13 +55,13 @@ public class OkexMarketDataServiceRaw extends OkexBaseService {
       throws OkexException, IOException {
     try {
       return decorateApiCall(
-              () ->
-                  okex.getTicker(
-                      instrumentId,
-                      (String)
-                          exchange
-                              .getExchangeSpecification()
-                              .getExchangeSpecificParametersItem(PARAM_SIMULATED)))
+          () ->
+              okex.getTicker(
+                  instrumentId,
+                  (String)
+                      exchange
+                          .getExchangeSpecification()
+                          .getExchangeSpecificParametersItem(PARAM_SIMULATED)))
           .withRateLimiter(rateLimiter(Okex.tickerPath))
           .call();
     } catch (OkexException e) {
@@ -72,13 +73,13 @@ public class OkexMarketDataServiceRaw extends OkexBaseService {
       throws OkexException, IOException {
     try {
       return decorateApiCall(
-              () ->
-                  okex.getTickers(
-                      instType.toString(),
-                      (String)
-                          exchange
-                              .getExchangeSpecification()
-                              .getExchangeSpecificParametersItem(PARAM_SIMULATED)))
+          () ->
+              okex.getTickers(
+                  instType.toString(),
+                  (String)
+                      exchange
+                          .getExchangeSpecification()
+                          .getExchangeSpecificParametersItem(PARAM_SIMULATED)))
           .withRateLimiter(rateLimiter(Okex.tickersPath))
           .call();
     } catch (OkexException e) {
@@ -90,13 +91,13 @@ public class OkexMarketDataServiceRaw extends OkexBaseService {
       throws OkexException, IOException {
     try {
       return decorateApiCall(
-              () ->
-                  okex.getFundingRate(
-                      instrumentId,
-                      (String)
-                          exchange
-                              .getExchangeSpecification()
-                              .getExchangeSpecificParametersItem(PARAM_SIMULATED)))
+          () ->
+              okex.getFundingRate(
+                  instrumentId,
+                  (String)
+                      exchange
+                          .getExchangeSpecification()
+                          .getExchangeSpecificParametersItem(PARAM_SIMULATED)))
           .withRateLimiter(rateLimiter(Okex.instrumentsPath))
           .call();
     } catch (OkexException e) {
@@ -107,19 +108,19 @@ public class OkexMarketDataServiceRaw extends OkexBaseService {
   public OkexResponse<List<OkexCurrency>> getOkexCurrencies() throws OkexException, IOException {
     try {
       return decorateApiCall(
-              () ->
-                  okexAuthenticated.getCurrencies(
-                      exchange.getExchangeSpecification().getApiKey(),
-                      signatureCreator,
-                      DateUtils.toUTCISODateString(new Date()),
-                      (String)
-                          exchange
-                              .getExchangeSpecification()
-                              .getExchangeSpecificParametersItem(PARAM_PASSPHRASE),
-                      (String)
-                          exchange
-                              .getExchangeSpecification()
-                              .getExchangeSpecificParametersItem(PARAM_SIMULATED)))
+          () ->
+              okexAuthenticated.getCurrencies(
+                  exchange.getExchangeSpecification().getApiKey(),
+                  signatureCreator,
+                  DateUtils.toUTCISODateString(new Date()),
+                  (String)
+                      exchange
+                          .getExchangeSpecification()
+                          .getExchangeSpecificParametersItem(PARAM_PASSPHRASE),
+                  (String)
+                      exchange
+                          .getExchangeSpecification()
+                          .getExchangeSpecificParametersItem(PARAM_SIMULATED)))
           .withRateLimiter(rateLimiter(OkexAuthenticated.currenciesPath))
           .call();
     } catch (OkexException e) {
@@ -149,14 +150,18 @@ public class OkexMarketDataServiceRaw extends OkexBaseService {
   public OkexResponse<List<OkexCandleStick>> getHistoryCandle(
       String instrument, String after, String before, String bar, String limit)
       throws OkexException, IOException {
-    return okex.getHistoryCandles(
-        instrument,
-        after,
-        before,
-        bar,
-        limit,
-        (String)
-            exchange.getExchangeSpecification().getExchangeSpecificParametersItem(PARAM_SIMULATED));
+    return decorateApiCall(
+        () ->
+            okex.getHistoryCandles(
+                instrument,
+                after,
+                before,
+                bar,
+                limit,
+                (String)
+                    exchange.getExchangeSpecification().getExchangeSpecificParametersItem(PARAM_SIMULATED)))
+        .withRateLimiter(rateLimiter(Okex.candlesHistoryPath))
+        .call();
   }
 
   public OkexResponse<List<OkexCandleStick>> getCandle(

--- a/xchange-okex/src/test/java/org/knowm/xchange/okex/OkexPublicDataIntegration.java
+++ b/xchange-okex/src/test/java/org/knowm/xchange/okex/OkexPublicDataIntegration.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import org.junit.Before;
@@ -16,6 +17,7 @@ import org.knowm.xchange.ExchangeFactory;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.derivative.FuturesContract;
+import org.knowm.xchange.dto.marketdata.CandleStickData;
 import org.knowm.xchange.dto.marketdata.FundingRate;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trades;
@@ -26,6 +28,7 @@ import org.knowm.xchange.okex.dto.OkexInstType;
 import org.knowm.xchange.okex.dto.OkexResponse;
 import org.knowm.xchange.okex.dto.marketdata.OkexCandleStick;
 import org.knowm.xchange.okex.service.OkexMarketDataService;
+import org.knowm.xchange.service.trade.params.DefaultCandleStickParam;
 
 public class OkexPublicDataIntegration {
 
@@ -115,6 +118,12 @@ public class OkexPublicDataIntegration {
         ((OkexMarketDataService) exchange.getMarketDataService())
             .getHistoryCandle("BTC-USDT", null, null, null, null);
     assertTrue(Objects.nonNull(barHistDtos) && !barHistDtos.getData().isEmpty());
+    DefaultCandleStickParam params = new DefaultCandleStickParam(new Date(System.currentTimeMillis() - 10 * 60 * 1000), new Date(System.currentTimeMillis()), 60);
+    CandleStickData candleStickData =
+        exchange.getMarketDataService()
+            .getCandleStickData(new FuturesContract("BTC/USDT/SWAP"), params);
+    assertTrue(Objects.nonNull(candleStickData));
+    assertTrue(!candleStickData.getCandleSticks().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
[OKX] get candles history, add Instrument method, deprecated CurrencyPair method. Add rate limiter. Error fix.
[CORE] MarketDataService getCandlesHistory method - add Instrument and set deprecated to CurrencyPair