### PR TITLE
Add regression test for #5074 (NPE on futures orders without cummulativeQuoteQty)

### DIFF
--- a/xchange-binance/src/test/java/org/knowm/xchange/binance/BinanceAdaptersTest.java
+++ b/xchange-binance/src/test/java/org/knowm/xchange/binance/BinanceAdaptersTest.java
@@ -38,6 +38,24 @@ public class BinanceAdaptersTest {
   }
 
   @Test
+  public void testFilledFuturesMarketOrderWithoutCumulativeQuoteQty() throws IOException {
+
+    // USDT-M futures order responses carry no "cummulativeQuoteQty" field; adapting such an
+    // order must not throw (regression test for #5074)
+    BinanceOrder binanceOrder =
+        ObjectMapperHelper.readValue(
+            BinanceAdaptersTest.class.getResource(
+                "/org/knowm/xchange/binance/filled-futures-market-order.json"),
+            BinanceOrder.class);
+    Order order = BinanceAdapters.adaptOrder(binanceOrder, true);
+    assertThat(order).isInstanceOf(MarketOrder.class);
+    assertThat(order.getStatus()).isEqualByComparingTo(Order.OrderStatus.FILLED);
+    assertThat(order.getOriginalAmount()).isEqualByComparingTo("0.5");
+    assertThat(order.getCumulativeAmount()).isEqualByComparingTo("0.5");
+    assertThat(order.getAveragePrice()).isNull();
+  }
+
+  @Test
   public void testAssetDividendList() throws Exception {
 
     AssetDividendResponse assetDividendList =

--- a/xchange-binance/src/test/resources/org/knowm/xchange/binance/filled-futures-market-order.json
+++ b/xchange-binance/src/test/resources/org/knowm/xchange/binance/filled-futures-market-order.json
@@ -1,0 +1,15 @@
+{
+    "symbol": "BTCUSDT",
+    "orderId": 283194212,
+    "clientOrderId": "testFuturesOrder",
+    "price": "0",
+    "origQty": "0.5",
+    "executedQty": "0.5",
+    "status": "FILLED",
+    "timeInForce": "GTC",
+    "type": "MARKET",
+    "side": "BUY",
+    "stopPrice": "0",
+    "time": 1566249504234,
+    "updateTime": 1566249504234
+}


### PR DESCRIPTION
Relates to #5074

USDT-M futures order responses carry no `cummulativeQuoteQty` field, which used to cause an NPE when adapting the order. The null guard added in #5075 (`BinanceAdapters.java` — `order.cumulativeQuoteQty != null` before the `divide`) already fixes the reported crash, but the issue was left open and nothing prevents a regression.

This PR adds a fixture for a filled USDT-M futures MARKET order without `cummulativeQuoteQty` and a test asserting `BinanceAdapters.adaptOrder(order, true)` adapts it without throwing.

With this in, #5074 can be closed as fixed by #5075.

`mvn -pl xchange-binance -am test -Dtest=BinanceAdaptersTest` passes (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)