### PR TITLE
Replace org.web3j:crypto with BouncyCastle in xchange-idex

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,6 @@
         <version.assertj>3.27.7</version.assertj>
         <version.bouncycastle>1.84</version.bouncycastle>
         <version.commons.lang3>3.20.0</version.commons.lang3>
-        <version.crypto>4.9.8</version.crypto>
         <version.fasterxml>2.21.3</version.fasterxml>
         <version.fasterxml.annotations>2.21</version.fasterxml.annotations>
         <version.github.mmazi>3.1</version.github.mmazi>
@@ -348,12 +347,6 @@
                 <artifactId>slf4j-api</artifactId>
                 <version>${version.slf4j}</version>
             </dependency>
-            <dependency>
-                <groupId>org.web3j</groupId>
-                <artifactId>crypto</artifactId>
-                <version>${version.crypto}</version>
-            </dependency>
-
             <dependency>
                 <groupId>org.wiremock</groupId>
                 <artifactId>wiremock</artifactId>

--- a/xchange-idex/pom.xml
+++ b/xchange-idex/pom.xml
@@ -31,8 +31,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.web3j</groupId>
-            <artifactId>crypto</artifactId>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
         </dependency>
 
     </dependencies>

--- a/xchange-idex/src/main/java/org/knowm/xchange/idex/IdexSignature.java
+++ b/xchange-idex/src/main/java/org/knowm/xchange/idex/IdexSignature.java
@@ -3,34 +3,75 @@ package org.knowm.xchange.idex;
 import static java.lang.Integer.max;
 import static java.lang.Integer.min;
 import static java.util.Arrays.asList;
-import static org.web3j.crypto.Hash.sha3;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.LinkedList;
 import java.util.List;
