### PR TITLE
Bump to 6.0.0-SNAPSHOT: Java 17, resilience4j 2.4.0, crypto 5.0.2, json-path-assert 3.0.0

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
     - name: Build with Maven
       run: mvn clean deploy --no-transfer-progress --batch-mode --settings etc/settings.xml -Dfmt.skip=true;

--- a/.github/workflows/maven_on_pull_request.yml
+++ b/.github/workflows/maven_on_pull_request.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
     - name: Build with Maven
       run: mvn clean verify --no-transfer-progress --batch-mode --settings etc/settings.xml -Dmaven.javadoc.skip=true -Dfmt.skip=true;

--- a/README.md
+++ b/README.md
@@ -166,12 +166,12 @@ Add the following dependencies in your pom.xml file. You will need at least xcha
 <dependency>
   <groupId>org.knowm.xchange</groupId>
   <artifactId>xchange-core</artifactId>
-  <version>5.2.5</version>
+  <version>6.0.0</version>
 </dependency>
 <dependency>
   <groupId>org.knowm.xchange</groupId>
   <artifactId>xchange-XYZ</artifactId>
-  <version>5.2.5</version>
+  <version>6.0.0</version>
 </dependency>
 ```
 
@@ -181,7 +181,7 @@ If it is available for your exchange, you may also want to use the streaming API
 <dependency>
   <groupId>org.knowm.xchange</groupId>
   <artifactId>xchange-stream-XYZ</artifactId>
-  <version>5.2.5</version>
+  <version>6.0.0</version>
 </dependency>
 ```
 
@@ -203,7 +203,7 @@ For snapshots, add the following repository to your pom.xml file.
 
 The current snapshot version is:
 
-    5.2.6-SNAPSHOT
+    6.0.0-SNAPSHOT
 
 ## Building with Maven
 

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
         <version.assertj>3.27.7</version.assertj>
         <version.bouncycastle>1.84</version.bouncycastle>
         <version.commons.lang3>3.20.0</version.commons.lang3>
-        <version.crypto>5.0.2</version.crypto>
+        <version.crypto>4.14.0</version.crypto>
         <version.fasterxml>2.21.3</version.fasterxml>
         <version.fasterxml.annotations>2.21</version.fasterxml.annotations>
         <version.github.mmazi>3.1</version.github.mmazi>

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
         <version.assertj>3.27.7</version.assertj>
         <version.bouncycastle>1.84</version.bouncycastle>
         <version.commons.lang3>3.20.0</version.commons.lang3>
-        <version.crypto>4.14.0</version.crypto>
+        <version.crypto>4.9.8</version.crypto>
         <version.fasterxml>2.21.3</version.fasterxml>
         <version.fasterxml.annotations>2.21</version.fasterxml.annotations>
         <version.github.mmazi>3.1</version.github.mmazi>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.knowm.xchange</groupId>
     <artifactId>xchange-parent</artifactId>
-    <version>5.2.6-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>XChange</name>
@@ -168,12 +168,12 @@
         <version.assertj>3.27.7</version.assertj>
         <version.bouncycastle>1.84</version.bouncycastle>
         <version.commons.lang3>3.20.0</version.commons.lang3>
-        <version.crypto>4.9.8</version.crypto>
+        <version.crypto>5.0.2</version.crypto>
         <version.fasterxml>2.21.3</version.fasterxml>
         <version.fasterxml.annotations>2.21</version.fasterxml.annotations>
         <version.github.mmazi>3.1</version.github.mmazi>
 
-        <version.java>11</version.java>
+        <version.java>17</version.java>
         <version.java-jwt>4.5.2</version.java-jwt>
         <version.junit>5.12.2</version.junit>
         <version.knowm.xchart>3.9.0</version.knowm.xchart>
@@ -184,7 +184,7 @@
         <version.nimbus-jose-jwt>10.9</version.nimbus-jose-jwt>
         <version.qos.logback>1.5.32</version.qos.logback>
         <version.reflections>0.10.2</version.reflections>
-        <version.resilience4j>1.7.1</version.resilience4j>
+        <version.resilience4j>2.4.0</version.resilience4j>
         <version.slf4j>2.0.17</version.slf4j>
         <version.wiremock>3.4.2</version.wiremock>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -473,7 +473,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Ensure compilation is done under Java 8 in all environments -->
+            <!-- Ensure compilation is done under Java 17 in all environments -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/xchange-ascendex/pom.xml
+++ b/xchange-ascendex/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-ascendex</artifactId>

--- a/xchange-bibox/pom.xml
+++ b/xchange-bibox/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-bibox</artifactId>

