### PR TITLE
Add Java 21 and 25 advisory builds to CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,16 +11,30 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ '17', '21', '25' ]
+        include:
+          - java: '21'
+            experimental: true
+          - java: '25'
+            experimental: true
+    continue-on-error: ${{ matrix.experimental || false }}
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: ${{ matrix.java }}
         distribution: 'temurin'
-    - name: Build with Maven
+    - name: Build with Maven (deploy)
+      if: matrix.java == '17'
       run: mvn clean deploy --no-transfer-progress --batch-mode --settings etc/settings.xml -Dfmt.skip=true;
       env:
         CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
         CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
+    - name: Build with Maven (verify)
+      if: matrix.java != '17'
+      run: mvn clean verify --no-transfer-progress --batch-mode --settings etc/settings.xml -Dfmt.skip=true;

--- a/.github/workflows/maven_on_pull_request.yml
+++ b/.github/workflows/maven_on_pull_request.yml
@@ -11,13 +11,23 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ '17', '21', '25' ]
+        include:
+          - java: '21'
+            experimental: true
+          - java: '25'
+            experimental: true
+    continue-on-error: ${{ matrix.experimental || false }}
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: ${{ matrix.java }}
         distribution: 'temurin'
     - name: Build with Maven
       run: mvn clean verify --no-transfer-progress --batch-mode --settings etc/settings.xml -Dmaven.javadoc.skip=true -Dfmt.skip=true;


### PR DESCRIPTION
Fixes #5304

Implements the proposal exactly as specified in the issue:

- Both `maven.yml` (push to develop) and `maven_on_pull_request.yml` (PRs) now build a JDK matrix over **17, 21, 25** with `fail-fast: false`.
- **Java 17 stays the only gating entry.** 21 and 25 carry `experimental: true` via matrix `include` and the job sets `continue-on-error: ${{ matrix.experimental || false }}`, so their failures leave the workflow conclusion green.
- On `maven.yml`, only the Java 17 entry runs `mvn clean deploy` (snapshot publish); 21 and 25 stop at `mvn clean verify` — no snapshots from non-17 JDKs.
- The Maven `<release>` target is untouched — this tests build/test compatibility on newer JDKs, not a retarget.

Check names become `build (17)`, `build (21)`, `build (25)` (the `experimental` flag is added via `include`, so it does not appear in the job name).

⚠️ Note for maintainers (from the issue's follow-up section): the required status check on `develop` branch protection needs updating from `build` to `build (17)` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)