### PR TITLE
Fix CoinexException getMessage to include error code

### DIFF
--- a/xchange-coinex/src/main/java/org/knowm/xchange/coinex/dto/CoinexException.java
+++ b/xchange-coinex/src/main/java/org/knowm/xchange/coinex/dto/CoinexException.java
@@ -14,4 +14,9 @@ public class CoinexException extends RuntimeException {
   Object data;
 
   String message;
+
+  @Override
+  public String getMessage() {
+    return "[" + code + "] " + message;
+  }
 }


### PR DESCRIPTION
Overrides `getMessage()` in `CoinexException` to return a more informative message that includes the error code: `[code] message`.