--- a/xchange-binance/pom.xml
+++ b/xchange-binance/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-binance</artifactId>

--- a/xchange-bitbay/pom.xml
+++ b/xchange-bitbay/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-bitbay</artifactId>

--- a/xchange-bitcoinaverage/pom.xml
+++ b/xchange-bitcoinaverage/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-bitcoinaverage</artifactId>

--- a/xchange-bitcoincore/pom.xml
+++ b/xchange-bitcoincore/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-bitcoincore</artifactId>

--- a/xchange-bitcoinde/pom.xml
+++ b/xchange-bitcoinde/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-bitcoinde</artifactId>

--- a/xchange-bitcointoyou/pom.xml
+++ b/xchange-bitcointoyou/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-bitcointoyou</artifactId>

--- a/xchange-bitfinex/pom.xml
+++ b/xchange-bitfinex/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-bitfinex</artifactId>

--- a/xchange-bitflyer/pom.xml
+++ b/xchange-bitflyer/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-bitflyer</artifactId>

--- a/xchange-bitget-futures/pom.xml
+++ b/xchange-bitget-futures/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-bitget-futures</artifactId>

--- a/xchange-bitget/pom.xml
+++ b/xchange-bitget/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-bitget</artifactId>

--- a/xchange-bithumb/pom.xml
+++ b/xchange-bithumb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-bithumb</artifactId>

--- a/xchange-bitmex/pom.xml
+++ b/xchange-bitmex/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-bitmex</artifactId>

--- a/xchange-bitso/pom.xml
+++ b/xchange-bitso/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-bitso</artifactId>

--- a/xchange-bitstamp/pom.xml
+++ b/xchange-bitstamp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-bitstamp</artifactId>

--- a/xchange-bity/pom.xml
+++ b/xchange-bity/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-bity</artifactId>

--- a/xchange-bitz/pom.xml
+++ b/xchange-bitz/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-bitz</artifactId>

--- a/xchange-blockchain/pom.xml
+++ b/xchange-blockchain/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-blockchain</artifactId>

--- a/xchange-btcc/pom.xml
+++ b/xchange-btcc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-btcc</artifactId>

--- a/xchange-btcmarkets/pom.xml
+++ b/xchange-btcmarkets/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-btcmarkets</artifactId>

--- a/xchange-btcturk/pom.xml
+++ b/xchange-btcturk/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-btcturk</artifactId>

--- a/xchange-bybit/pom.xml
+++ b/xchange-bybit/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-bybit</artifactId>

--- a/xchange-cexio/pom.xml
+++ b/xchange-cexio/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-cexio</artifactId>

--- a/xchange-coinbase/pom.xml
+++ b/xchange-coinbase/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-coinbase</artifactId>

--- a/xchange-coinbasepro/pom.xml
+++ b/xchange-coinbasepro/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-coinbasepro</artifactId>

--- a/xchange-coincheck/pom.xml
+++ b/xchange-coincheck/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-coincheck</artifactId>

--- a/xchange-coindeal/pom.xml
+++ b/xchange-coindeal/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-coindeal</artifactId>

--- a/xchange-coinex/pom.xml
+++ b/xchange-coinex/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-coinex</artifactId>

--- a/xchange-coinfloor/pom.xml
+++ b/xchange-coinfloor/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-coinfloor</artifactId>

--- a/xchange-coinjar/pom.xml
+++ b/xchange-coinjar/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-coinjar</artifactId>

--- a/xchange-coinmarketcap/pom.xml
+++ b/xchange-coinmarketcap/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-coinmarketcap</artifactId>

--- a/xchange-coinmate/pom.xml
+++ b/xchange-coinmate/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-coinmate</artifactId>

--- a/xchange-coinone/pom.xml
+++ b/xchange-coinone/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-coinone</artifactId>

--- a/xchange-coinsph/pom.xml
+++ b/xchange-coinsph/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-coinsph</artifactId>

--- a/xchange-core/pom.xml
+++ b/xchange-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-core</artifactId>

--- a/xchange-core/src/main/java/org/knowm/xchange/client/ResilienceUtils.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/client/ResilienceUtils.java
@@ -5,9 +5,9 @@ import java.util.concurrent.Callable;
 
 import org.knowm.xchange.ExchangeSpecification;
 
+import io.github.resilience4j.core.functions.Either;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.retry.Retry;
-import io.vavr.control.Either;
 import jakarta.ws.rs.core.Response;
 import si.mazi.rescu.HttpStatusExceptionSupport;
 

--- a/xchange-dase/pom.xml
+++ b/xchange-dase/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-dase</artifactId>