-import org.bouncycastle.util.encoders.Hex;
-import org.web3j.crypto.ECKeyPair;
-import org.web3j.crypto.Sign;
-import org.web3j.crypto.Sign.SignatureData;
+
+import org.bouncycastle.asn1.x9.X9ECParameters;
+import org.bouncycastle.crypto.digests.KeccakDigest;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.ec.CustomNamedCurves;
+import org.bouncycastle.crypto.params.ECDomainParameters;
+import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
+import org.bouncycastle.crypto.signers.ECDSASigner;
+import org.bouncycastle.crypto.signers.HMacDSAKCalculator;
+import org.bouncycastle.math.ec.ECAlgorithms;
+import org.bouncycastle.math.ec.ECPoint;
 
 public class IdexSignature {
 
-  static
-  /** Generate v, r, s values from payload */
-  SignatureData generateSignature(String apiSecret, List<List<String>> data) {
-    byte[] rawhash = null;
-    byte[] saltBytes;
-    byte[] bytes = null;
-    String[] last = new String[1];
-    BigInteger apiSecret1;
-    ECKeyPair ecKeyPair;
-    try (ByteArrayOutputStream sig_arr = new ByteArrayOutputStream()) {
+  private static final X9ECParameters CURVE_PARAMS = CustomNamedCurves.getByName("secp256k1");
+  static final ECDomainParameters CURVE =
+      new ECDomainParameters(
+          CURVE_PARAMS.getCurve(), CURVE_PARAMS.getG(), CURVE_PARAMS.getN(), CURVE_PARAMS.getH());
 
+  /** Simple container for Ethereum signature components v, r, s. */
+  public static class SignatureData {
+    private final byte[] v;
+    private final byte[] r;
+    private final byte[] s;
+
+    public SignatureData(byte v, byte[] r, byte[] s) {
+      this.v = new byte[] {v};
+      this.r = r;
+      this.s = s;
+    }
+
+    public byte[] getV() {
+      return v;
+    }
+
+    public byte[] getR() {
+      return r;
+    }
+
+    public byte[] getS() {
+      return s;
+    }
+  }
+
+  /** Compute Keccak-256 hash of the input bytes. */
+  static byte[] keccak256(byte[] input) {
+    KeccakDigest digest = new KeccakDigest(256);
+    digest.update(input, 0, input.length);
+    byte[] result = new byte[32];
+    digest.doFinal(result, 0);
+    return result;
+  }
+
+  /** Generate v, r, s values from payload */
+  static SignatureData generateSignature(String apiSecret, List<List<String>> data) {
+    byte[] rawhash;
+    byte[] saltBytes;
+    String[] last = new String[1];
+
+    try (ByteArrayOutputStream sig_arr = new ByteArrayOutputStream()) {
       for (List<String> d : data) {
         String data1 = d.get(1);
-        /* remove 0x prefix and convert to bytes*/
+        /* remove 0x prefix and convert to bytes */
         byte[] segment = new byte[0];
         byte[] r = new byte[0];
         last[0] = new LinkedList<>(asList(data1.toLowerCase().split("0x"))).getLast();
@@ -39,15 +80,12 @@ public class IdexSignature {
             {
               segment = new byte[20];
               r = new BigInteger(last[0], 16).toByteArray();
-
               break;
             }
-
           case "uint256":
             {
               segment = new byte[32];
               r = new BigInteger(last[0], 10).toByteArray();
-
               break;
             }
         }
@@ -60,36 +98,115 @@ public class IdexSignature {
             segment,
             oversize > 0 ? 0 : (segLen - rlen),
             min(segLen, rlen));
-
         sig_arr.write(segment);
       }
-      rawhash = sha3(sig_arr.toByteArray());
+      rawhash = keccak256(sig_arr.toByteArray());
     } catch (IOException e) {
-      e.printStackTrace();
+      throw new RuntimeException(e);
     }
 
-    // salt the hashed packed string
+    // Salt the hashed packed string (Ethereum personal sign prefix)
     saltBytes = "\u0019Ethereum Signed Message:\n32".getBytes();
-
-    assert (new String(Hex.toHexString(saltBytes)).toLowerCase()
-        == "19457468657265756d205369676e6564204d6573736167653a0a3332");
-
-    byte[] salted = null;
-    try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
-      byteArrayOutputStream.write(saltBytes);
-      byteArrayOutputStream.write(rawhash);
-      salted = bytes = byteArrayOutputStream.toByteArray();
-      //            sha3(bytes);
+    byte[] salted;
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+      baos.write(saltBytes);
+      baos.write(rawhash);
+      salted = baos.toByteArray();
     } catch (IOException e) {
-      e.printStackTrace();
+      throw new RuntimeException(e);
     }
 
-    last[0] = new LinkedList<>(asList(apiSecret.split("0x"))).getLast();
-    apiSecret1 = new BigInteger(last[0], 16);
-    ecKeyPair = ECKeyPair.create(apiSecret1);
+    // Hash the salted message
+    byte[] msgHash = keccak256(salted);
 
-    SignatureData signatureData;
-    signatureData = Sign.signMessage(/* message= */ salted, /* keyPair= */ ecKeyPair);
-    return signatureData;
+    // Derive the public key point from the private key
+    last[0] = new LinkedList<>(asList(apiSecret.split("0x"))).getLast();
+    BigInteger privateKeyInt = new BigInteger(last[0], 16);
+    ECPoint publicKeyPoint = CURVE.getG().multiply(privateKeyInt).normalize();
+
+    // Sign with ECDSA using RFC 6979 deterministic k (HMacDSAKCalculator with SHA-256)
+    ECDSASigner signer = new ECDSASigner(new HMacDSAKCalculator(new SHA256Digest()));
+    signer.init(true, new ECPrivateKeyParameters(privateKeyInt, CURVE));
+    BigInteger[] rs = signer.generateSignature(msgHash);
+    BigInteger r = rs[0];
+    BigInteger s = rs[1];
+
+    // Enforce low-s canonical form
+    BigInteger halfOrder = CURVE.getN().shiftRight(1);
+    if (s.compareTo(halfOrder) > 0) {
+      s = CURVE.getN().subtract(s);
+    }
+
+    // Calculate Ethereum recovery bit: v = 27 + recId
+    byte recId = -1;
+    for (byte i = 0; i < 4; i++) {
+      ECPoint recoveredKey = recoverPublicKey(i, r, s, msgHash);
+      if (recoveredKey != null && recoveredKey.equals(publicKeyPoint)) {
+        recId = i;
+        break;
+      }
+    }
+    if (recId == -1) {
+      throw new RuntimeException("Could not find valid recovery id for signature");
+    }
+
+    byte v = (byte) (recId + 27);
+    return new SignatureData(v, toBytes32(r), toBytes32(s));
+  }
+
+  /**
+   * Attempt to recover the public key from a signature given a recovery id.
+   *
+   * @param recId recovery id (0–3)
+   * @param r signature r component
+   * @param s signature s component
+   * @param msgHash the 32-byte message hash
+   * @return the recovered EC point, or null if recovery fails
+   */
+  static ECPoint recoverPublicKey(int recId, BigInteger r, BigInteger s, byte[] msgHash) {
+    BigInteger n = CURVE.getN();
+    BigInteger x = r.add(BigInteger.valueOf(recId / 2).multiply(n));
+    BigInteger prime = CURVE.getCurve().getField().getCharacteristic();
+    if (x.compareTo(prime) >= 0) {
+      return null;
+    }
+
+    // Reconstruct point R with the correct y-parity
+    byte[] xBytes = toBytes32(x);
+    byte[] compressedPoint = new byte[33];
+    compressedPoint[0] = (byte) (0x02 + (recId & 1));
+    System.arraycopy(xBytes, 0, compressedPoint, 1, 32);
+    ECPoint R;
+    try {
+      R = CURVE.getCurve().decodePoint(compressedPoint).normalize();
+    } catch (Exception e) {
+      return null;
+    }
+    if (!R.isValid()) {
+      return null;
+    }
+
+    // Q = r^-1 * (s * R - e * G)
+    BigInteger e = new BigInteger(1, msgHash);
+    BigInteger rInv = r.modInverse(n);
+    BigInteger u1 = rInv.multiply(n.subtract(e.mod(n))).mod(n); // -e * r^-1 mod n
+    BigInteger u2 = rInv.multiply(s).mod(n); // s * r^-1 mod n
+    return ECAlgorithms.sumOfTwoMultiplies(CURVE.getG(), u1, R, u2).normalize();
+  }
+
+  /** Convert a BigInteger to a 32-byte big-endian array. */
+  static byte[] toBytes32(BigInteger value) {
+    byte[] bytes = value.toByteArray();
+    if (bytes.length == 32) {
+      return bytes;
+    }
+    byte[] result = new byte[32];
+    if (bytes.length > 32) {
+      // strip leading zero byte from two's complement representation
+      System.arraycopy(bytes, bytes.length - 32, result, 0, 32);
+    } else {
+      System.arraycopy(bytes, 0, result, 32 - bytes.length, bytes.length);
+    }
+    return result;
   }
 }

--- a/xchange-idex/src/main/java/org/knowm/xchange/idex/IdexTradeService.java
+++ b/xchange-idex/src/main/java/org/knowm/xchange/idex/IdexTradeService.java
@@ -15,6 +15,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.bouncycastle.util.encoders.Hex;
 import org.knowm.xchange.client.ExchangeRestProxyBuilder;
 import org.knowm.xchange.currency.Currency;
@@ -32,6 +33,7 @@ import org.knowm.xchange.dto.trade.UserTrade;
 import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.idex.IdexExchange.Companion.IdexCurrencyMeta;
+import org.knowm.xchange.idex.IdexSignature.SignatureData;
 import org.knowm.xchange.idex.dto.IdexBuySell;
 import org.knowm.xchange.idex.dto.OpenOrdersReq;
 import org.knowm.xchange.idex.dto.OrderReq;
@@ -49,7 +51,6 @@ import org.knowm.xchange.service.trade.params.CancelOrderParams;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
-import org.web3j.crypto.Sign.SignatureData;
 
 public class IdexTradeService extends BaseExchangeService implements TradeService {
 

--- a/xchange-idex/src/test/java/org/knowm/xchange/idex/IdexSignatureTest.java
+++ b/xchange-idex/src/test/java/org/knowm/xchange/idex/IdexSignatureTest.java
@@ -1,0 +1,154 @@
+package org.knowm.xchange.idex;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import org.bouncycastle.math.ec.ECPoint;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.Test;
+import org.knowm.xchange.idex.IdexSignature.SignatureData;
+
+class IdexSignatureTest {
+
+  /**
+   * Well-known private key used in many Ethereum testing examples.
+   * Private key: 0x4c0883a69102937d6231471b5dbb6e538eba2ef51f71a7f38fb3a20ae97c8ed6
+   * Expected address: 0x2c7536E3605D9C16a7a3D7b1898e529396a65c23
+   */
+  private static final String TEST_PRIVATE_KEY =
+      "0x4c0883a69102937d6231471b5dbb6e538eba2ef51f71a7f38fb3a20ae97c8ed6";
+
+  @Test
+  void keccak256_producesCorrectHash() {
+    // "hello" → known keccak-256 digest
+    byte[] input = "hello".getBytes();
+    byte[] hash = IdexSignature.keccak256(input);
+    assertEquals(
+        "1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8",
+        Hex.toHexString(hash));
+  }
+
+  @Test
+  void toBytes32_paddingAndTruncation() {
+    // Small value should be left-padded to 32 bytes
+    BigInteger one = BigInteger.ONE;
+    byte[] result = IdexSignature.toBytes32(one);
+    assertEquals(32, result.length);
+    assertEquals(1, result[31]);
+    for (int i = 0; i < 31; i++) {
+      assertEquals(0, result[i]);
+    }
+  }
+
+  @Test
+  void generateSignature_returnsCorrectVLength() {
+    List<List<String>> hashData =
+        asList(
+            asList("contractAddress", "0xb794f5ea0ba39494ce839613fffba74279579268", "address"),
+            asList("tokenBuy", "0x0000000000000000000000000000000000000000", "address"),
+            asList("amountBuy", "1000000000000000000", "uint256"),
+            asList("tokenSell", "0x6810e776880c02933d47db1b9fc05908e5386b96", "address"),
+            asList("amountSell", "500000000000000000", "uint256"),
+            asList("expires", "100000", "uint256"),
+            asList("nonce", "1", "uint256"),
+            asList("address", "0x2c7536e3605d9c16a7a3d7b1898e529396a65c23", "address"));
+
+    SignatureData sig = IdexSignature.generateSignature(TEST_PRIVATE_KEY, hashData);
+
+    assertNotNull(sig);
+    assertEquals(1, sig.getV().length);
+    assertEquals(32, sig.getR().length);
+    assertEquals(32, sig.getS().length);
+    // Ethereum v is always 27 or 28
+    int v = sig.getV()[0] & 0xff;
+    assertTrue("v must be 27 or 28, got " + v, v == 27 || v == 28);
+  }
+
+  @Test
+  void generateSignature_signatureIsVerifiable() {
+    // Verify that the signature can be used to recover the correct public key,
+    // confirming the v, r, s values are internally consistent.
+    List<List<String>> hashData =
+        asList(
+            asList("contractAddress", "0xb794f5ea0ba39494ce839613fffba74279579268", "address"),
+            asList("tokenBuy", "0x0000000000000000000000000000000000000000", "address"),
+            asList("amountBuy", "1000000000000000000", "uint256"),
+            asList("tokenSell", "0x6810e776880c02933d47db1b9fc05908e5386b96", "address"),
+            asList("amountSell", "500000000000000000", "uint256"),
+            asList("expires", "100000", "uint256"),
+            asList("nonce", "1", "uint256"),
+            asList("address", "0x2c7536e3605d9c16a7a3d7b1898e529396a65c23", "address"));
+
+    SignatureData sig = IdexSignature.generateSignature(TEST_PRIVATE_KEY, hashData);
+
+    // Derive the expected public key from the private key
+    BigInteger privateKey = new BigInteger(TEST_PRIVATE_KEY.replace("0x", ""), 16);
+    ECPoint expectedPublicKey =
+        IdexSignature.CURVE.getG().multiply(privateKey).normalize();
+
+    // Reconstruct the message hash that was signed (mirrors generateSignature internals)
+    byte[] msgHash = computeMsgHash(hashData);
+
+    // Recovery: recId = v - 27
+    int recId = (sig.getV()[0] & 0xff) - 27;
+    BigInteger r = new BigInteger(1, sig.getR());
+    BigInteger s = new BigInteger(1, sig.getS());
+    ECPoint recovered = IdexSignature.recoverPublicKey(recId, r, s, msgHash);
+
+    assertNotNull(recovered);
+    assertEquals(expectedPublicKey, recovered);
+  }
+
+  /** Replicates the message-hash computation in IdexSignature.generateSignature. */
+  private byte[] computeMsgHash(List<List<String>> data) {
+    java.io.ByteArrayOutputStream sigArr = new java.io.ByteArrayOutputStream();
+    for (List<String> d : data) {
+      String data1 = d.get(1);
+      byte[] segment;
+      byte[] r;
+      String last =
+          new java.util.LinkedList<>(asList(data1.toLowerCase().split("0x"))).getLast();
+      switch (d.get(2)) {
+        case "address":
+          segment = new byte[20];
+          r = new BigInteger(last, 16).toByteArray();
+          break;
+        case "uint256":
+          segment = new byte[32];
+          r = new BigInteger(last, 10).toByteArray();
+          break;
+        default:
+          continue;
+      }
+      int segLen = segment.length;
+      int rlen = Math.min(Math.max(segLen, r.length), r.length);
+      int oversize = r.length - segLen;
+      System.arraycopy(
+          r,
+          oversize > 0 ? oversize : 0,
+          segment,
+          oversize > 0 ? 0 : (segLen - rlen),
+          Math.min(segLen, rlen));
+      try {
+        sigArr.write(segment);
+      } catch (java.io.IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    byte[] rawhash = IdexSignature.keccak256(sigArr.toByteArray());
+    byte[] saltBytes = "\u0019Ethereum Signed Message:\n32".getBytes();
+    java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+    try {
+      baos.write(saltBytes);
+      baos.write(rawhash);
+    } catch (java.io.IOException e) {
+      throw new RuntimeException(e);
+    }
+    return IdexSignature.keccak256(baos.toByteArray());
+  }
+}


### PR DESCRIPTION
Closes #5281

## Changes

- **`xchange-idex/pom.xml`**: Remove `org.web3j:crypto` dependency; add explicit `bcprov-jdk18on` (already managed project-wide).
- **`IdexSignature.java`**: Full rewrite using BouncyCastle only:
  - `KeccakDigest` for Keccak-256 hashing (replaces `Hash.sha3`)
  - secp256k1 EC key derivation from private key (replaces `ECKeyPair.create`)
  - `ECDSASigner` + `HMacDSAKCalculator` (RFC 6979 deterministic k) for signing (replaces `Sign.signMessage`)
  - Manual Ethereum recovery bit (`v`) calculation with low-s enforcement
  - Inner `SignatureData` class replaces `org.web3j.crypto.Sign.SignatureData`
- **`IdexTradeService.java`**: Update `SignatureData` import to the new local class.
- **`IdexSignatureTest.java`**: New unit tests covering `keccak256`, `toBytes32`, signature shape, and public-key recoverability. Output was verified byte-for-byte identical to the web3j implementation via a dedicated comparison test.