### PR TITLE
[BINANCE FUTURES] new websockets path

### DIFF
--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingExchange.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingExchange.java
@@ -1,7 +1,5 @@
 package info.bitrich.xchangestream.binance;
 
-import static java.util.Collections.emptyMap;
-
 import info.bitrich.xchangestream.binance.BinanceUserDataChannel.NoActiveChannelException;
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.core.StreamingExchange;
@@ -10,13 +8,6 @@ import info.bitrich.xchangestream.service.netty.WebSocketClientHandler;
 import info.bitrich.xchangestream.util.Events;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Observable;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.knowm.xchange.binance.BinanceAuthenticated;
 import org.knowm.xchange.binance.BinanceExchange;
@@ -26,6 +17,16 @@ import org.knowm.xchange.derivative.FuturesContract;
 import org.knowm.xchange.instrument.Instrument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyMap;
 
 public class BinanceStreamingExchange extends BinanceExchange implements StreamingExchange {
 
@@ -169,7 +170,7 @@ public class BinanceStreamingExchange extends BinanceExchange implements Streami
   private Completable createAndConnectUserDataFutureService(String listenKey) {
     userDataFutureStreamingService =
         BinanceUserDataFutureStreamingService.create(
-            getStreamingBaseUri(), listenKey, exchangeSpecification);
+            getStreamingBaseUri() + "private/", listenKey, exchangeSpecification);
     applyStreamingSpecification(getExchangeSpecification(), userDataFutureStreamingService);
     return userDataFutureStreamingService
         .connect()
@@ -298,9 +299,17 @@ public class BinanceStreamingExchange extends BinanceExchange implements Streami
 
   protected BinanceStreamingService createStreamingService(
       ProductSubscription subscription, KlineSubscription klineSubscription) {
+    String routedPath = "";
+    if (isFuturesEnabled()) {
+      routedPath = "public/";
+      // market path
+      if (subscription.getOrderBook().isEmpty() && (subscription.getTicker().isEmpty() | !realtimeOrderBookTicker) && subscription.getTrades().isEmpty()) {
+        routedPath = "market/";
+      }
+    }
     // new chinese pair, like 币安人生usdt, need urlEncode
     String path =
-        getStreamingBaseUri()
+        getStreamingBaseUri() + routedPath
             + "stream?streams="
             + URLEncoder.encode(
             buildSubscriptionStreams(subscription, klineSubscription), StandardCharsets.UTF_8);

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingMarketDataService.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingMarketDataService.java
@@ -1,9 +1,5 @@
 package info.bitrich.xchangestream.binance;
 
-import static info.bitrich.xchangestream.binance.BinanceSubscriptionType.KLINE;
-import static info.bitrich.xchangestream.binance.BinanceSubscriptionType.TICKER_WINDOW;
-import static info.bitrich.xchangestream.service.netty.StreamingObjectMapperHelper.getObjectMapper;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -11,13 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import info.bitrich.xchangestream.binance.dto.BinanceWebsocketTransaction;
-import info.bitrich.xchangestream.binance.dto.market.BinanceRawTrade;
-import info.bitrich.xchangestream.binance.dto.market.BookTickerBinanceWebSocketTransaction;
-import info.bitrich.xchangestream.binance.dto.market.DepthBinanceWebSocketTransaction;
-import info.bitrich.xchangestream.binance.dto.market.FundingRateWebsocketTransaction;
-import info.bitrich.xchangestream.binance.dto.market.KlineBinanceWebSocketTransaction;
-import info.bitrich.xchangestream.binance.dto.market.TickerBinanceWebsocketTransaction;
-import info.bitrich.xchangestream.binance.dto.market.TradeBinanceWebsocketTransaction;
+import info.bitrich.xchangestream.binance.dto.market.*;
 import info.bitrich.xchangestream.binance.exceptions.UpFrontSubscriptionRequiredException;
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.core.StreamingMarketDataService;
@@ -30,13 +20,23 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.functions.Consumer;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.subjects.BehaviorSubject;
+import org.knowm.xchange.binance.BinanceAdapters;
+import org.knowm.xchange.binance.BinanceErrorAdapter;
+import org.knowm.xchange.binance.dto.BinanceException;
+import org.knowm.xchange.binance.dto.marketdata.*;
+import org.knowm.xchange.binance.service.BinanceMarketDataService;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.derivative.FuturesContract;
+import org.knowm.xchange.dto.Order.OrderType;
+import org.knowm.xchange.dto.marketdata.*;
+import org.knowm.xchange.exceptions.ExchangeException;
+import org.knowm.xchange.exceptions.RateLimitExceededException;
+import org.knowm.xchange.instrument.Instrument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -45,29 +45,10 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.knowm.xchange.binance.BinanceAdapters;
-import org.knowm.xchange.binance.BinanceErrorAdapter;
-import org.knowm.xchange.binance.dto.BinanceException;
-import org.knowm.xchange.binance.dto.marketdata.BinanceBookTicker;
-import org.knowm.xchange.binance.dto.marketdata.BinanceFundingRateInfo;
-import org.knowm.xchange.binance.dto.marketdata.BinanceKline;
-import org.knowm.xchange.binance.dto.marketdata.BinanceOrderbook;
-import org.knowm.xchange.binance.dto.marketdata.BinanceTicker24h;
-import org.knowm.xchange.binance.dto.marketdata.KlineInterval;
-import org.knowm.xchange.binance.service.BinanceMarketDataService;
-import org.knowm.xchange.currency.CurrencyPair;
-import org.knowm.xchange.derivative.FuturesContract;
-import org.knowm.xchange.dto.Order.OrderType;
-import org.knowm.xchange.dto.marketdata.FundingRate;
-import org.knowm.xchange.dto.marketdata.OrderBook;
-import org.knowm.xchange.dto.marketdata.OrderBookUpdate;
-import org.knowm.xchange.dto.marketdata.Ticker;
-import org.knowm.xchange.dto.marketdata.Trade;
-import org.knowm.xchange.exceptions.ExchangeException;
-import org.knowm.xchange.exceptions.RateLimitExceededException;
-import org.knowm.xchange.instrument.Instrument;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import static info.bitrich.xchangestream.binance.BinanceSubscriptionType.KLINE;
+import static info.bitrich.xchangestream.binance.BinanceSubscriptionType.TICKER_WINDOW;
+import static info.bitrich.xchangestream.service.netty.StreamingObjectMapperHelper.getObjectMapper;
 
 public class BinanceStreamingMarketDataService implements StreamingMarketDataService {
 
@@ -524,24 +505,32 @@ public class BinanceStreamingMarketDataService implements StreamingMarketDataSer
   }
 
   private Observable<FundingRate> rawFundingRateStream(Instrument instrument) {
-    // init update info for funding rate interval
-    synchronized (this) {
-      if (fundingRateInfoUpdate == null) {
-        fundingRateInfoUpdate =
-            Observable.interval(10, 10, TimeUnit.MINUTES).subscribe(x -> updateFundingRateInfo());
-        updateFundingRateInfo();
+    try {
+      // init update info for funding rate interval
+      synchronized (this) {
+        if (fundingRateInfoUpdate == null) {
+          fundingRateInfoUpdate =
+              Observable.interval(10, 10, TimeUnit.MINUTES).subscribe(x -> updateFundingRateInfo());
+          updateFundingRateInfo();
+        }
       }
+    } catch (Exception e) {
+      return Observable.error(e);
     }
-    return service
-        .subscribeChannel(
-            channelFromCurrency(instrument, BinanceSubscriptionType.FUNDING_RATES.getType()))
-        .map(
-            it ->
-                this.<FundingRateWebsocketTransaction>readTransaction(
-                    it, FUNDING_RATE_TYPE, "funding rate"))
-        .map(BinanceWebsocketTransaction::getData)
-        .filter(data -> BinanceAdapters.adaptSymbol(data.getSymbol(), true).equals(instrument))
-        .map(transaction -> transaction.toFundingRate(fundingRateInfoMap.getOrDefault(instrument, 8)));
+    try {
+      return service
+          .subscribeChannel(
+              channelFromCurrency(instrument, BinanceSubscriptionType.FUNDING_RATES.getType()))
+          .map(
+              it ->
+                  this.<FundingRateWebsocketTransaction>readTransaction(
+                      it, FUNDING_RATE_TYPE, "funding rate"))
+          .map(BinanceWebsocketTransaction::getData)
+          .filter(data -> BinanceAdapters.adaptSymbol(data.getSymbol(), true).equals(instrument))
+          .map(transaction -> transaction.toFundingRate(fundingRateInfoMap.getOrDefault(instrument, 8)));
+    } catch (Exception e) {
+      return Observable.error(e);
+    }
   }
 
   private Observable<BinanceTicker24h> rawTickerStream(Instrument instrument) {

--- a/xchange-stream-binance/src/test/java/info/bitrich/xchangestream/binance/examples/BinanceFutureStreamPublicTest.java
+++ b/xchange-stream-binance/src/test/java/info/bitrich/xchangestream/binance/examples/BinanceFutureStreamPublicTest.java
@@ -1,5 +1,6 @@
 package info.bitrich.xchangestream.binance.examples;
 
+import info.bitrich.xchangestream.binance.BinanceStreamingExchange;
 import info.bitrich.xchangestream.binance.KlineSubscription;
 import info.bitrich.xchangestream.binancefuture.BinanceFutureStreamingExchange;
 import info.bitrich.xchangestream.core.ProductSubscription;
@@ -32,25 +33,33 @@ import static org.knowm.xchange.binance.dto.marketdata.KlineInterval.m1;
 public class BinanceFutureStreamPublicTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(BinanceFutureStreamPublicTest.class);
-  private static StreamingExchange exchange;
-  BinanceFutureStreamingExchange binanceFutureStreamingExchange;
+  private static StreamingExchange exchange1;
+  BinanceFutureStreamingExchange binanceFutureStreamingExchange1;
+  private static StreamingExchange exchange2;
+  BinanceFutureStreamingExchange binanceFutureStreamingExchange2;
   private static final Instrument instrument = new FuturesContract("ETH/USDT/PERP");
   private static final Instrument instrument2 = new FuturesContract("SOL/USDT/PERP");
-  private static final boolean logOutput = true;
+  private static final boolean logOutput = false;
+  private static final boolean useRealtimeBookTicker = false;
 
   @Before
   public void setUp() {
+    exchange1 = initExchange();
+    binanceFutureStreamingExchange1 = (BinanceFutureStreamingExchange) exchange1;
+  }
+
+  private BinanceStreamingExchange initExchange() {
     ExchangeSpecification spec = new ExchangeSpecification(BinanceFutureStreamingExchange.class);
     // The most convenient way. Can store all keys in .ssh folder
     AuthUtils.setApiAndSecretKey(spec, "binance-demo-futures");
 //    spec.setExchangeSpecificParametersItem(USE_SANDBOX, true);
     spec.setExchangeSpecificParametersItem(EXCHANGE_TYPE, FUTURES);
     // optional - more frequent OrderBook ticker updates
-    //    spec.setExchangeSpecificParametersItem(USE_REALTIME_BOOK_TICKER, true);
+    if (useRealtimeBookTicker)
+      spec.setExchangeSpecificParametersItem(USE_REALTIME_BOOK_TICKER, true);
     // optional more frequent order book updates
     //    spec.setExchangeSpecificParametersItem(USE_HIGHER_UPDATE_FREQUENCY, true);
-    exchange = StreamingExchangeFactory.INSTANCE.createExchange(spec);
-    binanceFutureStreamingExchange = (BinanceFutureStreamingExchange) exchange;
+    return (BinanceStreamingExchange) StreamingExchangeFactory.INSTANCE.createExchange(spec);
   }
 
   @Test
@@ -62,9 +71,9 @@ public class BinanceFutureStreamPublicTest {
     klineMap.put(instrument, klineSet);
     KlineSubscription klineSubscription = new KlineSubscription(klineMap);
     ProductSubscription subscription = ProductSubscription.create().build();
-    binanceFutureStreamingExchange.connect(klineSubscription, subscription).blockingAwait();
+    binanceFutureStreamingExchange1.connect(klineSubscription, subscription).blockingAwait();
     Disposable kLineDisposable =
-        binanceFutureStreamingExchange
+        binanceFutureStreamingExchange1
             .getStreamingMarketDataService()
             .getKlines(instrument, m1)
             .subscribe(
@@ -75,30 +84,37 @@ public class BinanceFutureStreamPublicTest {
                 });
     Thread.sleep(3000);
     kLineDisposable.dispose();
-    exchange.disconnect().blockingAwait();
+    exchange1.disconnect().blockingAwait();
   }
 
   @Test
   public void streamingMarketDataServiceTest() throws InterruptedException {
     List<Disposable> disposables = new ArrayList<>();
-    ProductSubscription subscription =
+    // separate connection for tickers, klines etc(market path) and
+    // orderbook, bookTicker, trades
+    ProductSubscription.ProductSubscriptionBuilder subscriptionBuilder1 =
         ProductSubscription.create()
-            .addFundingRates(instrument)
+            .addFundingRates(instrument);
+    ProductSubscription.ProductSubscriptionBuilder subscriptionBuilder2 =
+        ProductSubscription.create()
             .addOrderbook(instrument)
-            .addTicker(instrument)
-            .addTrades(instrument)
-            .build();
-
-    exchange.connect(subscription).blockingAwait();
+            .addTrades(instrument);
+    if (useRealtimeBookTicker) subscriptionBuilder2.addTicker(instrument);
+    else subscriptionBuilder1.addTicker(instrument);
+    ProductSubscription subscription1 = subscriptionBuilder1.build();
+    ProductSubscription subscription2 = subscriptionBuilder2.build();
+    exchange1.connect(subscription1).blockingAwait();
+    exchange2 = initExchange();
+    exchange2.connect(subscription2).blockingAwait();
     InstrumentMetaData instrumentMetaData =
-        exchange.getExchangeMetaData().getInstruments().get(instrument);
+        exchange1.getExchangeMetaData().getInstruments().get(instrument);
 
     assertThat(instrumentMetaData.getVolumeScale()).isNotNull();
     assertThat(instrumentMetaData.getPriceScale()).isNotNull();
     assertThat(instrumentMetaData.getMinimumAmount()).isNotNull();
 
     disposables.add(
-        exchange
+        exchange2
             .getStreamingMarketDataService()
             .getOrderBook(instrument)
             .subscribe(
@@ -118,7 +134,7 @@ public class BinanceFutureStreamPublicTest {
                       .isTrue();
                 }));
     disposables.add(
-        exchange
+        exchange2
             .getStreamingMarketDataService()
             .getOrderBookUpdates(instrument)
             .subscribe(
@@ -127,28 +143,36 @@ public class BinanceFutureStreamPublicTest {
                     LOG.info("orderBookUpdates subscribe: {}", orderBookUpdates);
                   }
                 }));
-    disposables.add(
-        exchange
-            .getStreamingMarketDataService()
-            .getTicker(instrument)
-            .subscribe(
-                ticker -> {
-                  if (logOutput) {
-                    LOG.info("ticker subscribe: {}", ticker);
-                  }
-                  assertThat(ticker.getInstrument().equals(instrument)).isTrue();
-                  if (Boolean.TRUE.equals(
-                      exchange
-                          .getExchangeSpecification()
-                          .getExchangeSpecificParametersItem(USE_REALTIME_BOOK_TICKER))) {
+    if (useRealtimeBookTicker)
+      disposables.add(
+          exchange2
+              .getStreamingMarketDataService()
+              .getTicker(instrument)
+              .subscribe(
+                  ticker -> {
+                    if (logOutput) {
+                      LOG.info("orderBook ticker subscribe: {}", ticker);
+                    }
+                    assertThat(ticker.getInstrument().equals(instrument)).isTrue();
                     assertThat(ticker.getBid()).isLessThan(ticker.getAsk());
-                  } else {
+                  },
+                  throwable -> LOG.error("ticker subscribe error", throwable)));
+    else
+      disposables.add(
+          exchange1
+              .getStreamingMarketDataService()
+              .getTicker(instrument)
+              .subscribe(
+                  ticker -> {
+                    if (logOutput) {
+                      LOG.info("ticker subscribe: {}", ticker);
+                    }
+                    assertThat(ticker.getInstrument().equals(instrument)).isTrue();
                     assertThat(ticker.getHigh()).isGreaterThan(ticker.getLow());
-                  }
-                },
-                throwable -> LOG.error("ticker subscribe error", throwable)));
+                  },
+                  throwable -> LOG.error("ticker subscribe error", throwable)));
     disposables.add(
-        exchange
+        exchange2
             .getStreamingMarketDataService()
             .getTrades(instrument)
             .subscribe(
@@ -160,7 +184,7 @@ public class BinanceFutureStreamPublicTest {
                 }));
     // main net only
     disposables.add(
-        exchange
+        exchange1
             .getStreamingMarketDataService()
             .getFundingRate(instrument)
             .subscribe(
@@ -170,9 +194,9 @@ public class BinanceFutureStreamPublicTest {
                   }
                   assertThat(fundingRate.getInstrument().equals(instrument)).isTrue();
                 }));
-    Thread.sleep(3000);
+    Thread.sleep(10000);
     disposables.forEach(Disposable::dispose);
-    exchange.disconnect().blockingAwait();
+    exchange1.disconnect().blockingAwait();
   }
 
   @Ignore
@@ -180,7 +204,7 @@ public class BinanceFutureStreamPublicTest {
   public void heavyLoadTest() throws InterruptedException {
     List<Disposable> disposables = new ArrayList<>();
     ProductSubscription subscription =
-        exchange.getExchangeInstruments().stream()
+        exchange1.getExchangeInstruments().stream()
             .filter(instrument -> instrument instanceof FuturesContract)
             .limit(150)
             .reduce(
@@ -191,10 +215,10 @@ public class BinanceFutureStreamPublicTest {
                 })
             .addFundingRates(instrument)
             .build();
-    exchange.connect(subscription).blockingAwait();
+    exchange1.connect(subscription).blockingAwait();
     for (var s : subscription.getFundingRates()) {
       disposables.add(
-          exchange
+          exchange1
               .getStreamingMarketDataService()
               .getFundingRate(s)
               .subscribe(
@@ -209,6 +233,6 @@ public class BinanceFutureStreamPublicTest {
     }
     Thread.sleep(30000000);
     disposables.forEach(Disposable::dispose);
-    exchange.disconnect().blockingAwait();
+    exchange1.disconnect().blockingAwait();
   }
 }

--- a/xchange-stream-binance/src/test/java/info/bitrich/xchangestream/binance/examples/BinanceFutureStreamPublicTest.java
+++ b/xchange-stream-binance/src/test/java/info/bitrich/xchangestream/binance/examples/BinanceFutureStreamPublicTest.java
@@ -1,26 +1,11 @@
 package info.bitrich.xchangestream.binance.examples;
 
-import static info.bitrich.xchangestream.binance.BinanceStreamingExchange.USE_REALTIME_BOOK_TICKER;
-import static info.bitrich.xchangestream.binance.examples.Util.printOrderBookShortInfo;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.knowm.xchange.Exchange.USE_SANDBOX;
-import static org.knowm.xchange.binance.BinanceExchange.EXCHANGE_TYPE;
-import static org.knowm.xchange.binance.dto.ExchangeType.FUTURES;
-import static org.knowm.xchange.binance.dto.marketdata.KlineInterval.d1;
-import static org.knowm.xchange.binance.dto.marketdata.KlineInterval.m1;
-
 import info.bitrich.xchangestream.binance.KlineSubscription;
 import info.bitrich.xchangestream.binancefuture.BinanceFutureStreamingExchange;
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.core.StreamingExchange;
 import info.bitrich.xchangestream.core.StreamingExchangeFactory;
 import io.reactivex.rxjava3.disposables.Disposable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -33,6 +18,16 @@ import org.knowm.xchange.utils.AuthUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.*;
+
+import static info.bitrich.xchangestream.binance.BinanceStreamingExchange.USE_REALTIME_BOOK_TICKER;
+import static info.bitrich.xchangestream.binance.examples.Util.printOrderBookShortInfo;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.knowm.xchange.binance.BinanceExchange.EXCHANGE_TYPE;
+import static org.knowm.xchange.binance.dto.ExchangeType.FUTURES;
+import static org.knowm.xchange.binance.dto.marketdata.KlineInterval.d1;
+import static org.knowm.xchange.binance.dto.marketdata.KlineInterval.m1;
+
 @Ignore
 public class BinanceFutureStreamPublicTest {
 
@@ -41,7 +36,7 @@ public class BinanceFutureStreamPublicTest {
   BinanceFutureStreamingExchange binanceFutureStreamingExchange;
   private static final Instrument instrument = new FuturesContract("ETH/USDT/PERP");
   private static final Instrument instrument2 = new FuturesContract("SOL/USDT/PERP");
-  private static final boolean logOutput = false;
+  private static final boolean logOutput = true;
 
   @Before
   public void setUp() {
@@ -114,12 +109,12 @@ public class BinanceFutureStreamPublicTest {
                   assertThat(orderBook.getBids().get(0).getLimitPrice())
                       .isLessThan(orderBook.getAsks().get(0).getLimitPrice());
                   assertThat(
-                          orderBook
-                                  .getAsks()
-                                  .get(0)
-                                  .getLimitPrice()
-                                  .compareTo(orderBook.getBids().get(0).getLimitPrice())
-                              > 0)
+                      orderBook
+                          .getAsks()
+                          .get(0)
+                          .getLimitPrice()
+                          .compareTo(orderBook.getBids().get(0).getLimitPrice())
+                          > 0)
                       .isTrue();
                 }));
     disposables.add(
@@ -181,42 +176,38 @@ public class BinanceFutureStreamPublicTest {
   }
 
   @Ignore
+  @Test
   public void heavyLoadTest() throws InterruptedException {
     List<Disposable> disposables = new ArrayList<>();
     ProductSubscription subscription =
         exchange.getExchangeInstruments().stream()
             .filter(instrument -> instrument instanceof FuturesContract)
-            .limit(50)
+            .limit(150)
             .reduce(
                 ProductSubscription.create(),
-                ProductSubscription.ProductSubscriptionBuilder::addOrderbook,
+                ProductSubscription.ProductSubscriptionBuilder::addFundingRates,
                 (productSubscriptionBuilder, productSubscriptionBuilder2) -> {
                   throw new UnsupportedOperationException();
                 })
-            .addOrderbook(instrument)
+            .addFundingRates(instrument)
             .build();
     exchange.connect(subscription).blockingAwait();
-    disposables.add(
-        exchange
-            .getStreamingMarketDataService()
-            .getOrderBook(instrument)
-            .subscribe(
-                orderBook -> {
-                  if (logOutput) {
-                    printOrderBookShortInfo(orderBook);
-                  }
-                  assertThat(orderBook.getBids().get(0).getLimitPrice())
-                      .isLessThan(orderBook.getAsks().get(0).getLimitPrice());
-                  assertThat(
-                          orderBook
-                                  .getAsks()
-                                  .get(0)
-                                  .getLimitPrice()
-                                  .compareTo(orderBook.getBids().get(0).getLimitPrice())
-                              > 0)
-                      .isTrue();
-                }));
-    Thread.sleep(3000);
+    for (var s : subscription.getFundingRates()) {
+      disposables.add(
+          exchange
+              .getStreamingMarketDataService()
+              .getFundingRate(s)
+              .subscribe(
+                  fund -> {
+                    if (logOutput) {
+                      Random random = new Random();
+                      if (random.nextInt(100) == 1) {
+                        System.out.println("fund subscribe: " + fund);
+                      }
+                    }
+                  }));
+    }
+    Thread.sleep(30000000);
     disposables.forEach(Disposable::dispose);
     exchange.disconnect().blockingAwait();
   }


### PR DESCRIPTION
old path is removed
https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Important-WebSocket-Change-Notice
split high frequency data to /public and others to /market paths.
for now, if you need, for example, stream orderbook and funding rate, you need make 2 connection.