--- a/xchange-deribit/pom.xml
+++ b/xchange-deribit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-deribit</artifactId>

--- a/xchange-dvchain/pom.xml
+++ b/xchange-dvchain/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-dvchain</artifactId>

--- a/xchange-dydx/pom.xml
+++ b/xchange-dydx/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-dydx</artifactId>
 

--- a/xchange-enigma/pom.xml
+++ b/xchange-enigma/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-enigma</artifactId>

--- a/xchange-examples/pom.xml
+++ b/xchange-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-examples</artifactId>

--- a/xchange-exmo/pom.xml
+++ b/xchange-exmo/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-exmo</artifactId>

--- a/xchange-gateio-v4/pom.xml
+++ b/xchange-gateio-v4/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-gateio-v4</artifactId>

--- a/xchange-gateio/pom.xml
+++ b/xchange-gateio/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-gateio</artifactId>

--- a/xchange-gemini/pom.xml
+++ b/xchange-gemini/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-gemini</artifactId>

--- a/xchange-hitbtc/pom.xml
+++ b/xchange-hitbtc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-hitbtc</artifactId>

--- a/xchange-huobi/pom.xml
+++ b/xchange-huobi/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-huobi</artifactId>

--- a/xchange-idex/pom.xml
+++ b/xchange-idex/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-idex</artifactId>

--- a/xchange-independentreserve/pom.xml
+++ b/xchange-independentreserve/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-independentreserve</artifactId>

--- a/xchange-itbit/pom.xml
+++ b/xchange-itbit/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-itbit</artifactId>

--- a/xchange-koinim/pom.xml
+++ b/xchange-koinim/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-koinim</artifactId>

--- a/xchange-kraken/pom.xml
+++ b/xchange-kraken/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-kraken</artifactId>

--- a/xchange-krakenfutures/pom.xml
+++ b/xchange-krakenfutures/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-krakenfutures</artifactId>

--- a/xchange-kucoin/pom.xml
+++ b/xchange-kucoin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-kucoin</artifactId>

--- a/xchange-latoken/pom.xml
+++ b/xchange-latoken/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-latoken</artifactId>

--- a/xchange-luno/pom.xml
+++ b/xchange-luno/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-luno</artifactId>

--- a/xchange-mercadobitcoin/pom.xml
+++ b/xchange-mercadobitcoin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-mercadobitcoin</artifactId>

--- a/xchange-mexc/pom.xml
+++ b/xchange-mexc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-mexc</artifactId>

--- a/xchange-okcoin/pom.xml
+++ b/xchange-okcoin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-okcoin</artifactId>

--- a/xchange-okex/pom.xml
+++ b/xchange-okex/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-okex</artifactId>

--- a/xchange-openexchangerates/pom.xml
+++ b/xchange-openexchangerates/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-openexchangerates</artifactId>

--- a/xchange-paribu/pom.xml
+++ b/xchange-paribu/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-paribu</artifactId>

--- a/xchange-paymium/pom.xml
+++ b/xchange-paymium/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-paymium</artifactId>

--- a/xchange-poloniex/pom.xml
+++ b/xchange-poloniex/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-poloniex</artifactId>

--- a/xchange-ripple/pom.xml
+++ b/xchange-ripple/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-ripple</artifactId>

--- a/xchange-simulated/pom.xml
+++ b/xchange-simulated/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-simulated</artifactId>

--- a/xchange-stream-binance/pom.xml
+++ b/xchange-stream-binance/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-binance</artifactId>
 

--- a/xchange-stream-bitfinex/pom.xml
+++ b/xchange-stream-bitfinex/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-bitfinex</artifactId>
 

--- a/xchange-stream-bitflyer/pom.xml
+++ b/xchange-stream-bitflyer/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-bitflyer</artifactId>
 

--- a/xchange-stream-bitget/pom.xml
+++ b/xchange-stream-bitget/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-bitget</artifactId>
 

--- a/xchange-stream-bitmex/pom.xml
+++ b/xchange-stream-bitmex/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-bitmex</artifactId>
 

--- a/xchange-stream-bitstamp/pom.xml
+++ b/xchange-stream-bitstamp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-bitstamp</artifactId>
 

--- a/xchange-stream-btcmarkets/pom.xml
+++ b/xchange-stream-btcmarkets/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-btcmarkets</artifactId>
 

--- a/xchange-stream-bybit/pom.xml
+++ b/xchange-stream-bybit/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-bybit</artifactId>
 

--- a/xchange-stream-cexio/pom.xml
+++ b/xchange-stream-cexio/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-cexio</artifactId>
 

