### PR TITLE
Fix swapped arguments in SimulatedTradeService.cancelOrder

### DIFF
--- a/xchange-simulated/src/main/java/org/knowm/xchange/simulated/SimulatedTradeService.java
+++ b/xchange-simulated/src/main/java/org/knowm/xchange/simulated/SimulatedTradeService.java
@@ -122,7 +122,7 @@ public class SimulatedTradeService extends BaseExchangeService<SimulatedExchange
         String orderId = ((CancelOrderByIdParams) orderParams).getOrderId();
         Order.OrderType type = ((CancelOrderByOrderTypeParams) orderParams).getOrderType();
 
-        engine.cancelOrder(orderId, getApiKey(), type);
+        engine.cancelOrder(getApiKey(), orderId, type);
 
         return true;
       }

--- a/xchange-simulated/src/test/java/org/knowm/xchange/simulated/TestSimulatedExchange.java
+++ b/xchange-simulated/src/test/java/org/knowm/xchange/simulated/TestSimulatedExchange.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeFactory;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.account.Balance;
 import org.knowm.xchange.dto.marketdata.OrderBook;
@@ -29,6 +30,9 @@ import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.FundsExceededException;
+import org.knowm.xchange.service.trade.params.CancelOrderByCurrencyPair;
+import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
+import org.knowm.xchange.service.trade.params.CancelOrderByOrderTypeParams;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamCurrencyPair;
 
@@ -358,6 +362,59 @@ public class TestSimulatedExchange {
     assertThat(baseBalance.getTotal()).isEqualTo(INITIAL_BALANCE);
     assertThat(baseBalance.getFrozen()).isEqualTo(ZERO);
     assertThat(baseBalance.getAvailable()).isEqualTo(INITIAL_BALANCE);
+  }
+
+  @Test
+  public void testCancelByCurrencyPairIdAndOrderType() throws IOException {
+    // When
+    String orderId =
+        exchange
+            .getTradeService()
+            .placeLimitOrder(
+                new LimitOrder.Builder(BID, BTC_USD)
+                    .limitPrice(new BigDecimal(10))
+                    .originalAmount(new BigDecimal("0.7"))
+                    .build());
+    exchange
+        .getTradeService()
+        .cancelOrder(new CancelByCurrencyPairIdAndType(BTC_USD, orderId, BID));
+    Balance counterBalance =
+        exchange.getAccountService().getAccountInfo().getWallet().getBalance(USD);
+
+    // Then
+    assertThat(getOpenOrders().getOpenOrders()).isEmpty();
+    assertThat(counterBalance.getFrozen()).isEqualByComparingTo(ZERO);
+    assertThat(counterBalance.getAvailable()).isEqualByComparingTo(INITIAL_BALANCE);
+  }
+
+  private static final class CancelByCurrencyPairIdAndType
+      implements CancelOrderByCurrencyPair, CancelOrderByIdParams, CancelOrderByOrderTypeParams {
+
+    private final CurrencyPair currencyPair;
+    private final String orderId;
+    private final Order.OrderType orderType;
+
+    private CancelByCurrencyPairIdAndType(
+        CurrencyPair currencyPair, String orderId, Order.OrderType orderType) {
+      this.currencyPair = currencyPair;
+      this.orderId = orderId;
+      this.orderType = orderType;
+    }
+
+    @Override
+    public CurrencyPair getCurrencyPair() {
+      return currencyPair;
+    }
+
+    @Override
+    public String getOrderId() {
+      return orderId;
+    }
+
+    @Override
+    public Order.OrderType getOrderType() {
+      return orderType;
+    }
   }
 
   private OpenOrders getOpenOrders() throws IOException {


### PR DESCRIPTION
Fixes #5187

## Problem

In the `CancelOrderByCurrencyPair` path of `SimulatedTradeService.cancelOrder`, the call was:

```java
engine.cancelOrder(orderId, getApiKey(), type);
```

but the engine signature is `MatchingEngine.cancelOrder(String apiKey, String orderId, OrderType type)`. Since both parameters are `String`s, this compiled fine but meant the book lookup compared order IDs against the API key — so the cancellation silently did nothing: the order stayed on the book and the reserved balance was never released. (The `DefaultCancelOrderParamId` path a few lines below already used the correct order.)

## Fix

Swap the arguments to match the signature, plus a regression test (`testCancelByCurrencyPairIdAndOrderType`) that cancels via a params object implementing `CancelOrderByCurrencyPair` + `CancelOrderByIdParams` + `CancelOrderByOrderTypeParams` and asserts the order is removed and the frozen balance released. The test fails without the one-line fix.

`mvn -pl xchange-simulated -am test` passes (12/12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)