### PR TITLE
[bitfinex] Use preconfigured object mapper

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/config/BitfinexJacksonObjectMapperFactory.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/config/BitfinexJacksonObjectMapperFactory.java
@@ -19,5 +19,9 @@ public class BitfinexJacksonObjectMapperFactory extends DefaultJacksonObjectMapp
 
     // enable parsing to Instant
     objectMapper.registerModule(new JavaTimeModule());
+
+    // store object mapper for using in module
+    Config.getInstance().setObjectMapper(objectMapper);
+
   }
 }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/config/Config.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/config/Config.java
@@ -1,5 +1,6 @@
 package org.knowm.xchange.bitfinex.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.concurrent.TimeUnit;
 import lombok.Data;
 import org.knowm.xchange.utils.nonce.CurrentTimeIncrementalNonceFactory;
@@ -8,6 +9,7 @@ import si.mazi.rescu.SynchronizedValueFactory;
 @Data
 public final class Config {
 
+  private ObjectMapper objectMapper;
   private SynchronizedValueFactory<Long> nonceFactory;
 
   private static Config instance = new Config();

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexAdapters.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.knowm.xchange.bitfinex.config.Config;
 import org.knowm.xchange.bitfinex.v1.BitfinexOrderType;
 import org.knowm.xchange.bitfinex.v1.BitfinexUtils;
 import org.knowm.xchange.bitfinex.v1.dto.account.BitfinexBalancesResponse;
@@ -92,7 +93,7 @@ public class BitfinexAdapters {
       Pattern.compile(("transfer of .* from .* to exchange sa\\(.*\\).*"));
   private static final Pattern WITHDRAWAL_PATTERN = Pattern.compile((".* withdrawal .*"));
 
-  private final ObjectMapper mapper = new ObjectMapper();
+  private final ObjectMapper mapper = Config.getInstance().getObjectMapper();
 
   private final AtomicBoolean warnedStopLimit = new AtomicBoolean();
 

--- a/xchange-bitfinex/src/test/resources/logback.xml
+++ b/xchange-bitfinex/src/test/resources/logback.xml
@@ -18,6 +18,6 @@
 
     <!-- Define logging for organization applications only -->
 <!--    <logger name="org.knowm.xchange" level="DEBUG"/>-->
-<!--    <logger name="si.mazi.rescu" level="<Root level="WARN">"/>-->
+<!--    <logger name="si.mazi.rescu" level="TRACE"/>-->
 
 </configuration>


### PR DESCRIPTION
For tickers unmarshalling the empty object mapper was used.

Bitfinex added new field to the payload and caused empty object mapper to fail on unknown property.
That was detected by integration tests that are failing for some days.

Changed the `BitfinexAdapters` so that it uses preconfigured object mapper instead of empty