--- a/xchange-stream-coinbasepro/pom.xml
+++ b/xchange-stream-coinbasepro/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-coinbasepro</artifactId>
 

--- a/xchange-stream-coincheck/pom.xml
+++ b/xchange-stream-coincheck/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-coincheck</artifactId>
 

--- a/xchange-stream-coinjar/pom.xml
+++ b/xchange-stream-coinjar/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-coinjar</artifactId>
 

--- a/xchange-stream-coinmate/pom.xml
+++ b/xchange-stream-coinmate/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-coinmate</artifactId>
 

--- a/xchange-stream-coinsph/pom.xml
+++ b/xchange-stream-coinsph/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-coinsph</artifactId>
 

--- a/xchange-stream-core/pom.xml
+++ b/xchange-stream-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-core</artifactId>
 

--- a/xchange-stream-deribit/pom.xml
+++ b/xchange-stream-deribit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-deribit</artifactId>
 

--- a/xchange-stream-dydx/pom.xml
+++ b/xchange-stream-dydx/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-dydx</artifactId>
 

--- a/xchange-stream-gateio/pom.xml
+++ b/xchange-stream-gateio/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-gateio</artifactId>
 

--- a/xchange-stream-gemini-v2/pom.xml
+++ b/xchange-stream-gemini-v2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-gemini-v2</artifactId>
 

--- a/xchange-stream-gemini/pom.xml
+++ b/xchange-stream-gemini/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-gemini</artifactId>
 

--- a/xchange-stream-hitbtc/pom.xml
+++ b/xchange-stream-hitbtc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-hitbtc</artifactId>
 
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path-assert</artifactId>
-            <version>2.9.0</version>
+            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/xchange-stream-huobi/pom.xml
+++ b/xchange-stream-huobi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-huobi</artifactId>
 

--- a/xchange-stream-kraken-v2/pom.xml
+++ b/xchange-stream-kraken-v2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-stream-kraken-v2</artifactId>

--- a/xchange-stream-kraken/pom.xml
+++ b/xchange-stream-kraken/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-kraken</artifactId>
 

--- a/xchange-stream-krakenfutures/pom.xml
+++ b/xchange-stream-krakenfutures/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-stream-krakenfutures</artifactId>

--- a/xchange-stream-kucoin/pom.xml
+++ b/xchange-stream-kucoin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-kucoin</artifactId>
 

--- a/xchange-stream-okcoin/pom.xml
+++ b/xchange-stream-okcoin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-okcoin</artifactId>
 

--- a/xchange-stream-okex/pom.xml
+++ b/xchange-stream-okex/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-okex</artifactId>
 

--- a/xchange-stream-poloniex2/pom.xml
+++ b/xchange-stream-poloniex2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-poloniex2</artifactId>
 

--- a/xchange-stream-service-core/pom.xml
+++ b/xchange-stream-service-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-service-core</artifactId>
 

--- a/xchange-stream-service-netty/pom.xml
+++ b/xchange-stream-service-netty/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-service-netty</artifactId>
 

--- a/xchange-stream-service-pubnub/pom.xml
+++ b/xchange-stream-service-pubnub/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-stream-service-pubnub</artifactId>
 

--- a/xchange-tradeogre/pom.xml
+++ b/xchange-tradeogre/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-tradeogre</artifactId>

--- a/xchange-truefx/pom.xml
+++ b/xchange-truefx/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-truefx</artifactId>

--- a/xchange-upbit/pom.xml
+++ b/xchange-upbit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-upbit</artifactId>

--- a/xchange-vaultoro/pom.xml
+++ b/xchange-vaultoro/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-vaultoro</artifactId>

--- a/xchange-yobit/pom.xml
+++ b/xchange-yobit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>xchange-yobit</artifactId>
     <name>XChange YoBit</name>

--- a/xchange-zaif/pom.xml
+++ b/xchange-zaif/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.knowm.xchange</groupId>
         <artifactId>xchange-parent</artifactId>
-        <version>5.2.6-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xchange-zaif</artifactId>


### PR DESCRIPTION
## Changes

- Bump project version: `5.2.6-SNAPSHOT` → `6.0.0-SNAPSHOT`
- Update Java source/target: `11` → `17`
- Update `resilience4j`: `1.7.1` → `2.4.0` (migrate from `io.vavr.control.Either` to `io.github.resilience4j.core.functions.Either`)
- Update `crypto` (web3j): `4.9.8` → `5.0.2`
- Update `json-path-assert`: `2.9.0` → `3.0.0`
- Update GitHub Actions workflows to JDK 17
- Update README version references to 6.0.0